### PR TITLE
Unify client and server simulation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if(BUILD_TESTS_ONLY)
     return()
 endif()
 
-set(GAME_SOURCES src/main.c src/net.c src/commodity.c src/ship.c src/audio.c src/economy.c src/asteroid.c src/npc.c src/render.c)
+set(GAME_SOURCES src/main.c src/net.c src/commodity.c src/ship.c src/audio.c src/economy.c src/asteroid.c src/npc.c src/render.c server/game_sim.c)
 
 if(WIN32 AND NOT EMSCRIPTEN)
     add_executable(space_miner WIN32 ${GAME_SOURCES})
@@ -35,7 +35,7 @@ else()
     add_executable(space_miner ${GAME_SOURCES})
 endif()
 
-target_include_directories(space_miner PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/vendor/sokol" "${CMAKE_CURRENT_SOURCE_DIR}/src" "${CMAKE_CURRENT_SOURCE_DIR}/shared")
+target_include_directories(space_miner PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/vendor/sokol" "${CMAKE_CURRENT_SOURCE_DIR}/src" "${CMAKE_CURRENT_SOURCE_DIR}/shared" "${CMAKE_CURRENT_SOURCE_DIR}/server")
 
 if(MSVC)
     target_compile_definitions(space_miner PRIVATE _CRT_SECURE_NO_WARNINGS)

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache gcc musl-dev make
 WORKDIR /app
 COPY shared/ ./shared/
 COPY server/*.c server/*.h ./
-RUN gcc -O2 -static -Ishared -o signal-server main.c game_sim.c mongoose.c -lm -DMG_ENABLE_LOG=0
+RUN gcc -O2 -static -Ishared -o signal-server main.c game_sim.c mongoose.c -lm -DMG_ENABLE_LOG=0 -DGAME_SIM_VERBOSE
 
 FROM alpine:3.19
 RUN apk --no-cache add ca-certificates

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -1,13 +1,17 @@
 /*
- * game_sim.c -- Headless game simulation for the Signal Space Miner
- * authoritative server.
- *
- * Extracted from src/main.c.  All rendering, audio, and sokol
- * references have been removed.  Global state `g.` has been replaced
- * with world_t *w and server_player_t *sp parameters.
+ * game_sim.c -- Game simulation for Signal Space Miner.
+ * Used by both the authoritative server and the client (local sim).
+ * All rendering, audio, and sokol references are excluded.
+ * Global state replaced with world_t *w and server_player_t *sp parameters.
  */
 #include "game_sim.h"
 #include <stdlib.h>
+
+#ifdef GAME_SIM_VERBOSE
+#define SIM_LOG(...) printf(__VA_ARGS__)
+#else
+#define SIM_LOG(...) ((void)0)
+#endif
 
 /* ================================================================== */
 /* Hull definitions                                                   */
@@ -412,7 +416,7 @@ static void fracture_asteroid(world_t *w, int idx, vec2 outward_dir) {
     }
 
     /* audio_play_fracture removed */
-    printf("[sim] asteroid %d fractured into %d children\n", idx, child_count);
+    SIM_LOG("[sim] asteroid %d fractured into %d children\n", idx, child_count);
 }
 
 /* ================================================================== */
@@ -813,7 +817,7 @@ static void dock_ship(world_t *w, server_player_t *sp) {
     sp->docked = true;
     sp->in_dock_range = true;
     anchor_ship_in_station(sp, w);
-    printf("[sim] player %d docked at station %d\n", sp->id, sp->current_station);
+    SIM_LOG("[sim] player %d docked at station %d\n", sp->id, sp->current_station);
 }
 
 static void launch_ship(world_t *w, server_player_t *sp) {
@@ -821,7 +825,7 @@ static void launch_ship(world_t *w, server_player_t *sp) {
     sp->nearby_station = sp->current_station;
     sp->in_dock_range = true;
     anchor_ship_in_station(sp, w);
-    printf("[sim] player %d launched\n", sp->id);
+    SIM_LOG("[sim] player %d launched\n", sp->id);
 }
 
 static void emergency_recover_ship(world_t *w, server_player_t *sp) {
@@ -829,7 +833,7 @@ static void emergency_recover_ship(world_t *w, server_player_t *sp) {
     sp->ship.hull = ship_max_hull(&sp->ship);
     sp->ship.angle = PI_F * 0.5f;
     dock_ship(w, sp);
-    printf("[sim] player %d emergency recovered\n", sp->id);
+    SIM_LOG("[sim] player %d emergency recovered\n", sp->id);
 }
 
 static void apply_ship_damage(world_t *w, server_player_t *sp, float damage) {
@@ -900,7 +904,7 @@ static void try_sell_station_cargo(world_t *w, server_player_t *sp) {
         sp->ship.cargo[ore] -= accepted;
     }
     sp->ship.credits += payout;
-    printf("[sim] player %d sold ore for %.0f cr\n", sp->id, payout);
+    SIM_LOG("[sim] player %d sold ore for %.0f cr\n", sp->id, payout);
 }
 
 static void try_repair_ship(world_t *w, server_player_t *sp) {
@@ -910,7 +914,7 @@ static void try_repair_ship(world_t *w, server_player_t *sp) {
     if (cost <= 0.0f) return;
     if (!try_spend_credits(&sp->ship, cost)) return;
     sp->ship.hull = ship_max_hull(&sp->ship);
-    printf("[sim] player %d repaired for %.0f cr\n", sp->id, cost);
+    SIM_LOG("[sim] player %d repaired for %.0f cr\n", sp->id, cost);
 }
 
 static void try_apply_ship_upgrade(world_t *w, server_player_t *sp, ship_upgrade_t upgrade) {
@@ -932,7 +936,7 @@ static void try_apply_ship_upgrade(world_t *w, server_player_t *sp, ship_upgrade
     case SHIP_UPGRADE_TRACTOR: sp->ship.tractor_level++; break;
     default: break;
     }
-    printf("[sim] player %d upgraded %d to level %d\n", sp->id, (int)upgrade,
+    SIM_LOG("[sim] player %d upgraded %d to level %d\n", sp->id, (int)upgrade,
            ship_upgrade_level(&sp->ship, upgrade));
 }
 
@@ -1203,7 +1207,7 @@ void world_reset(world_t *w) {
         npc->thrusting     = false;
     }
 
-    printf("[sim] world reset complete (%d asteroids, %d NPCs)\n", FIELD_ASTEROID_TARGET, 5);
+    SIM_LOG("[sim] world reset complete (%d asteroids, %d NPCs)\n", FIELD_ASTEROID_TARGET, 5);
 }
 
 /* ================================================================== */

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -487,24 +487,33 @@ static void step_station_production(world_t *w, float dt) {
     for (int s = 0; s < MAX_STATIONS; s++) {
         station_t *st = &w->stations[s];
         if (st->role == STATION_ROLE_YARD) {
-            float buf = st->ingot_buffer[INGOT_IDX(COMMODITY_FRAME_INGOT)];
-            if (buf > 0.01f) {
-                float consume = fminf(buf, STATION_PRODUCTION_RATE * dt);
-                st->ingot_buffer[INGOT_IDX(COMMODITY_FRAME_INGOT)] -= consume;
-                st->product_stock[PRODUCT_FRAME] += consume;
+            if (st->product_stock[PRODUCT_FRAME] < MAX_PRODUCT_STOCK) {
+                float buf = st->ingot_buffer[INGOT_IDX(COMMODITY_FRAME_INGOT)];
+                if (buf > 0.01f) {
+                    float room = MAX_PRODUCT_STOCK - st->product_stock[PRODUCT_FRAME];
+                    float consume = fminf(buf, fminf(STATION_PRODUCTION_RATE * dt, room));
+                    st->ingot_buffer[INGOT_IDX(COMMODITY_FRAME_INGOT)] -= consume;
+                    st->product_stock[PRODUCT_FRAME] += consume;
+                }
             }
         } else if (st->role == STATION_ROLE_BEAMWORKS) {
-            float buf_co = st->ingot_buffer[INGOT_IDX(COMMODITY_CONDUCTOR_INGOT)];
-            if (buf_co > 0.01f) {
-                float consume = fminf(buf_co, STATION_PRODUCTION_RATE * dt);
-                st->ingot_buffer[INGOT_IDX(COMMODITY_CONDUCTOR_INGOT)] -= consume;
-                st->product_stock[PRODUCT_LASER_MODULE] += consume;
+            if (st->product_stock[PRODUCT_LASER_MODULE] < MAX_PRODUCT_STOCK) {
+                float buf_co = st->ingot_buffer[INGOT_IDX(COMMODITY_CONDUCTOR_INGOT)];
+                if (buf_co > 0.01f) {
+                    float room = MAX_PRODUCT_STOCK - st->product_stock[PRODUCT_LASER_MODULE];
+                    float consume = fminf(buf_co, fminf(STATION_PRODUCTION_RATE * dt, room));
+                    st->ingot_buffer[INGOT_IDX(COMMODITY_CONDUCTOR_INGOT)] -= consume;
+                    st->product_stock[PRODUCT_LASER_MODULE] += consume;
+                }
             }
-            float buf_ln = st->ingot_buffer[INGOT_IDX(COMMODITY_LENS_INGOT)];
-            if (buf_ln > 0.01f) {
-                float consume = fminf(buf_ln, STATION_PRODUCTION_RATE * dt);
-                st->ingot_buffer[INGOT_IDX(COMMODITY_LENS_INGOT)] -= consume;
-                st->product_stock[PRODUCT_TRACTOR_MODULE] += consume;
+            if (st->product_stock[PRODUCT_TRACTOR_MODULE] < MAX_PRODUCT_STOCK) {
+                float buf_ln = st->ingot_buffer[INGOT_IDX(COMMODITY_LENS_INGOT)];
+                if (buf_ln > 0.01f) {
+                    float room = MAX_PRODUCT_STOCK - st->product_stock[PRODUCT_TRACTOR_MODULE];
+                    float consume = fminf(buf_ln, fminf(STATION_PRODUCTION_RATE * dt, room));
+                    st->ingot_buffer[INGOT_IDX(COMMODITY_LENS_INGOT)] -= consume;
+                    st->product_stock[PRODUCT_TRACTOR_MODULE] += consume;
+                }
             }
         }
     }
@@ -564,20 +573,30 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
         npc->vel = v2(0.0f, 0.0f);
         if (npc->state_timer <= 0.0f) {
             station_t *home = &w->stations[npc->home_station];
-            float available = 0.0f;
-            for (int i = 0; i < INGOT_COUNT; i++)
-                available += home->inventory[COMMODITY_RAW_ORE_COUNT + i];
-            if (available > 1.0f) {
-                float space = hull->ingot_capacity;
-                for (int i = 0; i < INGOT_COUNT; i++) {
-                    commodity_t ingot = (commodity_t)(COMMODITY_RAW_ORE_COUNT + i);
-                    float take = fminf(home->inventory[ingot], space / (float)INGOT_COUNT);
+            station_t *dest = &w->stations[npc->dest_station];
+            float space = hull->ingot_capacity;
+            bool loaded = false;
+            if (dest->role == STATION_ROLE_YARD) {
+                commodity_t ingot = COMMODITY_FRAME_INGOT;
+                float take = fminf(home->inventory[ingot], space);
+                if (take > 0.5f) {
+                    npc->ingots[INGOT_IDX(ingot)] += take;
+                    home->inventory[ingot] -= take;
+                    loaded = true;
+                }
+            } else if (dest->role == STATION_ROLE_BEAMWORKS) {
+                commodity_t ingots[2] = { COMMODITY_CONDUCTOR_INGOT, COMMODITY_LENS_INGOT };
+                for (int i = 0; i < 2; i++) {
+                    float take = fminf(home->inventory[ingots[i]], space / 2.0f);
                     if (take > 0.01f) {
-                        npc->ingots[i] += take;
-                        home->inventory[ingot] -= take;
+                        npc->ingots[INGOT_IDX(ingots[i])] += take;
+                        home->inventory[ingots[i]] -= take;
                         space -= take;
+                        loaded = true;
                     }
                 }
+            }
+            if (loaded) {
                 npc->state = NPC_STATE_TRAVEL_TO_DEST;
             } else {
                 npc->state_timer = HAULER_LOAD_TIME;
@@ -714,7 +733,7 @@ static void step_npc_ships(world_t *w, float dt) {
             a->hp -= mined;
 
             float cs = hull->ore_capacity - npc_total_cargo(npc);
-            float ore_gained = fminf(mined * 0.4f, cs);
+            float ore_gained = fminf(mined * 0.15f, cs);
             if (ore_gained > 0.0f) npc->cargo[a->commodity] += ore_gained;
 
             if (a->hp <= 0.01f) {

--- a/src/main.c
+++ b/src/main.c
@@ -2860,13 +2860,13 @@ static void sim_step(float dt) {
         return;
     }
 
+    step_asteroid_dynamics(g.asteroids, MAX_ASTEROIDS, g.ship.pos, dt);
     if (!g.multiplayer_enabled || !net_is_connected()) {
-        step_asteroid_dynamics(g.asteroids, MAX_ASTEROIDS, g.ship.pos, dt);
         maintain_asteroid_field(dt);
-        step_refinery_production(g.stations, MAX_STATIONS, dt);
-        step_station_production(g.stations, MAX_STATIONS, dt);
-        step_npc_ships(dt);
     }
+    step_refinery_production(g.stations, MAX_STATIONS, dt);
+    step_station_production(g.stations, MAX_STATIONS, dt);
+    step_npc_ships(dt);
 
     if (!g.docked) {
         step_ship_rotation(dt, intent.turn);
@@ -2882,16 +2882,13 @@ static void sim_step(float dt) {
         if (!g.docked) {
             update_targeting_state(forward);
             step_mining_system(dt, intent.mine, forward);
-            if (!g.multiplayer_enabled || !net_is_connected()) {
-                step_fragment_collection(dt);
-            }
+            step_fragment_collection(dt);
         }
     } else {
+        update_docking_state(dt);
         if (!g.multiplayer_enabled || !net_is_connected()) {
-            update_docking_state(dt);
             step_station_interaction_system(&intent);
         }
-        /* Multiplayer + docked: server controls undocking via PLAYER_SHIP. */
     }
 
     step_notice_timer(dt);

--- a/src/main.c
+++ b/src/main.c
@@ -2532,15 +2532,13 @@ static void step_mining_system(float dt, bool mining, vec2 forward) {
         g.beam_hit = true;
         audio_play_mining_tick(&g.audio);
 
-        if (!net_is_connected()) {
-            /* Single-player: apply damage locally. */
-            float mined = fminf(ship_mining_rate(&g.ship) * dt, asteroid->hp);
-            asteroid->hp -= mined;
-            if (asteroid->hp <= 0.01f) {
-                fracture_asteroid(g.hover_asteroid, normal);
-            }
+        /* Apply damage locally (single-player) or as prediction (multiplayer).
+         * Server corrects via asteroid state snapshots. */
+        float mined = fminf(ship_mining_rate(&g.ship) * dt, asteroid->hp);
+        asteroid->hp -= mined;
+        if (asteroid->hp <= 0.01f) {
+            fracture_asteroid(g.hover_asteroid, normal);
         }
-        /* Multiplayer: server applies damage, client just shows beam. */
     } else {
         g.beam_end = v2_add(muzzle, v2_scale(forward, MINING_RANGE));
     }

--- a/src/main.c
+++ b/src/main.c
@@ -14,6 +14,7 @@
 #include "asteroid.h"
 #include "npc.h"
 #include "render.h"
+#include "game_sim.h"
 
 /* --- Multiplayer networking --- */
 #include "net.h"
@@ -68,18 +69,7 @@ typedef struct {
     bool key_pressed[KEY_COUNT];
 } input_state_t;
 
-typedef struct {
-    float turn;
-    float thrust;
-    bool mine;
-    bool interact;
-    bool service_sell;
-    bool service_repair;
-    bool upgrade_mining;
-    bool upgrade_hold;
-    bool upgrade_tractor;
-    bool reset;
-} input_intent_t;
+/* input_intent_t defined in game_sim.h */
 
 typedef struct {
     float accumulator;
@@ -117,6 +107,8 @@ typedef struct {
     runtime_state_t runtime;
     audio_state_t audio;
     sg_pass_action pass_action;
+    /* --- Simulation --- */
+    world_t world;
     /* --- Multiplayer --- */
     bool multiplayer_enabled;
     float net_send_timer;
@@ -125,9 +117,6 @@ typedef struct {
 
 static game_t g;
 
-static const float WORLD_RADIUS = 2200.0f;
-static const float SHIP_BRAKE = 180.0f;
-static const float MINING_RANGE = 170.0f;
 static const float HUD_MARGIN = 28.0f;
 static const float HUD_TOP_PANEL_WIDTH = 332.0f;
 static const float HUD_TOP_PANEL_HEIGHT = 78.0f;
@@ -149,64 +138,9 @@ static const float UI_SCALE_TIGHT = 1.85f;
 static const float UI_SCALE_COMPACT = 1.60f;
 static const float UI_SCALE_DEFAULT = 1.42f;
 static const float UI_SCALE_WIDE = 1.28f;
-static const float SIM_DT = 1.0f / 120.0f;
 static const int MAX_SIM_STEPS_PER_FRAME = 8;
-static const int FIELD_ASTEROID_TARGET = 32;
-static const float FIELD_ASTEROID_RESPAWN_DELAY = 0.6f;
-static const float FRACTURE_CHILD_CLEANUP_AGE = 22.0f;
-static const float FRACTURE_CHILD_CLEANUP_DISTANCE = 940.0f;
-static const float FRAGMENT_NEARBY_RANGE = 220.0f;
-static const float FRAGMENT_TRACTOR_ACCEL = 380.0f;
-static const float FRAGMENT_MAX_SPEED = 210.0f;
-static const float NPC_DOCK_TIME = 3.0f;
-static const float HAULER_DOCK_TIME = 4.0f;
-static const float HAULER_LOAD_TIME = 2.0f;
 
-const hull_def_t HULL_DEFS[HULL_CLASS_COUNT] = {
-    [HULL_CLASS_MINER] = {
-        .name = "Mining Cutter",
-        .max_hull = 100.0f,
-        .accel = 300.0f,
-        .turn_speed = 2.75f,
-        .drag = 0.45f,
-        .ore_capacity = 120.0f,
-        .ingot_capacity = 0.0f,
-        .mining_rate = 28.0f,
-        .tractor_range = 150.0f,
-        .ship_radius = 16.0f,
-        .render_scale = 1.0f,
-    },
-    [HULL_CLASS_HAULER] = {
-        .name = "Cargo Hauler",
-        .max_hull = 150.0f,
-        .accel = 140.0f,
-        .turn_speed = 1.6f,
-        .drag = 0.55f,
-        .ore_capacity = 0.0f,
-        .ingot_capacity = 40.0f,
-        .mining_rate = 0.0f,
-        .tractor_range = 0.0f,
-        .ship_radius = 18.0f,
-        .render_scale = 0.85f,
-    },
-    [HULL_CLASS_NPC_MINER] = {
-        .name = "Mining Drone",
-        .max_hull = 80.0f,
-        .accel = 180.0f,
-        .turn_speed = 2.0f,
-        .drag = 0.5f,
-        .ore_capacity = 60.0f,
-        .ingot_capacity = 0.0f,
-        .mining_rate = 14.0f,
-        .tractor_range = 0.0f,
-        .ship_radius = 12.0f,
-        .render_scale = 0.7f,
-    },
-};
-static const float COLLECTION_FEEDBACK_TIME = 1.1f;
-static const float STATION_DOCK_APPROACH_OFFSET = 34.0f;
-static const float SHIP_COLLISION_DAMAGE_THRESHOLD = 115.0f;
-static const float SHIP_COLLISION_DAMAGE_SCALE = 0.12f;
+/* HULL_DEFS defined in game_sim.c */
 
 /* Audio system: see audio.h/c */
 
@@ -2846,10 +2780,56 @@ static void step_npc_ships(float dt) {
 
 /* step_refinery_production, step_station_production: see economy.h/c */
 
+static void sync_globals_to_world(void) {
+    server_player_t* sp = &g.world.players[0];
+    sp->connected = true;
+    sp->id = 0;
+    sp->ship = g.ship;
+    sp->input = (input_intent_t){0};
+    sp->current_station = g.current_station;
+    sp->nearby_station = g.nearby_station;
+    sp->docked = g.docked;
+    sp->in_dock_range = g.in_dock_range;
+    sp->hover_asteroid = g.hover_asteroid;
+    sp->beam_active = g.beam_active;
+    sp->beam_hit = g.beam_hit;
+    sp->beam_start = g.beam_start;
+    sp->beam_end = g.beam_end;
+    sp->nearby_fragments = g.nearby_fragments;
+    sp->tractor_fragments = g.tractor_fragments;
+    memcpy(g.world.stations, g.stations, sizeof(g.stations));
+    memcpy(g.world.asteroids, g.asteroids, sizeof(g.asteroids));
+    memcpy(g.world.npc_ships, g.npc_ships, sizeof(g.npc_ships));
+    g.world.rng = g.rng;
+    g.world.time = g.time;
+    g.world.field_spawn_timer = g.field_spawn_timer;
+}
+
+static void sync_world_to_globals(void) {
+    server_player_t* sp = &g.world.players[0];
+    g.ship = sp->ship;
+    g.current_station = sp->current_station;
+    g.nearby_station = sp->nearby_station;
+    g.docked = sp->docked;
+    g.in_dock_range = sp->in_dock_range;
+    g.hover_asteroid = sp->hover_asteroid;
+    g.beam_active = sp->beam_active;
+    g.beam_hit = sp->beam_hit;
+    g.beam_start = sp->beam_start;
+    g.beam_end = sp->beam_end;
+    g.nearby_fragments = sp->nearby_fragments;
+    g.tractor_fragments = sp->tractor_fragments;
+    memcpy(g.stations, g.world.stations, sizeof(g.stations));
+    memcpy(g.asteroids, g.world.asteroids, sizeof(g.asteroids));
+    memcpy(g.npc_ships, g.world.npc_ships, sizeof(g.npc_ships));
+    g.rng = g.world.rng;
+    g.time = g.world.time;
+    g.field_spawn_timer = g.world.field_spawn_timer;
+}
+
 static void sim_step(float dt) {
     reset_step_feedback();
     audio_step(&g.audio, dt);
-    g.time += dt;
 
     input_intent_t intent = sample_input_intent();
     if (intent.reset) {
@@ -2858,34 +2838,34 @@ static void sim_step(float dt) {
         return;
     }
 
-    step_asteroid_dynamics(g.asteroids, MAX_ASTEROIDS, g.ship.pos, dt);
     if (!g.multiplayer_enabled || !net_is_connected()) {
-        maintain_asteroid_field(dt);
-    }
-    step_refinery_production(g.stations, MAX_STATIONS, dt);
-    step_station_production(g.stations, MAX_STATIONS, dt);
-    step_npc_ships(dt);
-
-    if (!g.docked) {
-        step_ship_rotation(dt, intent.turn);
-        vec2 forward = ship_forward();
-        step_ship_thrust(dt, intent.thrust, forward);
-        step_ship_motion(dt);
-        resolve_world_collisions();
-
-        update_docking_state(dt);
-        if (!g.multiplayer_enabled || !net_is_connected()) {
-            step_station_interaction_system(&intent);
-        }
-        if (!g.docked) {
-            update_targeting_state(forward);
-            step_mining_system(dt, intent.mine, forward);
-            step_fragment_collection(dt);
-        }
+        /* Single player: run authoritative sim locally */
+        sync_globals_to_world();
+        g.world.players[0].input = intent;
+        world_sim_step(&g.world, dt);
+        sync_world_to_globals();
     } else {
-        update_docking_state(dt);
-        if (!g.multiplayer_enabled || !net_is_connected()) {
-            step_station_interaction_system(&intent);
+        /* Multiplayer: server is authoritative for world state.
+         * Run local player physics for responsiveness.
+         * World state arrives via network callbacks. */
+        g.time += dt;
+        step_asteroid_dynamics(g.asteroids, MAX_ASTEROIDS, g.ship.pos, dt);
+        step_npc_ships(dt);
+
+        if (!g.docked) {
+            step_ship_rotation(dt, intent.turn);
+            vec2 forward = ship_forward();
+            step_ship_thrust(dt, intent.thrust, forward);
+            step_ship_motion(dt);
+            resolve_world_collisions();
+            update_docking_state(dt);
+            if (!g.docked) {
+                update_targeting_state(forward);
+                step_mining_system(dt, intent.mine, forward);
+                step_fragment_collection(dt);
+            }
+        } else {
+            update_docking_state(dt);
         }
     }
 


### PR DESCRIPTION
## Summary
Client now compiles and uses `server/game_sim.c` directly for single-player simulation. One sim codebase, zero divergence.

- Single player: `world_sim_step(&g.world, dt)` — same function the server runs
- Multiplayer: client-side prediction for ship physics, server corrects via snapshots
- Removes duplicate HULL_DEFS, ~20 constants, input_intent_t from main.c
- Adds SIM_LOG macro so server keeps debug logging, client is silent
- Server economy synced: product cap, NPC ore rate, hauler routing (#76)

This is the foundation for sectors — `world_t` instances per sector.

Closes #75, closes #76

## Test plan
- [x] 41 tests passing
- [x] Single player: mining, NPCs, economy, upgrades all work
- [x] Native build clean
- [ ] WASM build + deploy
- [ ] Multiplayer: two players can mine together

🤖 Generated with [Claude Code](https://claude.com/claude-code)