### PR TITLE
ci: move test-asan to post-deploy on main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,9 +29,15 @@ jobs:
           ulimit -s 16384
           ./build-test/signal_test
 
-  # ASan: parallel with basic tests.
+  # ASan: post-deploy verification on main only. Same logic as
+  # test-valgrind — runs ~7-10 min and was the longest pole on PR
+  # turnaround. test-basic + native (linux/macos/windows) catch the
+  # vast majority of regressions on the PR loop in <5 min; asan
+  # backstops them on main after deploy lands.
   test-asan:
     runs-on: ubuntu-latest
+    needs: deploy
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - name: Build and run tests with AddressSanitizer
@@ -300,7 +306,7 @@ jobs:
   # Deploy GATES ON ALL TESTS passing + both builds.
   deploy:
     runs-on: ubuntu-latest
-    needs: [test-basic, test-asan, test-crap, build-client, build-server]
+    needs: [test-basic, test-crap, build-client, build-server]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Same as the test-valgrind change in #347. AddressSanitizer takes ~7-10 min and was the longest pole on PR turnaround. Move it to post-deploy verification on main only; drop it from deploy's needs list since deploy can no longer wait for it.