### PR TITLE
Manifest correctness on consume paths + selective filter

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -402,6 +402,11 @@ static void step_scaffold_delivery(world_t *w, server_player_t *sp) {
     float accepted = fminf(deliver, needed);
     sp->ship.cargo[COMMODITY_FRAME] -= accepted;
     st->scaffold_progress += accepted / SCAFFOLD_MATERIAL_NEEDED;
+    /* Consume the matching manifest units so the named identity can't
+     * be sold or transferred again from the same hold. */
+    int whole = (int)floorf(accepted + 0.0001f);
+    if (whole > 0)
+        manifest_consume_by_commodity(&sp->ship.manifest, COMMODITY_FRAME, whole);
     SIM_LOG("[sim] player %d delivered %.1f frames to scaffold %d (progress %.0f%%)\n",
             sp->id, accepted, sp->current_station, st->scaffold_progress * 100.0f);
     if (st->scaffold_progress >= 1.0f) {
@@ -2306,9 +2311,15 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
     if (!sp->docked) return;
     station_t *docked_st = &w->stations[sp->current_station];
     if (intent->service_sell) {
-        /* Deliver to scaffolds/modules first, then sell remaining */
-        step_scaffold_delivery(w, sp);
-        step_module_delivery(w, docked_st, sp->current_station, &sp->ship);
+        /* Deliver to scaffolds/modules first, then sell remaining.
+         * Honor service_sell_only as a filter: when the player picks a
+         * specific commodity row, scaffold/module delivery should not
+         * eat unrelated build materials (e.g. selecting "deliver
+         * ingots" must not silently pour frames into a scaffold). */
+        commodity_t filter = intent->service_sell_only;
+        bool deliver_frames = (filter == COMMODITY_COUNT) || (filter == COMMODITY_FRAME);
+        if (deliver_frames) step_scaffold_delivery(w, sp);
+        step_module_delivery(w, docked_st, sp->current_station, &sp->ship, filter);
         try_sell_station_cargo(w, sp);
     }
     else if (intent->service_repair) try_repair_ship(w, sp);
@@ -2353,10 +2364,17 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
                 ? mining_payout_multiplier((mining_grade_t)intent->buy_grade)
                 : 1.0f;
             float price_per = price_base * grade_mult;
-            /* Buy as much as you can afford and carry */
+            /* One unit per intent. The TRADE picker advertises a row
+             * as "buy 1 frame for $X" — the old "buy as much as you
+             * can afford" behavior could drain a station's stock and
+             * the player's wallet from a single keypress, charging the
+             * row's grade-multiplied price across the whole quantity
+             * even though manifest_transfer falls back to other grades
+             * once the named ones run out. Bulk-buy can come back as
+             * an explicit `buy_quantity` intent if/when needed. */
             float bal = ledger_balance(docked_st, sp->session_token);
             float afford = (price_per > 0.01f) ? floorf(bal / price_per) : 0.0f;
-            float amount = fminf(fminf(available, space), afford);
+            float amount = fminf(fminf(fminf(available, space), afford), 1.0f);
             float total_cost = amount * price_per;
             SIM_LOG("[buy] avail=%.2f space=%.2f price/u=%.2f bal=%.2f afford=%.0f amount=%.2f\n",
                     available, space, price_per, bal, afford, amount);
@@ -3851,6 +3869,19 @@ void world_cleanup(world_t *w) {
     w->signal_cache.valid = false;
     free(w->asteroid_grid.entries);
     w->asteroid_grid.entries = NULL;
+}
+
+void world_seed_station_manifests(world_t *w) {
+    if (!w) return;
+    for (int i = 0; i < MAX_STATIONS; i++) {
+        if (!station_exists(&w->stations[i])) continue;
+        uint8_t origin[8] = { 'S','E','E','D','0','0','0','0' };
+        origin[7] = (uint8_t)('0' + (i % 10));
+        manifest_migrate_legacy_inventory(&w->stations[i].manifest,
+                                          w->stations[i].inventory,
+                                          COMMODITY_COUNT, origin);
+        w->stations[i].named_ingots_dirty = true;
+    }
 }
 
 void world_reset(world_t *w) {

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -340,7 +340,23 @@ void rebuild_signal_chain(world_t *w);
 bool can_place_outpost(const world_t *w, vec2 pos);
 void begin_module_construction(world_t *w, station_t *st, int station_idx, module_type_t type);
 void begin_module_construction_at(world_t *w, station_t *st, int station_idx, module_type_t type, int ring, int slot);
-void step_module_delivery(world_t *w, station_t *st, int station_idx, ship_t *ship);
+/* Deliver build material from `ship` (player or NPC) into modules at
+ * this station awaiting supply. `filter` restricts which commodity may
+ * be consumed; pass COMMODITY_COUNT to allow any. The filter prevents
+ * "deliver ingots only" from also draining frames into a half-built
+ * module behind the player's back. */
+void step_module_delivery(world_t *w, station_t *st, int station_idx,
+                          ship_t *ship, commodity_t filter);
+
+/* Backfill every active station's manifest from its seeded float
+ * inventory (RECIPE_LEGACY_MIGRATE units, deterministic per-station
+ * origin). Idempotent: skips zero-inventory commodities and only adds
+ * units the manifest doesn't already represent. world_reset leaves
+ * manifests pristine so tests stay clean; this is the seed path that
+ * both the dedicated server (after world_load fails) and the singleplayer
+ * embedded server (after world_reset) call so the manifest-only TRADE
+ * picker surfaces the seed stock. */
+void world_seed_station_manifests(world_t *w);
 int spawn_scaffold(world_t *w, module_type_t type, vec2 pos, int owner);
 bool world_save(const world_t *w, const char *path);
 bool world_load(world_t *w, const char *path);

--- a/server/main.c
+++ b/server/main.c
@@ -1198,20 +1198,7 @@ int main(void) {
                     world.stations[i].credit_pool = 10000.0f;
             }
         }
-        /* Backfill manifest entries for the seeded float inventory.
-         * world_reset leaves manifests pristine (tests rely on this);
-         * the server-only load path adds the synthetic legacy units so
-         * the TRADE picker — which now reads from manifest only — has
-         * something to surface for fresh stations. */
-        for (int i = 0; i < MAX_STATIONS; i++) {
-            if (!station_exists(&world.stations[i])) continue;
-            uint8_t origin[8] = { 'S','E','E','D','0','0','0','0' };
-            origin[7] = (uint8_t)('0' + (i % 10));
-            manifest_migrate_legacy_inventory(&world.stations[i].manifest,
-                                              world.stations[i].inventory,
-                                              COMMODITY_COUNT, origin);
-            world.stations[i].named_ingots_dirty = true;
-        }
+        world_seed_station_manifests(&world);
     }
 
     /* Assign stable IDs to any stations loaded from v1 catalogs (id == 0) */

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -536,7 +536,7 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                             activate_outpost(w, npc->dest_station);
                     }
                 }
