### PR TITLE
Make manifest the source of truth for finished goods

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -2318,6 +2318,11 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
     /* Buy ingots from station inventory */
     if (intent->buy_product && !w->player_only_mode) {
         commodity_t c = intent->buy_commodity;
+        SIM_LOG("[buy] player %d req c=%d grade=%d at station %d (produces=%d)\n",
+                sp->id, (int)c, (int)intent->buy_grade,
+                sp->current_station,
+                (c >= COMMODITY_RAW_ORE_COUNT && c < COMMODITY_COUNT) ?
+                    station_produces(docked_st, c) : -1);
         if (c >= COMMODITY_RAW_ORE_COUNT && c < COMMODITY_COUNT
             && station_produces(docked_st, c)) {
             /* Exact-grade buys must refuse if the station has nothing
@@ -2332,6 +2337,8 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
                 && intent->buy_grade > MINING_GRADE_COMMON) {
                 if (manifest_find_first_cg(&docked_st->manifest, c,
                                            (mining_grade_t)intent->buy_grade) < 0) {
+                    SIM_LOG("[buy] REJECT: no manifest unit at c=%d grade=%d\n",
+                            (int)c, (int)intent->buy_grade);
                     return;
                 }
             }
@@ -2351,23 +2358,30 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
             float afford = (price_per > 0.01f) ? floorf(bal / price_per) : 0.0f;
             float amount = fminf(fminf(available, space), afford);
             float total_cost = amount * price_per;
+            SIM_LOG("[buy] avail=%.2f space=%.2f price/u=%.2f bal=%.2f afford=%.0f amount=%.2f\n",
+                    available, space, price_per, bal, afford, amount);
             if (amount > 0.01f && ledger_spend(docked_st, sp->session_token, total_cost, &sp->ship)) {
                 sp->ship.cargo[c] += amount;
                 docked_st->inventory[c] -= amount;
-                /* Manifest-first: transfer matching cargo_unit_t entries
-                 * (preferred grade first, FIFO fallback) so provenance and
-                 * grade follow the purchase into the ship's hold. Mirrors
-                 * the nearby-station hail-buy path. */
                 int whole = (int)floorf(amount + 0.0001f);
+                int moved = 0;
                 if (whole > 0) {
-                    int moved = manifest_transfer_by_commodity_ex(
+                    moved = manifest_transfer_by_commodity_ex(
                         &docked_st->manifest, &sp->ship.manifest,
                         c, intent->buy_grade, whole);
                     if (moved > 0) manifest_mark_station_dirty(w, &docked_st->manifest);
                 }
-                SIM_LOG("[sim] player %d bought %.0f of commodity %d for %.0f cr\n",
-                        sp->id, amount, c, total_cost);
+                SIM_LOG("[buy] OK player %d bought %.0f of c=%d for %.0f cr (manifest moved=%d)\n",
+                        sp->id, amount, c, total_cost, moved);
+            } else if (amount > 0.01f) {
+                SIM_LOG("[buy] REJECT: ledger_spend failed (bal=%.2f cost=%.2f)\n",
+                        bal, total_cost);
+            } else {
+                SIM_LOG("[buy] REJECT: amount=%.2f too small (avail=%.2f space=%.2f afford=%.0f)\n",
+                        amount, available, space, afford);
             }
+        } else {
+            SIM_LOG("[buy] REJECT: c=%d out of range or station doesn't produce\n", (int)c);
         }
     }
 }

--- a/server/main.c
+++ b/server/main.c
@@ -1198,6 +1198,20 @@ int main(void) {
                     world.stations[i].credit_pool = 10000.0f;
             }
         }
+        /* Backfill manifest entries for the seeded float inventory.
+         * world_reset leaves manifests pristine (tests rely on this);
+         * the server-only load path adds the synthetic legacy units so
+         * the TRADE picker — which now reads from manifest only — has
+         * something to surface for fresh stations. */
+        for (int i = 0; i < MAX_STATIONS; i++) {
+            if (!station_exists(&world.stations[i])) continue;
+            uint8_t origin[8] = { 'S','E','E','D','0','0','0','0' };
+            origin[7] = (uint8_t)('0' + (i % 10));
+            manifest_migrate_legacy_inventory(&world.stations[i].manifest,
+                                              world.stations[i].inventory,
+                                              COMMODITY_COUNT, origin);
+            world.stations[i].named_ingots_dirty = true;
+        }
     }
 
     /* Assign stable IDs to any stations loaded from v1 catalogs (id == 0) */

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -8,8 +8,47 @@
 #include "sim_nav.h"
 #include "sim_flight.h"
 #include "signal_model.h"
