### PR TITLE
Spawn-fee debt + global highscore + grade-aware buy/sell + foundation ritual

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ if(NOT EMSCRIPTEN AND NOT BUILD_TESTS_ONLY)
     add_executable(signal_server
         server/main.c
         server/mongoose.c
+        server/highscore.c
         ${SIGNAL_SIM_SOURCES}
         ${SIGNAL_SIM_HELPERS}
     )

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,11 +35,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends cmake git build
     && rm -rf /var/lib/apt/lists/*
 COPY . /src
 RUN GIT_HASH=$(git -C /src rev-parse --short HEAD 2>/dev/null || echo local) \
-    && cmake -S /src -B /src/build -DGIT_HASH=$GIT_HASH \
+    && cmake -S /src -B /src/build -DBUILD_SERVER_ONLY=ON -DGIT_HASH=$GIT_HASH \
     && cmake --build /src/build --target signal_server --parallel
 
 # ----- stage 3: runtime -----------------------------------------------------
-FROM python:3.12-slim AS runtime
+# Pin to linux/amd64 so the native signal_server binary (built in the
+# emscripten/emsdk amd64 image) executes natively on amd64 hosts and via
+# qemu on arm64 hosts. Without this pin, arm64 Macs pull an arm64 python
+# base and the amd64 binary fails with "ld-linux-x86-64.so.2 not found".
+FROM --platform=linux/amd64 python:3.12-slim AS runtime
 WORKDIR /app
 
 # Only what the server binary needs at runtime (libc, libm are in slim).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      platforms:
+        - linux/amd64
     image: signal:local
+    platform: linux/amd64
     container_name: signal
     ports:
       - "8080:8080"   # static HTTP — serves build-web/ (browser client)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -28,6 +28,9 @@ python3 -m http.server 8080 --directory /app/build-web &
 HTTP_PID=$!
 
 # Exit as soon as either child dies so docker restarts correctly.
-wait -n "$SERVER_PID" "$HTTP_PID"
+# python:slim ships dash as /bin/sh, which lacks `wait -n`; poll instead.
+while kill -0 "$SERVER_PID" 2>/dev/null && kill -0 "$HTTP_PID" 2>/dev/null; do
+    sleep 1
+done
 cleanup
 wait

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -77,6 +77,21 @@ bool ledger_spend(station_t *st, const uint8_t *token, float amount, ship_t *shi
     return true;
 }
 
+/* Force a debit through even when the balance can't cover it. The
+ * shortfall pushes the ledger into negative — the player owes the
+ * station. Use for unrefusable services (spawn fee, mandatory repair)
+ * where rejecting the spend would leave the ship in a worse state.
+ * Conservation still holds: the station's credit_pool gains exactly
+ * what the player loses. */
+void ledger_force_debit(station_t *st, const uint8_t *token, float amount, ship_t *ship) {
+    if (amount <= 0.0f) return;
+    int idx = ledger_find_or_create(st, token);
+    if (idx < 0) return;
+    st->ledger[idx].balance -= amount;
+    if (ship) ship->stat_credits_spent += amount;
+    st->credit_pool += amount;
+}
+
 void emit_event(world_t *w, sim_event_t ev) {
     if (w->events.count < SIM_MAX_EVENTS) {
         w->events.events[w->events.count++] = ev;
@@ -873,16 +888,27 @@ static void try_sell_station_cargo(world_t *w, server_player_t *sp) {
         float space = fmaxf(0.0f, capacity - st->inventory[c]);
         if (space < 0.01f) continue;
         float deliver = fminf(fminf(sp->ship.cargo[c], ct->quantity_needed), space);
-        payout += deliver * contract_price(ct);
+        float price_per = contract_price(ct);
+        payout += deliver * price_per;
         if (deliver > 0.01f) sold_against_contract = true;
         sp->ship.cargo[c] -= deliver;
         st->inventory[c] += deliver;
         /* Phase 1 manifest-first: move whole-unit deliveries across the
          * ship/station manifests so provenance survives the transaction.
-         * Fractional deliveries still ride the float dual-write. */
+         * Fractional deliveries still ride the float dual-write. Grade
+         * bonus is added per-unit BEFORE the transfer (FIFO order so the
+         * units we price are the units that move). */
         {
             int whole = (int)floorf(deliver + 0.0001f);
             if (whole > 0) {
+                int counted = 0;
+                for (uint16_t u = 0; u < sp->ship.manifest.count && counted < whole; u++) {
+                    const cargo_unit_t *cu = &sp->ship.manifest.units[u];
+                    if (cu->commodity != c) continue;
+                    float mult = mining_payout_multiplier((mining_grade_t)cu->grade);
+                    payout += (mult - 1.0f) * price_per;  /* base already in deliver*price_per */
+                    counted++;
+                }
                 int moved = manifest_transfer_by_commodity(&sp->ship.manifest,
                                                            &st->manifest, c, whole);
                 if (moved > 0) manifest_mark_station_dirty(w, &st->manifest);
@@ -923,9 +949,17 @@ static void try_sell_station_cargo(world_t *w, server_player_t *sp) {
                 payout += accepted * price;
                 sp->ship.cargo[buy] -= accepted;
                 st->inventory[buy] += accepted;
-                /* Manifest dual-write — see the contract branch above. */
+                /* Manifest dual-write + per-unit grade bonus — see contract branch. */
                 int whole = (int)floorf(accepted + 0.0001f);
                 if (whole > 0) {
+                    int counted = 0;
+                    for (uint16_t u = 0; u < sp->ship.manifest.count && counted < whole; u++) {
+                        const cargo_unit_t *cu = &sp->ship.manifest.units[u];
+                        if (cu->commodity != buy) continue;
+                        float mult = mining_payout_multiplier((mining_grade_t)cu->grade);
+                        payout += (mult - 1.0f) * price;
+                        counted++;
+                    }
                     int moved = manifest_transfer_by_commodity(&sp->ship.manifest,
                                                                &st->manifest, buy, whole);
                     if (moved > 0) manifest_mark_station_dirty(w, &st->manifest);
@@ -966,9 +1000,12 @@ static void try_repair_ship(world_t *w, server_player_t *sp) {
     if (!station_has_service(st, STATION_SERVICE_REPAIR)) return;
     float cost = sim_station_repair_cost(&sp->ship);
     if (cost <= 0.0f) return;
-    if (!ledger_spend(st, sp->session_token, cost, &sp->ship)) return;
+    /* Repair is unrefusable — a docked ship with damaged hull always
+     * heals. The cost runs the ledger into debt rather than refusing
+     * the service; players earn it back through work. */
+    ledger_force_debit(st, sp->session_token, cost, &sp->ship);
     sp->ship.hull = ship_max_hull(&sp->ship);
-    SIM_LOG("[sim] player %d repaired for %.0f cr\n", sp->id, cost);
+    SIM_LOG("[sim] player %d repaired for %.0f cr (now in debt if negative)\n", sp->id, cost);
     emit_event(w, (sim_event_t){.type = SIM_EVENT_REPAIR, .player_id = sp->id});
 }
 
@@ -2260,9 +2297,32 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
         commodity_t c = intent->buy_commodity;
         if (c >= COMMODITY_RAW_ORE_COUNT && c < COMMODITY_COUNT
             && station_produces(docked_st, c)) {
+            /* Exact-grade buys must refuse if the station has nothing
+             * matching — otherwise the ship lands a common ingot at
+             * the fine/rare price and the row the player tapped lied
+             * to them. Only enforced for non-common grades (1+);
+             * COMMON falls through so products like FRAMES that live
+             * on the float inventory without a manifest entry can
+             * still be purchased. The sentinel MINING_GRADE_COUNT
+             * path stays any-grade FIFO. */
+            if (intent->buy_grade < MINING_GRADE_COUNT
+                && intent->buy_grade > MINING_GRADE_COMMON) {
+                if (manifest_find_first_cg(&docked_st->manifest, c,
+                                           (mining_grade_t)intent->buy_grade) < 0) {
+                    return;
+                }
+            }
             float available = docked_st->inventory[c];
             float space = ship_cargo_capacity(&sp->ship) - ship_total_cargo(&sp->ship);
-            float price_per = station_sell_price(docked_st, c);
+            float price_base = station_sell_price(docked_st, c);
+            /* Grade-aware pricing: if the client picked a specific-grade row
+             * in TRADE the row's displayed price was base * grade_multiplier,
+             * so charge the same here. Sentinel MINING_GRADE_COUNT keeps the
+             * legacy any-grade path at 1.0x. */
+            float grade_mult = (intent->buy_grade < MINING_GRADE_COUNT)
+                ? mining_payout_multiplier((mining_grade_t)intent->buy_grade)
+                : 1.0f;
+            float price_per = price_base * grade_mult;
             /* Buy as much as you can afford and carry */
             float bal = ledger_balance(docked_st, sp->session_token);
             float afford = (price_per > 0.01f) ? floorf(bal / price_per) : 0.0f;
@@ -2271,6 +2331,17 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
             if (amount > 0.01f && ledger_spend(docked_st, sp->session_token, total_cost, &sp->ship)) {
                 sp->ship.cargo[c] += amount;
                 docked_st->inventory[c] -= amount;
+                /* Manifest-first: transfer matching cargo_unit_t entries
+                 * (preferred grade first, FIFO fallback) so provenance and
+                 * grade follow the purchase into the ship's hold. Mirrors
+                 * the nearby-station hail-buy path. */
+                int whole = (int)floorf(amount + 0.0001f);
+                if (whole > 0) {
+                    int moved = manifest_transfer_by_commodity_ex(
+                        &docked_st->manifest, &sp->ship.manifest,
+                        c, intent->buy_grade, whole);
+                    if (moved > 0) manifest_mark_station_dirty(w, &docked_st->manifest);
+                }
                 SIM_LOG("[sim] player %d bought %.0f of commodity %d for %.0f cr\n",
                         sp->id, amount, c, total_cost);
             }
@@ -2490,8 +2561,25 @@ static void step_player(world_t *w, server_player_t *sp, float dt) {
             if (sp->input.buy_product) {
                 commodity_t c = sp->input.buy_commodity;
                 if (c >= COMMODITY_RAW_ORE_COUNT && c < COMMODITY_COUNT) {
-                    float available = nearby_st->inventory[c];
-                    float price_per = station_sell_price(nearby_st, c);
+                    /* Exact-grade hail-buys must refuse if the station
+                     * has nothing matching — same rule as the docked
+                     * path; only enforced for non-common grades so
+                     * products without a manifest entry still buy. */
+                    bool grade_ok = true;
+                    if (sp->input.buy_grade < MINING_GRADE_COUNT
+                        && sp->input.buy_grade > MINING_GRADE_COMMON) {
+                        if (manifest_find_first_cg(&nearby_st->manifest, c,
+                                                   (mining_grade_t)sp->input.buy_grade) < 0) {
+                            sp->input.buy_product = false;
+                            grade_ok = false;
+                        }
+                    }
+                    float available = grade_ok ? nearby_st->inventory[c] : 0.0f;
+                    float base = station_sell_price(nearby_st, c);
+                    float gmult = (sp->input.buy_grade < MINING_GRADE_COUNT)
+                        ? mining_payout_multiplier((mining_grade_t)sp->input.buy_grade)
+                        : 1.0f;
+                    float price_per = base * gmult;
                     float nbal = ledger_balance(nearby_st, sp->session_token);
                     float afford = (price_per > FLOAT_EPSILON) ? floorf(nbal / price_per) : 0.0f;
                     float amount = fminf(fminf(available, 1.0f), afford); /* buy 1 at a time */
@@ -3928,13 +4016,26 @@ void player_init_ship(server_player_t *sp, world_t *w) {
     anchor_ship_in_station(sp, w);
 }
 
-/* Grant starting credits at the docked station. Call AFTER session_token is set. */
+/* Charge the spawn / docking fee at the player's current station.
+ * Replaces the legacy "+50 starter grant" — ships now begin in the
+ * red and have to earn their way out. Fee scales with station ring
+ * count: 50 cr at a 1-ring outpost, 100 at a 2-ring station, 300 at
+ * a full 3-ring hub. Skips if a ledger entry already exists for this
+ * token (e.g. save reload, reconnect, post-death respawn) so a
+ * player isn't charged twice for the same berth. */
 void player_seed_credits(server_player_t *sp, world_t *w) {
     int st = sp->current_station;
     if (st < 0 || st >= MAX_STATIONS) st = 0;
-    /* Already has balance at this station? Skip (e.g., loaded from save). */
-    if (ledger_balance(&w->stations[st], sp->session_token) > 0.01f) return;
-    float seed = fminf(50.0f, w->stations[st].credit_pool);
-    w->stations[st].credit_pool -= seed;
-    ledger_earn(&w->stations[st], sp->session_token, seed);
+    /* Already established a ledger here? Skip — debt and earnings
+     * carry across reconnects and respawns. We probe by entry
+     * existence (any nonzero balance, positive or negative) since
+     * fresh entries always start at exactly 0. */
+    for (int i = 0; i < w->stations[st].ledger_count; i++) {
+        if (memcmp(w->stations[st].ledger[i].player_token,
+                   sp->session_token, 8) == 0) {
+            return;
+        }
+    }
+    int fee = station_spawn_fee(&w->stations[st]);
+    ledger_force_debit(&w->stations[st], sp->session_token, (float)fee, &sp->ship);
 }

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -1635,8 +1635,12 @@ static void place_towed_scaffold(world_t *w, server_player_t *sp) {
         }
     }
 
-    /* Materialize a nearby planned station if scaffold is close to it. */
-    {
+    /* Materialize a nearby planned station if scaffold is close to it.
+     * Only a SIGNAL RELAY scaffold can found (or materialize) a
+     * station — the relay IS the station's core, not just another
+     * module. Other module types must be towed to an already-active
+     * outpost and snapped into a ring slot. */
+    if (sc->module_type == MODULE_SIGNAL_RELAY) {
         const float MATERIALIZE_RANGE = 600.0f;
         const float MATERIALIZE_RANGE_SQ = MATERIALIZE_RANGE * MATERIALIZE_RANGE;
         for (int s = 3; s < MAX_STATIONS; s++) {
@@ -1651,7 +1655,8 @@ static void place_towed_scaffold(world_t *w, server_player_t *sp) {
             st->dock_radius = OUTPOST_DOCK_RADIUS;
             st->signal_range = OUTPOST_SIGNAL_RANGE;
             add_module_at(st, MODULE_DOCK, 0, 0xFF);
-            add_module_at(st, MODULE_SIGNAL_RELAY, 0, 0xFF);
+            /* The towed relay becomes the station's core relay below;
+             * don't auto-add an extra one here. */
             rebuild_station_services(st);
             /* Generate supply contract for activation frames */
             for (int k = 0; k < MAX_CONTRACTS; k++) {
@@ -1720,8 +1725,14 @@ static void place_towed_scaffold(world_t *w, server_player_t *sp) {
         }
     }
 
-    /* Not near an outpost — found a new station if in signal range */
-    if (signal_strength_at(w, sc->pos) > 0.0f && can_place_outpost(w, sc->pos)) {
+    /* Not near an outpost — found a new station if the towed kit is a
+     * SIGNAL RELAY (only relays can found stations, per the founding
+     * ritual: tow the seed, not every brick) and we're in signal
+     * range. Other module types fall through and keep towing — they
+     * need an existing outpost to snap to. */
+    if (sc->module_type == MODULE_SIGNAL_RELAY
+        && signal_strength_at(w, sc->pos) > 0.0f
+        && can_place_outpost(w, sc->pos)) {
         int slot = -1;
         for (int s = 3; s < MAX_STATIONS; s++) {
             if (!station_exists(&w->stations[s])) { slot = s; break; }
@@ -1736,13 +1747,13 @@ static void place_towed_scaffold(world_t *w, server_player_t *sp) {
             st->radius = OUTPOST_RADIUS;
             st->dock_radius = OUTPOST_DOCK_RADIUS;
             st->signal_range = OUTPOST_SIGNAL_RANGE;
-            /* Outpost is born under construction — needs frames delivered to
-             * activate. The scaffold you towed becomes the first module
-             * (pre-paid), but it can't go live until the station does. */
+            /* Outpost is born under construction — needs frames delivered
+             * to activate. The towed relay seed becomes the station's
+             * core relay (added below); the dock comes pre-stamped. */
             st->scaffold = true;
             st->scaffold_progress = 0.0f;
             add_module_at(st, MODULE_DOCK, 0, 0xFF);
-            add_module_at(st, MODULE_SIGNAL_RELAY, 0, 0xFF);
+            /* Relay added by the founding-tow path below. */
             rebuild_station_services(st);
             /* Generate supply contract for the outpost activation frames */
             for (int k = 0; k < MAX_CONTRACTS; k++) {
@@ -1777,7 +1788,19 @@ static void place_towed_scaffold(world_t *w, server_player_t *sp) {
             return;
         }
     }
-    /* Can't place here — do nothing, keep towing */
+    /* Can't place here — do nothing, keep towing.
+     *
+     * Common reasons:
+     *   - Towed kit isn't a signal relay (only relays can found new
+     *     outposts; other modules need an existing station ring slot).
+     *   - Position is outside signal coverage or fails can_place_outpost.
+     *
+     * Surface a notice so the player knows why the [E] press fizzled
+     * instead of silently continuing the tow. */
+    emit_event(w, (sim_event_t){
+        .type = SIM_EVENT_ORDER_REJECTED,
+        .player_id = sp->id,
+    });
 }
 
 static void step_scaffold_tow(world_t *w, server_player_t *sp, float dt) {

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -365,6 +365,9 @@ void ledger_credit_supply(station_t *st, const uint8_t *token, float ore_value);
  * otherwise debits the ledger, refunds the credit_pool, and bumps the
  * ship's stat_credits_spent. */
 bool ledger_spend(station_t *st, const uint8_t *token, float amount, ship_t *ship);
+/* Always-succeeds debit for unrefusable services (spawn, repair).
+ * Allows the balance to go negative (debt). */
+void ledger_force_debit(station_t *st, const uint8_t *token, float amount, ship_t *ship);
 /* Signal channel — station broadcast log (#316). */
 uint64_t signal_channel_post(world_t *w, int sender_station, const char *text, const char *audio_url);
 const signal_channel_msg_t *signal_channel_at(const world_t *w, int i);

--- a/server/highscore.c
+++ b/server/highscore.c
@@ -1,0 +1,135 @@
+#include "highscore.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#define HIGHSCORE_MAGIC   0x48494753u  /* 'H' 'I' 'G' 'S' */
+#define HIGHSCORE_VERSION 1u
+
+static void write_f32_le(uint8_t *p, float f) {
+    uint32_t u;
+    memcpy(&u, &f, 4);
+    p[0] = (uint8_t)(u);
+    p[1] = (uint8_t)(u >> 8);
+    p[2] = (uint8_t)(u >> 16);
+    p[3] = (uint8_t)(u >> 24);
+}
+
+void highscore_load(highscore_table_t *t, const char *path) {
+    memset(t, 0, sizeof(*t));
+    if (!path) return;
+    FILE *f = fopen(path, "rb");
+    if (!f) return;
+    uint32_t magic = 0, version = 0;
+    int32_t  count = 0;
+    if (fread(&magic, sizeof(magic), 1, f) != 1 ||
+        fread(&version, sizeof(version), 1, f) != 1 ||
+        fread(&count, sizeof(count), 1, f) != 1 ||
+        magic != HIGHSCORE_MAGIC || version != HIGHSCORE_VERSION ||
+        count < 0 || count > HIGHSCORE_TOP_N) {
+        fclose(f);
+        return;
+    }
+    for (int i = 0; i < count; i++) {
+        if (fread(&t->entries[i], sizeof(highscore_entry_t), 1, f) != 1) {
+            memset(t, 0, sizeof(*t));
+            fclose(f);
+            return;
+        }
+    }
+    t->count = count;
+    fclose(f);
+}
+
+bool highscore_save(const highscore_table_t *t, const char *path) {
+    if (!path) return false;
+    char tmp[512];
+    snprintf(tmp, sizeof(tmp), "%s.tmp", path);
+    FILE *f = fopen(tmp, "wb");
+    if (!f) return false;
+    uint32_t magic = HIGHSCORE_MAGIC;
+    uint32_t version = HIGHSCORE_VERSION;
+    int32_t  count = t->count;
+    if (fwrite(&magic, sizeof(magic), 1, f) != 1 ||
+        fwrite(&version, sizeof(version), 1, f) != 1 ||
+        fwrite(&count, sizeof(count), 1, f) != 1) {
+        fclose(f);
+        remove(tmp);
+        return false;
+    }
+    for (int i = 0; i < count; i++) {
+        if (fwrite(&t->entries[i], sizeof(highscore_entry_t), 1, f) != 1) {
+            fclose(f);
+            remove(tmp);
+            return false;
+        }
+    }
+    fclose(f);
+    return rename(tmp, path) == 0;
+}
+
+bool highscore_submit(highscore_table_t *t,
+                      const char *callsign, float credits_earned)
+{
+    if (!t) return false;
+    /* Reject NaN/inf and negative runs. Zero-credit deaths still
+     * qualify — they show the player they're on the board (sorted to
+     * the bottom) and get replaced once they earn something. NaN
+     * compares false against everything, so the explicit isfinite
+     * check is required. */
+    if (!isfinite(credits_earned) || credits_earned < 0.0f) return false;
+
+    /* Dedup by callsign: if this player already has an entry, only
+     * mutate when the new run is strictly better (then re-sort by
+     * removing the old + inserting fresh). One row per callsign keeps
+     * the table from being overrun by repeated low-credit deaths. */
+    if (callsign && callsign[0]) {
+        for (int i = 0; i < t->count; i++) {
+            if (memcmp(t->entries[i].callsign, callsign,
+                       strnlen(callsign, sizeof(t->entries[i].callsign))) == 0
+                && (size_t)strnlen(callsign, sizeof(t->entries[i].callsign))
+                   == strnlen(t->entries[i].callsign, sizeof(t->entries[i].callsign))) {
+                if (credits_earned <= t->entries[i].credits_earned) return false;
+                /* Remove the old entry; fall through to insert. */
+                for (int j = i; j < t->count - 1; j++) t->entries[j] = t->entries[j + 1];
+                t->count--;
+                memset(&t->entries[t->count], 0, sizeof(t->entries[t->count]));
+                break;
+            }
+        }
+    }
+
+    /* Find insertion position — descending by credits_earned. */
+    int ins = t->count;
+    for (int i = 0; i < t->count; i++) {
+        if (credits_earned > t->entries[i].credits_earned) { ins = i; break; }
+    }
+    if (ins >= HIGHSCORE_TOP_N) return false;
+
+    /* Shift down (drop tail when full). */
+    int end = (t->count < HIGHSCORE_TOP_N) ? t->count : HIGHSCORE_TOP_N - 1;
+    for (int i = end; i > ins; i--) t->entries[i] = t->entries[i - 1];
+
+    highscore_entry_t *e = &t->entries[ins];
+    memset(e, 0, sizeof(*e));
+    if (callsign) {
+        size_t n = strnlen(callsign, sizeof(e->callsign));
+        memcpy(e->callsign, callsign, n);
+    }
+    e->credits_earned = credits_earned;
+
+    if (t->count < HIGHSCORE_TOP_N) t->count++;
+    return true;
+}
+
+int highscore_serialize(uint8_t *buf, const highscore_table_t *t) {
+    buf[0] = NET_MSG_HIGHSCORES;
+    buf[1] = (uint8_t)t->count;
+    for (int i = 0; i < t->count; i++) {
+        uint8_t *p = &buf[HIGHSCORE_HEADER + i * HIGHSCORE_ENTRY_SIZE];
+        memcpy(p, t->entries[i].callsign, 8);
+        write_f32_le(&p[8], t->entries[i].credits_earned);
+    }
+    return HIGHSCORE_HEADER + t->count * HIGHSCORE_ENTRY_SIZE;
+}

--- a/server/highscore.h
+++ b/server/highscore.h
@@ -1,0 +1,39 @@
+/*
+ * highscore.h — persistent global leaderboard.
+ *
+ * Server keeps the top-N death runs by `credits_earned`. Entries are
+ * pushed at death, persisted to disk on change, and broadcast to all
+ * connected clients via NET_MSG_HIGHSCORES so the death cinematic can
+ * render the current standings.
+ */
+#ifndef SIGNAL_HIGHSCORE_H
+#define SIGNAL_HIGHSCORE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "protocol.h"
+
+typedef struct {
+    char  callsign[8];      /* not NUL-terminated if 8 chars used */
+    float credits_earned;
+} highscore_entry_t;
+
+typedef struct {
+    highscore_entry_t entries[HIGHSCORE_TOP_N];
+    int               count;
+} highscore_table_t;
+
+void highscore_load(highscore_table_t *t, const char *path);
+bool highscore_save(const highscore_table_t *t, const char *path);
+
+/* Returns true if the table was mutated (i.e. entry qualified for top-N). */
+bool highscore_submit(highscore_table_t *t,
+                      const char *callsign, float credits_earned);
+
+/* Serialize the table as a NET_MSG_HIGHSCORES packet. Returns bytes written.
+ * buf must be at least HIGHSCORE_HEADER + HIGHSCORE_TOP_N * HIGHSCORE_ENTRY_SIZE. */
+int highscore_serialize(uint8_t *buf, const highscore_table_t *t);
+
+#endif /* SIGNAL_HIGHSCORE_H */

--- a/server/main.c
+++ b/server/main.c
@@ -6,6 +6,7 @@
  */
 #include "mongoose.h"
 #include "game_sim.h"
+#include "highscore.h"
 #include "manifest.h"
 #include "mining.h"  /* mining_render_callsign for chain log copy */
 #include "net_protocol.h"
@@ -32,6 +33,29 @@ static char api_headers[256];
 static bool station_identity_dirty[MAX_STATIONS];
 static bool station_econ_dirty = true;   /* station inventories changed */
 static bool contracts_dirty = true;       /* contract list changed */
+static highscore_table_t highscores;
+static bool highscores_dirty = true;      /* broadcast + persist pending */
+
+/* Defined further down; forward-declared so the highscore helpers can
+ * use the same send wrapper as every other broadcast in this file
+ * (consistent with future send-queue / rate-limiting changes). */
+static void ws_send(struct mg_connection *c, const void *data, size_t len);
+
+static void broadcast_highscores(void) {
+    uint8_t buf[HIGHSCORE_HEADER + HIGHSCORE_TOP_N * HIGHSCORE_ENTRY_SIZE];
+    int len = highscore_serialize(buf, &highscores);
+    for (int p = 0; p < MAX_PLAYERS; p++) {
+        if (!world.players[p].connected || !world.players[p].conn) continue;
+        ws_send(world.players[p].conn, buf, (size_t)len);
+    }
+}
+
+static void send_highscores_to(struct mg_connection *c) {
+    if (!c) return;
+    uint8_t buf[HIGHSCORE_HEADER + HIGHSCORE_TOP_N * HIGHSCORE_ENTRY_SIZE];
+    int len = highscore_serialize(buf, &highscores);
+    ws_send(c, buf, (size_t)len);
+}
 
 #define STATION_IDENTITY_FALLBACK_MS 2000
 static uint64_t last_station_identity = 0;
@@ -45,6 +69,7 @@ static uint64_t last_station_identity = 0;
 #define SAVE_PATH "world.sav"
 #define PLAYER_SAVE_DIR "saves"
 #define STATION_CATALOG_DIR "stations"
+#define HIGHSCORE_PATH "highscores.dat"
 #define AUTOSAVE_MS 30000   /* autosave every 30 seconds */
 
 /* ------------------------------------------------------------------ */
@@ -887,6 +912,10 @@ static void ev_handler(struct mg_connection *c, int ev, void *ev_data) {
                 new_sp->asteroid_sent[ai] = world.asteroids[ai].active;
         }
 
+        /* Global highscores: newcomer gets the current leaderboard so the
+         * death cinematic can render it before they've played a run. */
+        send_highscores_to(c);
+
         /* Signal channel snapshot (#316): newcomer gets the full ring
          * buffer so the Network tab has content immediately. */
         if (world.signal_channel.count > 0) {
@@ -1105,6 +1134,12 @@ static void broadcast_ship_states(void) {
 /* ------------------------------------------------------------------ */
 
 int main(void) {
+    /* Line-buffer stdout and unbuffer stderr so `docker compose logs`
+     * sees server output in real time. Without this, fully-buffered
+     * stdout holds [server] printf lines until a 4KB page fills,
+     * which in practice means we never see startup/death logs. */
+    setvbuf(stdout, NULL, _IOLBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
     signal(SIGINT, signal_handler);
     signal(SIGTERM, signal_handler);
 
@@ -1172,6 +1207,29 @@ int main(void) {
             world.stations[i].id = world.next_station_id++;
     }
 
+    /* The station catalog format doesn't persist currency_name (yet) and
+     * the catalog loader memsets the whole struct, so the defaults set
+     * by world_reset() get wiped. Re-stamp the names for the three
+     * starter stations whenever they come back empty so WORK rows show
+     * "+N prospect vouchers" / "kepler bonds" / "helios credits"
+     * instead of the bare "cr" fallback. */
+    {
+        const char *defaults[3] = {
+            "prospect vouchers",
+            "kepler bonds",
+            "helios credits",
+        };
+        for (int i = 0; i < 3 && i < MAX_STATIONS; i++) {
+            if (!station_exists(&world.stations[i])) continue;
+            if (world.stations[i].currency_name[0] == '\0') {
+                snprintf(world.stations[i].currency_name,
+                         sizeof(world.stations[i].currency_name),
+                         "%s", defaults[i]);
+                station_identity_dirty[i] = true;
+            }
+        }
+    }
+
     rebuild_signal_chain(&world);
     station_rebuild_all_nav(&world);
     for (int i = 0; i < MAX_STATIONS; i++) station_identity_dirty[i] = true;
@@ -1180,6 +1238,11 @@ int main(void) {
      * server restart and the chain links continue from where we left
      * off (no fork at the genesis block). */
     signal_chain_load(&world);
+
+    highscore_load(&highscores, HIGHSCORE_PATH);
+    if (highscores.count > 0)
+        printf("[server] loaded %d highscore(s) from %s\n",
+               highscores.count, HIGHSCORE_PATH);
 
     struct mg_mgr mgr;
     mg_mgr_init(&mgr);
@@ -1247,6 +1310,18 @@ int main(void) {
                     }
                     if (ev->type == SIM_EVENT_DEATH) {
                         int pid = ev->player_id;
+                        /* Submit the run to the global leaderboard. Runs that
+                         * don't qualify for top-N return false and no-op. */
+                        if (pid >= 0 && pid < MAX_PLAYERS && world.players[pid].connected) {
+                            const char *cs = world.players[pid].callsign;
+                            bool qualified = highscore_submit(
+                                &highscores, cs, ev->death.credits_earned);
+                            printf("[server] death pid=%d cs=%s earned=%.0f cr → %s (top=%d)\n",
+                                   pid, cs[0] ? cs : "?", ev->death.credits_earned,
+                                   qualified ? "qualified" : "skipped",
+                                   highscores.count);
+                            if (qualified) highscores_dirty = true;
+                        }
                         if (pid >= 0 && pid < MAX_PLAYERS && world.players[pid].connected && world.players[pid].conn) {
                             /* Death packet now carries position + stats so
                              * the client cinematic anchors at the wreckage
@@ -1410,6 +1485,11 @@ int main(void) {
         if (now - last_ship >= SHIP_TICK_MS) {
             broadcast_ship_states();
             last_ship = now;
+        }
+        if (highscores_dirty) {
+            broadcast_highscores();
+            (void)highscore_save(&highscores, HIGHSCORE_PATH);
+            highscores_dirty = false;
         }
         if (now - last_save >= AUTOSAVE_MS) {
             station_catalog_save_all(world.stations, MAX_STATIONS, STATION_CATALOG_DIR);

--- a/server/sim_construction.c
+++ b/server/sim_construction.c
@@ -46,8 +46,23 @@ void activate_outpost(world_t *w, int station_idx) {
     st->scaffold = false;
     st->scaffold_progress = 1.0f;
     st->signal_range = OUTPOST_SIGNAL_RANGE;
-    /* First module: signal relay on ring 1, orbiting the placement point */
-    add_module_at(st, MODULE_SIGNAL_RELAY, 1, 0);
+    /* The signal relay module was placed when the player towed the
+     * relay-core seed here in place_towed_scaffold. Activation just
+     * promotes it (and the dock + any other founding scaffolds) from
+     * pending → built. Fallback: if no relay is present (legacy save
+     * or NPC-built outpost), add one so the station still works. */
+    bool have_relay = false;
+    for (int m = 0; m < st->module_count; m++) {
+        if (st->modules[m].type == MODULE_SIGNAL_RELAY) {
+            st->modules[m].scaffold = false;
+            st->modules[m].build_progress = 1.0f;
+            have_relay = true;
+        } else if (st->modules[m].type == MODULE_DOCK) {
+            st->modules[m].scaffold = false;
+            st->modules[m].build_progress = 1.0f;
+        }
+    }
+    if (!have_relay) add_module_at(st, MODULE_SIGNAL_RELAY, 1, 0);
     st->arm_count = 1;
     st->arm_speed[0] = STATION_RING_SPEED;
     rebuild_station_services(st);

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -483,14 +483,12 @@ void step_furnace_smelting(world_t *w, float dt) {
             /* Wait out active, unresolved fracture claims before paying out. */
             if (claim_state->active && !claim_state->resolved) continue;
 
-            /* M5: refuse smelt when the station's output bin is already full.
-             * Fragment stays in the beam (smelt_progress capped at 1.0) and
-             * will fire next tick once space frees up — creates visible back-
-             * pressure instead of silently over-capping the inventory float. */
-            commodity_t ingot_peek = commodity_refined_form(a->commodity);
-            commodity_t output_peek = (ingot_peek != a->commodity) ? ingot_peek : a->commodity;
-            float space_peek = MAX_PRODUCT_STOCK - st->inventory[output_peek];
-            if (space_peek < a->ore - 0.01f) continue;
+            /* M5 backpressure removed: it stuck fragments on the beam
+             * forever when the station's output bin filled up (e.g.
+             * Prospect with no local ferrite consumer). UX bias is to
+             * clear the player's tractor — let the smelt run and clamp
+             * the inventory below; overshoot is lost to atmospheric
+             * exhaust but the player keeps the payout. */
 
             /* M3: scan all matching contracts (was break-on-first). Pick the
              * contract whose price is highest above the station buy price. */
@@ -601,11 +599,16 @@ void step_furnace_smelting(world_t *w, float dt) {
                 }
             }
 
-            /* Smelt: ore -> ingot in station inventory */
+            /* Smelt: ore -> ingot in station inventory. Clamp at the
+             * stockpile cap — overshoot is lost (and the manifest dual-
+             * write below sees a smaller delta). The player still gets
+             * paid for the full ore value via the ledger above. */
             commodity_t ingot = commodity_refined_form(a->commodity);
             commodity_t output = (ingot != a->commodity) ? ingot : a->commodity;
             float stock_before = st->inventory[output];
             st->inventory[output] += a->ore;
+            if (st->inventory[output] > MAX_PRODUCT_STOCK)
+                st->inventory[output] = MAX_PRODUCT_STOCK;
 
             /* Dual-write discrete units for the floored stock delta so
              * manifest counts stay aligned with the legacy float path.

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -60,7 +60,7 @@ static uint32_t crc32_file(FILE *f) {
 }
 
 #define SAVE_MAGIC 0x5349474E  /* "SIGN" */
-#define SAVE_VERSION 29  /* #339 slice A: real manifest serialization */
+#define SAVE_VERSION 30  /* contract.required_grade persisted */
 #define MIN_SAVE_VERSION 20  /* migrate v20 by mapping old module_buffer → input */
 
 /* Set by world_load() before read_station() so per-station readers know
@@ -492,6 +492,7 @@ static bool write_contract(FILE *f, const contract_t *c) {
     WRITE_FIELD(f, c->action);
     WRITE_FIELD(f, c->station_index);
     WRITE_FIELD(f, c->commodity);
+    WRITE_FIELD(f, c->required_grade);
     WRITE_FIELD(f, c->quantity_needed);
     WRITE_FIELD(f, c->base_price);
     WRITE_FIELD(f, c->age);
@@ -506,6 +507,12 @@ static bool read_contract(FILE *f, contract_t *c) {
     READ_FIELD(f, c->action);
     READ_FIELD(f, c->station_index);
     READ_FIELD(f, c->commodity);
+    /* v30+ persists required_grade. Older saves default to COMMON. */
+    if (g_loaded_save_version >= 30) {
+        READ_FIELD(f, c->required_grade);
+    } else {
+        c->required_grade = (uint8_t)MINING_GRADE_COMMON;
+    }
     READ_FIELD(f, c->quantity_needed);
     READ_FIELD(f, c->base_price);
     READ_FIELD(f, c->age);

--- a/shared/economy_const.h
+++ b/shared/economy_const.h
@@ -14,7 +14,12 @@ static const int   REFINERY_MAX_FURNACES = 3;
 /* Production: ~1 unit/sec → conversions are visible inside 5-10s of docked
  * dwell time. Slower felt like nothing was happening. */
 static const float STATION_PRODUCTION_RATE = 1.0f;
-static const float STATION_REPAIR_COST_PER_HULL = 2.0f;
+/* Tuned 2026-04-24 (#299): bumped 2.0 → 5.0 cr/HP. Miner runs average
+ * 50-100 cr/rock; the old rate let pilots crash through belts and pay
+ * back damage in two rocks. 5.0 makes a full miner repair (~500 cr)
+ * cost a real handful of work, and pairs with the spawn-fee debt model
+ * so reckless flying actually keeps the ledger negative. */
+static const float STATION_REPAIR_COST_PER_HULL = 5.0f;
 /* Refined-product stockpile cap: needs to be wide enough that a full hold
  * of ingots can be converted without stalling at the cap. */
 static const float MAX_PRODUCT_STOCK = 120.0f;

--- a/shared/protocol.h
+++ b/shared/protocol.h
@@ -56,6 +56,15 @@ enum {
     NET_MSG_FRACTURE_CLAIM     = 0x2D, /* client -> server: [type:1][fracture_id:u32][burst_nonce:u32][claimed_grade:u8] */
     NET_MSG_FRACTURE_RESOLVED  = 0x2E, /* server -> nearby clients: [type:1][fracture_id:u32][fragment_pub:32][winner_pub:32][grade:u8] */
     NET_MSG_STATION_MANIFEST   = 0x2F, /* server -> client: per-station manifest summary grouped by (commodity, grade) — see STATION_MANIFEST_* below. */
+    NET_MSG_HIGHSCORES         = 0x30, /* server -> client: top-N leaderboard. [type:1][count:1] + count × [callsign:8][credits_earned:f32] */
+};
+
+/* Top-N global leaderboard persisted server-side, broadcast on join and
+ * after every death. */
+enum {
+    HIGHSCORE_TOP_N      = 10,
+    HIGHSCORE_ENTRY_SIZE = 12,   /* 8-byte callsign + f32 credits_earned */
+    HIGHSCORE_HEADER     = 2,    /* type + count */
 };
 
 /* NET_MSG_STATION_MANIFEST wire layout:

--- a/shared/station_util.h
+++ b/shared/station_util.h
@@ -56,6 +56,34 @@ static inline bool station_has_module(const station_t *st, module_type_t type) {
     return false;
 }
 
+/* How many rings of the station are populated with active modules?
+ * Returns 1..STATION_NUM_RINGS. Empty stations report 1 (the inner
+ * dock ring is always assumed to exist). Used to scale the docking
+ * spawn fee — bigger stations charge more. */
+static inline int station_max_ring(const station_t *st) {
+    int max = 1;
+    for (int i = 0; i < st->module_count; i++) {
+        if (st->modules[i].scaffold) continue;
+        int r = (int)st->modules[i].ring;
+        if (r > max && r <= STATION_NUM_RINGS) max = r;
+    }
+    return max;
+}
+
+/* Spawn / re-dock fee charged when a player first establishes a
+ * ledger entry at this station. Scales with ring count: tier-1
+ * outposts are cheap, full 3-ring hubs are premium. The fee is
+ * debited even if the player has no balance, putting them into
+ * debt — earn it back by working. */
+static inline int station_spawn_fee(const station_t *st) {
+    switch (station_max_ring(st)) {
+        case 1:  return 50;
+        case 2:  return 100;
+        case 3:  return 300;
+        default: return 50;
+    }
+}
+
 /* Returns true if the station consumes this commodity as production input. */
 static inline bool station_consumes(const station_t *st, commodity_t c) {
     switch (c) {

--- a/src/client.h
+++ b/src/client.h
@@ -183,6 +183,13 @@ typedef struct {
     float death_credits_earned;
     float death_credits_spent;
     int death_asteroids_fractured;
+    /* Global leaderboard from server (top-N by credits earned at death).
+     * Populated on join + after every death in MP. SP leaves it empty. */
+    struct {
+        char  callsign[8];
+        float credits_earned;
+    } highscores[10 /* HIGHSCORE_TOP_N */];
+    int highscore_count;
     /* Smoothed fog intensity (0..1). Tracks 1 - (hull/max_hull) but
      * eases in/out so the vignette rolls smoothly instead of snapping. */
     float fog_intensity;
@@ -375,6 +382,24 @@ void hull_fog_init(void);
 
 void build_station_ui_state(station_ui_state_t* ui);
 void draw_station_services(const station_ui_state_t* ui);
+
+/* WORK-tab contract slot ordering. Single source of truth shared
+ * between draw_jobs_view (renders the rows) and the input layer
+ * (handles [1]/[2]/[3] selection) so the keypress always maps to the
+ * row the player sees. Up to 3 slots filled in this order:
+ *   1. Active TRACTOR contracts at this station the player can
+ *      currently fulfill (carries the commodity in cargo or towed
+ *      raw-ore fragments). Marked fulfillable=true.
+ *   2. Nearest active contracts (any station) by squared distance
+ *      from `here`, used to fill remaining slots. fulfillable=false.
+ *
+ * Returns the number of slots filled (0..3). out_held holds the
+ * integer-rounded carry quantity for the fulfillable slots and 0 for
+ * the nearest-fill slots. Pass `here_idx = -1` if not docked. */
+int build_work_slots(int here_idx, vec2 here_pos,
+                     int out_contracts[3],
+                     bool out_fulfillable[3],
+                     int out_held[3]);
 
 /* Station label/color helpers */
 const char* station_role_hub_label(const station_t* station);

--- a/src/hud.c
+++ b/src/hud.c
@@ -805,7 +805,44 @@ void draw_hud(void) {
         sdtx_pos(left, row);
         sdtx_color4b(PAL_DEATH_SPENT, a8);
         sdtx_printf("Credits spent: %8.0f", g.death_credits_spent);
-        row += 4.0f;
+        row += 3.0f;
+
+        /* Global highscores — top runs broadcast by the server. The
+         * player's just-submitted run is highlighted in the death-earned
+         * color so they can spot where they landed. Always render the
+         * header so the player knows the leaderboard exists even when
+         * empty (first run on a fresh server) or before the server's
+         * post-death broadcast has arrived. */
+        {
+            const char *lb = "-- TOP RUNS --";
+            float lb_w = (float)strlen(lb) * cell;
+            sdtx_pos((cx - lb_w * 0.5f) / cell, row);
+            sdtx_color4b(PAL_NOTICE, a8);
+            sdtx_puts(lb);
+            row += 1.6f;
+            if (g.highscore_count > 0) {
+                int show = (g.highscore_count > 8) ? 8 : g.highscore_count;
+                for (int i = 0; i < show; i++) {
+                    char cs[9];
+                    memcpy(cs, g.highscores[i].callsign, 8);
+                    cs[8] = '\0';
+                    for (int k = 7; k >= 0 && (cs[k] == ' ' || cs[k] == '\0'); k--) cs[k] = '\0';
+                    bool is_me = (g.death_credits_earned > 0.5f
+                                  && fabsf(g.highscores[i].credits_earned - g.death_credits_earned) < 0.5f);
+                    if (is_me) sdtx_color4b(PAL_DEATH_EARNED, a8);
+                    else       sdtx_color4b(PAL_TEXT_FADED,  a8);
+                    sdtx_pos(left, row);
+                    sdtx_printf("%2d. %-8s %8.0f", i + 1, cs, g.highscores[i].credits_earned);
+                    row += 1.4f;
+                }
+            } else {
+                sdtx_color4b(PAL_TEXT_FADED, a8);
+                sdtx_pos(left, row);
+                sdtx_puts("  (no records yet)");
+                row += 1.4f;
+            }
+            row += 1.0f;
+        }
 
         /* Prompt — RED, hard FLASH on/off */
         float flash = (sinf(g.world.time * 7.0f) > 0.0f) ? 1.0f : 0.25f;
@@ -997,7 +1034,7 @@ void draw_hud(void) {
             }
         } else if (cargo_units >= cargo_capacity) {
             sdtx_color3b(PAL_ORE_AMBER);
-            sdtx_puts("HOLD FULL // RETURN");
+            sdtx_puts("Hold full. Dock to sell.");
         } else {
             /* Check for pending credits from ledger (singleplayer) */
             float pending = 0.0f;
@@ -1014,10 +1051,10 @@ void draw_hud(void) {
             }
             if (pending > 0.5f) {
                 sdtx_color3b(PAL_ORE_AMBER);
-                sdtx_printf("H HAIL // %d CR", (int)lroundf(pending));
+                sdtx_printf("[H] collect %d", (int)lroundf(pending));
             } else {
                 sdtx_color3b(PAL_TEXT_MUTED);
-                sdtx_puts("FIELD CLEAR // SCAN");
+                sdtx_puts("Nothing in range. Scan for rocks.");
             }
         }
 
@@ -1092,7 +1129,7 @@ void draw_hud(void) {
         sdtx_printf("%s // docked // E launch", current_station->name);
     } else if (LOCAL_PLAYER.in_dock_range) {
         sdtx_color3b(PAL_SIGNAL_MINT);
-        sdtx_puts("Dock ring hot // E to dock");
+        sdtx_puts("In dock range. [E] to dock.");
     } else {
         sdtx_color3b(PAL_NAV_BLUE);
         sdtx_printf("%s %d u // %d deg %s",
@@ -1144,7 +1181,7 @@ void draw_hud(void) {
         }
     } else if (cargo_units >= cargo_capacity) {
         sdtx_color3b(PAL_ORE_AMBER);
-        sdtx_puts("Hold full // return run");
+        sdtx_puts("Hold full. Dock to sell.");
     } else {
         /* Check for pending credits from ledger (singleplayer) */
         float pending_n = 0.0f;

--- a/src/input.c
+++ b/src/input.c
@@ -362,45 +362,18 @@ input_intent_t sample_input_intent(void) {
          * learn a new deliver key per tab. [E] is LAUNCH, period. */
         const station_t *here_st = current_station_ptr();
         int here_idx = LOCAL_PLAYER.current_station;
+        vec2 here_pos = here_st ? here_st->pos : v2(0.0f, 0.0f);
 
-        /* Re-derive the same slot ordering as station_ui.c so the
-         * keypress maps to the visible row. */
+        /* Slot listing comes from build_work_slots() — the same helper
+         * draw_jobs_view uses, so [1]/[2]/[3] always selects the row
+         * the player sees. */
         int slot_contract[3] = {-1, -1, -1};
-        int slot_count = 0;
-        for (int ci = 0; ci < MAX_CONTRACTS && slot_count < 3; ci++) {
-            const contract_t *ct = &g.world.contracts[ci];
-            if (!ct->active || ct->action != CONTRACT_TRACTOR) continue;
-            if (here_idx < 0 || ct->station_index != here_idx) continue;
-            if (LOCAL_PLAYER.ship.cargo[ct->commodity] < 0.5f) continue;
-            slot_contract[slot_count++] = ci;
-        }
-        if (slot_count < 3 && here_st) {
-            int nearest[3] = {-1, -1, -1};
-            float nearest_d[3] = {1e18f, 1e18f, 1e18f};
-            vec2 here = here_st->pos;
-            for (int ci = 0; ci < MAX_CONTRACTS; ci++) {
-                const contract_t *ct = &g.world.contracts[ci];
-                if (!ct->active || ct->station_index >= MAX_STATIONS) continue;
-                if (!station_exists(&g.world.stations[ct->station_index])) continue;
-                bool already = false;
-                for (int s = 0; s < slot_count; s++)
-                    if (slot_contract[s] == ci) { already = true; break; }
-                if (already) continue;
-                vec2 target = (ct->action == CONTRACT_TRACTOR) ? g.world.stations[ct->station_index].pos : ct->target_pos;
-                float d = v2_dist_sq(here, target);
-                for (int s = 0; s < 3; s++) {
-                    if (d < nearest_d[s]) {
-                        for (int j = 2; j > s; j--) { nearest[j] = nearest[j-1]; nearest_d[j] = nearest_d[j-1]; }
-                        nearest[s] = ci;
-                        nearest_d[s] = d;
-                        break;
-                    }
-                }
-            }
-            for (int s = 0; s < 3 && slot_count < 3; s++) {
-                if (nearest[s] >= 0) slot_contract[slot_count++] = nearest[s];
-            }
-        }
+        bool slot_full[3] = {false, false, false};
+        int slot_held_in[3] = {0, 0, 0};
+        (void)build_work_slots(here_idx, here_pos,
+                               slot_contract, slot_full, slot_held_in);
+        (void)slot_full;
+        (void)slot_held_in;
 
         /* [1/2/3] select a contract slot. */
         for (int k = 0; k < 3; k++) {

--- a/src/main.c
+++ b/src/main.c
@@ -924,6 +924,7 @@ static void init(void) {
             cbs.on_signal_channel = apply_remote_signal_channel;
             cbs.on_station_ingots = apply_remote_station_ingots;
             cbs.on_station_manifest = apply_remote_station_manifest;
+            cbs.on_highscores = apply_remote_highscores;
             cbs.on_hold_ingots = apply_remote_hold_ingots;
             g.multiplayer_enabled = net_init(server_url, &cbs);
             if (g.multiplayer_enabled) {
@@ -1352,7 +1353,7 @@ static void render_world(void) {
                 int stock = (int)lroundf(tst->inventory[sell_c]);
                 int price = (int)lroundf(station_sell_price(tst, sell_c));
                 if (stock > 0)
-                    sdtx_printf("FIRE to buy  %d@%dcr  [%d]", stock, price, stock);
+                    sdtx_printf("[Fire] buy 1 @ %dcr  (stock %d)", price, stock);
                 else
                     sdtx_puts("Out of stock");
             } else switch (tm->type) {
@@ -1360,7 +1361,7 @@ static void render_world(void) {
                     sdtx_puts("Dock to repair hull");
                     break;
                 case MODULE_DOCK:
-                    sdtx_puts("FIRE to dock");
+                    sdtx_puts("[Fire] dock");
                     break;
                 case MODULE_SIGNAL_RELAY:
                     sdtx_printf("Signal range %.0f", tst->signal_range);
@@ -1371,24 +1372,10 @@ static void render_world(void) {
         }
     }
 
-    /* Tracked contract target outline (yellow) */
-    if (g.tracked_contract >= 0 && g.tracked_contract < MAX_CONTRACTS) {
-        contract_t *ct = &g.world.contracts[g.tracked_contract];
-        if (ct->active) {
-            float pulse = 0.5f + 0.3f * sinf(g.world.time * 3.0f);
-            if (ct->action == CONTRACT_FRACTURE && ct->target_index >= 0 && ct->target_index < MAX_ASTEROIDS
-                && g.world.asteroids[ct->target_index].active) {
-                /* Outline the target asteroid */
-                asteroid_t *a = &g.world.asteroids[ct->target_index];
-                draw_circle_outline(a->pos, a->radius + 16.0f, 24, 1.0f, 0.87f, 0.20f, pulse);
-            } else if (ct->action == CONTRACT_TRACTOR && ct->station_index < MAX_STATIONS) {
-                /* Outline the target station */
-                station_t *st = &g.world.stations[ct->station_index];
-                if (station_exists(st))
-                    draw_circle_outline(st->pos, st->dock_radius + 20.0f, 32, 1.0f, 0.87f, 0.20f, pulse);
-            }
-        }
-    }
+    /* Tracked contract highlight is owned by draw_tracked_contract_highlight()
+     * (called earlier in the world pass). The legacy duplicate that lived
+     * here drew a giant dock-radius ring around stations on TRACTOR contracts
+     * and a stale target_index ring for FRACTURE — both wrong. Single source. */
 
     /* Hail ping — draw last so the ring sits on top of stations and
      * modules, hard to miss. */

--- a/src/net.c
+++ b/src/net.c
@@ -605,6 +605,22 @@ static void handle_message(const uint8_t* data, int len) {
         }
         break;
 
+    case NET_MSG_HIGHSCORES:
+        if (len >= HIGHSCORE_HEADER && net_state.callbacks.on_highscores) {
+            int count = data[1];
+            int expected = HIGHSCORE_HEADER + count * HIGHSCORE_ENTRY_SIZE;
+            if (len < expected) break;
+            if (count > HIGHSCORE_TOP_N) count = HIGHSCORE_TOP_N;
+            static NetHighscoreEntry scratch[HIGHSCORE_TOP_N];
+            for (int i = 0; i < count; i++) {
+                const uint8_t *p = &data[HIGHSCORE_HEADER + i * HIGHSCORE_ENTRY_SIZE];
+                memcpy(scratch[i].callsign, p, 8);
+                scratch[i].credits_earned = read_f32_le(&p[8]);
+            }
+            net_state.callbacks.on_highscores(scratch, count);
+        }
+        break;
+
     case NET_MSG_STATION_MANIFEST:
         if (len >= STATION_MANIFEST_HEADER && net_state.callbacks.on_station_manifest) {
             uint8_t station_id = data[1];

--- a/src/net.h
+++ b/src/net.h
@@ -192,6 +192,13 @@ typedef void (*net_on_station_manifest_fn)(uint8_t station_id,
                                            const NetStationManifestEntry *entries,
                                            int count);
 
+/* Global leaderboard — top-N death runs by credits earned. */
+typedef struct {
+    char  callsign[8];    /* not NUL-terminated if 8 chars */
+    float credits_earned;
+} NetHighscoreEntry;
+typedef void (*net_on_highscores_fn)(const NetHighscoreEntry *entries, int count);
+
 typedef void (*net_on_players_begin_fn)(void);
 
 typedef struct {
@@ -217,6 +224,7 @@ typedef struct {
     net_on_station_ingots_fn on_station_ingots;
     net_on_hold_ingots_fn    on_hold_ingots;
     net_on_station_manifest_fn on_station_manifest;
+    net_on_highscores_fn       on_highscores;
 } NetCallbacks;
 
 /* Initialize networking and connect to the relay server.

--- a/src/net_sync.c
+++ b/src/net_sync.c
@@ -176,6 +176,18 @@ void apply_remote_station_manifest(uint8_t station_id,
     }
 }
 
+void apply_remote_highscores(const NetHighscoreEntry *entries, int count) {
+    if (count < 0) count = 0;
+    int cap = (int)(sizeof(g.highscores) / sizeof(g.highscores[0]));
+    if (count > cap) count = cap;
+    memset(g.highscores, 0, sizeof(g.highscores));
+    for (int i = 0; i < count; i++) {
+        memcpy(g.highscores[i].callsign, entries[i].callsign, 8);
+        g.highscores[i].credits_earned = entries[i].credits_earned;
+    }
+    g.highscore_count = count;
+}
+
 void apply_remote_hold_ingots(const named_ingot_t *ingots, int count) {
     if (g.local_player_slot < 0 || g.local_player_slot >= MAX_PLAYERS) return;
     if (count < 0) count = 0;

--- a/src/net_sync.h
+++ b/src/net_sync.h
@@ -32,6 +32,8 @@ void apply_remote_hold_ingots(const named_ingot_t *ingots, int count);
 void apply_remote_station_manifest(uint8_t station_id,
                                    const NetStationManifestEntry *entries,
                                    int count);
+/* Global leaderboard snapshot. */
+void apply_remote_highscores(const NetHighscoreEntry *entries, int count);
 void apply_remote_events(const sim_event_t *events, int count);
 void begin_player_state_batch(void);
 void apply_remote_player_state(const NetPlayerState* state);

--- a/src/station_ui.c
+++ b/src/station_ui.c
@@ -206,6 +206,95 @@ void format_ingot_stock_line(const station_t* station, char* text, size_t text_s
 }
 
 /* ------------------------------------------------------------------ */
+/* WORK-tab contract slot builder                                      */
+/* ------------------------------------------------------------------ */
+
+int build_work_slots(int here_idx, vec2 here_pos,
+                     int out_contracts[3],
+                     bool out_fulfillable[3],
+                     int out_held[3])
+{
+    for (int i = 0; i < 3; i++) {
+        out_contracts[i]   = -1;
+        out_fulfillable[i] = false;
+        out_held[i]        = 0;
+    }
+    int count = 0;
+
+    /* Pass 1: TRACTOR contracts at this station the player can fulfill
+     * right now. Raw ore lives in towed S-tier fragments rather than
+     * ship.cargo[]; finished goods live on ship.cargo[]. */
+    for (int ci = 0; ci < MAX_CONTRACTS && count < 3; ci++) {
+        const contract_t *ct = &g.world.contracts[ci];
+        if (!ct->active) continue;
+        if (ct->action != CONTRACT_TRACTOR) continue;
+        if (here_idx < 0 || ct->station_index != here_idx) continue;
+        int held_int = 0;
+        if (ct->commodity < COMMODITY_RAW_ORE_COUNT) {
+            float held_ore = 0.0f;
+            const ship_t *ship = &LOCAL_PLAYER.ship;
+            for (int t = 0; t < ship->towed_count; t++) {
+                int fi = ship->towed_fragments[t];
+                if (fi < 0 || fi >= MAX_ASTEROIDS) continue;
+                const asteroid_t *a = &g.world.asteroids[fi];
+                if (!a->active || a->tier != ASTEROID_TIER_S) continue;
+                if (a->commodity != ct->commodity) continue;
+                held_ore += a->ore;
+            }
+            held_int = (int)lroundf(held_ore);
+        } else {
+            held_int = (int)lroundf(LOCAL_PLAYER.ship.cargo[ct->commodity]);
+        }
+        if (held_int <= 0) continue;
+        out_contracts[count]   = ci;
+        out_fulfillable[count] = true;
+        out_held[count]        = held_int;
+        count++;
+    }
+
+    /* Pass 2: fill any remaining slots with the nearest active
+     * contracts (any station) by squared distance from `here_pos`,
+     * skipping anything already in pass 1. */
+    if (count < 3) {
+        int nearest[3] = {-1, -1, -1};
+        float nearest_d[3] = {1e18f, 1e18f, 1e18f};
+        for (int ci = 0; ci < MAX_CONTRACTS; ci++) {
+            const contract_t *ct = &g.world.contracts[ci];
+            if (!ct->active) continue;
+            if (ct->station_index >= MAX_STATIONS) continue;
+            if (!station_exists(&g.world.stations[ct->station_index])) continue;
+            bool already = false;
+            for (int s = 0; s < count; s++)
+                if (out_contracts[s] == ci) { already = true; break; }
+            if (already) continue;
+            vec2 target = (ct->action == CONTRACT_TRACTOR)
+                ? g.world.stations[ct->station_index].pos : ct->target_pos;
+            float d = v2_dist_sq(here_pos, target);
+            for (int s = 0; s < 3; s++) {
+                if (d < nearest_d[s]) {
+                    for (int j = 2; j > s; j--) {
+                        nearest[j] = nearest[j-1];
+                        nearest_d[j] = nearest_d[j-1];
+                    }
+                    nearest[s] = ci;
+                    nearest_d[s] = d;
+                    break;
+                }
+            }
+        }
+        for (int s = 0; s < 3 && count < 3; s++) {
+            if (nearest[s] < 0) continue;
+            out_contracts[count]   = nearest[s];
+            out_fulfillable[count] = false;
+            out_held[count]        = 0;
+            count++;
+        }
+    }
+
+    return count;
+}
+
+/* ------------------------------------------------------------------ */
 /* Station UI state builder                                            */
 /* ------------------------------------------------------------------ */
 
@@ -617,8 +706,8 @@ static void draw_trade_view(const station_ui_state_t *ui,
     float row_h = compact ? 13.0f : 15.0f;
     float inner_right = cx + inner_w - 36.0f;
     float my = cy;
-    const uint8_t COL_BUY[3]   = { PAL_CONTRACT_AFFORD };
-    const uint8_t COL_SELL[3]  = { PAL_CONTRACT_READY };
+    const uint8_t COL_GAIN[3]  = { 130, 230, 150 };  /* + sell: green */
+    const uint8_t COL_COST[3]  = { 230, 110, 110 };  /* - buy:  red   */
     const uint8_t COL_DIM[3]   = { PAL_AFFORD_INACTIVE };
     const uint8_t COL_FADED[3] = { PAL_TEXT_FADED };
     const uint8_t COL_TEXT[3]  = { PAL_TEXT_SECONDARY };
@@ -736,21 +825,17 @@ static void draw_trade_view(const station_ui_state_t *ui,
         char key_buf[8];
         snprintf(key_buf, sizeof(key_buf), "[%d]", slot + 1);
 
-        const uint8_t *row_rgb  = (r->kind == 0)
-            ? (r->actionable ? COL_BUY : COL_DIM)
-            : (r->actionable ? COL_SELL : COL_DIM);
         const uint8_t *info_rgb = r->actionable ? COL_TEXT : COL_FADED;
 
         uint8_t ggr, ggg, ggb;
         mining_grade_rgb(r->grade, &ggr, &ggg, &ggb);
         uint8_t gr_rgb[3] = { ggr, ggg, ggb };
 
-        /* Commodity tint for the signed amount — ferrite amber, cuprite
-         * green, crystal violet, etc. Lets the eye scan the column by
-         * what's changing hands rather than by buy-vs-sell state. */
-        uint8_t cr_r, cr_g, cr_b;
-        commodity_color_u8(r->commodity, &cr_r, &cr_g, &cr_b);
-        uint8_t total_rgb[3] = { cr_r, cr_g, cr_b };
+        /* Sign-based row color: SELL (+ gain) reads green, BUY (- cost)
+         * reads red. Hotkey, verb, and signed amount all share it so the
+         * direction of cash flow is unambiguous at a glance. */
+        const uint8_t *total_rgb = (r->kind == 0) ? COL_COST : COL_GAIN;
+        const uint8_t *row_rgb   = r->actionable ? total_rgb : COL_DIM;
 
         const char *verb = (r->kind == 0) ? "buy" : "sell";
         char qty_buf[24], total_buf[32];
@@ -959,83 +1044,15 @@ static void draw_jobs_view(const station_ui_state_t *ui,
         my += row_h;
     }
 
-    /* Build slot listing (same logic as before: fulfillable here first,
-     * then nearest by distance). */
+    /* Build slot listing via the shared helper so the rows the player
+     * sees here are exactly the rows [1]/[2]/[3] selects from in
+     * input.c — no duplication, no drift. */
     int slots[3] = {-1, -1, -1};
-    int slot_count = 0;
     bool slot_fulfillable[3] = {false, false, false};
     int slot_held[3] = {0, 0, 0};
     int here_idx = LOCAL_PLAYER.current_station;
-
-    for (int ci = 0; ci < MAX_CONTRACTS && slot_count < 3; ci++) {
-        contract_t *ct = &g.world.contracts[ci];
-        if (!ct->active) continue;
-        if (ct->action != CONTRACT_TRACTOR) continue;
-        if (here_idx < 0 || ct->station_index != here_idx) continue;
-
-        /* Raw ore isn't in ship.cargo[] — it rides in towed_fragments.
-         * Sum the ore amount across towed fragments that match the
-         * commodity so ore contracts can show "ready" when the player
-         * actually has the material, not just "missing" forever. */
-        int held_int = 0;
-        if (ct->commodity < COMMODITY_RAW_ORE_COUNT) {
-            float held_ore = 0.0f;
-            const ship_t *ship = &LOCAL_PLAYER.ship;
-            for (int t = 0; t < ship->towed_count; t++) {
-                int fi = ship->towed_fragments[t];
-                if (fi < 0 || fi >= MAX_ASTEROIDS) continue;
-                const asteroid_t *a = &g.world.asteroids[fi];
-                if (!a->active || a->tier != ASTEROID_TIER_S) continue;
-                if (a->commodity != ct->commodity) continue;
-                held_ore += a->ore;
-            }
-            held_int = (int)lroundf(held_ore);
-        } else {
-            float held = LOCAL_PLAYER.ship.cargo[ct->commodity];
-            held_int = (int)lroundf(held);
-        }
-        if (held_int <= 0) continue;
-        slots[slot_count] = ci;
-        slot_fulfillable[slot_count] = true;
-        slot_held[slot_count] = held_int;
-        slot_count++;
-    }
-    if (slot_count < 3) {
-        int nearest[3] = {-1, -1, -1};
-        float nearest_d[3] = {1e18f, 1e18f, 1e18f};
-        vec2 here = ui->station->pos;
-        for (int ci = 0; ci < MAX_CONTRACTS; ci++) {
-            contract_t *ct = &g.world.contracts[ci];
-            if (!ct->active) continue;
-            if (ct->station_index >= MAX_STATIONS) continue;
-            if (!station_exists(&g.world.stations[ct->station_index])) continue;
-            bool already = false;
-            for (int s = 0; s < slot_count; s++)
-                if (slots[s] == ci) { already = true; break; }
-            if (already) continue;
-            vec2 target = (ct->action == CONTRACT_TRACTOR)
-                ? g.world.stations[ct->station_index].pos : ct->target_pos;
-            float d = v2_dist_sq(here, target);
-            for (int s = 0; s < 3; s++) {
-                if (d < nearest_d[s]) {
-                    for (int j = 2; j > s; j--) {
-                        nearest[j] = nearest[j-1];
-                        nearest_d[j] = nearest_d[j-1];
-                    }
-                    nearest[s] = ci;
-                    nearest_d[s] = d;
-                    break;
-                }
-            }
-        }
-        for (int s = 0; s < 3 && slot_count < 3; s++) {
-            if (nearest[s] < 0) continue;
-            slots[slot_count] = nearest[s];
-            slot_fulfillable[slot_count] = false;
-            slot_held[slot_count] = 0;
-            slot_count++;
-        }
-    }
+    int slot_count = build_work_slots(here_idx, ui->station->pos,
+                                      slots, slot_fulfillable, slot_held);
 
     if (slot_count == 0) {
         draw_row_lr(cx, my, inner_right, COL_DIM, "No active contracts.", NULL, NULL);

--- a/src/tests/test_bug_regression.c
+++ b/src/tests/test_bug_regression.c
@@ -63,7 +63,8 @@ TEST(test_bug9_repair_cost_consistent) {
     memset(&st, 0, sizeof(st));
     st.services = STATION_SERVICE_REPAIR;
     float cost = station_repair_cost(&ship, &st);
-    ASSERT_EQ_FLOAT(cost, 40.0f, 0.01f);
+    /* (max 100 - hull 80) * 5.0 cr/HP = 100 cr (#299 raised the rate). */
+    ASSERT_EQ_FLOAT(cost, 100.0f, 0.01f);
 }
 
 TEST(test_bug10_damage_event_has_amount) {

--- a/src/tests/test_econ_sim.c
+++ b/src/tests/test_econ_sim.c
@@ -127,8 +127,11 @@ TEST(test_econ_sim_credit_circulation) {
         + w.stations[1].credit_pool
         + w.stations[2].credit_pool;
     /* Total = all station pools + all player ledger balances.
-     * initial_pool_0 already reflects the 50cr seed deduction (player_init_ship ran). */
-    float initial_seed = 50.0f; /* from player_init_ship → ledger_earn at station 0 */
+     * initial_pool_0 already reflects the spawn fee being added to the
+     * pool by player_seed_credits — so the player's starting balance
+     * is the negative of that fee, and conservation is the sum of
+     * pools + the negative seed. */
+    float initial_seed = -(float)station_spawn_fee(&w.stations[0]);
     float initial_total = initial_seed + initial_pool_0 + initial_pool_1 + w.stations[2].credit_pool;
     printf("    total system credits: %.0f (started at %.0f)\n",
         total_credits, initial_total);
@@ -233,22 +236,24 @@ TEST(test_bug312_3_init_ship_does_not_seed_with_zero_token) {
     ASSERT_EQ_INT(w.stations[0].ledger_count, ledger_before);
     ASSERT_EQ_FLOAT(w.stations[0].credit_pool, pool_before, 0.001f);
 
-    /* Now set the real token and seed — credits should land on the
-     * real token, and no zero-token entry should exist. */
+    /* Now set the real token and seed — the spawn-fee debit should
+     * land on the real token, push it into debt, and no zero-token
+     * entry should exist. */
     uint8_t token[8] = {0x42,1,2,3,4,5,6,7};
     memcpy(w.players[0].session_token, token, 8);
     w.players[0].session_ready = true;
+    int fee = station_spawn_fee(&w.stations[0]);
     player_seed_credits(&w.players[0], &w);
 
-    ASSERT_EQ_FLOAT(ledger_balance(&w.stations[0], token), 50.0f, 0.001f);
+    ASSERT_EQ_FLOAT(ledger_balance(&w.stations[0], token), -(float)fee, 0.001f);
     uint8_t zero[8] = {0};
     ASSERT_EQ_FLOAT(ledger_balance(&w.stations[0], zero), 0.0f, 0.001f);
-    ASSERT_EQ_FLOAT(w.stations[0].credit_pool, pool_before - 50.0f, 0.001f);
+    ASSERT_EQ_FLOAT(w.stations[0].credit_pool, pool_before + (float)fee, 0.001f);
 
-    /* Double-seed is idempotent (guard against credit leak on reconnect). */
+    /* Re-seed is idempotent (guard against double-charge on reconnect). */
     player_seed_credits(&w.players[0], &w);
-    ASSERT_EQ_FLOAT(ledger_balance(&w.stations[0], token), 50.0f, 0.001f);
-    ASSERT_EQ_FLOAT(w.stations[0].credit_pool, pool_before - 50.0f, 0.001f);
+    ASSERT_EQ_FLOAT(ledger_balance(&w.stations[0], token), -(float)fee, 0.001f);
+    ASSERT_EQ_FLOAT(w.stations[0].credit_pool, pool_before + (float)fee, 0.001f);
 }
 
 TEST(test_econ_invariant_npc_only_conservation) {
@@ -354,10 +359,101 @@ TEST(test_econ_invariant_player_session_conservation) {
     #undef ASSERT_CONSERVED
 }
 
+/* Locks the contract that grade-aware sell pays a real bonus for high-
+ * grade ingots AND that the units the pricing walk priced are the
+ * units the manifest transfer actually moves. Compares two identical
+ * runs that differ only in one ingot's grade — the bonus is the
+ * delta, immune to dynamic-price scaling. */
+static float run_sell_with_grades(int g0, int g1, int g2,
+                                  int *out_common, int *out_rare,
+                                  float *out_ship_inventory_remaining) {
+    world_t *w = (world_t *)calloc(1, sizeof(world_t));
+    if (!w) return -1.0f;
+    world_reset(w);
+    /* Drain auto-spawned contracts so the fab-fallback branch handles
+     * the sell (deterministic price = station_buy_price, not contract). */
+    for (int k = 0; k < MAX_CONTRACTS; k++) w->contracts[k].active = false;
+    int kepler = -1;
+    for (int i = 0; i < MAX_STATIONS; i++) {
+        if (w->stations[i].id == 0) continue;
+        if (station_consumes(&w->stations[i], COMMODITY_FERRITE_INGOT)) { kepler = i; break; }
+    }
+    if (kepler < 0) { free(w); return -1.0f; }
+    station_t *st = &w->stations[kepler];
+    st->inventory[COMMODITY_FERRITE_INGOT] = 0.0f;
+
+    uint8_t token[8] = {7,7,7,7,7,7,7,7};
+    memcpy(w->players[0].session_token, token, 8);
+    w->players[0].session_ready = true;
+    player_init_ship(&w->players[0], w);
+    w->players[0].connected = true;
+    w->players[0].docked = true;
+    w->players[0].current_station = kepler;
+    w->players[0].ship.cargo[COMMODITY_FERRITE_INGOT] = 3.0f;
+    ship_manifest_bootstrap(&w->players[0].ship);
+    cargo_unit_t u; memset(&u, 0, sizeof(u));
+    u.commodity = COMMODITY_FERRITE_INGOT; u.kind = CARGO_KIND_INGOT;
+    u.grade = (uint8_t)g0; u.pub[0] = 1; manifest_push(&w->players[0].ship.manifest, &u);
+    u.grade = (uint8_t)g1; u.pub[0] = 2; manifest_push(&w->players[0].ship.manifest, &u);
+    u.grade = (uint8_t)g2; u.pub[0] = 3; manifest_push(&w->players[0].ship.manifest, &u);
+
+    float bal_before = ledger_balance(st, token);
+    w->players[0].input.service_sell = true;
+    world_sim_step(w, SIM_DT);
+    w->players[0].input.service_sell = false;
+    float earned = ledger_balance(st, token) - bal_before;
+
+    int common = 0, rare = 0;
+    for (uint16_t i = 0; i < st->manifest.count; i++) {
+        if (st->manifest.units[i].commodity != COMMODITY_FERRITE_INGOT) continue;
+        if (st->manifest.units[i].grade == MINING_GRADE_COMMON) common++;
+        if (st->manifest.units[i].grade == MINING_GRADE_RARE)   rare++;
+    }
+    if (out_common) *out_common = common;
+    if (out_rare)   *out_rare   = rare;
+    if (out_ship_inventory_remaining)
+        *out_ship_inventory_remaining = w->players[0].ship.cargo[COMMODITY_FERRITE_INGOT];
+    free(w);
+    return earned;
+}
+
+TEST(test_grade_aware_sell_pays_per_unit_grade) {
+    int common_a = 0, rare_a = 0, common_b = 0, rare_b = 0;
+    float remain_a = 0, remain_b = 0;
+
+    /* Run A: 3 commons. Run B: 2 commons + 1 rare in the middle. */
+    float earned_all_common = run_sell_with_grades(
+        MINING_GRADE_COMMON, MINING_GRADE_COMMON, MINING_GRADE_COMMON,
+        &common_a, &rare_a, &remain_a);
+    float earned_with_rare = run_sell_with_grades(
+        MINING_GRADE_COMMON, MINING_GRADE_RARE, MINING_GRADE_COMMON,
+        &common_b, &rare_b, &remain_b);
+
+    /* Both runs delivered all 3 units to station manifest with grades
+     * preserved. Proves the transfer walked the same units the pricing
+     * walk priced — if it had reordered, station_rare would land in
+     * the wrong slot or stay 0. */
+    ASSERT_EQ_FLOAT(remain_a, 0.0f, 0.001f);
+    ASSERT_EQ_FLOAT(remain_b, 0.0f, 0.001f);
+    ASSERT_EQ_INT(common_a, 3);
+    ASSERT_EQ_INT(rare_a,   0);
+    ASSERT_EQ_INT(common_b, 2);
+    ASSERT_EQ_INT(rare_b,   1);
+
+    /* Run B = run A + (rare_mult - 1.0) * base on the rare unit. With
+     * rare_mult = 2.0, the bonus equals one common's pay — earned_b
+     * must be ~4/3 of earned_a (within 5% to absorb price-curve noise
+     * from the extra inventory unit on the second run). */
+    ASSERT(earned_with_rare > earned_all_common + 0.5f);
+    float ratio = earned_with_rare / earned_all_common;
+    ASSERT(ratio > 1.25f && ratio < 1.45f);
+}
+
 void register_econ_sim_sim_tests(void) {
     TEST_SECTION("\nEconomy simulations:\n");
     RUN(test_econ_sim_npc_only_5min);
     RUN(test_econ_sim_credit_circulation);
+    RUN(test_grade_aware_sell_pays_per_unit_grade);
 }
 
 void register_econ_sim_bug312_tests(void) {

--- a/src/tests/test_save.c
+++ b/src/tests/test_save.c
@@ -451,7 +451,8 @@ TEST(test_world_save_load_preserves_smelted_ingots) {
 /* v23: station credit pool added (#312) — +4 bytes per station (8×4=32). */
 /* v29: +2 bytes per station (uint16 manifest count) = +128 bytes for all
  * MAX_STATIONS=64 slots. Empty stations carry only the count; no units. */
-#define EXPECTED_SAVE_SIZE 268756 /* v29: #339 slice A manifest count header */
+/* v30: +1 byte per contract (required_grade) = +24 for MAX_CONTRACTS=24. */
+#define EXPECTED_SAVE_SIZE 268780 /* v30: contract.required_grade persisted */
 
 TEST(test_save_file_size_stable) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
@@ -488,7 +489,7 @@ TEST(test_save_header_golden_bytes) {
     ASSERT_EQ_INT((int)fread(&spawn_timer, 4, 1, f), 1);
     fclose(f);
     ASSERT_EQ_INT((int)magic, (int)0x5349474E);    /* "SIGN" */
-    ASSERT_EQ_INT((int)version, 29);
+    ASSERT_EQ_INT((int)version, 30);
     ASSERT(rng != 0);  /* seed is set */
     ASSERT_EQ_FLOAT(time_val, 0.0f, 0.001f);
     ASSERT_EQ_FLOAT(spawn_timer, 0.0f, 0.001f);

--- a/src/tests/test_world_sim.c
+++ b/src/tests/test_world_sim.c
@@ -667,10 +667,15 @@ TEST(test_scenario_two_players_mining) {
     ASSERT(w.asteroids[ast0].hp < hp0_before);
     ASSERT(w.asteroids[ast1].hp < hp1_before);
 
-    /* No state bleed: player 0's cargo didn't affect player 1 */
-    /* Verify credits are independent (both start at 50 from player_init_ship in station 0 ledger) */
-    ASSERT_EQ_FLOAT(ledger_balance(&w.stations[0], w.players[0].session_token), 50.0f, 0.01f);
-    ASSERT_EQ_FLOAT(ledger_balance(&w.stations[0], w.players[1].session_token), 50.0f, 0.01f);
+    /* No state bleed: player 0's cargo didn't affect player 1.
+     * Both spawned with the same spawn-fee debit at station 0, so
+     * their balances should be the same negative number regardless of
+     * what either of them mined. */
+    float p0 = ledger_balance(&w.stations[0], w.players[0].session_token);
+    float p1 = ledger_balance(&w.stations[0], w.players[1].session_token);
+    int fee = station_spawn_fee(&w.stations[0]);
+    ASSERT_EQ_FLOAT(p0, -(float)fee, 0.01f);
+    ASSERT_EQ_FLOAT(p1, -(float)fee, 0.01f);
 }
 
 TEST(test_scenario_npc_economy_30_seconds) {

--- a/src/world_draw.c
+++ b/src/world_draw.c
@@ -1574,11 +1574,50 @@ static bool resolve_tracked_contract_target(vec2 *out_pos, float *out_radius) {
                 }
             }
         } else if (ct->station_index < MAX_STATIONS) {
-            /* Carrying the fragment — aim at the furnace (station pos). */
-            radius = g.world.stations[ct->station_index].radius + 260.0f;
+            /* Carrying the fragment — aim at the matching furnace module's
+             * actual world position, not the station center. The furnace
+             * is what eats the ore; the player needs to fly that ring. */
+            const station_t *st = &g.world.stations[ct->station_index];
+            module_type_t want = (ct->commodity == COMMODITY_FERRITE_ORE) ? MODULE_FURNACE
+                              : (ct->commodity == COMMODITY_CUPRITE_ORE) ? MODULE_FURNACE_CU
+                              : (ct->commodity == COMMODITY_CRYSTAL_ORE) ? MODULE_FURNACE_CR
+                              : (module_type_t)-1;
+            bool found_mod = false;
+            for (int m = 0; m < st->module_count; m++) {
+                if (st->modules[m].scaffold) continue;
+                if (st->modules[m].type != want) continue;
+                target = module_world_pos_ring(st, st->modules[m].ring, st->modules[m].slot);
+                radius = 22.0f;  /* tight ring around the furnace body */
+                found_mod = true;
+                break;
+            }
+            if (!found_mod) {
+                /* Fallback: ring the station body itself. */
+                target = st->pos;
+                radius = st->radius + 20.0f;
+            }
         }
     } else if (ct->action == CONTRACT_FRACTURE) {
-        radius = 180.0f;
+        /* Ring the nearest non-S rock of the contract's commodity rather
+         * than ct->target_pos (often a stale station coord). Distance
+         * only — any crackable rock will do. */
+        const ship_t *ship = &LOCAL_PLAYER.ship;
+        float best_d = 1e18f;
+        int best_i = -1;
+        for (int i = 0; i < MAX_ASTEROIDS; i++) {
+            const asteroid_t *a = &g.world.asteroids[i];
+            if (!a->active) continue;
+            if (a->tier == ASTEROID_TIER_S) continue;  /* already cracked */
+            if (a->commodity != ct->commodity) continue;
+            float d = v2_dist_sq(a->pos, ship->pos);
+            if (d < best_d) { best_d = d; best_i = i; }
+        }
+        if (best_i >= 0) {
+            target = g.world.asteroids[best_i].pos;
+            radius = g.world.asteroids[best_i].radius + 32.0f;
+        } else {
+            return false;  /* nothing to fracture */
+        }
     }
 
     *out_pos = target;
@@ -1596,9 +1635,7 @@ void draw_tracked_contract_highlight(void) {
     float t = g.world.time;
     float pulse = 0.5f + 0.5f * sinf(t * 2.4f);
     float r = radius * (1.0f + 0.06f * pulse);
-    /* Double-ring: bright outer, softer inner. */
-    draw_circle_outline(target, r,         40, 1.0f, 0.87f, 0.20f, 0.75f + 0.20f * pulse);
-    draw_circle_outline(target, r + 6.0f,  40, 1.0f, 0.87f, 0.20f, 0.25f);
+    draw_circle_outline(target, r, 40, 1.0f, 0.87f, 0.20f, 0.75f + 0.20f * pulse);
 }
 
 void draw_compass_ring(void) {

--- a/web/shell.html
+++ b/web/shell.html
@@ -100,6 +100,21 @@
           console.error(text);
         }
       };
+
+      /* Default SIGNAL_SERVER to the local docker websocket when this
+       * page is served from a localhost / private-LAN host. Without
+       * this, opening http://localhost:8080/signal.html stays in
+       * singleplayer and the docker signal_server on :9091 is unused —
+       * which means no global highscore broadcast reaches the client.
+       * Production sets window.SIGNAL_SERVER explicitly before this
+       * script runs, so this default never fires there. */
+      if (!window.SIGNAL_SERVER) {
+        var h = window.location.hostname;
+        var isLocal = (h === 'localhost' || h === '127.0.0.1' || h === '0.0.0.0'
+                    || /^192\.168\./.test(h) || /^10\./.test(h)
+                    || /^172\.(1[6-9]|2[0-9]|3[01])\./.test(h));
+        if (isLocal) window.SIGNAL_SERVER = 'ws://' + h + ':9091/ws';
+      }
     </script>
     {{{ SCRIPT }}}
   </body>


### PR DESCRIPTION
Two commits — full session of economy + UX rework.

## Summary

- **Economy direction shift.** Players spawn at -50 / -100 / -300 cr (by station ring count). Repair is unrefusable and runs the ledger into debt. Repair rate bumped 2.0 → 5.0 cr/HP (#299).
- **Global highscore on death** (server-side leaderboard, broadcast on every death + new-joiner sync, render block in the death cinematic).
- **Grade-aware buy + sell** end-to-end (price scales with grade multiplier; exact-grade buys refuse if no matching unit exists; sells walk the ship manifest in FIFO and add per-unit grade premium to payout). New regression test locks pricing-walk vs transfer alignment.
- **Smelt always completes** — removed the M5 backpressure that stuck rocks on the furnace beam when output bins filled (Prospect with no local ferrite consumer was the worst offender).
- **Foundation ritual** — only ` MODULE_SIGNAL_RELAY` scaffolds can found a new outpost. The towed relay BECOMES the station core; activate_outpost() promotes it instead of double-stamping. Non-relay scaffolds still snap to existing outposts but emit ORDER_REJECTED for frontier placement.
- **Tracked-contract highlight** is now single-source: nearest non-S rock for FRACTURE, matching furnace module for carrying-TRACTOR. Removed the legacy duplicate that ringed the whole station.
- **TRADE +/- coloring**: SELL totals green, BUY totals red, hotkey + verb match.
- **WORK currency labels**: re-stamps default station names after catalog load (catalog format doesn't persist currency_name yet).
- **HUD copy sweep** (#333): replaced opaque shorthand with sentence-case clarity.
- **WORK row/input parity** (#308): extracted ` build_work_slots()` so [1]/[2]/[3] always picks the row the player sees.
- **Local docker dev** is now self-contained (auto-connects to ws://localhost:9091/ws via shell.html default; native server stage builds with BUILD_SERVER_ONLY; runtime pinned to linux/amd64; entrypoint poll loop instead of bash-only ` wait -n`; setvbuf so logs flow live).

## Test plan

- [x] `make test` — 294/294 passing
- [ ] Hard-reload http://localhost:8080/signal.html
- [ ] Verify spawn balance shows negative (-50 / -100 / -300 by station)
- [ ] Buy a fine ingot → ship gets fine ingot in manifest
- [ ] Sell graded ingots → payout reflects grade multiplier
- [ ] Tow a frame-press scaffold to open space → [E] emits ORDER_REJECTED
- [ ] Tow a signal-relay scaffold to fringe → [E] founds an outpost; activate doesn't double-stamp the relay
- [ ] Die → death cinematic shows TOP RUNS leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)