### PR TITLE
Manifest is authoritative for finished-good BUY + MP sync

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -2377,7 +2377,29 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
                     return;
                 }
             }
-            float available = docked_st->inventory[c];
+            /* Common-grade buys for INGOTS must also find an exact-grade
+             * manifest entry. Otherwise manifest_transfer_by_commodity_ex
+             * would fall back to a higher grade and the player walks away
+             * with a fine/rare ingot at the 1× COMMON price. Fabs (frames,
+             * lasers, tractors, kits) only ever carry COMMON, so the check
+             * is redundant for them — keep them on the legacy fallback. */
+            if (intent->buy_grade == MINING_GRADE_COMMON
+                && (c == COMMODITY_FERRITE_INGOT
+                    || c == COMMODITY_CUPRITE_INGOT
+                    || c == COMMODITY_CRYSTAL_INGOT)) {
+                if (manifest_find_first_cg(&docked_st->manifest, c,
+                                           MINING_GRADE_COMMON) < 0) {
+                    SIM_LOG("[buy] REJECT: no COMMON-grade manifest unit at c=%d\n", (int)c);
+                    return;
+                }
+            }
+            /* Manifest is authoritative for finished goods. Reading the
+             * float here previously rejected buys that the picker had
+             * advertised — every drift bug surfaced as "row shown,
+             * server says avail=0". */
+            float available = (c >= COMMODITY_RAW_ORE_COUNT)
+                ? (float)manifest_count_by_commodity(&docked_st->manifest, c)
+                : docked_st->inventory[c];
             float space = ship_cargo_capacity(&sp->ship) - ship_total_cargo(&sp->ship);
             float price_base = station_sell_price(docked_st, c);
             /* Grade-aware pricing: if the client picked a specific-grade row
@@ -2405,6 +2427,7 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
             if (amount > 0.01f && ledger_spend(docked_st, sp->session_token, total_cost, &sp->ship)) {
                 sp->ship.cargo[c] += amount;
                 docked_st->inventory[c] -= amount;
+                if (docked_st->inventory[c] < 0.0f) docked_st->inventory[c] = 0.0f;
                 int whole = (int)floorf(amount + 0.0001f);
                 int moved = 0;
                 if (whole > 0) {
@@ -3862,6 +3885,30 @@ void world_sim_step(world_t *w, float dt) {
     sim_step_station_production(w, dt);
     step_dock_repair_kit_fab(w, dt);
     step_module_flow(w, dt);
+
+    /* Manifest-as-truth reconciliation: ensure floor(inventory[c]) is
+     * AT LEAST manifest_count(c) for every finished commodity. This
+     * kills the orphan-manifest drift (manifest entries with no float
+     * backing) which was making the BUY check reject rows the picker
+     * advertised. We deliberately don't snap float DOWN to manifest:
+     * legacy float-only inventory (tests that set inventory[c] without
+     * minting manifest, or pre-manifest production paths) still works
+     * for SELL / production / upgrade, while the BUY path explicitly
+     * reads manifest_count and won't sell phantom stock. */
+    for (int s = 0; s < MAX_STATIONS; s++) {
+        station_t *st = &w->stations[s];
+        if (!station_exists(st)) continue;
+        for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++) {
+            int mc = manifest_count_by_commodity(&st->manifest, (commodity_t)c);
+            if (mc <= 0) continue;
+            float frac = st->inventory[c] - floorf(st->inventory[c]);
+            if (frac < 0.0f) frac = 0.0f;
+            float target = (float)mc + frac;
+            if (st->inventory[c] + 0.01f < target) {
+                st->inventory[c] = target;
+            }
+        }
+    }
     step_module_activation(w, dt);
     step_scaffolds(w, dt);
     step_contracts(w, dt);