+#include "manifest.h"
 #include <math.h>
 #include <string.h>
+
+/* Remove up to `n` cargo units of `c` from a station's manifest.
+ * Returns the number actually removed. Walks backward so removing
+ * doesn't disturb earlier indices. Used by NPC haulers so the
+ * manifest stays in lockstep with the inventory float; otherwise the
+ * trade picker (manifest-only) shows phantom rows for stock the
+ * hauler already carried away. */
+static int station_manifest_drain_commodity(station_t *st, commodity_t c, int n) {
+    if (!st || !st->manifest.units || n <= 0) return 0;
+    int removed = 0;
+    for (int16_t i = (int16_t)st->manifest.count - 1; i >= 0 && removed < n; i--) {
+        if (st->manifest.units[i].commodity == (uint8_t)c) {
+            if (manifest_remove(&st->manifest, (uint16_t)i, NULL)) removed++;
+        }
+    }
+    return removed;
+}
+
+/* Inverse: push `n` synthetic legacy-migrate units of `c` into a
+ * station's manifest. Used at NPC unload until haulers get their own
+ * manifest_t. The origin is per-hauler so the units are traceable to
+ * "delivered by NPC slot K". */
+static int station_manifest_seed_from_npc(station_t *st, commodity_t c, int n,
+                                          int npc_slot) {
+    if (!st || n <= 0) return 0;
+    if (st->manifest.cap == 0 && !station_manifest_bootstrap(st)) return 0;
+    uint8_t origin[8] = { 'N','P','C','D','0','0','0','0' };
+    origin[7] = (uint8_t)('0' + (npc_slot % 10));
+    int pushed = 0;
+    for (int i = 0; i < n; i++) {
+        if (st->manifest.count >= st->manifest.cap) break;
+        cargo_unit_t unit = {0};
+        if (!hash_legacy_migrate_unit(origin, c, (uint16_t)i, &unit)) continue;
+        if (!manifest_push(&st->manifest, &unit)) break;
+        pushed++;
+    }
+    return pushed;
+}
 
 /* ================================================================== */
 /* NPC ships                                                          */
@@ -361,6 +400,11 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                 if (take > 0.5f) {
                     npc->cargo[ingot] += take;
                     home->inventory[ingot] -= take;
+                    int whole = (int)floorf(take + 0.0001f);
+                    if (whole > 0) {
+                        if (station_manifest_drain_commodity(home, ingot, whole) > 0)
+                            home->named_ingots_dirty = true;
+                    }
                 }
             } else {
                 /* Fallback: original round-trip behavior (leave reserve for players) */
@@ -403,6 +447,11 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                     if (take > 0.5f) {
                         npc->cargo[best_ingot] += take;
                         home->inventory[best_ingot] -= take;
+                        int whole = (int)floorf(take + 0.0001f);
+                        if (whole > 0) {
+                            if (station_manifest_drain_commodity(home, best_ingot, whole) > 0)
+                                home->named_ingots_dirty = true;
+                        }
                     }
                 }
             }
