### PR TITLE
RATi v2 (slices 1+2): named ingots — data model, wire, read-only UI

### DIFF
--- a/server/main.c
+++ b/server/main.c
@@ -718,6 +718,16 @@ static void ev_handler(struct mg_connection *c, int ev, void *ev_data) {
             }
         }
 
+        /* RATi v2: per-station named-ingot stockpile snapshot. New
+         * client sees what's currently on offer at every station so
+         * the MARKET stockpile UI is populated immediately. */
+        for (int sidx = 0; sidx < MAX_STATIONS; sidx++) {
+            if (world.stations[sidx].named_ingots_count <= 0) continue;
+            uint8_t buf[STATION_INGOTS_HEADER + STATION_NAMED_INGOTS_MAX * NAMED_INGOT_RECORD_SIZE];
+            int len = serialize_station_ingots(buf, sidx, &world.stations[sidx]);
+            ws_send(c, buf, (size_t)len);
+        }
+
         /* Send server version hash. */
         {
 #ifdef GIT_HASH
@@ -874,6 +884,12 @@ static void broadcast_ship_states(void) {
         int len = send_player_ship(buf, (uint8_t)i, &world.players[i]);
         /* Full ship state sent only to the owning player. */
         ws_send(world.players[i].conn, buf, (size_t)len);
+
+        /* RATi v2: also push hold-ingot snapshot. Cheap (max 8 × 52B
+         * = 416B + header). Ride along with the per-player ship tick. */
+        uint8_t hbuf[HOLD_INGOTS_HEADER + SHIP_HOLD_INGOTS_MAX * NAMED_INGOT_RECORD_SIZE];
+        int hlen = serialize_hold_ingots(hbuf, &world.players[i].ship);
+        ws_send(world.players[i].conn, hbuf, (size_t)hlen);
     }
 
     if (station_econ_dirty) {
@@ -1164,6 +1180,22 @@ int main(void) {
                         ws_send(world.players[p].conn, id_buf, (size_t)id_len);
                 }
                 station_identity_dirty[s] = false;
+            }
+
+            /* RATi v2: re-broadcast dirty named-ingot stockpiles to all
+             * connected players. Smaller payload than identity (~3KB
+             * worst case for a full stockpile) so we send to everyone
+             * regardless of signal range — the MARKET tab is global. */
+            for (int s = 0; s < MAX_STATIONS; s++) {
+                if (!world.stations[s].named_ingots_dirty) continue;
+                if (!station_exists(&world.stations[s])) continue;
+                uint8_t buf[STATION_INGOTS_HEADER + STATION_NAMED_INGOTS_MAX * NAMED_INGOT_RECORD_SIZE];
+                int len = serialize_station_ingots(buf, s, &world.stations[s]);
+                for (int p = 0; p < MAX_PLAYERS; p++) {
+                    if (!world.players[p].connected || !world.players[p].conn) continue;
+                    ws_send(world.players[p].conn, buf, (size_t)len);
+                }
+                world.stations[s].named_ingots_dirty = false;
             }
             last_world = now;
         }

--- a/server/net_protocol.h
+++ b/server/net_protocol.h
@@ -248,6 +248,51 @@ static inline int serialize_asteroids_full(uint8_t *buf, const asteroid_t *aster
     return ASTEROID_MSG_HEADER + count * ASTEROID_RECORD_SIZE;
 }
 
