### PR TITLE
Fix 5 post-#124 issues: dead code and UI fallthrough

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -134,6 +134,7 @@ bool can_place_outpost(const world_t *w, vec2 pos) {
 
 static void add_module(station_t *st, module_type_t type) {
     if (st->module_count >= MAX_MODULES_PER_STATION) return;
+    if (station_has_module(st, type)) return;
     station_module_t *m = &st->modules[st->module_count++];
     m->type = type;
     m->scaffold = false;
@@ -247,16 +248,6 @@ static uint32_t station_upgrade_service(ship_upgrade_t upgrade) {
 /* Station helpers                                                    */
 /* ================================================================== */
 
-static int nearest_station_index(world_t *w, vec2 pos) {
-    float best_d = 0.0f;
-    int best = -1;
-    for (int i = 0; i < MAX_STATIONS; i++) {
-        float d = v2_dist_sq(pos, w->stations[i].pos);
-        if (best < 0 || d < best_d) { best_d = d; best = i; }
-    }
-    return best;
-}
-
 static vec2 station_dock_anchor(const station_t *station, const hull_def_t *hull) {
     if (!station) return v2(0.0f, 0.0f);
     return v2_add(station->pos, v2(0.0f, -(station->radius + hull->ship_radius + STATION_DOCK_APPROACH_OFFSET)));
@@ -264,15 +255,6 @@ static vec2 station_dock_anchor(const station_t *station, const hull_def_t *hull
 
 static bool station_has_service(const station_t *station, uint32_t service) {
     return station && ((station->services & service) != 0);
-}
-
-static float sim_station_cargo_sale_value(const station_t *station, const ship_t *s) {
-    float total = 0.0f;
-    if (!station) return 0.0f;
-    for (int i = 0; i < COMMODITY_RAW_ORE_COUNT; i++) {
-        total += s->cargo[i] * station->buy_price[i];
-    }
-    return total;
 }
 
 static float sim_station_repair_cost(const ship_t *s) {

--- a/src/asteroid.c
+++ b/src/asteroid.c
@@ -115,13 +115,6 @@ static float rand_range_rng(float min_val, float max_val, uint32_t* rng) {
     return min_val + (max_val - min_val) * t;
 }
 
-static int rand_int_rng(int min_val, int max_val, uint32_t* rng) {
-    uint32_t x = *rng;
-    x ^= x << 13; x ^= x >> 17; x ^= x << 5;
-    *rng = x;
-    return min_val + (int)(x % (uint32_t)(max_val - min_val + 1));
-}
-
 void configure_asteroid_tier(asteroid_t* asteroid, asteroid_tier_t tier, commodity_t commodity, uint32_t* rng) {
     float spin_limit = asteroid_spin_limit(tier);
     asteroid->active = true;

--- a/src/station_ui.c
+++ b/src/station_ui.c
@@ -251,8 +251,10 @@ void format_station_market_summary(const station_ui_state_t* ui, bool compact, c
         }
     } else if (station_has_module(ui->station, MODULE_FRAME_PRESS)) {
         snprintf(text, text_size, "%s", compact ? "Hull service + hold refit" : "Hull service and hold refits.");
-    } else {
+    } else if (station_has_module(ui->station, MODULE_LASER_FAB) || station_has_module(ui->station, MODULE_TRACTOR_FAB)) {
         snprintf(text, text_size, "%s", compact ? "Laser + tractor tuning" : "Laser and tractor tuning.");
+    } else {
+        snprintf(text, text_size, "%s", compact ? "Signal relay outpost" : "Signal relay outpost.");
     }
 }
 
@@ -274,10 +276,12 @@ void format_station_market_detail(const station_ui_state_t* ui, bool compact, ch
         int buf = (int)lroundf(ui->station->ingot_buffer[INGOT_IDX(COMMODITY_FRAME_INGOT)]);
         int prod = (int)lroundf(ui->station->product_stock[PRODUCT_FRAME]);
         snprintf(text, text_size, "Ingots %d // Frames %d", buf, prod);
-    } else {
+    } else if (station_has_module(ui->station, MODULE_LASER_FAB) || station_has_module(ui->station, MODULE_TRACTOR_FAB)) {
         int lsr = (int)lroundf(ui->station->product_stock[PRODUCT_LASER_MODULE]);
         int trc = (int)lroundf(ui->station->product_stock[PRODUCT_TRACTOR_MODULE]);
         snprintf(text, text_size, "LSR %d  TRC %d", lsr, trc);
+    } else {
+        snprintf(text, text_size, "Signal range: %.0f", ui->station->signal_range);
     }
 }
 


### PR DESCRIPTION
Remove unused functions and fix station UI conditional logic:

- **server/game_sim.c**: Remove dead code (`nearest_station_index`, `sim_station_cargo_sale_value`) and add duplicate module check in `add_module`
- **src/asteroid.c**: Remove unused `rand_int_rng` function
- **src/station_ui.c**: Fix missing else-if conditions in market summary/detail to properly handle signal relay outposts and prevent incorrect fallthrough behavior