@@ -453,9 +502,22 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
         if (npc->state_timer <= 0.0f) {
             station_t *dest = &w->stations[npc->dest_station];
             for (int i = COMMODITY_RAW_ORE_COUNT; i < COMMODITY_COUNT; i++) {
+                if (npc->cargo[i] <= 0.0f) continue;
+                float before = dest->inventory[i];
                 dest->inventory[i] += npc->cargo[i];
                 if (dest->inventory[i] > MAX_PRODUCT_STOCK)
                     dest->inventory[i] = MAX_PRODUCT_STOCK;
+                /* Mirror the float bump into the manifest so the trade
+                 * picker (manifest-only) sees the new stock. Use the
+                 * post-clamp delta so overflow doesn't create phantom
+                 * manifest entries. */
+                int int_delta = (int)floorf(dest->inventory[i] + 0.0001f)
+                              - (int)floorf(before + 0.0001f);
+                if (int_delta > 0) {
+                    if (station_manifest_seed_from_npc(dest, (commodity_t)i,
+                                                       int_delta, n) > 0)
+                        dest->named_ingots_dirty = true;
+                }
                 npc->cargo[i] = 0.0f;
             }
             /* Hauler also delivers ingots to scaffold station and modules */

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -402,6 +402,22 @@ void step_furnace_smelting(world_t *w, float dt) {
                                || (st->modules[m].type == MODULE_FURNACE_CR);
                 if (!is_furnace) continue;
 
+                /* Output cap: refuse to engage the beam if the station's
+                 * ingot stockpile is already full. Without this, smelts
+                 * silently overflow (the inventory float clamps at
+                 * MAX_PRODUCT_STOCK and the manifest entry vanishes —
+                 * including the rare-grade identity the player worked
+                 * for). Skipping the beam keeps the fragment free; the
+                 * player gets visible feedback that this station can't
+                 * accept it (no tractor pull, no smelt) and can route
+                 * to a station with room. */
+                commodity_t furnace_ore = furnace_ore_type(st->modules[m].type);
+                if ((int)furnace_ore >= 0 && a->commodity == furnace_ore) {
+                    commodity_t furnace_ingot = commodity_refined_form(furnace_ore);
+                    if (st->inventory[furnace_ingot] + a->ore > MAX_PRODUCT_STOCK)
+                        continue;  /* hopper full — skip this furnace */
+                }
+
                 int ring = st->modules[m].ring;
                 vec2 furnace_pos = module_world_pos_ring(st, ring, st->modules[m].slot);
 
@@ -616,6 +632,10 @@ void step_furnace_smelting(world_t *w, float dt) {
              * an integer boundary — skips a sha256 per tick on partial
              * smelts. */
             {
+                /* The furnace beam-engagement check (above) guarantees
+                 * stock_before + a->ore <= MAX_PRODUCT_STOCK, so the
+                 * post-clamp delta = pre-clamp delta. No more silent
+                 * overflow → no more "unknown origin" rows. */
                 int units_before = (int)floorf(stock_before + 0.0001f);
                 int units_after = (int)floorf(st->inventory[output] + 0.0001f);
                 int manifest_units = units_after - units_before;
@@ -625,13 +645,19 @@ void step_furnace_smelting(world_t *w, float dt) {
                     if (have_named_unit)
                         prefix = mining_pubkey_class(named_unit.pub);
                 }
+                int pushed = 0;
                 for (int idx = 0; idx < manifest_units; idx++) {
                     cargo_unit_t unit = {0};
                     if (!hash_ingot(output, grade, a->fragment_pub, (uint16_t)idx, &unit))
                         continue;
                     if (!station_manifest_push_ingot(st, &unit))
                         break;
+                    pushed++;
                 }
+                (void)pushed;
+                SIM_LOG("[smelt] station %d %s grade=%d ore=%.2f units=%d pushed=%d\n",
+                        smelt_station, commodity_short_name(output),
+                        (int)grade, a->ore, manifest_units, pushed);
             }
 
             /* RATi v2 compatibility: mirror the first hashed ingot into

--- a/src/input.c
+++ b/src/input.c
@@ -463,19 +463,17 @@ input_intent_t sample_input_intent(void) {
             commodity_t row_c = 0;
             mining_grade_t row_g = MINING_GRADE_COMMON;
 
-            /* BUY rows — mirror draw_trade_view: every (commodity,
-             * grade) with > 0 manifest units, then an "unknown origin"
-             * row for inventory float that exceeds the manifest total.
-             * Unknown rows set row_g = MINING_GRADE_COUNT (sentinel)
-             * so the server uses any-grade FIFO and base price. */
+            /* BUY rows — one per (commodity, grade) with > 0 manifest
+             * units. The manifest is now authoritative: the furnace beam
+             * refuses to engage a fragment when the station's hopper is
+             * full, so manifest count == inventory float. There is no
+             * "unknown origin" path. */
             if ((int)sell_c >= 0 && st->base_price[sell_c] > FLOAT_EPSILON) {
                 int station_idx = (int)(st - g.world.stations);
-                int manifest_total = 0;
                 if (station_idx >= 0 && station_idx < MAX_STATIONS) {
                     for (int gi = 0; gi < MINING_GRADE_COUNT; gi++) {
                         int stock = (int)g.station_manifest_summary[station_idx][sell_c][gi];
                         if (stock <= 0) continue;
-                        manifest_total += stock;
                         if (global_idx == target) {
                             row_kind = 0; row_c = sell_c; row_g = (mining_grade_t)gi;
                             goto row_resolved;
@@ -483,39 +481,18 @@ input_intent_t sample_input_intent(void) {
                         global_idx++;
                     }
                 }
-                int unknown = (int)lroundf(st->inventory[sell_c]) - manifest_total;
-                if (unknown > 0) {
-                    if (global_idx == target) {
-                        row_kind = 0; row_c = sell_c; row_g = MINING_GRADE_COUNT;
-                        goto row_resolved;
-                    }
-                    global_idx++;
-                }
             }
-            /* SELL rows — manifest groupings on the ship, then an
-             * unknown row when ship.cargo[c] > manifest count. */
-            if ((int)buy_c >= 0) {
-                int manifest_total = 0;
-                if (ship->manifest.units) {
-                    for (int gi = 0; gi < MINING_GRADE_COUNT; gi++) {
-                        int cnt = 0;
-                        for (uint16_t u = 0; u < ship->manifest.count; u++) {
-                            const cargo_unit_t *cu = &ship->manifest.units[u];
-                            if (cu->commodity == (uint8_t)buy_c && cu->grade == (uint8_t)gi) cnt++;
-                        }
-                        if (cnt <= 0) continue;
-                        manifest_total += cnt;
-                        if (global_idx == target) {
-                            row_kind = 1; row_c = buy_c; row_g = (mining_grade_t)gi;
-                            goto row_resolved;
-                        }
-                        global_idx++;
+            /* SELL rows — same manifest-only pattern on the ship side. */
+            if ((int)buy_c >= 0 && ship->manifest.units) {
+                for (int gi = 0; gi < MINING_GRADE_COUNT; gi++) {
+                    int cnt = 0;
+                    for (uint16_t u = 0; u < ship->manifest.count; u++) {
+                        const cargo_unit_t *cu = &ship->manifest.units[u];
+                        if (cu->commodity == (uint8_t)buy_c && cu->grade == (uint8_t)gi) cnt++;
                     }
-                }
-                int unknown = (int)lroundf(ship_cargo_amount(ship, buy_c)) - manifest_total;
-                if (unknown > 0) {
+                    if (cnt <= 0) continue;
                     if (global_idx == target) {
-                        row_kind = 1; row_c = buy_c; row_g = MINING_GRADE_COUNT;
+                        row_kind = 1; row_c = buy_c; row_g = (mining_grade_t)gi;
                         goto row_resolved;
                     }
                     global_idx++;
@@ -547,10 +524,8 @@ input_intent_t sample_input_intent(void) {
                                 break;
                             }
                     }
-                    const char *gl = (row_g >= MINING_GRADE_COUNT)
-                        ? "unknown" : mining_grade_label(row_g);
                     set_notice("-$%d  %s %s",
-                               (int)lroundf(price), gl,
+                               (int)lroundf(price), mining_grade_label(row_g),
                                commodity_short_name(row_c));
                 }
             } else if (row_kind == 1) {
@@ -558,10 +533,8 @@ input_intent_t sample_input_intent(void) {
                  * sell path. Grade-precise server-side sell is a follow-up. */
                 intent.service_sell = true;
                 intent.service_sell_only = row_c;
-                const char *gl = (row_g >= MINING_GRADE_COUNT)
-                    ? "unknown" : mining_grade_label(row_g);
-                set_notice("Selling %s %s...", gl,
-                           commodity_short_name(row_c));
+                set_notice("Selling %s %s...",
+                           mining_grade_label(row_g), commodity_short_name(row_c));
             }
         }
     }

--- a/src/station_ui.c
+++ b/src/station_ui.c
@@ -712,22 +712,20 @@ static void draw_trade_view(const station_ui_state_t *ui,
     float space   = ship_cargo_capacity(ship) - ship_total_cargo(ship);
     float credits = player_current_balance();
 
-    /* BUY rows — manifest-first per (commodity, grade), then an
-     * "unknown origin" row covering inventory float that exceeds the
-     * manifest total (legacy-seeded stock or pre-manifest deliveries
-     * with no provenance). is_float_fallback marks the unknown row so
-     * the renderer shows "unknown" instead of a grade label. */
+    /* BUY rows — one per (commodity, grade) with > 0 manifest units.
+     * The manifest is now authoritative on both sides: smelt refuses
+     * to engage when the station hopper is full, so manifest count ==
+     * inventory float for every commodity in active circulation. The
+     * "unknown origin" path is gone. */
     for (int ci = 0; ci < 1 && row_count < TRADE_MAX_ROWS; ci++) {
         commodity_t c = sell_c_list[ci];
         if ((int)c < 0) continue;
         float price_base = station_sell_price(st, c);
         if (price_base <= FLOAT_EPSILON) continue;
 
-        int manifest_total = 0;
         for (int gi = 0; gi < MINING_GRADE_COUNT && row_count < TRADE_MAX_ROWS; gi++) {
             int stock = station_manifest_count_cg(st, c, (mining_grade_t)gi);
             if (stock <= 0) continue;
-            manifest_total += stock;
             int price = (int)lroundf(price_base
                     * mining_payout_multiplier((mining_grade_t)gi));
             bool can = (space >= 0.5f) && (credits >= (float)price);
@@ -737,48 +735,23 @@ static void draw_trade_view(const station_ui_state_t *ui,
                 .actionable = can, .is_float_fallback = false,
             };
         }
-        int inv_total = (int)lroundf(station_inventory_amount(st, c));
-        int unknown = inv_total - manifest_total;
-        if (unknown > 0 && row_count < TRADE_MAX_ROWS) {
-            int price = (int)lroundf(price_base);
-            bool can = (space >= 0.5f) && (credits >= (float)price);
-            rows[row_count++] = (trade_row_t){
-                .kind = 0, .commodity = c, .grade = MINING_GRADE_COMMON,
-                .stock = unknown, .unit_price = price,
-                .actionable = can, .is_float_fallback = true,
-            };
-        }
     }
 
-    /* SELL rows — same manifest-first + unknown-row pattern on the
-     * ship side, so legacy stock the player picked up before manifest
-     * tracking is explicitly visible (and sells at base price). */
+    /* SELL rows — same manifest-only pattern on the ship side. */
     for (int ci = 0; ci < 1 && row_count < TRADE_MAX_ROWS; ci++) {
         commodity_t c = buy_c_list[ci];
         if ((int)c < 0) continue;
         float price_base = station_buy_price(st, c);
 
-        int manifest_total = 0;
         for (int gi = 0; gi < MINING_GRADE_COUNT && row_count < TRADE_MAX_ROWS; gi++) {
             int held = ship_manifest_count_cg(ship, c, (mining_grade_t)gi);
             if (held <= 0) continue;
-            manifest_total += held;
             int price = (int)lroundf(price_base
                     * mining_payout_multiplier((mining_grade_t)gi));
             rows[row_count++] = (trade_row_t){
                 .kind = 1, .commodity = c, .grade = (mining_grade_t)gi,
                 .stock = held, .unit_price = price,
                 .actionable = (held > 0), .is_float_fallback = false,
-            };
-        }
-        int hold_total = (int)lroundf(ship_cargo_amount(ship, c));
-        int unknown = hold_total - manifest_total;
-        if (unknown > 0 && row_count < TRADE_MAX_ROWS) {
-            int price = (int)lroundf(price_base);
-            rows[row_count++] = (trade_row_t){
-                .kind = 1, .commodity = c, .grade = MINING_GRADE_COMMON,
-                .stock = unknown, .unit_price = price,
-                .actionable = true, .is_float_fallback = true,
             };
         }
     }
@@ -818,15 +791,14 @@ static void draw_trade_view(const station_ui_state_t *ui,
 
         const uint8_t *info_rgb = r->actionable ? COL_TEXT : COL_FADED;
 
-        /* Grade label / tint. Unknown-origin rows (legacy float stock
-         * with no manifest entry) render "unknown" in faded text
-         * instead of a grade name so the player sees the provenance gap. */
+        /* Grade label / tint. Unknown-origin rows are no longer
+         * generated — manifest is authoritative — so this just maps
+         * grade → tinted name. */
         uint8_t ggr, ggg, ggb;
         mining_grade_rgb(r->grade, &ggr, &ggg, &ggb);
         uint8_t gr_rgb[3] = { ggr, ggg, ggb };
-        const char *grade_label = r->is_float_fallback
-            ? "unknown" : mining_grade_label(r->grade);
-        const uint8_t *grade_rgb_ptr = r->is_float_fallback ? COL_FADED : gr_rgb;
+        const char *grade_label = mining_grade_label(r->grade);
+        const uint8_t *grade_rgb_ptr = gr_rgb;
 
         /* Sign-based row color: SELL (+ gain) reads green, BUY (- cost)
          * reads red. Hotkey, verb, and signed amount all share it so the


### PR DESCRIPTION
Cohesive cleanup of every place float inventory and manifest could drift apart.

## Core changes
- **Furnace beam refuses to engage on full hopper** (sim_production.c). Eliminates the silent overflow that vaporized rare-grade ingots. Fragment stays free; player routes elsewhere.
- **NPC haulers consume + emit manifest entries** mirroring their float bumps (sim_ai.c). Pickup no longer leaves phantom rows; unload no longer hides actual stock. Band-aid until ship unification ships.
- **Server-side seed-manifest backfill** (main.c). Fresh stations now have the seeded float represented as manifest units so the manifest-only TRADE picker has rows to surface.
- **\"unknown origin\" code path deleted** (input.c, station_ui.c). With manifest as source of truth, that row category cannot exist.

## Test plan
- [x] make test (319/319 pass)
- [ ] CI green on the gates
- [ ] Smoke test in browser: dock at Kepler with frames in hold → SELL row appears with grade; buy frames → row vanishes when stock zeros; mine + smelt fragments at Prospect with full hopper → fragment stays free instead of vanishing