### PR TITLE
[codex] Reset input on browser focus loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ Browser / WebAssembly with Emscripten:
 ```sh
 emcmake cmake -S . -B build-web
 cmake --build build-web
+python3 -m http.server 8080 --directory build-web
 ```
 
 That produces `build-web/space_miner.html` plus the `.js` and `.wasm` files.
+
+Open `http://127.0.0.1:8080/space_miner.html` and sanity-check browser input by holding `W` or `Space`, alt-tabbing away, then returning. The ship should stop taking active input when focus is lost.
 
 ## Notes
 

--- a/src/main.c
+++ b/src/main.c
@@ -186,6 +186,12 @@ static float rand_range(float min_value, float max_value) {
     return lerpf(min_value, max_value, randf());
 }
 
+// Drop transient and held input when the app loses focus.
+static void clear_input_state(void) {
+    memset(g.key_down, 0, sizeof(g.key_down));
+    memset(g.key_pressed, 0, sizeof(g.key_pressed));
+}
+
 static void set_notice(const char* fmt, ...) {
     va_list args;
     va_start(args, fmt);
@@ -781,6 +787,12 @@ static void event(const sapp_event* event) {
             if ((event->key_code >= 0) && (event->key_code < KEY_COUNT)) {
                 g.key_down[event->key_code] = false;
             }
+            break;
+
+        case SAPP_EVENTTYPE_UNFOCUSED:
+        case SAPP_EVENTTYPE_SUSPENDED:
+        case SAPP_EVENTTYPE_ICONIFIED:
+            clear_input_state();
             break;
 
         default:


### PR DESCRIPTION
## What changed
- added a `clear_input_state()` helper to reset held and transient keyboard state on focus loss
- clear input state when the app becomes unfocused, suspended, or iconified
- documented a minimal browser input sanity check in the README

## Why
The browser target could leave movement or mining controls latched if focus was lost while a key was held, because the corresponding `KEY_UP` event might never arrive.

## Review
- self-review completed after implementation
- no additional findings remained in the patch scope

## Validation
- `cmake --build build`
- `cmake --build build-web`

Closes #2