-                step_module_delivery(w, dest, npc->dest_station, &hauler_ship);
+                step_module_delivery(w, dest, npc->dest_station, &hauler_ship, COMMODITY_COUNT);
                 /* Put remaining back */
                 for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++) {
                     float consumed = dest->inventory[c] - hauler_ship.cargo[c];

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -875,29 +875,43 @@ void step_module_flow(world_t *w, float dt) {
  * immediately from cargo but build progress advances at a fixed rate --
  * delivery fills the module's internal hopper (tracked via build_progress
  * vs the total cost), construction ticks over time in step_module_activation. */
-void step_module_delivery(world_t *w, station_t *st, int station_idx, ship_t *ship) {
+void step_module_delivery(world_t *w, station_t *st, int station_idx,
+                          ship_t *ship, commodity_t filter) {
     (void)w; (void)station_idx;
     for (int i = 0; i < st->module_count; i++) {
         station_module_t *m = &st->modules[i];
         if (module_build_state(m) != MODULE_BUILD_AWAITING_SUPPLY) continue;
         commodity_t mat = module_build_material(m->type);
+        /* Selective-delivery filter: when the player picks "deliver
+         * <commodity>" the construction path must not eat anything
+         * else. COMMODITY_COUNT means "no filter, deliver anything". */
+        if (filter != COMMODITY_COUNT && filter != mat) continue;
         float cost = module_build_cost(m->type);
         float needed = cost * (1.0f - module_supply_fraction(m));
         if (needed < 0.01f) continue;
 
-        /* Pull from docked ship cargo */
+        /* Pull from docked ship cargo (consume the manifest unit so the
+         * named identity can't be sold or transferred again). */
         if (ship->cargo[mat] > 0.01f) {
             float deliver = fminf(ship->cargo[mat], needed);
             ship->cargo[mat] -= deliver;
             m->build_progress += deliver / cost;
+            int whole = (int)floorf(deliver + 0.0001f);
+            if (whole > 0)
+                manifest_consume_by_commodity(&ship->manifest, mat, whole);
             needed -= deliver;
         }
 
-        /* Also pull from station inventory (NPC deliveries land here) */
+        /* Also pull from station inventory (NPC deliveries land here).
+         * Match the consume on the station manifest too — same drift
+         * class as the ship side. */
         if (needed > 0.01f && st->inventory[mat] > 0.01f) {
             float deliver = fminf(st->inventory[mat], needed);
             st->inventory[mat] -= deliver;
             m->build_progress += deliver / cost;
+            int whole = (int)floorf(deliver + 0.0001f);
+            if (whole > 0)
+                manifest_consume_by_commodity(&st->manifest, mat, whole);
         }
 
         if (m->build_progress > 1.0f) m->build_progress = 1.0f;

--- a/shared/manifest.h
+++ b/shared/manifest.h
@@ -34,6 +34,14 @@ int manifest_find_first_cg(const manifest_t *manifest,
 int manifest_count_by_commodity(const manifest_t *manifest,
                                 commodity_t commodity);
 
+/* Remove up to `n` units of `commodity` from `manifest` (no destination
+ * — the units are destroyed). Used by construction delivery, where the
+ * cargo unit's identity is consumed into a built module rather than
+ * transferred to another holder. Walks backwards so removing doesn't
+ * disturb earlier indices. Returns the number actually removed. */
+int manifest_consume_by_commodity(manifest_t *manifest,
+                                  commodity_t commodity, int n);
+
 void ship_cleanup(ship_t *ship);
 bool ship_manifest_bootstrap(ship_t *ship);
 bool ship_copy(ship_t *dst, const ship_t *src);

--- a/src/local_server.c
+++ b/src/local_server.c
@@ -45,6 +45,11 @@ void local_server_init(local_server_t *ls, uint32_t seed) {
     memset(ls, 0, sizeof(*ls));
     ls->world.rng = seed ? seed : 2037u;
     world_reset(&ls->world);
+    /* Mirror the dedicated-server load path: turn the seeded float
+     * inventory into manifest units so the manifest-only TRADE picker
+     * has rows to surface. Without this, a fresh singleplayer start
+     * shows empty markets at every station. */
+    world_seed_station_manifests(&ls->world);
     ls->world.players[0].connected = true;
     ls->world.players[0].id = 0;
     ls->world.players[0].session_ready = true;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -307,6 +307,19 @@ int manifest_count_by_commodity(const manifest_t *manifest, commodity_t commodit
     return n;
 }
 
+int manifest_consume_by_commodity(manifest_t *manifest, commodity_t commodity, int n) {
+    if (!manifest || !manifest->units || n <= 0) return 0;
+    int removed = 0;
+    /* Walk backwards so manifest_remove (which compacts via tail-swap)
+     * doesn't shift later indices we still need to scan. */
+    for (int16_t i = (int16_t)manifest->count - 1; i >= 0 && removed < n; i--) {
+        if (manifest->units[i].commodity == (uint8_t)commodity) {
+            if (manifest_remove(manifest, (uint16_t)i, NULL)) removed++;
+        }
+    }
+    return removed;
+}
+
 bool hash_merkle_root(const uint8_t pubs[][32], size_t count, uint8_t out_root[32]) {
     uint8_t *level = NULL;
     uint8_t *next = NULL;

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -168,7 +168,7 @@ TEST(test_module_construction_and_delivery) {
     /* Deliver the required crystal ingots (goes into station inventory) */
     ship_t ship = {0};
     ship.cargo[COMMODITY_CRYSTAL_INGOT] = 200.0f;
-    step_module_delivery(&w, st, 0, &ship);
+    step_module_delivery(&w, st, 0, &ship, COMMODITY_COUNT);
     ASSERT(ship.cargo[COMMODITY_CRYSTAL_INGOT] < 200.0f);  /* consumed from ship */
     ASSERT_EQ_FLOAT(st->modules[mc_before].build_progress, 1.0f, 0.01f); /* fully supplied */
     ASSERT(st->modules[mc_before].scaffold);  /* still building — not instant */
@@ -176,6 +176,101 @@ TEST(test_module_construction_and_delivery) {
     for (int i = 0; i < (int)(15.0f / SIM_DT); i++)
         world_sim_step(&w, SIM_DT);
     ASSERT(!st->modules[mc_before].scaffold);  /* activated after build time */
+}
+
+/* Regression: a frame delivered into a scaffold via service_sell must
+ * also have its matching cargo_unit_t removed from the ship manifest.
+ * Without the consume, the named frame stays in the ship's manifest
+ * and could be sold or transferred again. */
+TEST(test_construction_consumes_manifest_units) {
+    WORLD_DECL;
+    world_reset(&w);
+    station_t *st = &w.stations[0];
+    st->scaffold = true;
+    st->scaffold_progress = 0.0f;
+
+    server_player_t *sp = &w.players[0];
+    sp->connected = true;
+    sp->session_ready = true;
+    sp->id = 0;
+    memset(sp->session_token, 0xCC, sizeof(sp->session_token));
+    sp->docked = true;
+    sp->current_station = 0;
+    ASSERT(manifest_init(&sp->ship.manifest, 16));
+    sp->ship.cargo[COMMODITY_FRAME] = 5.0f;
+    cargo_unit_t u = {0};
+    u.kind = CARGO_KIND_FRAME;
+    u.commodity = COMMODITY_FRAME;
+    for (int i = 0; i < 5; i++) {
+        u.pub[0] = (uint8_t)(i + 1);
+        ASSERT(manifest_push(&sp->ship.manifest, &u));
+    }
+    ASSERT_EQ_INT(manifest_count_by_commodity(&sp->ship.manifest, COMMODITY_FRAME), 5);
+
+    sp->input.service_sell = true;
+    sp->input.service_sell_only = COMMODITY_COUNT;
+    world_sim_step(&w, SIM_DT);
+
+    int frames_left = manifest_count_by_commodity(&sp->ship.manifest, COMMODITY_FRAME);
+    int cargo_left = (int)floorf(sp->ship.cargo[COMMODITY_FRAME] + 0.0001f);
+    ASSERT_EQ_INT(cargo_left, frames_left);
+    /* Some frames consumed by the scaffold (it needs them). */
+    ASSERT(frames_left < 5);
+}
+
+/* Regression: a single buy_product intent must purchase exactly one
+ * unit, not as-many-as-the-player-can-afford. The TRADE picker
+ * advertises rows as "buy 1 frame for $X"; bulk-buy from one keypress
+ * was charging the row's grade-multiplied price across the whole drain. */
+TEST(test_docked_buy_one_unit_per_intent) {
+    WORLD_DECL;
+    world_reset(&w);
+    world_seed_station_manifests(&w);
+    station_t *st = &w.stations[1]; /* Kepler — produces frames */
+    st->inventory[COMMODITY_FRAME] = 50.0f;
+
+    server_player_t *sp = &w.players[0];
+    sp->connected = true;
+    sp->session_ready = true;
+    sp->id = 0;
+    sp->docked = true;
+    sp->current_station = 1;
+    memset(sp->session_token, 0xAA, sizeof(sp->session_token));
+    ASSERT(manifest_init(&sp->ship.manifest, 16));
+    ledger_credit_supply(st, sp->session_token, 5000.0f);
+    float bal_before = ledger_balance(st, sp->session_token);
+    float cargo_before = sp->ship.cargo[COMMODITY_FRAME];
+
+    sp->input.buy_product = true;
+    sp->input.buy_commodity = COMMODITY_FRAME;
+    sp->input.buy_grade = MINING_GRADE_COMMON;
+    world_sim_step(&w, SIM_DT);
+
+    float cargo_delta = sp->ship.cargo[COMMODITY_FRAME] - cargo_before;
+    float bal_delta = bal_before - ledger_balance(st, sp->session_token);
+    ASSERT_EQ_FLOAT(cargo_delta, 1.0f, 0.01f);
+    ASSERT(bal_delta < 100.0f);
+}
+
+/* Regression: world_seed_station_manifests populates each active
+ * station's manifest from its float inventory so the manifest-only
+ * TRADE picker has rows to surface. The singleplayer init path must
+ * call this for parity with the dedicated server. */
+TEST(test_world_seed_station_manifests_matches_float) {
+    WORLD_DECL;
+    world_reset(&w);
+    for (int i = 0; i < 3; i++) {
+        ASSERT_EQ_INT(w.stations[i].manifest.count, 0);
+    }
+    world_seed_station_manifests(&w);
+    for (int s = 0; s < 3; s++) {
+        for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++) {
+            int expected = (int)floorf(w.stations[s].inventory[c] + 0.0001f);
+            int got = manifest_count_by_commodity(&w.stations[s].manifest,
+                                                  (commodity_t)c);
+            ASSERT_EQ_INT(got, expected);
+        }
+    }
 }
 
 TEST(test_module_activation_spawns_npc) {
@@ -189,7 +284,7 @@ TEST(test_module_activation_spawns_npc) {
     /* Deliver materials to station inventory */
     ship_t ship = {0};
     ship.cargo[COMMODITY_FRAME] = 200.0f;
-    step_module_delivery(&w, st, 1, &ship);
+    step_module_delivery(&w, st, 1, &ship, COMMODITY_COUNT);
     /* Run sim long enough for construction to complete (~60 frames / 4 per sec = 15s) */
     for (int i = 0; i < (int)(20.0f / SIM_DT); i++)
         world_sim_step(&w, SIM_DT);
@@ -1322,6 +1417,9 @@ void register_construction_modules_tests(void) {
     TEST_SECTION("\nModule construction:\n");
     RUN(test_module_build_material_types);
     RUN(test_module_construction_and_delivery);
+    RUN(test_construction_consumes_manifest_units);
+    RUN(test_docked_buy_one_unit_per_intent);
+    RUN(test_world_seed_station_manifests_matches_float);
     RUN(test_module_activation_spawns_npc);
 }
 


### PR DESCRIPTION
Four bug fixes addressing manifest/float drift on the consume side.

## Fixes
- **Construction consumes the manifest unit** (game_sim.c, sim_production.c). Previously frames delivered into a scaffold or modules left their `cargo_unit_t` entries in the ship/station manifest — the named identity could be sold or transferred again. New helper `manifest_consume_by_commodity` removes N units with no destination.
- **Selective \`service_sell_only\` filter is now respected** by scaffold + module delivery. \"Deliver ingots only\" no longer silently pours frames into a half-built module first.
- **Docked buy clamped to one unit per intent**. The TRADE picker shows \"buy 1 frame for \$X\"; the server was draining the whole stock at the row's grade-multiplied price from one keypress.
- **Singleplayer station manifests now seeded** like the dedicated server. \`world_seed_station_manifests\` extracted to a shared helper called from both \`load_world_state\` (server) and \`local_server_init\` (SP). Without this, fresh SP starts had empty TRADE markets.

## Test plan
- [x] make test (322/322 pass — 319 prior + 3 new regressions)
- [x] Native client + server build clean
- [ ] CI green
- [ ] Smoke test: SP start → dock at any station → TRADE shows seeded stock; buy frame → cargo+1 only, credits − price; deliver to scaffold → manifest count drops with cargo