### PR TITLE
fix(build): MSVC-portable fix for station_voice.h + hud.c format-truncation (supersedes #327, #328)

### DIFF
--- a/src/hud.c
+++ b/src/hud.c
@@ -292,7 +292,7 @@ static void split_hud_message_lines(const char* text, int max_cols, char* line0,
 
     size_t len = strlen(text);
     if ((int)len <= max_cols) {
-        snprintf(line0, line0_size, "%s", text);
+        snprintf(line0, line0_size, "%.*s", (int)(line0_size - 1), text);
         line1[0] = '\0';
         return;
     }
@@ -313,11 +313,11 @@ static void split_hud_message_lines(const char* text, int max_cols, char* line0,
     }
 
     if ((int)strlen(rest) <= max_cols) {
-        snprintf(line1, line1_size, "%s", rest);
+        snprintf(line1, line1_size, "%.*s", (int)(line1_size - 1), rest);
     } else if (max_cols > 3) {
         snprintf(line1, line1_size, "%.*s...", max_cols - 3, rest);
     } else {
-        snprintf(line1, line1_size, "%s", rest);
+        snprintf(line1, line1_size, "%.*s", (int)(line1_size - 1), rest);
     }
 }
 
@@ -337,7 +337,7 @@ static bool build_hud_message(char* label, size_t label_size, char* message, siz
         if (max_hull > 0.0f && LOCAL_PLAYER.ship.hull / max_hull < 0.20f) {
             label[0] = '\0';
             snprintf(message, message_size, "Hull failing. Dock for repairs.");
-            *r = PAL_WARNING; *g0 = 60; *b = 50;
+            *r = 255; *g0 = 60; *b = 50;
             return true;
         }
     }

--- a/src/station_voice.h
+++ b/src/station_voice.h
@@ -245,11 +245,20 @@ static const hail_response_t HELIOS_HAILS[] = {
 };
 #define HELIOS_HAIL_COUNT (int)(sizeof(HELIOS_HAILS) / sizeof(HELIOS_HAILS[0]))
 
-/* Lookup table for station index → response array */
-static const hail_response_t *STATION_HAIL_TABLES[] = {
+/* Lookup table for station index → response array.
+   Marked unused because most TUs that include this header don't dereference
+   these — only main.c does. GCC/Clang -Werror=unused-variable fires in the
+   others otherwise. MSVC has no equivalent warning at default levels. */
+#if defined(__GNUC__) || defined(__clang__)
+#  define SIGNAL_HAIL_MAYBE_UNUSED __attribute__((unused))
+#else
+#  define SIGNAL_HAIL_MAYBE_UNUSED
+#endif
+
+static const hail_response_t *STATION_HAIL_TABLES[] SIGNAL_HAIL_MAYBE_UNUSED = {
     PROSPECT_HAILS, KEPLER_HAILS, HELIOS_HAILS,
 };
-static const int STATION_HAIL_COUNTS[] = {
+static const int STATION_HAIL_COUNTS[] SIGNAL_HAIL_MAYBE_UNUSED = {
     PROSPECT_HAIL_COUNT, KEPLER_HAIL_COUNT, HELIOS_HAIL_COUNT,
 };
 


### PR DESCRIPTION
## Summary

Closes #326. Supersedes #327 and #328 (both used `__attribute__((unused))` unguarded, which MSVC rejects with `C2061`).

Three `-Werror` sites that block linux CI on main HEAD `989c262a`:

1. **`src/station_voice.h:249`** — `STATION_HAIL_TABLES` / `STATION_HAIL_COUNTS` are `static const` in a header included by 4 TUs but only dereferenced by `main.c`. `-Werror=unused-variable` fires in the other 3. Guard `__attribute__((unused))` behind `__GNUC__ || __clang__` so MSVC doesn't choke on the attribute syntax.

2. **`src/hud.c` — `split_hud_message_lines`** — three `snprintf(dst, dst_size, "%s", src)` sites trip `-Werror=format-truncation` because gcc can't prove `src` fits. Switch to `"%.*s"` with explicit `(dst_size - 1)` precision.

3. **`src/hud.c:337`** — `*r = PAL_WARNING;` expands to `*r = 255, 60, 50;` (comma expression), tripping `-Werror=unused-value` on the stray 60/50. Inline `255` at this one site; the macro remains valid for its proper rgb-triple uses elsewhere.

## Verified locally

- Native build: `[100%] Built target signal`
- Test suite: `260 tests run, 260 passed, 0 failed`
- WASM build: `[100%] Built target signal`

## Unblocks

- #317 — Station control API for external agents
- #318 — Station ownership binding + dock event queue

## Why direct push (not via agent)

The agent produced #327 and #328 from issue #326 twice in a row, both using the MSVC-breaking attribute syntax despite reviewer guidance. Pushing a three-line fix directly to close the retry loop.