+/* RATi v2 — write a single named ingot record into the buffer.
+ * Layout matches the on-wire NAMED_INGOT_RECORD_SIZE definition. */
+static inline void write_named_ingot(uint8_t *p, const named_ingot_t *m) {
+    memset(p, 0, NAMED_INGOT_RECORD_SIZE);
+    memcpy(&p[0], m->pubkey, 32);
+    p[32] = m->prefix_class;
+    p[33] = m->metal;
+    /* p[34..35] pad */
+    for (int k = 0; k < 8; k++) p[36 + k] = (uint8_t)(m->mined_block >> (8 * k));
+    p[44] = m->origin_station;
+    /* p[45..51] pad */
+}
+
+/* Per-station named-ingot stockpile snapshot. Sent on dock + on
+ * stockpile change. */
+static inline int serialize_station_ingots(uint8_t *buf, int station_idx,
+                                           const station_t *st) {
+    int n = st->named_ingots_count;
+    if (n < 0) n = 0;
+    if (n > STATION_NAMED_INGOTS_MAX) n = STATION_NAMED_INGOTS_MAX;
+    if (n > 255) n = 255; /* count fits in u8 */
+    buf[0] = NET_MSG_STATION_INGOTS;
+    buf[1] = (uint8_t)station_idx;
+    buf[2] = (uint8_t)n;
+    for (int i = 0; i < n; i++) {
+        uint8_t *p = &buf[STATION_INGOTS_HEADER + i * NAMED_INGOT_RECORD_SIZE];
+        write_named_ingot(p, &st->named_ingots[i]);
+    }
+    return STATION_INGOTS_HEADER + n * NAMED_INGOT_RECORD_SIZE;
+}
+
+/* Local player's hold-ingot snapshot. Sent on contents change. */
+static inline int serialize_hold_ingots(uint8_t *buf, const ship_t *ship) {
+    int n = ship->hold_ingots_count;
+    if (n < 0) n = 0;
+    if (n > SHIP_HOLD_INGOTS_MAX) n = SHIP_HOLD_INGOTS_MAX;
+    buf[0] = NET_MSG_HOLD_INGOTS;
+    buf[1] = (uint8_t)n;
+    for (int i = 0; i < n; i++) {
+        uint8_t *p = &buf[HOLD_INGOTS_HEADER + i * NAMED_INGOT_RECORD_SIZE];
+        write_named_ingot(p, &ship->hold_ingots[i]);
+    }
+    return HOLD_INGOTS_HEADER + n * NAMED_INGOT_RECORD_SIZE;
+}
+
 /* Signal channel (#316) snapshot — the client dedupes by id so this
  * works as both the connect-time full sync and the per-post update. */
 static inline int serialize_signal_channel(uint8_t *buf, const signal_channel_t *ch) {

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -161,16 +161,36 @@ static const uint8_t MINING_UNIVERSE_KEY[32] = {
 };
 
 mining_grade_t sim_roll_fragment_grade(const asteroid_t *a) {
-    (void)a; /* ore tonnage no longer scales burst — flat per-fragment */
+    mining_keypair_t winner;
+    return sim_roll_fragment_winner(a, &winner);
+}
+
+/* RATi v2: also surface the keypair of the highest-grade candidate so
+ * the refinery can stamp it onto a named ingot. The roll is identical
+ * to sim_roll_fragment_grade — same seed, same universe key, same loop —
+ * we just remember which nonce won. Deterministic; any client could
+ * recompute this from the rock's fracture_seed. */
+mining_grade_t sim_roll_fragment_winner(const asteroid_t *a, mining_keypair_t *out_winner) {
     mining_grade_t best = MINING_GRADE_COMMON;
+    mining_keypair_t best_kp;
+    memset(&best_kp, 0, sizeof(best_kp));
+    /* Seed the winner with the very first roll so we always return
+     * SOMETHING valid even when every candidate is COMMON. */
+    bool have_winner = false;
     for (int i = 0; i < MINING_BURST_PER_FRAGMENT; i++) {
         mining_keypair_t kp;
         mining_keypair_derive(a->fracture_seed, MINING_UNIVERSE_KEY, (uint32_t)i, &kp);
         char callsign[8];
         mining_callsign_from_pubkey(kp.pub, callsign);
         mining_grade_t g = mining_classify_base58(callsign);
-        if (g > best) best = g;
+        /* Prefer higher grade; break ties to first-seen (lower nonce). */
+        if (!have_winner || g > best) {
+            best = g;
+            best_kp = kp;
+            have_winner = true;
+        }
     }
+    if (out_winner) *out_winner = best_kp;
     return best;
 }
 
@@ -368,6 +388,54 @@ void step_furnace_smelting(world_t *w, float dt) {
                 st->inventory[ingot] += a->ore;
             else
                 st->inventory[a->commodity] += a->ore;
+
+            /* RATi v2: also re-roll the winning candidate's keypair
+             * and, if its base58 carries a class-letter prefix,
+             * deposit a named ingot into the station's stockpile. The
+             * player still gets paid the bulk credits above; this is
+             * an additional output unique per-fragment. */
+            mining_keypair_t winner;
+            sim_roll_fragment_winner(a, &winner);
+            int prefix = mining_pubkey_class(winner.pub);
+            if (prefix != MINING_CLASS_ANONYMOUS) {
+                /* If the stockpile is full, LRU-evict the entry with
+                 * the smallest mined_block (oldest first). The evicted
+                 * pubkey is voided to the chain so it can never be
+                 * re-deposited, keeping namespace honest. */
+                if (st->named_ingots_count >= STATION_NAMED_INGOTS_MAX) {
+                    int worst = 0;
+                    uint64_t oldest = st->named_ingots[0].mined_block;
+                    for (int k = 1; k < STATION_NAMED_INGOTS_MAX; k++) {
+                        if (st->named_ingots[k].mined_block < oldest) {
+                            oldest = st->named_ingots[k].mined_block;
+                            worst = k;
+                        }
+                    }
+                    char ev_cs[12];
+                    mining_render_callsign(st->named_ingots[worst].pubkey, ev_cs);
+                    char ev_msg[96];
+                    snprintf(ev_msg, sizeof(ev_msg),
+                             "stockpile full — voided %s", ev_cs);
+                    signal_channel_post(w, smelt_station, ev_msg, "");
+                    /* Compact: move last into evicted slot. */
+                    st->named_ingots[worst] = st->named_ingots[STATION_NAMED_INGOTS_MAX - 1];
+                    st->named_ingots_count = STATION_NAMED_INGOTS_MAX - 1;
+                }
+
+                named_ingot_t *ing = &st->named_ingots[st->named_ingots_count++];
+                memset(ing, 0, sizeof(*ing));
+                memcpy(ing->pubkey, winner.pub, 32);
+                ing->prefix_class   = (uint8_t)prefix;
+                ing->metal          = (uint8_t)ingot;
+                ing->origin_station = (uint8_t)smelt_station;
+
+                char cs[12];
+                mining_render_callsign(winner.pub, cs);
+                char text[96];
+                snprintf(text, sizeof(text), "smelted %s", cs);
+                ing->mined_block = signal_channel_post(w, smelt_station, text, "");
+            }
+
             clear_asteroid(a);
         }
     }

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -434,6 +434,7 @@ void step_furnace_smelting(world_t *w, float dt) {
                 char text[96];
                 snprintf(text, sizeof(text), "smelted %s", cs);
                 ing->mined_block = signal_channel_post(w, smelt_station, text, "");
+                st->named_ingots_dirty = true;
             }
 
             clear_asteroid(a);

--- a/server/sim_production.h
+++ b/server/sim_production.h
@@ -22,6 +22,12 @@ bool sim_can_smelt_ore(const station_t *st, commodity_t ore);
  * stable for the rock's lifetime — the in-world dot reveals it. */
 mining_grade_t sim_roll_fragment_grade(const asteroid_t *a);
 
+/* Variant that also returns the keypair of the winning candidate
+ * (the one whose base58 callsign achieved best grade). Used by
+ * the refinery to stamp the winning pubkey onto a named ingot. */
+mining_grade_t sim_roll_fragment_winner(const asteroid_t *a,
+                                        mining_keypair_t *out_winner);
+
 /*
  * Already declared in game_sim.h:
  *   step_module_delivery

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -52,7 +52,7 @@ static uint32_t crc32_file(FILE *f) {
 }
 
 #define SAVE_MAGIC 0x5349474E  /* "SIGN" */
-#define SAVE_VERSION 25  /* bumped: MAX_STATIONS 8→64, station_count in header (#285 Phase 1) */
+#define SAVE_VERSION 26  /* RATi v2: per-station named ingot stockpile */
 #define MIN_SAVE_VERSION 20  /* migrate v20 by mapping old module_buffer → input */
 
 /* Set by world_load() before read_station() so per-station readers know
@@ -187,6 +187,10 @@ static bool write_station_session(FILE *f, const station_t *s) {
         WRITE_FIELD(f, s->arm_rotation[a]);
         WRITE_FIELD(f, s->arm_speed[a]);
     }
+    /* RATi v2: named ingot stockpile (v26+). */
+    WRITE_FIELD(f, s->named_ingots_count);
+    for (int i = 0; i < STATION_NAMED_INGOTS_MAX; i++)
+        WRITE_FIELD(f, s->named_ingots[i]);
     return true;
 }
 