--- a/server/main.c
+++ b/server/main.c
@@ -1112,6 +1112,17 @@ static void broadcast_ship_states(void) {
         uint8_t hbuf[HOLD_INGOTS_HEADER + SHIP_HOLD_INGOTS_MAX * NAMED_INGOT_RECORD_SIZE];
         int hlen = serialize_hold_ingots(hbuf, &world.players[i].ship);
         ws_send(world.players[i].conn, hbuf, (size_t)hlen);
+
+        /* Player manifest summary — keeps the trade UI's SELL rows in
+         * sync with server-authoritative manifest mutations (buy/sell/
+         * smelt move units across the player's manifest server-side, but
+         * PLAYER_SHIP only carries the float cargo). Worst case is
+         * COMMODITY_COUNT * MINING_GRADE_COUNT entries; we cap header
+         * + entries with a generous bound. */
+        uint8_t pmbuf[PLAYER_MANIFEST_HEADER
+                      + COMMODITY_COUNT * MINING_GRADE_COUNT * PLAYER_MANIFEST_ENTRY];
+        int pmlen = serialize_player_manifest(pmbuf, &world.players[i].ship);
+        ws_send(world.players[i].conn, pmbuf, (size_t)pmlen);
     }
 
     if (station_econ_dirty) {

--- a/server/net_protocol.h
+++ b/server/net_protocol.h
@@ -317,6 +317,41 @@ static inline int serialize_station_manifest(uint8_t *buf, int station_idx,
     return STATION_MANIFEST_HEADER + n * STATION_MANIFEST_ENTRY;
 }
 
+/* Local player's manifest summary. Same (commodity × grade) count
+ * shape as the station summary, with no station_idx (the recipient is
+ * the implicit local player). Sent each tick alongside PLAYER_SHIP so
+ * the trade UI's SELL rows reflect server-authoritative manifest state
+ * (buy/sell/transfer mutations on the server side reach the client
+ * without being lost). */
+static inline int serialize_player_manifest(uint8_t *buf, const ship_t *ship) {
+    uint16_t table[COMMODITY_COUNT][MINING_GRADE_COUNT];
+    memset(table, 0, sizeof(table));
+    if (ship && ship->manifest.units) {
+        for (uint16_t i = 0; i < ship->manifest.count; i++) {
+            const cargo_unit_t *u = &ship->manifest.units[i];
+            if (u->commodity >= COMMODITY_COUNT) continue;
+            if (u->grade >= MINING_GRADE_COUNT) continue;
+            if (table[u->commodity][u->grade] < 0xFFFF)
+                table[u->commodity][u->grade]++;
+        }
+    }
+    buf[0] = NET_MSG_PLAYER_MANIFEST;
+    int n = 0;
+    for (int c = 0; c < COMMODITY_COUNT; c++) {
+        for (int g = 0; g < MINING_GRADE_COUNT; g++) {
+            uint16_t count = table[c][g];
+            if (count == 0) continue;
+            uint8_t *p = &buf[PLAYER_MANIFEST_HEADER + n * PLAYER_MANIFEST_ENTRY];
+            p[0] = (uint8_t)c;
+            p[1] = (uint8_t)g;
+            write_u16_le(&p[2], count);
+            n++;
+        }
+    }
+    write_u16_le(&buf[1], (uint16_t)n);
+    return PLAYER_MANIFEST_HEADER + n * PLAYER_MANIFEST_ENTRY;
+}
+
 /* Local player's hold-ingot snapshot. Sent on contents change. */
 static inline int serialize_hold_ingots(uint8_t *buf, const ship_t *ship) {
     int n = ship->hold_ingots_count;

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -904,14 +904,19 @@ void step_module_delivery(world_t *w, station_t *st, int station_idx,
 
         /* Also pull from station inventory (NPC deliveries land here).
          * Match the consume on the station manifest too — same drift
-         * class as the ship side. */
+         * class as the ship side. Mark the manifest dirty so the
+         * multiplayer broadcaster forwards the new station summary;
+         * otherwise clients keep showing materials that construction
+         * already consumed until some unrelated event triggers a sync. */
         if (needed > 0.01f && st->inventory[mat] > 0.01f) {
             float deliver = fminf(st->inventory[mat], needed);
             st->inventory[mat] -= deliver;
             m->build_progress += deliver / cost;
             int whole = (int)floorf(deliver + 0.0001f);
-            if (whole > 0)
-                manifest_consume_by_commodity(&st->manifest, mat, whole);
+            if (whole > 0) {
+                int drained = manifest_consume_by_commodity(&st->manifest, mat, whole);
+                if (drained > 0) st->named_ingots_dirty = true;
+            }
         }
 
         if (m->build_progress > 1.0f) m->build_progress = 1.0f;

--- a/shared/manifest.h
+++ b/shared/manifest.h
@@ -82,4 +82,38 @@ bool manifest_migrate_legacy_inventory(manifest_t *manifest,
                                        size_t inventory_count,
                                        const uint8_t origin[8]);
 
+/* ---------------------------------------------------------------- */
+/* Manifest-as-truth helpers (PR: kill the float<->manifest drift)   */
+/* ---------------------------------------------------------------- */
+/* For finished-good commodities (c >= COMMODITY_RAW_ORE_COUNT) the
+ * manifest is the authoritative store. The float `station_t::inventory[c]`
+ * is a derived count whose floor() must always equal
+ * manifest_count_by_commodity(c). These helpers preserve that
+ * invariant by mutating both the manifest and the float in lockstep.
+ *
+ * Raw-ore commodities (c < COMMODITY_RAW_ORE_COUNT) are NOT covered —
+ * raw ore lives only in the float (hopper amounts) and never gains a
+ * manifest entry. Calling these on a raw ore commodity returns 0 and
+ * does nothing. */
+
+/* Mint `n` whole units of finished `c` into the station. Pushes `n`
+ * legacy-migrate manifest entries (origin = 8-byte provenance prefix,
+ * may be NULL for a generic "STATION " stamp), then bumps the float
+ * cache so floor(inventory[c]) == manifest_count. Returns the number
+ * actually minted (may be < n if manifest cap is hit). */
+int station_finished_mint(station_t *st, commodity_t c, int n,
+                          const uint8_t origin[8]);
+
+/* Drain up to `n` units of finished `c` from the manifest (FIFO) and
+ * decrement the float cache by the same number. Returns units drained. */
+int station_finished_drain(station_t *st, commodity_t c, int n);
+
+/* Production accumulator for finished `c`. Adds `amount` (may be
+ * fractional) to the float; for any integer crossings, mints that
+ * many manifest units (using origin) so the invariant
+ * floor(inventory[c]) == manifest_count holds at the end of the call.
+ * Returns the integer count minted this call. */
+int station_finished_accumulate(station_t *st, commodity_t c, float amount,
+                                const uint8_t origin[8]);
+
 #endif /* SHARED_MANIFEST_H */

--- a/shared/protocol.h
+++ b/shared/protocol.h
@@ -57,6 +57,7 @@ enum {
     NET_MSG_FRACTURE_RESOLVED  = 0x2E, /* server -> nearby clients: [type:1][fracture_id:u32][fragment_pub:32][winner_pub:32][grade:u8] */
     NET_MSG_STATION_MANIFEST   = 0x2F, /* server -> client: per-station manifest summary grouped by (commodity, grade) — see STATION_MANIFEST_* below. */
     NET_MSG_HIGHSCORES         = 0x30, /* server -> client: top-N leaderboard. [type:1][count:1] + count × [callsign:8][credits_earned:f32] */
+    NET_MSG_PLAYER_MANIFEST    = 0x31, /* server -> client: local player's ship manifest summary, same shape as STATION_MANIFEST minus station idx — see PLAYER_MANIFEST_* below. */
 };
 
 /* Top-N global leaderboard persisted server-side, broadcast on join and
@@ -73,6 +74,18 @@ enum {
 enum {
     STATION_MANIFEST_HEADER = 4,
     STATION_MANIFEST_ENTRY  = 4,
+};
+
+/* NET_MSG_PLAYER_MANIFEST wire layout (player is implicit — local pilot):
+ *   [type:1][entry_count:u16]
+ *     entry_count × [commodity:1][grade:1][count:u16]   (little-endian)
+ * Lets the local client build SELL rows from a manifest count even when
+ * the authoritative manifest mutations happened server-side (buy/sell/
+ * smelt). Provenance (cargo_unit_t pubkeys) is intentionally dropped —
+ * the picker only needs counts; the server keeps the real manifest. */
+enum {
+    PLAYER_MANIFEST_HEADER = 3,
+    PLAYER_MANIFEST_ENTRY  = 4,
 };
 
 /* Per-class buy price at any station's stockpile. RATi/commissioned

--- a/src/main.c
+++ b/src/main.c
@@ -924,6 +924,7 @@ static void init(void) {
             cbs.on_signal_channel = apply_remote_signal_channel;
             cbs.on_station_ingots = apply_remote_station_ingots;
             cbs.on_station_manifest = apply_remote_station_manifest;
+            cbs.on_player_manifest = apply_remote_player_manifest;
             cbs.on_highscores = apply_remote_highscores;
             cbs.on_hold_ingots = apply_remote_hold_ingots;
             g.multiplayer_enabled = net_init(server_url, &cbs);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -500,3 +500,83 @@ bool manifest_migrate_legacy_inventory(manifest_t *manifest,
     }
     return true;
 }
+
+/* ---------------------------------------------------------------- */
+/* Manifest-as-truth helpers — keep float[] in sync with manifest    */
+/* ---------------------------------------------------------------- */
+
+/* Default 8-byte origin tag when caller passes NULL. */
+static const uint8_t kStationDefaultOrigin[8] = { 'S','T','A','T','I','O','N',' ' };
+
+int station_finished_mint(station_t *st, commodity_t c, int n,
+                          const uint8_t origin[8]) {
+    if (!st || n <= 0) return 0;
+    if ((int)c < (int)COMMODITY_RAW_ORE_COUNT) return 0;
+    if ((int)c >= (int)COMMODITY_COUNT) return 0;
+    cargo_kind_t kind;
+    if (!cargo_kind_for_commodity(c, &kind)) return 0;
+    if (st->manifest.cap == 0 && !station_manifest_bootstrap(st)) return 0;
+
+    const uint8_t *use_origin = origin ? origin : kStationDefaultOrigin;
+    int minted = 0;
+    /* output_index is just provenance disambiguation per call — start at
+     * the current manifest count so identical calls hash to distinct
+     * units. */
+    uint16_t base_idx = st->manifest.count;
+    for (int i = 0; i < n; i++) {
+        if (st->manifest.count >= st->manifest.cap) break;
+        cargo_unit_t unit = {0};
+        if (!hash_legacy_migrate_unit(use_origin, c,
+                                      (uint16_t)(base_idx + i), &unit)) continue;
+        if (!manifest_push(&st->manifest, &unit)) break;
+        minted++;
+    }
+    if (minted > 0) {
+        /* Sync float to the new manifest count, preserving any fractional
+         * residue (production accumulator) below 1.0. */
+        float frac = st->inventory[c] - floorf(st->inventory[c]);
+        st->inventory[c] = (float)manifest_count_by_commodity(&st->manifest, c) + frac;
+        st->named_ingots_dirty = true;
+    }
+    return minted;
+}
+
+int station_finished_drain(station_t *st, commodity_t c, int n) {
+    if (!st || n <= 0) return 0;
+    if ((int)c < (int)COMMODITY_RAW_ORE_COUNT) return 0;
+    if ((int)c >= (int)COMMODITY_COUNT) return 0;
+    int drained = manifest_consume_by_commodity(&st->manifest, c, n);
+    if (drained > 0) {
+        float frac = st->inventory[c] - floorf(st->inventory[c]);
+        st->inventory[c] = (float)manifest_count_by_commodity(&st->manifest, c) + frac;
+        if (st->inventory[c] < 0.0f) st->inventory[c] = 0.0f;
+        st->named_ingots_dirty = true;
+    }
+    return drained;
+}
+
+int station_finished_accumulate(station_t *st, commodity_t c, float amount,
+                                const uint8_t origin[8]) {
+    if (!st || amount <= 0.0f) return 0;
+    if ((int)c < (int)COMMODITY_RAW_ORE_COUNT) return 0;
+    if ((int)c >= (int)COMMODITY_COUNT) return 0;
+
+    /* Compute how many integer crossings this addition triggers. The
+     * float currently holds: (manifest count) + (fractional residue).
+     * After adding `amount`, the new int count is floor(old + amount). */
+    float before = st->inventory[c];
+    float after  = before + amount;
+    int int_before = (int)floorf(before + 0.0001f);
+    int int_after  = (int)floorf(after + 0.0001f);
+    int delta = int_after - int_before;
+
+    /* Update float first so any partial residue is preserved even if
+     * minting partially fails (manifest cap). */
+    st->inventory[c] = after;
+
+    if (delta <= 0) return 0;
+    int minted = station_finished_mint(st, c, delta, origin);
+    /* mint sets inventory[c] = manifest_count + frac; that already
+     * captures any cap-induced shortfall. */
+    return minted;
+}

--- a/src/net.c
+++ b/src/net.c
@@ -621,6 +621,24 @@ static void handle_message(const uint8_t* data, int len) {
         }
         break;
 
+    case NET_MSG_PLAYER_MANIFEST:
+        if (len >= PLAYER_MANIFEST_HEADER && net_state.callbacks.on_player_manifest) {
+            int count = (int)(data[1] | ((uint16_t)data[2] << 8));
+            int expected = PLAYER_MANIFEST_HEADER + count * PLAYER_MANIFEST_ENTRY;
+            if (len < expected) break;
+            if (count > COMMODITY_COUNT * MINING_GRADE_COUNT)
+                count = COMMODITY_COUNT * MINING_GRADE_COUNT;
+            static NetStationManifestEntry pmscratch[COMMODITY_COUNT * MINING_GRADE_COUNT];
+            for (int i = 0; i < count; i++) {
+                const uint8_t *p = &data[PLAYER_MANIFEST_HEADER + i * PLAYER_MANIFEST_ENTRY];
+                pmscratch[i].commodity = p[0];
+                pmscratch[i].grade     = p[1];
+                pmscratch[i].count     = (uint16_t)(p[2] | ((uint16_t)p[3] << 8));
+            }
+            net_state.callbacks.on_player_manifest(pmscratch, count);
+        }
+        break;
+
     case NET_MSG_STATION_MANIFEST:
         if (len >= STATION_MANIFEST_HEADER && net_state.callbacks.on_station_manifest) {
             uint8_t station_id = data[1];

--- a/src/net.h
+++ b/src/net.h
@@ -192,6 +192,13 @@ typedef void (*net_on_station_manifest_fn)(uint8_t station_id,
                                            const NetStationManifestEntry *entries,
                                            int count);
 
+/* Player manifest summary — same shape as the station summary, scoped
+ * to the local pilot (no station_idx). Server-authoritative state
+ * mirrored down each tick so the trade UI's SELL rows reflect actual
+ * server-side ship.manifest contents in multiplayer. */
+typedef void (*net_on_player_manifest_fn)(const NetStationManifestEntry *entries,
+                                          int count);
+
 /* Global leaderboard — top-N death runs by credits earned. */
 typedef struct {
     char  callsign[8];    /* not NUL-terminated if 8 chars */
@@ -224,6 +231,7 @@ typedef struct {
     net_on_station_ingots_fn on_station_ingots;
     net_on_hold_ingots_fn    on_hold_ingots;
     net_on_station_manifest_fn on_station_manifest;
+    net_on_player_manifest_fn  on_player_manifest;
     net_on_highscores_fn       on_highscores;
 } NetCallbacks;
 

--- a/src/net_sync.c
+++ b/src/net_sync.c
@@ -188,6 +188,44 @@ void apply_remote_highscores(const NetHighscoreEntry *entries, int count) {
     g.highscore_count = count;
 }
 
+/* Replace the local player's ship.manifest with synthesized
+ * legacy-migrate units that match the server-authoritative count
+ * summary. Provenance pubkeys are dropped (only counts matter for the
+ * SELL trade UI); the server still owns the real manifest. Without
+ * this, multiplayer SELL rows reflected only locally-predicted state
+ * and went stale the moment the server transferred a unit. */
+void apply_remote_player_manifest(const NetStationManifestEntry *entries,
+                                  int count) {
+    if (g.local_player_slot < 0 || g.local_player_slot >= MAX_PLAYERS) return;
+    ship_t *ship = &g.world.players[g.local_player_slot].ship;
+    /* Skip overwriting while a local action is being predicted to
+     * avoid flicker between predicted state and a slightly older
+     * server snapshot. */
+    if (g.action_predict_timer > 0.0f) return;
+    if (!ship->manifest.units && !ship_manifest_bootstrap(ship)) return;
+    manifest_clear(&ship->manifest);
+    if (count <= 0) return;
+    uint8_t origin[8] = { 'S','R','V','M','I','R','R','0' };
+    uint16_t out_idx = 0;
+    for (int i = 0; i < count; i++) {
+        uint8_t c = entries[i].commodity;
+        uint8_t gr = entries[i].grade;
+        uint16_t n = entries[i].count;
+        if (c >= COMMODITY_COUNT) continue;
+        if (gr >= MINING_GRADE_COUNT) continue;
+        cargo_kind_t kind;
+        if (!cargo_kind_for_commodity((commodity_t)c, &kind)) continue;
+        for (uint16_t k = 0; k < n; k++) {
+            if (ship->manifest.count >= ship->manifest.cap) break;
+            cargo_unit_t unit = {0};
+            if (!hash_legacy_migrate_unit(origin, (commodity_t)c, out_idx++, &unit))
+                continue;
+            unit.grade = gr;
+            if (!manifest_push(&ship->manifest, &unit)) break;
+        }
+    }
+}
+
 void apply_remote_hold_ingots(const named_ingot_t *ingots, int count) {
     if (g.local_player_slot < 0 || g.local_player_slot >= MAX_PLAYERS) return;
     if (count < 0) count = 0;

--- a/src/net_sync.h
+++ b/src/net_sync.h
@@ -32,6 +32,9 @@ void apply_remote_hold_ingots(const named_ingot_t *ingots, int count);
 void apply_remote_station_manifest(uint8_t station_id,
                                    const NetStationManifestEntry *entries,
                                    int count);
+/* Local player ship manifest summary (server-mirrored). */
+void apply_remote_player_manifest(const NetStationManifestEntry *entries,
+                                  int count);
 /* Global leaderboard snapshot. */
 void apply_remote_highscores(const NetHighscoreEntry *entries, int count);
 void apply_remote_events(const sim_event_t *events, int count);

--- a/src/station_ui.c
+++ b/src/station_ui.c
@@ -6,6 +6,7 @@
 #include "render.h"
 #include "palette.h"
 #include "mining_client.h"
+#include "manifest.h"
 /* Grade palette lives in shared/mining.h (pulled in via client.h →
  * types.h → mining.h) alongside the grade enum + label + multiplier. */
 
@@ -720,7 +721,9 @@ static void draw_trade_view(const station_ui_state_t *ui,
         const float slot_w = cell_w * 7.0f; /* "FEx99 " = 6 chars + sep */
         for (int i = 0; i < 6; i++) {
             float sx = cx + (float)i * slot_w;
-            int stock = (int)floorf(st->inventory[slots[i].c] + 0.0001f);
+            /* Manifest is the truth for finished goods (matches the BUY
+             * picker so the strip and the rows can never disagree). */
+            int stock = manifest_count_by_commodity(&st->manifest, slots[i].c);
             bool has_module = station_has_module(st, slots[i].producer);
             uint8_t r, g, b;
             if (!has_module) {

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -227,7 +227,10 @@ TEST(test_docked_buy_one_unit_per_intent) {
     world_reset(&w);
     world_seed_station_manifests(&w);
     station_t *st = &w.stations[1]; /* Kepler — produces frames */
-    st->inventory[COMMODITY_FRAME] = 50.0f;
+    /* Mint manifest entries (and float in lockstep) — manifest is the
+     * truth for finished-good BUY availability, so seeding only the
+     * float would leave the BUY check reading 0. */
+    station_finished_mint(st, COMMODITY_FRAME, 50, NULL);
 
     server_player_t *sp = &w.players[0];
     sp->connected = true;


### PR DESCRIPTION
## Root bug
\`inventory[c]\` (float) and \`station.manifest\` could drift. The MARKET picker reads the manifest; the BUY check read the float. Players saw rows the server then rejected with \`avail=0.00\` — the "purchase reverts" symptom across multiple sessions.

## Fix
- **BUY check** (\`try_buy_product\`) reads \`manifest_count_by_commodity\` for finished commodities. Picker, supply strip, and BUY now agree by construction.
- **Per-tick reconciliation** snaps float UP to manifest count so the supply strip and other float readers see real stock. Deliberately one-directional: \`manifest > float\` wins; \`float > manifest\` (legacy fixtures, smelter-side production) is left alone.
- **Common-grade BUY for INGOTS** now requires an exact-grade COMMON manifest entry. Previously, a COMMON request would fall back to fine/rare units via \`manifest_transfer_by_commodity_ex\` at the 1× price — under-charging for premium ingots.
- **\`step_module_delivery\`** marks \`named_ingots_dirty\` after consuming station inventory so MP clients see construction drains promptly.
- **NET_MSG_PLAYER_MANIFEST** — server pushes a per-(commodity, grade) count summary of the local pilot's \`ship.manifest\` each tick. Client rebuilds \`ship.manifest\` as legacy-migrate units (counts only — server keeps real provenance). Fixes MP SELL rows being stuck on stale predicted state.
- **Helpers** in \`shared/manifest.h\`:
  - \`station_finished_mint(st, c, n, origin)\`
  - \`station_finished_drain(st, c, n)\`
  - \`station_finished_accumulate(st, c, amount, origin)\`

## Test plan
- [x] \`make test\` — 322/322 pass
- [ ] Live: dock at Kepler with frames in stock → BUY clears, doesn't revert
- [ ] Live: supply strip and TRADE rows show identical counts
- [ ] MP: a player buying frames sees their hold update server-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)