### PR TITLE
Zero-seed economy, native-arch docker, fix Kepler ingot contracts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,30 +28,38 @@ RUN GIT_HASH=$(git -C /src rev-parse --short HEAD 2>/dev/null || echo local) \
     && emcmake cmake -S /src -B /src/build-web -DGIT_HASH=$GIT_HASH \
     && cmake --build /src/build-web --parallel
 
-# ----- stage 2: native server build ----------------------------------------
-FROM emscripten/emsdk:3.1.64 AS native-build
-WORKDIR /src
-RUN apt-get update && apt-get install -y --no-install-recommends cmake git build-essential \
+# ----- stage 2: runtime (native server build happens here) -----------------
+# Build the native server in the runtime image's own arch so it runs
+# natively on both amd64 and arm64 hosts. Pinning the runtime to amd64
+# made the binary segfault under qemu on M-series Macs (signal 11 in
+# the contract/production loop) — much worse than the original "wrong
+# loader" symptom that the pin was working around. Solution: rebuild
+# signal_server inside the runtime stage so it matches the host arch.
+FROM python:3.12-slim AS runtime
+WORKDIR /app
+
+# Build toolchain + runtime deps. Building signal_server here (instead of
+# in a cross-arch stage) means the binary always matches the host arch.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates tini cmake build-essential git \
     && rm -rf /var/lib/apt/lists/*
+
+# Compile signal_server in this stage so it's native arch.
 COPY . /src
 RUN GIT_HASH=$(git -C /src rev-parse --short HEAD 2>/dev/null || echo local) \
     && cmake -S /src -B /src/build -DBUILD_SERVER_ONLY=ON -DGIT_HASH=$GIT_HASH \
-    && cmake --build /src/build --target signal_server --parallel
+    && cmake --build /src/build --target signal_server --parallel \
+    && cp /src/build/signal_server /app/signal_server \
+    && rm -rf /src
 
-# ----- stage 3: runtime -----------------------------------------------------
-# Pin to linux/amd64 so the native signal_server binary (built in the
-# emscripten/emsdk amd64 image) executes natively on amd64 hosts and via
-# qemu on arm64 hosts. Without this pin, arm64 Macs pull an arm64 python
-# base and the amd64 binary fails with "ld-linux-x86-64.so.2 not found".
-FROM --platform=linux/amd64 python:3.12-slim AS runtime
-WORKDIR /app
-
-# Only what the server binary needs at runtime (libc, libm are in slim).
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates tini \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY --from=native-build /src/build/signal_server /app/signal_server
-COPY --from=wasm-build   /src/build-web            /app/build-web
+COPY --from=wasm-build /src/build-web /app/build-web
+# Ship the play/shell wrappers alongside the emscripten bundle. These set
+# window.SIGNAL_SERVER = ws://<host>:9091/ws when served from a local
+# host, so the wasm client connects to the in-container server instead
+# of falling into singleplayer ("offline"). Without these, opening
+# /signal.html directly bypasses the WS autoconfig.
+COPY --from=wasm-build /src/web/play.html  /app/build-web/play.html
+COPY --from=wasm-build /src/web/shell.html /app/build-web/shell.html
 
 # Persistence dirs (world.sav, chain/, saves/, stations/). Bind a host dir
 # to /app/data via `docker run -v $(pwd)/data:/app/data` to make them

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      platforms:
-        - linux/amd64
     image: signal:local
-    platform: linux/amd64
     container_name: signal
     ports:
       - "8080:8080"   # static HTTP — serves build-web/ (browser client)

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -3132,13 +3132,45 @@ static void step_contracts(world_t *w, float dt) {
             }
         }
 
-        /* Priority 3.5: dock kit-fab inputs. Every dock needs frames +
-         * lasers + tractor modules to mint repair kits. If any input is
-         * low (and the station can't make it itself), surface a contract
-         * so haulers actually move finished goods between stations
-         * instead of letting Kepler/Helios saturate. Kit fab is the
-         * load-bearing demand sink — without these contracts a dock that
-         * can't self-produce its inputs will just sit idle. */
+        /* Priority 4: ingot buffer deficit (production slot). Runs
+         * BEFORE the dock kit-fab fallback because a station's own
+         * production chain (e.g. Kepler smelting ferrite ingots into
+         * frames) is upstream of, and feeds, the kit-fab demand. If
+         * Kepler stops asking for ferrite ingots its frame press dries
+         * up, and then Helios's kit fab dries up too. */
+        if (!need.active && !has_production_contract) {
+            struct { commodity_t ingot; bool needed; } checks[] = {
+                { COMMODITY_FERRITE_INGOT, station_has_module(st, MODULE_FRAME_PRESS) },
+                { COMMODITY_CUPRITE_INGOT,
+                  station_has_module(st, MODULE_LASER_FAB) ||
+                  station_has_module(st, MODULE_TRACTOR_FAB) },
+                { COMMODITY_CRYSTAL_INGOT, station_has_module(st, MODULE_LASER_FAB) },
+            };
+            float worst_deficit = 0.0f;
+            int worst_idx = -1;
+            for (int j = 0; j < 3; j++) {
+                if (!checks[j].needed) continue;
+                float deficit = MAX_PRODUCT_STOCK * 0.5f - st->inventory[checks[j].ingot];
+                if (deficit > worst_deficit) { worst_deficit = deficit; worst_idx = j; }
+            }
+            if (worst_idx >= 0) {
+                need = (contract_t){
+                    .active = true, .action = CONTRACT_TRACTOR,
+                    .station_index = (uint8_t)s,
+                    .commodity = checks[worst_idx].ingot,
+                    .quantity_needed = worst_deficit,
+                    .base_price = st->base_price[checks[worst_idx].ingot] * 1.15f * pool_factor,
+                    .target_index = -1, .claimed_by = -1,
+                };
+            }
+        }
+
+        /* Priority 5: dock kit-fab inputs. Last-resort: every dock needs
+         * frames + lasers + tractor modules to mint repair kits, but the
+         * upstream production contracts (above) come first so they don't
+         * starve. Only fires when the station's own ingot/scaffold
+         * pipeline is satisfied, ensuring kit fab gets fed without
+         * cannibalising the chain that produces its inputs. */
         if (!need.active && !has_production_contract && station_has_module(st, MODULE_DOCK)) {
             const struct { commodity_t c; module_type_t producer; } kit_inputs[] = {
                 { COMMODITY_FRAME,          MODULE_FRAME_PRESS  },
@@ -3163,34 +3195,6 @@ static void step_contracts(world_t *w, float dt) {
                     .base_price = st->base_price[mat] > 0.0f
                                   ? st->base_price[mat] * 1.25f * pool_factor
                                   : 28.0f * pool_factor,
-                    .target_index = -1, .claimed_by = -1,
-                };
-            }
-        }
-
-        /* Priority 4: ingot buffer deficit (production slot) */
-        if (!need.active && !has_production_contract) {
-            struct { commodity_t ingot; bool needed; } checks[] = {
-                { COMMODITY_FERRITE_INGOT, station_has_module(st, MODULE_FRAME_PRESS) },
-                { COMMODITY_CUPRITE_INGOT,
-                  station_has_module(st, MODULE_LASER_FAB) ||
-                  station_has_module(st, MODULE_TRACTOR_FAB) },
-                { COMMODITY_CRYSTAL_INGOT, station_has_module(st, MODULE_LASER_FAB) },
-            };
-            float worst_deficit = 0.0f;
-            int worst_idx = -1;
-            for (int j = 0; j < 3; j++) {
-                if (!checks[j].needed) continue;
-                float deficit = MAX_PRODUCT_STOCK * 0.5f - st->inventory[checks[j].ingot];
-                if (deficit > worst_deficit) { worst_deficit = deficit; worst_idx = j; }
-            }
-            if (worst_idx >= 0) {
-                need = (contract_t){
-                    .active = true, .action = CONTRACT_TRACTOR,
-                    .station_index = (uint8_t)s,
-                    .commodity = checks[worst_idx].ingot,
-                    .quantity_needed = worst_deficit,
-                    .base_price = st->base_price[checks[worst_idx].ingot] * 1.15f * pool_factor,
                     .target_index = -1, .claimed_by = -1,
                 };
             }
@@ -3991,8 +3995,8 @@ void world_reset(world_t *w) {
     w->stations[0].ring_offset[0] = 0.0f;
     w->stations[0].ring_offset[1] = 1.05f;  /* ~60° offset — unique silhouette */
     rebuild_station_services(&w->stations[0]);
-    /* Seed inventory and credit pool */
-    w->stations[0].inventory[COMMODITY_FERRITE_INGOT] = 20.0f;
+    /* No inventory handout — the chain has to be earned. Stations only
+     * start with a credit pool to pay miners + haulers. */
     w->stations[0].credit_pool = 10000.0f;
     snprintf(w->stations[0].station_slug, sizeof(w->stations[0].station_slug), "prospect");
     snprintf(w->stations[0].currency_name, sizeof(w->stations[0].currency_name), "prospect vouchers");
@@ -4028,9 +4032,6 @@ void world_reset(world_t *w) {
     w->stations[1].ring_offset[0] = 0.0f;
     w->stations[1].ring_offset[1] = 2.40f;  /* ~137° offset */
     rebuild_station_services(&w->stations[1]);
-    /* Seed inventory and credit pool */
-    w->stations[1].inventory[COMMODITY_FERRITE_INGOT] = 15.0f;
-    w->stations[1].inventory[COMMODITY_FRAME] = 12.0f;
     w->stations[1].credit_pool = 10000.0f;
     snprintf(w->stations[1].station_slug, sizeof(w->stations[1].station_slug), "kepler");
     snprintf(w->stations[1].currency_name, sizeof(w->stations[1].currency_name), "kepler bonds");
@@ -4081,11 +4082,6 @@ void world_reset(world_t *w) {
     w->stations[2].ring_offset[1] = 0.52f;  /* ~30° offset */
     w->stations[2].ring_offset[2] = 1.83f;  /* ~105° offset */
     rebuild_station_services(&w->stations[2]);
-    /* Seed inventory and credit pool */
-    w->stations[2].inventory[COMMODITY_CUPRITE_INGOT] = 15.0f;
-    w->stations[2].inventory[COMMODITY_CRYSTAL_INGOT] = 15.0f;
-    w->stations[2].inventory[COMMODITY_LASER_MODULE] = 10.0f;
-    w->stations[2].inventory[COMMODITY_TRACTOR_MODULE] = 10.0f;
     w->stations[2].credit_pool = 10000.0f;
     snprintf(w->stations[2].station_slug, sizeof(w->stations[2].station_slug), "helios");
     snprintf(w->stations[2].currency_name, sizeof(w->stations[2].currency_name), "helios credits");

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -61,7 +61,13 @@ static uint32_t crc32_file(FILE *f) {
 
 #define SAVE_MAGIC 0x5349474E  /* "SIGN" */
 #define SAVE_VERSION 31  /* COMMODITY_REPAIR_KIT added; inventory/base_price arrays widen by 1 */
-#define MIN_SAVE_VERSION 20  /* migrate v20 by mapping old module_buffer → input */
+/* v31 widened inventory[] / base_price[] by one slot (REPAIR_KIT). The
+ * read paths use raw READ_FIELD on those arrays, so loading any save
+ * older than v31 misaligns the rest of the station record and corrupts
+ * the world silently — leading to a delayed crash on the first player
+ * join. Bump the floor so older saves are rejected with a clear log
+ * line and the server falls back to a fresh world instead. */
+#define MIN_SAVE_VERSION 31
 
 /* Set by world_load() before read_station() so per-station readers know
  * which version they're parsing and can handle field additions. */


### PR DESCRIPTION
## Summary
- **Zero-seed economy** — `world_reset` no longer hands out starter ferrite/cuprite/crystal/frame/laser/tractor stock at any station. Cold start = empty hoppers, 10000 cr pool. The chain has to be earned from the first NPC miner trip onward.
- **Reorder contract priorities** — ingot-deficit now wins over the dock kit-fab fallback. Kepler had stopped asking for ferrite ingots because the new kit-input contract grabbed its single production slot, starving the press (and one tier later, Helios's kit fab).
- **Drop linux/amd64 pin** — compose and the runtime stage no longer force amd64. The amd64 binary segfaulted under qemu on M-series Macs ("offline [P] reconnect" within seconds of every connect). Server now compiles inline in the runtime stage so the binary always matches the host arch.
- **Ship `play.html` / `shell.html`** — copied into `/app/build-web` so the SIGNAL_SERVER autoconfig fires; without it `localhost:8080/signal.html` boots in singleplayer.
- **MIN_SAVE_VERSION 20 → 31** — v31 widened `inventory[]` / `base_price[]` for COMMODITY_REPAIR_KIT but the READ_FIELD paths don't gate array width by version, so older saves silently misaligned the rest of each station record. Surface symptom: delayed crash on first player join (we hit this with a leftover v30 `world.sav` and qemu core dumps in `data/`). Reject incompatible saves cleanly and fall through to fresh.

## Test plan
- [x] `make test` — 322/322 pass
- [x] `make dev` — fresh container starts, no qemu segfaults, save loader rejects pre-v31 cleanly
- [ ] Live: dock at Kepler with ferrite ingots → SELL row should appear and the trade actually clears
- [ ] Live: hail Kepler within ~30s of cold start → contract should be "deliver ferrite ingots" (not laser/tractor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)