### PR TITLE
RATi v2 (slice 3): buy + deliver named ingots between stations

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -63,7 +63,7 @@ void ledger_earn(station_t *st, const uint8_t *token, float amount) {
     st->ledger[idx].balance += amount;
 }
 
-static bool ledger_spend(station_t *st, const uint8_t *token, float amount, ship_t *ship) {
+bool ledger_spend(station_t *st, const uint8_t *token, float amount, ship_t *ship) {
     if (amount <= 0.0f) return true;
     int idx = ledger_find_or_create(st, token);
     if (idx < 0) return false;

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -308,6 +308,10 @@ void emit_event(world_t *w, sim_event_t ev);
 float ledger_balance(const station_t *st, const uint8_t *token);
 void ledger_earn(station_t *st, const uint8_t *token, float amount);
 void ledger_credit_supply(station_t *st, const uint8_t *token, float ore_value);
+/* Returns false if the player can't afford `amount` at this station;
+ * otherwise debits the ledger, refunds the credit_pool, and bumps the
+ * ship's stat_credits_spent. */
+bool ledger_spend(station_t *st, const uint8_t *token, float amount, ship_t *ship);
 /* Signal channel — station broadcast log (#316). */
 uint64_t signal_channel_post(world_t *w, int sender_station, const char *text, const char *audio_url);
 const signal_channel_msg_t *signal_channel_at(const world_t *w, int i);

--- a/server/main.c
+++ b/server/main.c
@@ -6,6 +6,7 @@
  */
 #include "mongoose.h"
 #include "game_sim.h"
+#include "mining.h"  /* mining_render_callsign for chain log copy */
 #include "net_protocol.h"
 
 #include <stdio.h>
@@ -139,6 +140,83 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
         break;
     case NET_MSG_MINING_ACTION:
         /* Legacy -- mining handled via INPUT flags now. */
+        break;
+    case NET_MSG_BUY_INGOT:
+        /* RATi v2: purchase a specific named ingot from the docked
+         * station's stockpile. Payload: [type:1][pubkey:32]. */
+        if (len >= 33 && world.players[pid].docked) {
+            int sidx = world.players[pid].current_station;
+            if (sidx < 0 || sidx >= MAX_STATIONS) break;
+            station_t *st = &world.stations[sidx];
+            ship_t *ship = &world.players[pid].ship;
+            const uint8_t *pk = &data[1];
+            int slot = -1;
+            for (int i = 0; i < st->named_ingots_count; i++) {
+                if (memcmp(st->named_ingots[i].pubkey, pk, 32) == 0) { slot = i; break; }
+            }
+            if (slot < 0) break;
+            named_ingot_t *src = &st->named_ingots[slot];
+            int price;
+            switch (src->prefix_class) {
+            case INGOT_PREFIX_RATI:         price = INGOT_PRICE_RATI; break;
+            case INGOT_PREFIX_COMMISSIONED: price = INGOT_PRICE_COMMISSIONED; break;
+            case INGOT_PREFIX_ANONYMOUS:    price = 0; break;
+            default:                        price = INGOT_PRICE_M; break;
+            }
+            if (price <= 0) break;
+            if (ship->hold_ingots_count >= SHIP_HOLD_INGOTS_MAX) break;
+            /* Use ledger_spend so the credit pool stays conserved. */
+            if (!ledger_spend(st, world.players[pid].session_token, (float)price, ship)) break;
+            /* Move ingot: append to hold, compact stockpile. */
+            ship->hold_ingots[ship->hold_ingots_count++] = *src;
+            *src = st->named_ingots[--st->named_ingots_count];
+            memset(&st->named_ingots[st->named_ingots_count], 0, sizeof(named_ingot_t));
+            st->named_ingots_dirty = true;
+            char cs[12]; mining_render_callsign(ship->hold_ingots[ship->hold_ingots_count - 1].pubkey, cs);
+            char msg[96];
+            snprintf(msg, sizeof(msg), "%s purchased %s for %d", world.players[pid].callsign, cs, price);
+            signal_channel_post(&world, sidx, msg, "");
+        }
+        break;
+    case NET_MSG_DELIVER_INGOT:
+        /* RATi v2: deposit a specific hold-ingot into the docked
+         * station's stockpile. Payload: [type:1][hold_index:1]. */
+        if (len >= 2 && world.players[pid].docked) {
+            int sidx = world.players[pid].current_station;
+            if (sidx < 0 || sidx >= MAX_STATIONS) break;
+            station_t *st = &world.stations[sidx];
+            ship_t *ship = &world.players[pid].ship;
+            int hidx = data[1];
+            if (hidx < 0 || hidx >= ship->hold_ingots_count) break;
+            /* LRU evict on full stockpile, same path as smelt. */
+            if (st->named_ingots_count >= STATION_NAMED_INGOTS_MAX) {
+                int worst = 0;
+                uint64_t oldest = st->named_ingots[0].mined_block;
+                for (int k = 1; k < STATION_NAMED_INGOTS_MAX; k++) {
+                    if (st->named_ingots[k].mined_block < oldest) {
+                        oldest = st->named_ingots[k].mined_block;
+                        worst = k;
+                    }
+                }
+                char ev_cs[12]; mining_render_callsign(st->named_ingots[worst].pubkey, ev_cs);
+                char ev_msg[96];
+                snprintf(ev_msg, sizeof(ev_msg), "stockpile full — voided %s", ev_cs);
+                signal_channel_post(&world, sidx, ev_msg, "");
+                st->named_ingots[worst] = st->named_ingots[STATION_NAMED_INGOTS_MAX - 1];
+                st->named_ingots_count = STATION_NAMED_INGOTS_MAX - 1;
+            }
+            st->named_ingots[st->named_ingots_count++] = ship->hold_ingots[hidx];
+            ship->hold_ingots[hidx] = ship->hold_ingots[--ship->hold_ingots_count];
+            memset(&ship->hold_ingots[ship->hold_ingots_count], 0, sizeof(named_ingot_t));
+            /* Pay delivery credit through the ledger so supply stays balanced. */
+            ledger_credit_supply(st, world.players[pid].session_token, (float)INGOT_DELIVERY_CREDIT);
+            st->named_ingots_dirty = true;
+            const named_ingot_t *deposited = &st->named_ingots[st->named_ingots_count - 1];
+            char cs[12]; mining_render_callsign(deposited->pubkey, cs);
+            char msg[96];
+            snprintf(msg, sizeof(msg), "%s delivered %s", world.players[pid].callsign, cs);
+            signal_channel_post(&world, sidx, msg, "");
+        }
         break;
     case NET_MSG_SESSION:
         if (len >= 9 && !world.players[pid].session_ready) {

--- a/shared/protocol.h
+++ b/shared/protocol.h
@@ -50,7 +50,24 @@ enum {
     NET_MSG_SIGNAL_CHANNEL  = 0x27, /* server -> client: broadcast-log snapshot / append (#316) */
     NET_MSG_STATION_INGOTS  = 0x28, /* server -> client: station's named-ingot stockpile (RATi v2) */
     NET_MSG_HOLD_INGOTS     = 0x29, /* server -> client: local player's hold ingots (RATi v2) */
+    NET_MSG_BUY_INGOT       = 0x2A, /* client -> server: [type:1][pubkey:32] purchase from current docked station */
+    NET_MSG_DELIVER_INGOT   = 0x2B, /* client -> server: [type:1][hold_index:1] deposit to current docked station */
 };
+
+/* Per-class buy price at any station's stockpile. RATi/commissioned
+ * are an order of magnitude scarcer so they cost proportionally more.
+ * Indexed by ingot_prefix_t. Anonymous = 0 (not purchasable). */
+#define INGOT_PRICE_M             1500
+#define INGOT_PRICE_H             1500
+#define INGOT_PRICE_T             1500
+#define INGOT_PRICE_S             1500
+#define INGOT_PRICE_F             1500
+#define INGOT_PRICE_K             1500
+#define INGOT_PRICE_RATI          35000
+#define INGOT_PRICE_COMMISSIONED  100000
+/* Delivery credit paid to the player when they deposit a named ingot
+ * at a station's stockpile — small flat reward for transit. */
+#define INGOT_DELIVERY_CREDIT     100
 
 /* Named ingot wire record: [pubkey:32][prefix:1][metal:1][_pad:2][mined_block:8][origin:1][_pad2:7] = 52 bytes
  * Mirrors named_ingot_t exactly so the server can write the struct

--- a/src/input.c
+++ b/src/input.c
@@ -8,6 +8,15 @@
 #include "net.h"
 #include "onboarding.h"
 #include "signal_model.h"
+#include "mining.h"
+
+/* Local helper — station's currency_name with fallback. station_ui.c
+ * has its own private copy; we duplicate here to avoid leaking a
+ * private string through a header just for one keybind. */
+static const char *input_station_currency(const station_t *st) {
+    if (!st) return "cr";
+    return (st->currency_name[0]) ? st->currency_name : "cr";
+}
 
 void clear_input_state(void) {
     memset(g.input.key_down, 0, sizeof(g.input.key_down));
@@ -370,6 +379,91 @@ input_intent_t sample_input_intent(void) {
         intent.upgrade_hold = is_key_pressed(SAPP_KEYCODE_4);
         intent.upgrade_tractor = is_key_pressed(SAPP_KEYCODE_5);
     }
+    /* RATi v2: B key buys the first named ingot in the station's
+     * stockpile (player can repeatedly press to walk down the list).
+     * N key delivers the first hold ingot into the docked station's
+     * stockpile. Slice 3 — single-action keys keep the UX simple
+     * before per-row pickers land. */
+    if (LOCAL_PLAYER.docked && is_key_pressed(SAPP_KEYCODE_B)) {
+        const station_t *st = current_station_ptr();
+        if (st && st->named_ingots_count > 0) {
+            ship_t *ship = &LOCAL_PLAYER.ship;
+            if (ship->hold_ingots_count >= 8) {
+                set_notice("Hold full — can't carry more lots.");
+            } else {
+                const named_ingot_t *ing = &st->named_ingots[0];
+                int price;
+                switch (ing->prefix_class) {
+                case INGOT_PREFIX_RATI:         price = INGOT_PRICE_RATI; break;
+                case INGOT_PREFIX_COMMISSIONED: price = INGOT_PRICE_COMMISSIONED; break;
+                default:                        price = INGOT_PRICE_M; break;
+                }
+                if (player_current_balance() < (float)price) {
+                    set_notice("Need %d %s.", price, input_station_currency(st));
+                } else {
+                    char cs[12]; mining_render_callsign(ing->pubkey, cs);
+                    if (g.multiplayer_enabled) {
+                        net_send_buy_ingot(ing->pubkey);
+                    } else {
+                        /* Singleplayer mirror: shift first ingot from
+                         * station stockpile into hold, drop balance
+                         * from the local ledger directly. */
+                        station_t *mst = &g.world.stations[LOCAL_PLAYER.current_station];
+                        ship->hold_ingots[ship->hold_ingots_count++] = mst->named_ingots[0];
+                        for (int i = 0; i < mst->named_ingots_count - 1; i++)
+                            mst->named_ingots[i] = mst->named_ingots[i + 1];
+                        mst->named_ingots_count--;
+                        memset(&mst->named_ingots[mst->named_ingots_count], 0, sizeof(named_ingot_t));
+                        const uint8_t *tk = g.world.players[g.local_player_slot].session_token;
+                        for (int li = 0; li < mst->ledger_count; li++) {
+                            if (memcmp(mst->ledger[li].player_token, tk, 8) == 0) {
+                                mst->ledger[li].balance -= (float)price;
+                                if (mst->ledger[li].balance < 0.0f) mst->ledger[li].balance = 0.0f;
+                                mst->credit_pool += (float)price;
+                                break;
+                            }
+                        }
+                    }
+                    set_notice("Bought %s for %d %s.", cs, price, input_station_currency(st));
+                }
+            }
+        } else if (st) {
+            set_notice("No high-grade lots in stock.");
+        }
+    }
+    if (LOCAL_PLAYER.docked && is_key_pressed(SAPP_KEYCODE_N)) {
+        const station_t *st = current_station_ptr();
+        ship_t *ship = &LOCAL_PLAYER.ship;
+        if (st && ship->hold_ingots_count > 0) {
+            const named_ingot_t *ing = &ship->hold_ingots[0];
+            char cs[12]; mining_render_callsign(ing->pubkey, cs);
+            if (g.multiplayer_enabled) {
+                net_send_deliver_ingot(0);
+            } else {
+                /* Singleplayer mirror: shift first hold ingot into
+                 * the local station stockpile and pay the credit. */
+                station_t *mst = &g.world.stations[LOCAL_PLAYER.current_station];
+                if (mst->named_ingots_count < STATION_NAMED_INGOTS_MAX) {
+                    mst->named_ingots[mst->named_ingots_count++] = ship->hold_ingots[0];
+                }
+                for (int i = 0; i < ship->hold_ingots_count - 1; i++)
+                    ship->hold_ingots[i] = ship->hold_ingots[i + 1];
+                ship->hold_ingots_count--;
+                memset(&ship->hold_ingots[ship->hold_ingots_count], 0, sizeof(named_ingot_t));
+                const uint8_t *tk = g.world.players[g.local_player_slot].session_token;
+                for (int li = 0; li < mst->ledger_count; li++) {
+                    if (memcmp(mst->ledger[li].player_token, tk, 8) == 0) {
+                        mst->ledger[li].balance += (float)INGOT_DELIVERY_CREDIT;
+                        break;
+                    }
+                }
+            }
+            set_notice("Delivered %s. +%d %s.", cs, INGOT_DELIVERY_CREDIT, input_station_currency(st));
+        } else if (st) {
+            set_notice("No lots in your hold.");
+        }
+    }
+
     /* Buy product from station (F key while docked) */
     if (LOCAL_PLAYER.docked && is_key_pressed(SAPP_KEYCODE_F)) {
         const station_t *st = current_station_ptr();

--- a/src/net.c
+++ b/src/net.c
@@ -848,6 +848,20 @@ void net_send_input(uint8_t flags, uint8_t action, uint8_t mining_target) {
     ws_send_binary(buf, 4);
 }
 
+void net_send_buy_ingot(const uint8_t ingot_pubkey[32]) {
+    uint8_t buf[33];
+    buf[0] = NET_MSG_BUY_INGOT;
+    memcpy(&buf[1], ingot_pubkey, 32);
+    ws_send_binary(buf, 33);
+}
+
+void net_send_deliver_ingot(uint8_t hold_index) {
+    uint8_t buf[2];
+    buf[0] = NET_MSG_DELIVER_INGOT;
+    buf[1] = hold_index;
+    ws_send_binary(buf, 2);
+}
+
 void net_send_plan(uint8_t op, int8_t station, int8_t ring, int8_t slot,
                    uint8_t module_type, float px, float py) {
     uint8_t buf[NET_PLAN_MSG_SIZE];
@@ -970,6 +984,20 @@ void net_send_input(uint8_t flags, uint8_t action, uint8_t mining_target) {
     buf[2] = action;
     buf[3] = mining_target;
     ws_send_binary(buf, 4);
+}
+
+void net_send_buy_ingot(const uint8_t ingot_pubkey[32]) {
+    uint8_t buf[33];
+    buf[0] = NET_MSG_BUY_INGOT;
+    memcpy(&buf[1], ingot_pubkey, 32);
+    ws_send_binary(buf, 33);
+}
+
+void net_send_deliver_ingot(uint8_t hold_index) {
+    uint8_t buf[2];
+    buf[0] = NET_MSG_DELIVER_INGOT;
+    buf[1] = hold_index;
+    ws_send_binary(buf, 2);
 }
 
 void net_send_plan(uint8_t op, int8_t station, int8_t ring, int8_t slot,

--- a/src/net.h
+++ b/src/net.h
@@ -228,6 +228,14 @@ void net_send_session(const uint8_t token[8]);
  * mining_target: client's hover_asteroid index (255=none) */
 void net_send_input(uint8_t flags, uint8_t action, uint8_t mining_target);
 
+/* RATi v2: purchase a specific named ingot from the docked station's
+ * stockpile. Server will validate ledger balance + hold space. */
+void net_send_buy_ingot(const uint8_t ingot_pubkey[32]);
+
+/* RATi v2: deposit a hold ingot into the docked station's stockpile.
+ * Pays a small delivery credit; LRU evicts on full. */
+void net_send_deliver_ingot(uint8_t hold_index);
+
 /* Send a planning intent (outpost create / module slot / cancel). */
 void net_send_plan(uint8_t op, int8_t station, int8_t ring, int8_t slot,
                    uint8_t module_type, float px, float py);

--- a/src/station_ui.c
+++ b/src/station_ui.c
@@ -756,7 +756,45 @@ void draw_station_services(const station_ui_state_t* ui) {
                 sdtx_printf("(+%d more)", ui->station->named_ingots_count - show);
                 my += 12.0f;
             }
-            my += compact ? 8.0f : 12.0f;
+            sdtx_pos(ui_text_pos(cx + 3.0f), ui_text_pos(my));
+            sdtx_color3b(PAL_STATION_HINT);
+            sdtx_puts("[B] buy first lot");
+            my += compact ? 12.0f : 16.0f;
+        }
+
+        /* === YOUR HOLD (RATi v2 named ingots in player's cargo) === */
+        if (LOCAL_PLAYER.ship.hold_ingots_count > 0) {
+            sdtx_color3b(PAL_HOLD_STATUS);
+            sdtx_pos(ui_text_pos(cx), ui_text_pos(my));
+            sdtx_puts("YOUR HOLD");
+            draw_ui_rule(cx, rule_right_m, my + 11.0f, 0.12f, 0.22f, 0.34f, 0.45f);
+            my += 16.0f;
+            static const char *grade_letter_h[INGOT_PREFIX_COUNT] = {
+                "?", "M", "H", "T", "S", "F", "K", "RATi", "★"
+            };
+            for (int i = 0; i < LOCAL_PLAYER.ship.hold_ingots_count; i++) {
+                const named_ingot_t *ing = &LOCAL_PLAYER.ship.hold_ingots[i];
+                const char *grade = (ing->prefix_class < INGOT_PREFIX_COUNT)
+                    ? grade_letter_h[ing->prefix_class] : "?";
+                char rendered[12];
+                mining_render_callsign(ing->pubkey, rendered);
+                const char *suffix = strchr(rendered, '-');
+                suffix = suffix ? suffix + 1 : rendered;
+                sdtx_pos(ui_text_pos(cx + 3.0f), ui_text_pos(my));
+                if (ing->prefix_class >= INGOT_PREFIX_RATI)
+                    sdtx_color3b(PAL_ORE_AMBER);
+                else
+                    sdtx_color3b(PAL_TEXT_SECONDARY);
+                sdtx_printf("%s-grade %s lot %s",
+                            grade,
+                            commodity_short_name((commodity_t)ing->metal),
+                            suffix);
+                my += 12.0f;
+            }
+            sdtx_pos(ui_text_pos(cx + 3.0f), ui_text_pos(my));
+            sdtx_color3b(PAL_STATION_HINT);
+            sdtx_puts("[N] deliver first lot");
+            my += compact ? 12.0f : 16.0f;
         }
 
         /* === SELL TO STATION === */


### PR DESCRIPTION
## Summary

Closes the trade loop on the named-ingot economy landed in #334. Players can now physically buy a high-grade lot from one station's stockpile and deliver it to another, with full ledger + chain plumbing.

## What ships

- **\`NET_MSG_BUY_INGOT\` (0x2A)** — client sends \`[type:1][pubkey:32]\`. Server validates docked station holds the ingot, player has hold space and ledger balance, then transfers via the existing \`ledger_spend\` path so credit_pool stays conserved.
- **\`NET_MSG_DELIVER_INGOT\` (0x2B)** — client sends \`[type:1][hold_index:1]\`. Server moves the ingot from hold into station stockpile (LRU evict on full, same path as smelt) and pays \`INGOT_DELIVERY_CREDIT\` through \`ledger_credit_supply\`.
- **Per-class buy prices** in \`shared/protocol.h\`: M/H/T/S/F/K = 1500, RATi = 35000, commissioned = 100000. Delivery credit = 100. All shown in the station's \`currency_name\`.
- **Chain blocks** for both transitions: \`atimics purchased M-9kx for 1500\` / \`atimics delivered M-9kx\`.

## Player UX (slice 3 keeps it minimal)

Single-press hotkeys before per-row pickers land:
- **[B]** while docked: buys the first lot in the station's stockpile. Repeat to walk down the list.
- **[N]** while docked: delivers the first lot from your hold to the current station's stockpile.
- MARKET tab gains a **YOUR HOLD** subsection alongside HIGH-GRADE STOCK, both using industrial framing (\`M-grade ferrite lot 9kx\`). Hint lines under each.

Singleplayer mirrors both moves locally so the loop works without a server.

## Wire/header changes

- \`ledger_spend\` exposed in \`game_sim.h\` (was static)
- \`net_send_buy_ingot\` / \`net_send_deliver_ingot\` in \`net.h\`/\`net.c\` (both WASM + native paths)

## Verified

- 262/262 tests pass
- Native + WASM both build clean
- Manual smoke: smelt at Prospect → buy lot with B → fly to Helios → deliver with N → balance increments at Helios; stockpile snapshot updates land in real time

## Branch story

Builds on #334 (just merged). Slice 4 (hull construction from named ingots) and slice 5 (dog tags) follow on the same branch line; this slice independently shippable as soon as CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)