@@ -233,6 +237,16 @@ static bool read_station_session(FILE *f, station_t *s) {
     for (int a = 0; a < MAX_ARMS; a++) {
         READ_FIELD(f, s->arm_rotation[a]);
         READ_FIELD(f, s->arm_speed[a]);
+    }
+    /* RATi v2: named ingot stockpile (v26+). Older saves leave the
+     * stockpile zero-initialized, which is the empty state. */
+    if (g_loaded_save_version >= 26) {
+        READ_FIELD(f, s->named_ingots_count);
+        if (s->named_ingots_count < 0) s->named_ingots_count = 0;
+        if (s->named_ingots_count > STATION_NAMED_INGOTS_MAX)
+            s->named_ingots_count = STATION_NAMED_INGOTS_MAX;
+        for (int i = 0; i < STATION_NAMED_INGOTS_MAX; i++)
+            READ_FIELD(f, s->named_ingots[i]);
     }
     return true;
 }
@@ -620,9 +634,59 @@ bool world_load(world_t *w, const char *path) {
 /* Player persistence                                                  */
 /* ================================================================== */
 
-#define PLAYER_MAGIC    0x504C5933u  /* "PLY3" — v25+: station-local credits (#312) */
+#define PLAYER_MAGIC    0x504C5934u  /* "PLY4" — v26+: ship_t.hold_ingots[] for RATi v2 */
+#define PLAYER_MAGIC_V3 0x504C5933u  /* "PLY3" — v25: station-local credits (#312) */
 #define PLAYER_MAGIC_V2 0x504C5932u  /* "PLY2" — v22-v24: post #280 enum cleanup */
 #define PLAYER_MAGIC_V1 0x504C5952u  /* "PLYR" — v21 and earlier */
+
+/* PLY3 ship layout — same as current ship_t but WITHOUT hold_ingots.
+ * Kept here so we can read PLY3 files and zero-init the new field. */
+typedef struct {
+    vec2 pos; vec2 vel; float angle; float hull;
+    float cargo[COMMODITY_COUNT];
+    hull_class_t hull_class;
+    int mining_level, hold_level, tractor_level;
+    int16_t towed_fragments[10]; uint8_t towed_count;
+    int16_t towed_scaffold; bool tractor_active;
+    float comm_range;
+    uint32_t unlocked_modules;
+    float stat_ore_mined, stat_credits_earned, stat_credits_spent;
+    int stat_asteroids_fractured;
+} ship_v3_t;
+
+typedef struct {
+    uint32_t magic;
+    ship_v3_t ship;
+    int last_station;
+    vec2 last_pos;
+    float last_angle;
+} player_save_v3_t;
+
+static void migrate_v3_ship(ship_t *dst, const ship_v3_t *src) {
+    /* All fields are identical except dst gains hold_ingots[]. */
+    dst->pos = src->pos;
+    dst->vel = src->vel;
+    dst->angle = src->angle;
+    dst->hull = src->hull;
+    memcpy(dst->cargo, src->cargo, sizeof(dst->cargo));
+    dst->hull_class = src->hull_class;
+    dst->mining_level = src->mining_level;
+    dst->hold_level = src->hold_level;
+    dst->tractor_level = src->tractor_level;
+    memcpy(dst->towed_fragments, src->towed_fragments, sizeof(dst->towed_fragments));
+    dst->towed_count = src->towed_count;
+    dst->towed_scaffold = src->towed_scaffold;
+    dst->tractor_active = src->tractor_active;
+    dst->comm_range = src->comm_range;
+    dst->unlocked_modules = src->unlocked_modules;
+    dst->stat_ore_mined = src->stat_ore_mined;
+    dst->stat_credits_earned = src->stat_credits_earned;
+    dst->stat_credits_spent = src->stat_credits_spent;
+    dst->stat_asteroids_fractured = src->stat_asteroids_fractured;
+    /* New fields — zero-init. */
+    memset(dst->hold_ingots, 0, sizeof(dst->hold_ingots));
+    dst->hold_ingots_count = 0;
+}
 
 typedef struct {
     uint32_t magic;
@@ -715,6 +779,10 @@ static void migrate_v2_ship(ship_t *dst, const ship_v2_t *src) {
     dst->stat_credits_earned = src->stat_credits_earned;
     dst->stat_credits_spent = src->stat_credits_spent;
     dst->stat_asteroids_fractured = src->stat_asteroids_fractured;
+    /* RATi v2 fields not present in PLY2 — zero-init. */
+    dst->comm_range = 0.0f;
+    memset(dst->hold_ingots, 0, sizeof(dst->hold_ingots));
+    dst->hold_ingots_count = 0;
 }
 
 static bool player_load_from_path(server_player_t *sp, world_t *w, const char *path, int slot) {
@@ -730,11 +798,20 @@ static bool player_load_from_path(server_player_t *sp, world_t *w, const char *p
     bool is_v1 = false;
 
     if (magic == PLAYER_MAGIC) {
-        /* Current format (PLY3) */
+        /* Current format (PLY4 — RATi v2 with hold_ingots) */
         player_save_data_t data;
         if (fread(&data, sizeof(data), 1, f) != 1) { fclose(f); return false; }
         fclose(f);
         sp->ship = data.ship;
+        sp->current_station = data.last_station;
+        sp->ship.pos = data.last_pos;
+        sp->ship.angle = data.last_angle;
+    } else if (magic == PLAYER_MAGIC_V3) {
+        /* PLY3 → PLY4: migrate ship_v3_t → ship_t, zero-init hold_ingots. */
+        player_save_v3_t data;
+        if (fread(&data, sizeof(data), 1, f) != 1) { fclose(f); return false; }
+        fclose(f);
+        migrate_v3_ship(&sp->ship, &data.ship);
         sp->current_station = data.last_station;
         sp->ship.pos = data.last_pos;
         sp->ship.angle = data.last_angle;

--- a/shared/mining.h
+++ b/shared/mining.h
@@ -242,4 +242,75 @@ static inline void mining_callsign_from_pubkey(const uint8_t pub[MINING_PUBKEY_B
     out[7] = '\0';
 }
 
+/* Class prefix indices — must mirror ingot_prefix_t in shared/types.h.
+ * Kept as plain integers here so this header has no types.h dependency.
+ * Single source of truth lives in types.h; v2 callers should compare
+ * against the typed enum names. */
+enum {
+    MINING_CLASS_ANONYMOUS    = 0,
+    MINING_CLASS_M            = 1,
+    MINING_CLASS_H            = 2,
+    MINING_CLASS_T            = 3,
+    MINING_CLASS_S            = 4,
+    MINING_CLASS_F            = 5,
+    MINING_CLASS_K            = 6,
+    MINING_CLASS_RATI         = 7,
+    MINING_CLASS_COMMISSIONED = 8,
+};
+
+/* Inspect the leading character(s) of base58(pubkey) to determine
+ * which hull class an ingot can mint. Returns one of MINING_CLASS_*. */
+static inline int mining_pubkey_class(const uint8_t pub[MINING_PUBKEY_BYTES]) {
+    char b58[MINING_BASE58_CAP];
+    size_t n = base58_encode(pub, MINING_PUBKEY_BYTES, b58, sizeof(b58));
+    if (n < 4) return MINING_CLASS_ANONYMOUS;
+    if (b58[0]=='R' && b58[1]=='A' && b58[2]=='T' && b58[3]=='i')
+        return MINING_CLASS_RATI;
+    switch (b58[0]) {
+    case 'M': return MINING_CLASS_M;
+    case 'H': return MINING_CLASS_H;
+    case 'T': return MINING_CLASS_T;
+    case 'S': return MINING_CLASS_S;
+    case 'F': return MINING_CLASS_F;
+    case 'K': return MINING_CLASS_K;
+    /* R/A/T/i alone are reserved (RATi disambiguation) — anonymous. */
+    default:  return MINING_CLASS_ANONYMOUS;
+    }
+}
+
+/* Render a pubkey as its display callsign, with the class-prefix dash
+ * inserted at the boundary:
+ *   M-class:    "M-ABCDEF"   (8 chars + null = 9)
+ *   RATi-class: "RATi-XYZ"   (8 chars + null = 9)
+ *   anonymous:  "ABCDEFG"    (7 chars + null = 8)
+ * Caller buffer must be at least 12 bytes. */
+static inline void mining_render_callsign(const uint8_t pub[MINING_PUBKEY_BYTES],
+                                          char out[12]) {
+    char b58[MINING_BASE58_CAP];
+    size_t n = base58_encode(pub, MINING_PUBKEY_BYTES, b58, sizeof(b58));
+    if (n < 7) {
+        /* Should never happen with a 32B pubkey, but be defensive. */
+        size_t i;
+        for (i = 0; i < n && i < 11; i++) out[i] = b58[i];
+        out[i] = '\0';
+        return;
+    }
+    int cls = mining_pubkey_class(pub);
+    if (cls == MINING_CLASS_RATI) {
+        /* Skip the 4 RATi chars, render 3 of the body chars. */
+        out[0]='R'; out[1]='A'; out[2]='T'; out[3]='i'; out[4]='-';
+        out[5]=b58[4]; out[6]=b58[5]; out[7]=b58[6];
+        out[8]='\0';
+    } else if (cls != MINING_CLASS_ANONYMOUS) {
+        out[0] = b58[0];
+        out[1] = '-';
+        out[2] = b58[1]; out[3] = b58[2]; out[4] = b58[3];
+        out[5] = b58[4]; out[6] = b58[5]; out[7] = b58[6];
+        out[8] = '\0';
+    } else {
+        memcpy(out, b58, 7);
+        out[7] = '\0';
+    }
+}
+
 #endif /* SHARED_MINING_H */

--- a/shared/protocol.h
+++ b/shared/protocol.h
@@ -48,7 +48,21 @@ enum {
     NET_MSG_HAIL_RESPONSE   = 0x25, /* server -> client: hail collected payout */
     NET_MSG_EVENTS          = 0x26, /* server -> client: sim event batch */
     NET_MSG_SIGNAL_CHANNEL  = 0x27, /* server -> client: broadcast-log snapshot / append (#316) */
+    NET_MSG_STATION_INGOTS  = 0x28, /* server -> client: station's named-ingot stockpile (RATi v2) */
+    NET_MSG_HOLD_INGOTS     = 0x29, /* server -> client: local player's hold ingots (RATi v2) */
 };
+
+/* Named ingot wire record: [pubkey:32][prefix:1][metal:1][_pad:2][mined_block:8][origin:1][_pad2:7] = 52 bytes
+ * Mirrors named_ingot_t exactly so the server can write the struct
+ * directly. Class authorization is in the leading char(s) of base58(pubkey). */
+#define NAMED_INGOT_RECORD_SIZE 52
+
+/* NET_MSG_STATION_INGOTS layout:
+ *   [type:1][station_id:1][count:1] + count × NAMED_INGOT_RECORD_SIZE
+ * NET_MSG_HOLD_INGOTS layout (player is implicit — local pilot):
+ *   [type:1][count:1] + count × NAMED_INGOT_RECORD_SIZE */
+#define STATION_INGOTS_HEADER 3
+#define HOLD_INGOTS_HEADER    2
 
 /* Signal channel wire record:
  *   [id:u64][ts_ms:u32][sender:i8][text_len:u8][text:200][entry_hash:32] = 246 bytes

--- a/shared/types.h
+++ b/shared/types.h
@@ -88,6 +88,43 @@ typedef struct {
 
 extern const hull_def_t HULL_DEFS[HULL_CLASS_COUNT];
 
+/* RATi mining v2 — class authorization encoded in the leading char(s)
+ * of base58(pubkey). Determines what hull class an ingot can mint.
+ *   M / H / T / S / F / K = single-letter classes
+ *   RATi (4-char prefix)  = brand fleet
+ *   anything else         = anonymous (bulk material only)
+ * Reserved letters R/A/T/i (RATi disambiguation) and digits/lowercase
+ * fall into anonymous. */
+typedef enum {
+    INGOT_PREFIX_ANONYMOUS = 0,
+    INGOT_PREFIX_M,
+    INGOT_PREFIX_H,
+    INGOT_PREFIX_T,
+    INGOT_PREFIX_S,
+    INGOT_PREFIX_F,
+    INGOT_PREFIX_K,
+    INGOT_PREFIX_RATI,
+    INGOT_PREFIX_COMMISSIONED,  /* reserved for v1.5 station bounties */
+    INGOT_PREFIX_COUNT
+} ingot_prefix_t;
+
+/* A named ingot is a uniquely-identified unit of refined ore. The
+ * pubkey IS the future hull's name; the prefix decides which hull
+ * class can be minted from it. Provenance fields let any client trace
+ * the ingot's history through the chain log. */
+typedef struct {
+    uint8_t  pubkey[32];      /* identity, set at smelt */
+    uint8_t  prefix_class;    /* ingot_prefix_t */
+    uint8_t  metal;           /* commodity_t — FERRITE/CUPRITE/CRYSTAL_INGOT */
+    uint8_t  _pad[2];
+    uint64_t mined_block;     /* chain block id at mint */
+    uint8_t  origin_station;  /* refinery that smelted it */
+    uint8_t  _pad2[7];
+} named_ingot_t;
+
+#define STATION_NAMED_INGOTS_MAX 64
+#define SHIP_HOLD_INGOTS_MAX     8
+
 typedef struct {
     vec2 pos;
     vec2 vel;
@@ -112,6 +149,11 @@ typedef struct {
     float stat_credits_earned;
     float stat_credits_spent;
     int stat_asteroids_fractured;
+    /* Named ingots in the player's hold — carried between stations
+     * for sale or hull construction. Bulk anonymous ingots still ride
+     * in cargo[] as fungible counts; this list holds identified ones. */
+    named_ingot_t hold_ingots[SHIP_HOLD_INGOTS_MAX];
+    int           hold_ingots_count;
 } ship_t;
 
 typedef enum {
@@ -233,6 +275,12 @@ typedef struct {
     /* Station credit pool: fixed money supply, no inflation.
      * Smelting pays from pool, player spending refills it. */
     float credit_pool;
+    /* Named ingot stockpile (RATi v2). Refinery deposits here on smelt
+     * when the winning pubkey carries a class prefix. Players buy from
+     * this list at the MARKET tab; shipyards consume entries to mint
+     * hulls bound to the ingot's pubkey identity. LRU evict on full. */
+    named_ingot_t named_ingots[STATION_NAMED_INGOTS_MAX];
+    int           named_ingots_count;
 } station_t;
 
 /* Station lifecycle helpers, module queries, and ring/geometry helpers

--- a/shared/types.h
+++ b/shared/types.h
@@ -281,6 +281,7 @@ typedef struct {
      * hulls bound to the ingot's pubkey identity. LRU evict on full. */
     named_ingot_t named_ingots[STATION_NAMED_INGOTS_MAX];
     int           named_ingots_count;
+    bool          named_ingots_dirty;  /* server-only: drives wire push */
 } station_t;
 
 /* Station lifecycle helpers, module queries, and ring/geometry helpers

--- a/src/main.c
+++ b/src/main.c
@@ -852,6 +852,8 @@ static void init(void) {
             cbs.on_world_time = on_remote_world_time;
             cbs.on_events = apply_remote_events;
             cbs.on_signal_channel = apply_remote_signal_channel;
+            cbs.on_station_ingots = apply_remote_station_ingots;
+            cbs.on_hold_ingots = apply_remote_hold_ingots;
             g.multiplayer_enabled = net_init(server_url, &cbs);
             if (g.multiplayer_enabled) {
                 /* Deactivate the local server — the remote server is authoritative.

--- a/src/net.c
+++ b/src/net.c
@@ -562,6 +562,49 @@ static void handle_message(const uint8_t* data, int len) {
         }
         break;
 
+    case NET_MSG_STATION_INGOTS:
+        if (len >= STATION_INGOTS_HEADER && net_state.callbacks.on_station_ingots) {
+            uint8_t station_id = data[1];
+            int count = data[2];
+            int expected = STATION_INGOTS_HEADER + count * NAMED_INGOT_RECORD_SIZE;
+            if (len < expected) break;
+            if (count > STATION_NAMED_INGOTS_MAX) count = STATION_NAMED_INGOTS_MAX;
+            static named_ingot_t scratch[STATION_NAMED_INGOTS_MAX];
+            for (int i = 0; i < count; i++) {
+                const uint8_t *p = &data[STATION_INGOTS_HEADER + i * NAMED_INGOT_RECORD_SIZE];
+                memcpy(scratch[i].pubkey, &p[0], 32);
+                scratch[i].prefix_class = p[32];
+                scratch[i].metal        = p[33];
+                uint64_t mb = 0;
+                for (int k = 0; k < 8; k++) mb |= ((uint64_t)p[36 + k]) << (8 * k);
+                scratch[i].mined_block = mb;
+                scratch[i].origin_station = p[44];
+            }
+            net_state.callbacks.on_station_ingots(station_id, scratch, count);
+        }
+        break;
+
+    case NET_MSG_HOLD_INGOTS:
+        if (len >= HOLD_INGOTS_HEADER && net_state.callbacks.on_hold_ingots) {
+            int count = data[1];
+            int expected = HOLD_INGOTS_HEADER + count * NAMED_INGOT_RECORD_SIZE;
+            if (len < expected) break;
+            if (count > SHIP_HOLD_INGOTS_MAX) count = SHIP_HOLD_INGOTS_MAX;
+            static named_ingot_t scratch[SHIP_HOLD_INGOTS_MAX];
+            for (int i = 0; i < count; i++) {
+                const uint8_t *p = &data[HOLD_INGOTS_HEADER + i * NAMED_INGOT_RECORD_SIZE];
+                memcpy(scratch[i].pubkey, &p[0], 32);
+                scratch[i].prefix_class = p[32];
+                scratch[i].metal        = p[33];
+                uint64_t mb = 0;
+                for (int k = 0; k < 8; k++) mb |= ((uint64_t)p[36 + k]) << (8 * k);
+                scratch[i].mined_block = mb;
+                scratch[i].origin_station = p[44];
+            }
+            net_state.callbacks.on_hold_ingots(scratch, count);
+        }
+        break;
+
     case NET_MSG_SIGNAL_CHANNEL:
         if (len >= 3 && net_state.callbacks.on_signal_channel) {
             int count = (int)(data[1] | ((uint16_t)data[2] << 8));

--- a/src/net.h
+++ b/src/net.h
@@ -175,6 +175,12 @@ typedef struct {
 
 typedef void (*net_on_signal_channel_fn)(const NetSignalChannelMsg *msgs, int count);
 
+/* RATi v2 — per-station named ingot stockpile snapshot. */
+typedef void (*net_on_station_ingots_fn)(uint8_t station_id,
+                                         const named_ingot_t *ingots, int count);
+/* RATi v2 — local player's hold ingots snapshot. */
+typedef void (*net_on_hold_ingots_fn)(const named_ingot_t *ingots, int count);
+
 typedef void (*net_on_players_begin_fn)(void);
 
 typedef struct {
@@ -197,6 +203,8 @@ typedef struct {
     void (*on_world_time)(float server_time);
     void (*on_events)(const sim_event_t *events, int count);
     net_on_signal_channel_fn on_signal_channel;
+    net_on_station_ingots_fn on_station_ingots;
+    net_on_hold_ingots_fn    on_hold_ingots;
 } NetCallbacks;
 
 /* Initialize networking and connect to the relay server.

--- a/src/net_sync.c
+++ b/src/net_sync.c
@@ -127,6 +127,28 @@ void apply_remote_stations(uint8_t index, const float* inventory, float credit_p
     st->credit_pool = credit_pool;
 }
 
+void apply_remote_station_ingots(uint8_t station_id,
+                                 const named_ingot_t *ingots, int count) {
+    if (station_id >= MAX_STATIONS) return;
+    if (count < 0) count = 0;
+    if (count > STATION_NAMED_INGOTS_MAX) count = STATION_NAMED_INGOTS_MAX;
+    station_t *st = &g.world.stations[station_id];
+    /* Full replacement — server is the source of truth. */
+    memset(st->named_ingots, 0, sizeof(st->named_ingots));
+    for (int i = 0; i < count; i++) st->named_ingots[i] = ingots[i];
+    st->named_ingots_count = count;
+}
+
+void apply_remote_hold_ingots(const named_ingot_t *ingots, int count) {
+    if (g.local_player_slot < 0 || g.local_player_slot >= MAX_PLAYERS) return;
+    if (count < 0) count = 0;
+    if (count > SHIP_HOLD_INGOTS_MAX) count = SHIP_HOLD_INGOTS_MAX;
+    ship_t *ship = &g.world.players[g.local_player_slot].ship;
+    memset(ship->hold_ingots, 0, sizeof(ship->hold_ingots));
+    for (int i = 0; i < count; i++) ship->hold_ingots[i] = ingots[i];
+    ship->hold_ingots_count = count;
+}
+
 void apply_remote_contracts(const contract_t* contracts, int count) {
     /* Full replacement: clear all, then copy received */
     for (int i = 0; i < MAX_CONTRACTS; i++)

--- a/src/net_sync.h
+++ b/src/net_sync.h
@@ -22,6 +22,12 @@ void apply_remote_station_identity(const NetStationIdentity* si);
 void apply_remote_scaffolds(const NetScaffoldState* scaffolds, int count);
 void apply_remote_hail_response(uint8_t station, float credits, int contract_index);
 void apply_remote_signal_channel(const NetSignalChannelMsg *msgs, int count);
+/* RATi v2 — copy a station's named-ingot stockpile into world.stations[]
+ * so the MARKET tab can render it. */
+void apply_remote_station_ingots(uint8_t station_id,
+                                 const named_ingot_t *ingots, int count);
+/* RATi v2 — copy local pilot's hold-ingot snapshot into LOCAL_PLAYER.ship. */
+void apply_remote_hold_ingots(const named_ingot_t *ingots, int count);
 void apply_remote_events(const sim_event_t *events, int count);
 void begin_player_state_batch(void);
 void apply_remote_player_state(const NetPlayerState* state);

--- a/src/station_ui.c
+++ b/src/station_ui.c
@@ -706,6 +706,55 @@ void draw_station_services(const station_ui_state_t* ui) {
             my += compact ? 18.0f : 22.0f;
         }
 
+        /* === HIGH-GRADE STOCK (RATi v2 named ingots) ===
+         * Player-facing copy treats these as "ore quality grades" — the
+         * cryptographic identity is hidden until the player notices the
+         * grade letter and the eventual hull's callsign share characters.
+         * Listed at any station holding them, not just refineries. */
+        if (ui->station->named_ingots_count > 0) {
+            sdtx_color3b(PAL_HOLD_STATUS);
+            sdtx_pos(ui_text_pos(cx), ui_text_pos(my));
+            sdtx_puts("HIGH-GRADE STOCK");
+            draw_ui_rule(cx, rule_right_m, my + 11.0f, 0.12f, 0.22f, 0.34f, 0.45f);
+            my += 16.0f;
+            /* Map ingot_prefix_t → display letter / brand. Player reads
+             * these as quality designations; later they'll spot the
+             * letter showing up on a hull's callsign. */
+            static const char *grade_letter[INGOT_PREFIX_COUNT] = {
+                "?", "M", "H", "T", "S", "F", "K", "RATi", "★"
+            };
+            int show = ui->station->named_ingots_count;
+            int max_rows = compact ? 4 : 6;
+            if (show > max_rows) show = max_rows;
+            for (int i = 0; i < show; i++) {
+                const named_ingot_t *ing = &ui->station->named_ingots[i];
+                const char *grade = (ing->prefix_class < INGOT_PREFIX_COUNT)
+                    ? grade_letter[ing->prefix_class] : "?";
+                /* Suffix = base58[1..3] for single-letter classes,
+                 * base58[4..6] for RATi. Read off the pubkey. */
+                char rendered[12];
+                mining_render_callsign(ing->pubkey, rendered);
+                /* Find the dash; the suffix is everything after it. */
+                const char *suffix = strchr(rendered, '-');
+                suffix = suffix ? suffix + 1 : rendered;
+                sdtx_pos(ui_text_pos(cx + 3.0f), ui_text_pos(my));
+                sdtx_color3b(ing->prefix_class >= INGOT_PREFIX_RATI
+                             ? PAL_ORE_AMBER : PAL_TEXT_SECONDARY);
+                sdtx_printf("%s-grade %s lot %s",
+                            grade,
+                            commodity_short_name((commodity_t)ing->metal),
+                            suffix);
+                my += 12.0f;
+            }
+            if (ui->station->named_ingots_count > show) {
+                sdtx_pos(ui_text_pos(cx + 3.0f), ui_text_pos(my));
+                sdtx_color3b(PAL_STATUS_DISABLED);
+                sdtx_printf("(+%d more)", ui->station->named_ingots_count - show);
+                my += 12.0f;
+            }
+            my += compact ? 8.0f : 12.0f;
+        }
+
         /* === SELL TO STATION === */
         {
             commodity_t buy = station_primary_buy(ui->station);

--- a/src/station_ui.c
+++ b/src/station_ui.c
@@ -738,8 +738,12 @@ void draw_station_services(const station_ui_state_t* ui) {
                 const char *suffix = strchr(rendered, '-');
                 suffix = suffix ? suffix + 1 : rendered;
                 sdtx_pos(ui_text_pos(cx + 3.0f), ui_text_pos(my));
-                sdtx_color3b(ing->prefix_class >= INGOT_PREFIX_RATI
-                             ? PAL_ORE_AMBER : PAL_TEXT_SECONDARY);
+                /* PAL_X macros are 3-arg comma literals — using one
+                 * inside a ternary trips gcc -Werror=unused-value. */
+                if (ing->prefix_class >= INGOT_PREFIX_RATI)
+                    sdtx_color3b(PAL_ORE_AMBER);
+                else
+                    sdtx_color3b(PAL_TEXT_SECONDARY);
                 sdtx_printf("%s-grade %s lot %s",
                             grade,
                             commodity_short_name((commodity_t)ing->metal),

--- a/src/test_main.c
+++ b/src/test_main.c
@@ -27,6 +27,8 @@ static int truncate(const char *path, long size) {
 #include "sim_nav.h"
 #include "chunk.h"
 #include "net_protocol.h"
+#include "mining.h"
+#include "sha256.h"
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -562,6 +564,98 @@ TEST(test_world_sim_step_refinery_produces_ingots) {
         world_sim_step(&w, 1.0f / 120.0f);
     ASSERT(w.stations[0].inventory[COMMODITY_FERRITE_INGOT] > 0.0f);
     ASSERT(w.stations[0].inventory[COMMODITY_FERRITE_ORE] < 50.0f);
+}
+
+/* RATi v2 — verify mining_pubkey_class agrees with mining_render_callsign
+ * across a sweep of synthetic pubkeys. */
+TEST(test_mining_class_prefix_round_trip) {
+    /* Pubkeys whose first base58 char is M, H, T, S, F, K, RATi prefix,
+     * and one that is "anonymous" (digit/lowercase). We don't have direct
+     * control over base58 output but we can iterate seeds until each
+     * prefix appears. */
+    int seen[MINING_CLASS_COMMISSIONED + 1] = {0};
+    int found = 0;
+    for (uint32_t seed = 1; seed < 1000000 && found < 7; seed++) {
+        uint8_t s[32];
+        for (int i = 0; i < 32; i++)
+            s[i] = (uint8_t)((seed >> ((i & 3) * 8)) ^ (seed * 2654435761u >> (i & 7)));
+        uint8_t pub[32];
+        sha256_bytes(s, 32, pub);
+        int cls = mining_pubkey_class(pub);
+        if (cls < 0 || cls > MINING_CLASS_COMMISSIONED) continue;
+        if (cls == MINING_CLASS_ANONYMOUS || cls == MINING_CLASS_COMMISSIONED) continue;
+        if (!seen[cls]) {
+            seen[cls] = 1;
+            found++;
+            char render[12];
+            mining_render_callsign(pub, render);
+            /* Render must contain a dash, and the prefix segment must
+             * match what mining_pubkey_class said. */
+            ASSERT(strchr(render, '-') != NULL);
+        }
+    }
+    /* Should hit M/H/T/S/F/K within 1M iterations. RATi is ~1 in 11M so
+     * not asserted here. */
+    ASSERT(seen[MINING_CLASS_M]);
+    ASSERT(seen[MINING_CLASS_H]);
+    ASSERT(seen[MINING_CLASS_T]);
+    ASSERT(seen[MINING_CLASS_S]);
+    ASSERT(seen[MINING_CLASS_F]);
+    ASSERT(seen[MINING_CLASS_K]);
+}
+
+/* RATi v2 — refinery deposits a named ingot when smelting a fragment
+ * whose winning candidate's pubkey starts with a class letter. */
+TEST(test_refinery_deposits_named_ingot) {
+    WORLD_HEAP w = calloc(1, sizeof(world_t));
+    ASSERT(w != NULL);
+    world_reset(w);
+    /* Force a furnace at station 0 — already exists by default in
+     * world_reset, but assert. */
+    bool has_furnace = false;
+    for (int m = 0; m < w->stations[0].module_count; m++) {
+        if (w->stations[0].modules[m].type == MODULE_FURNACE) has_furnace = true;
+    }
+    ASSERT(has_furnace);
+
+    /* Spawn an S-tier ferrite fragment near the station's hopper, with
+     * an arbitrary fracture_seed. Hopper pull radius will draw it in. */
+    int slot = -1;
+    for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        if (!w->asteroids[i].active) { slot = i; break; }
+    }
+    ASSERT(slot >= 0);
+    asteroid_t *a = &w->asteroids[slot];
+    memset(a, 0, sizeof(*a));
+    a->active = true;
+    a->tier = ASTEROID_TIER_S;
+    a->commodity = COMMODITY_FERRITE_ORE;
+    a->ore = 10.0f;
+    a->max_ore = 10.0f;
+    a->radius = 6.0f;
+    /* Seed values intentionally varied so the roll lands somewhere. */
+    for (int i = 0; i < 32; i++) a->fracture_seed[i] = (uint8_t)(i * 17 + 3);
+    a->pos = w->stations[0].pos;  /* dead center for instant pull */
+    a->vel = v2(0, 0);
+    a->net_dirty = true;
+
+    /* Run sim until smelt completes (smelt_progress accumulates ~0.5/s). */
+    int initial_named = w->stations[0].named_ingots_count;
+    for (int i = 0; i < 600 && w->asteroids[slot].active; i++)
+        world_sim_step(w, 1.0f / 120.0f);
+    /* Asteroid should be consumed. */
+    ASSERT(!w->asteroids[slot].active);
+    /* Either an anonymous ingot landed in inventory, or a named ingot
+     * landed in the stockpile — depending on what the universe rolled. */
+    bool got_named = (w->stations[0].named_ingots_count > initial_named);
+    bool got_bulk = (w->stations[0].inventory[COMMODITY_FERRITE_INGOT] > 0.0f);
+    ASSERT(got_named || got_bulk);
+    /* If named, validate prefix_class matches mining_pubkey_class. */
+    if (got_named) {
+        named_ingot_t *ing = &w->stations[0].named_ingots[w->stations[0].named_ingots_count - 1];
+        ASSERT_EQ_INT(ing->prefix_class, mining_pubkey_class(ing->pubkey));
+        ASSERT(ing->prefix_class != MINING_CLASS_ANONYMOUS);
+    }
 }
 
 TEST(test_world_sim_step_events_emitted) {
@@ -3218,7 +3312,7 @@ TEST(test_world_save_load_preserves_smelted_ingots) {
  *   3. Update this constant to the new size
  */
 /* v23: station credit pool added (#312) — +4 bytes per station (8×4=32). */
-#define EXPECTED_SAVE_SIZE 38988  /* v25: 64 stations, station_count + next_station_id header */
+#define EXPECTED_SAVE_SIZE 268620 /* v26: 64 stations × (count + 64 × 56-byte named_ingots) added */
 
 TEST(test_save_file_size_stable) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
@@ -3255,7 +3349,7 @@ TEST(test_save_header_golden_bytes) {
     ASSERT_EQ_INT((int)fread(&spawn_timer, 4, 1, f), 1);
     fclose(f);
     ASSERT_EQ_INT((int)magic, (int)0x5349474E);    /* "SIGN" */
-    ASSERT_EQ_INT((int)version, 25);
+    ASSERT_EQ_INT((int)version, 26);
     ASSERT(rng != 0);  /* seed is set */
     ASSERT_EQ_FLOAT(time_val, 0.0f, 0.001f);
     ASSERT_EQ_FLOAT(spawn_timer, 0.0f, 0.001f);
@@ -6101,6 +6195,8 @@ int main(int argc, char **argv) {
     RUN(test_world_sim_step_mining_damages_asteroid);
     RUN(test_world_sim_step_docking);
     RUN(test_world_sim_step_refinery_produces_ingots);
+    RUN(test_mining_class_prefix_round_trip);
+    RUN(test_refinery_deposits_named_ingot);
     RUN(test_world_sim_step_events_emitted);
     RUN(test_world_sim_step_npc_miners_work);
     RUN(test_world_network_writes_persist);


### PR DESCRIPTION
## Summary

First two slices of the RATi v2 named-ingot mechanic (full design doc covered in our brainstorm thread). Ships landed on \`feat/named-ingots\`:

- **Slice 1** (\`e272e3a\`): refineries gain identity-stamped ingots. When a fragment smelts, the universe rolls a winning pubkey; if its leading char(s) match a class prefix (M/H/T/S/F/K or RATi), the ingot is deposited into the station's stockpile as a named record. Otherwise it flows into the existing fungible bulk count.
- **Slice 2** (\`4890699\`): server pushes \`NET_MSG_STATION_INGOTS\` (per-station snapshot, on dock + on change) and \`NET_MSG_HOLD_INGOTS\` (per-pilot, rides on ship-state tick). Client deserializes both. MARKET tab in the station UI gains a **HIGH-GRADE STOCK** section listing each lot.

## Player-facing framing

Read the rendered UI as **ore quality**, not cryptography. Lots show as \`M-grade ferrite lot 9kx\` — the player thinks \"high-grade ingot,\" not \"named asset.\" The cryptographic identity is hidden until they later see a hull's HUD callsign and notice the lot code matches. Internals keep the crypto-accurate names (\`named_ingot_t\`, \`mining_render_callsign\`, \`prefix_class\`) so future contributors aren't confused.

## What's in scope

- Per-station 64-slot stockpile (LRU evict by oldest \`mined_block\`)
- Per-pilot 8-slot hold (will populate when slice 3 lands buy/sell)
- Save format v25 → v26, PLY3 → PLY4 with zero-init migration
- Wire: \`NAMED_INGOT_RECORD_SIZE = 52\`, two new message types
- Chain blocks for every smelt that produces a named ingot (\"smelted M-9kx\")
- Two new tests (262/262 passing)

## What's **not** in this PR (follow-up slices)

These don't ship gameplay value yet — slice 2 is read-only:

- **Slice 3:** buy / sell / deliver named ingots between stations
- **Slice 4:** shipyard hull-construction recipe consumes a named ingot of matching class; hull spawns named after the ingot
- **Slice 5:** dog tag drop on hull destruction; recovery flow
- **Slice 6:** chain block extensions for the new transitions
- **Slice 7:** UI polish + content-addressed provenance for non-named commodities (slice 1.5 follow-up)

I'd suggest landing slices 1+2 to main now (they're independently safe — no behavior change for existing flows, just new data flowing through the wire) and continuing on the same branch for 3-7. Or hold this PR until the loop is complete. Your call.

## Verified

- Native + WASM both build clean
- 262/262 tests pass
- Manual smoke: smelt fragments at Prospect, watch the chain log fill with \`smelted M-9kx\` lines, dock at the refinery, see the stockpile in the MARKET tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)