### PR TITLE
Fix Kepler frame-buy reset; add MARKET supply strip

### DIFF
--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -537,10 +537,23 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                     }
                 }
                 step_module_delivery(w, dest, npc->dest_station, &hauler_ship, COMMODITY_COUNT);
-                /* Put remaining back */
+                /* Put remaining back. The float was drained into
+                 * module_input by step_module_delivery; we have to drain
+                 * the matching manifest entries too or the BUY picker
+                 * (manifest-only) will keep advertising stock that the
+                 * server-side float check (game_sim.c try_buy_product)
+                 * sees as 0 and silently rejects. */
                 for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++) {
                     float consumed = dest->inventory[c] - hauler_ship.cargo[c];
-                    if (consumed > 0.01f) dest->inventory[c] -= consumed;
+                    if (consumed > 0.01f) {
+                        dest->inventory[c] -= consumed;
+                        int whole = (int)floorf(consumed + 0.0001f);
+                        if (whole > 0) {
+                            manifest_consume_by_commodity(&dest->manifest,
+                                                          (commodity_t)c, whole);
+                            dest->named_ingots_dirty = true;
+                        }
+                    }
                 }
             }
             npc->state = NPC_STATE_RETURN_TO_STATION;

--- a/src/station_ui.c
+++ b/src/station_ui.c
@@ -702,6 +702,53 @@ static void draw_trade_view(const station_ui_state_t *ui,
 
     my += draw_section_header(cx, my, inner_right, "MARKET", HDR_TRADE);
 
+    /* Supply strip — six commodity slots showing this station's stock.
+     * Each cell is colored by the commodity when the station has the
+     * matching producing module; gray when it doesn't. The number is
+     * floored stock. Lets the player scan a station's tier role at a
+     * glance ("Helios is making lasers + tractors but no frames"). */
+    {
+        struct { commodity_t c; module_type_t producer; const char *code; } slots[6] = {
+            { COMMODITY_FERRITE_INGOT,  MODULE_FURNACE,      "FE" },
+            { COMMODITY_CUPRITE_INGOT,  MODULE_FURNACE_CU,   "CU" },
+            { COMMODITY_CRYSTAL_INGOT,  MODULE_FURNACE_CR,   "CR" },
+            { COMMODITY_FRAME,          MODULE_FRAME_PRESS,  "FM" },
+            { COMMODITY_LASER_MODULE,   MODULE_LASER_FAB,    "LM" },
+            { COMMODITY_TRACTOR_MODULE, MODULE_TRACTOR_FAB,  "TM" },
+        };
+        const float cell_w = 8.0f;
+        const float slot_w = cell_w * 7.0f; /* "FEx99 " = 6 chars + sep */
+        for (int i = 0; i < 6; i++) {
+            float sx = cx + (float)i * slot_w;
+            int stock = (int)floorf(st->inventory[slots[i].c] + 0.0001f);
+            bool has_module = station_has_module(st, slots[i].producer);
+            uint8_t r, g, b;
+            if (!has_module) {
+                /* No producing module: dark gray label, em-dash for stock. */
+                r = 90; g = 90; b = 90;
+            } else if (stock <= 0) {
+                /* Module present but bone dry: faded commodity color. */
+                commodity_color_u8(slots[i].c, &r, &g, &b);
+                r = (uint8_t)(r / 3); g = (uint8_t)(g / 3); b = (uint8_t)(b / 3);
+            } else {
+                /* In stock: full commodity color. */
+                commodity_color_u8(slots[i].c, &r, &g, &b);
+            }
+            sdtx_color3b(r, g, b);
+            sdtx_pos(ui_text_pos(sx), ui_text_pos(my));
+            char cell[8];
+            if (!has_module) {
+                snprintf(cell, sizeof(cell), "%s --", slots[i].code);
+            } else if (stock > 99) {
+                snprintf(cell, sizeof(cell), "%s99+", slots[i].code);
+            } else {
+                snprintf(cell, sizeof(cell), "%s %2d", slots[i].code, stock);
+            }
+            sdtx_puts(cell);
+        }
+        my += row_h;
+    }
+
     /* Build the unified row list. BUY rows first (station's offering),
      * SELL rows after (what the station buys from the hold). */
     trade_row_t rows[TRADE_MAX_ROWS];


### PR DESCRIPTION
## Root cause
NPC haulers unloading at a station with active scaffold/module construction call \`step_module_delivery\` from a *copy* of float inventory and then subtract the consumed delta from float — but **leave matching manifest entries in place**. Result: \`manifest > float\` drift. The MARKET picker is manifest-driven so it kept advertising frame stock; \`try_buy_product\` checks float and silently rejected with \`avail=0.00\`.

Live container log right now (commit a35ffd6, fresh world):
\`\`\`
[buy] player 1 req c=6 grade=0 at station 1 (produces=1)
[buy] avail=0.00 space=24.00 price/u=40.00 bal=1235.42 afford=30 amount=0.00
[buy] REJECT: amount=0.00 too small
\`\`\`
Symptom in-game: client predicts the buy, snapshot wipes it next frame.

## Fix
\`server/sim_ai.c\` unloading path: drain whole-unit count from the destination manifest in lockstep with the float deduction.

## Bonus: MARKET supply strip
New row directly under the MARKET header — six commodity slots (FE / CU / CR / FM / LM / TM):
- Colored by commodity when the station has the producing module
- Gray with "--" when it doesn't
- Faded color when the module is present but stock is 0

Lets the player scan a station's tier role at a glance and see why a trade row can't actually fill.

## Test plan
- [x] \`make test\` — 322/322 pass
- [ ] Live: rebuild container, dock at Kepler, watch FRAMES rise via the strip, click BUY → server log shows \`[buy] OK\` not REJECT.
- [ ] Live: at Helios, FE column should be gray (no MODULE_FURNACE), CU/CR/LM/TM colored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)