### PR TITLE
Drop dead client refinery duplicate and unfulfillable ore TRACTOR

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -2189,59 +2189,30 @@ static int hail_find_or_issue_contract(world_t *w, server_player_t *sp, int issu
     }
     if (slot < 0) return -1;
 
-    bool has_payload = (sp->ship.towed_count > 0);
-    if (!has_payload) {
-        for (int k = 0; k < COMMODITY_COUNT; k++) {
-            if (sp->ship.cargo[k] > 0.1f) { has_payload = true; break; }
-        }
-    }
-
     contract_t *c = &w->contracts[slot];
     memset(c, 0, sizeof(*c));
 
-    if (has_payload) {
-        /* TRACTOR: deliver raw ore to the nearest station with a furnace. */
-        int dest = -1;
-        float best_d = 1e18f;
-        for (int s = 0; s < MAX_STATIONS; s++) {
-            station_t *st = &w->stations[s];
-            if (!station_is_active(st)) continue;
-            if (!station_has_module(st, MODULE_FURNACE) &&
-                !station_has_module(st, MODULE_FURNACE_CU) &&
-                !station_has_module(st, MODULE_FURNACE_CR)) continue;
-            float d = v2_dist_sq(sp->ship.pos, st->pos);
-            if (d < best_d) { best_d = d; dest = s; }
-        }
-        if (dest < 0) return -1;
-        c->active = true;
-        c->action = CONTRACT_TRACTOR;
-        c->station_index = (uint8_t)dest;
-        c->commodity = COMMODITY_FERRITE_ORE;
-        c->quantity_needed = 10.0f;
-        c->base_price = w->stations[dest].base_price[COMMODITY_FERRITE_ORE] * 1.2f;
-        c->target_index = -1;
-        c->claimed_by = (int8_t)sp->id;
-    } else {
-        /* FRACTURE: nearest mineable rock in signal coverage. */
-        int best_a = -1;
-        float best_d = 1e18f;
-        for (int a = 0; a < MAX_ASTEROIDS; a++) {
-            asteroid_t *ast = &w->asteroids[a];
-            if (!ast->active) continue;
-            if (ast->tier == ASTEROID_TIER_S) continue;
-            if (signal_strength_at(w, ast->pos) <= 0.0f) continue;
-            float d = v2_dist_sq(sp->ship.pos, ast->pos);
-            if (d < best_d) { best_d = d; best_a = a; }
-        }
-        if (best_a < 0) return -1;
-        c->active = true;
-        c->action = CONTRACT_FRACTURE;
-        c->station_index = (uint8_t)((issuer_station >= 0) ? issuer_station : 0);
-        c->target_pos = w->asteroids[best_a].pos;
-        c->target_index = best_a;
-        c->base_price = 25.0f;
-        c->claimed_by = (int8_t)sp->id;
+    /* FRACTURE: nearest mineable rock in signal coverage. Raw-ore TRACTOR
+     * contracts were removed because players can't carry ore — fragments
+     * ride in ship.towed_fragments[] and smelt directly on the beam. */
+    int best_a = -1;
+    float best_d = 1e18f;
+    for (int a = 0; a < MAX_ASTEROIDS; a++) {
+        asteroid_t *ast = &w->asteroids[a];
+        if (!ast->active) continue;
+        if (ast->tier == ASTEROID_TIER_S) continue;
+        if (signal_strength_at(w, ast->pos) <= 0.0f) continue;
+        float d = v2_dist_sq(sp->ship.pos, ast->pos);
+        if (d < best_d) { best_d = d; best_a = a; }
     }
+    if (best_a < 0) return -1;
+    c->active = true;
+    c->action = CONTRACT_FRACTURE;
+    c->station_index = (uint8_t)((issuer_station >= 0) ? issuer_station : 0);
+    c->target_pos = w->asteroids[best_a].pos;
+    c->target_index = best_a;
+    c->base_price = 25.0f;
+    c->claimed_by = (int8_t)sp->id;
     return slot;
 }
 
@@ -4062,6 +4033,10 @@ void world_reset(world_t *w) {
     w->stations[0].pos         = v2(0.0f, -2400.0f);
     w->stations[0].radius      = 40.0f;
     w->stations[0].dock_radius = 240.0f;
+    /* Ore base prices are the smelt-payout floor when no TRACTOR contract
+     * is active (sim_production.c smelt-payout reads station_buy_price for
+     * the commodity). Never sold/bought as cargo — players don't carry
+     * raw ore. */
     w->stations[0].base_price[COMMODITY_FERRITE_ORE] = 10.0f;
     w->stations[0].base_price[COMMODITY_CUPRITE_ORE] = 14.0f;
     w->stations[0].base_price[COMMODITY_CRYSTAL_ORE] = 18.0f;
@@ -4099,6 +4074,7 @@ void world_reset(world_t *w) {
     w->stations[1].radius      = 36.0f;
     w->stations[1].dock_radius = 240.0f;
     w->stations[1].signal_range = 15000.0f;
+    /* Smelt-payout floor (see Prospect comment above). */
     w->stations[1].base_price[COMMODITY_FERRITE_ORE] = 10.0f;
     w->stations[1].base_price[COMMODITY_CUPRITE_ORE] = 14.0f;
     w->stations[1].base_price[COMMODITY_CRYSTAL_ORE] = 18.0f;
@@ -4134,6 +4110,7 @@ void world_reset(world_t *w) {
     w->stations[2].radius      = 36.0f;
     w->stations[2].dock_radius = 240.0f;
     w->stations[2].signal_range = 15000.0f;
+    /* Smelt-payout floor (see Prospect comment above). */
     w->stations[2].base_price[COMMODITY_FERRITE_ORE] = 10.0f;
     w->stations[2].base_price[COMMODITY_CUPRITE_ORE] = 14.0f;
     w->stations[2].base_price[COMMODITY_CRYSTAL_ORE] = 18.0f;

--- a/src/economy.c
+++ b/src/economy.c
@@ -3,16 +3,6 @@
 #include "economy.h"
 #include "manifest.h"
 
-/* Check if station can smelt a specific ore type */
-static bool can_smelt_ore(const station_t* station, commodity_t ore) {
-    switch (ore) {
-        case COMMODITY_FERRITE_ORE: return station_has_module(station, MODULE_FURNACE);
-        case COMMODITY_CUPRITE_ORE: return station_has_module(station, MODULE_FURNACE_CU);
-        case COMMODITY_CRYSTAL_ORE: return station_has_module(station, MODULE_FURNACE_CR);
-        default: return false;
-    }
-}
-
 typedef struct {
     commodity_t primary_input;
     float primary_units_per_output;
@@ -60,34 +50,6 @@ static bool producer_recipe_for_module(module_type_t mt, producer_recipe_t *out_
 
     return out_recipe->primary_units_per_output > 0.0f &&
            out_recipe->output == module_schema_output(mt);
-}
-
-void step_refinery_production(station_t* stations, int count, float dt) {
-    for (int s = 0; s < count; s++) {
-        station_t* station = &stations[s];
-        /* Need at least one furnace type */
-        if (!station_has_module(station, MODULE_FURNACE)
-            && !station_has_module(station, MODULE_FURNACE_CU)
-            && !station_has_module(station, MODULE_FURNACE_CR)) continue;
-
-        int active = 0;
-        for (int i = COMMODITY_FERRITE_ORE; i < COMMODITY_RAW_ORE_COUNT; i++) {
-            if (station->inventory[i] > FLOAT_EPSILON && can_smelt_ore(station, (commodity_t)i)) active++;
-        }
-        if (active == 0) continue;
-        if (active > REFINERY_MAX_FURNACES) active = REFINERY_MAX_FURNACES;
-
-        float rate = REFINERY_BASE_SMELT_RATE / (float)active;
-
-        for (int i = COMMODITY_FERRITE_ORE; i < COMMODITY_RAW_ORE_COUNT; i++) {
-            commodity_t ore = (commodity_t)i;
-            if (!can_smelt_ore(station, ore)) continue;
-            if (station->inventory[ore] <= FLOAT_EPSILON) continue;
-            float consume = fminf(station->inventory[ore], rate * dt);
-            station->inventory[ore] -= consume;
-            station->inventory[commodity_refined_form(ore)] += consume;
-        }
-    }
 }
 
 void step_station_production(station_t* stations, int count, float dt) {

--- a/src/economy.h
+++ b/src/economy.h
@@ -5,7 +5,6 @@
 #include "commodity.h"
 #include "ship.h"
 
-void step_refinery_production(station_t* stations, int count, float dt);
 void step_station_production(station_t* stations, int count, float dt);
 
 float station_repair_cost(const ship_t* ship, const station_t* station);

--- a/src/main.c
+++ b/src/main.c
@@ -236,8 +236,6 @@ static void step_notice_timer(float dt) {
     }
 }
 
-/* step_refinery_production, step_station_production: see economy.h/c */
-
 /* No sync_globals_to_world — world_t is the source of truth in single player. */
 
 /* sync_world_to_globals removed — everything reads from g.world directly */

--- a/src/test_main.c
+++ b/src/test_main.c
@@ -24,7 +24,6 @@ void register_bug_regression_b88_90_tests(void);
 void register_economy_contracts_tests(void);
 void register_save_persistence_tests(void);
 void register_save_format_tests(void);
-void register_economy_furnace_tests(void);
 void register_construction_modules_tests(void);
 void register_economy_contract3_tests(void);
 void register_economy_pricing_tests(void);
@@ -89,7 +88,6 @@ int main(int argc, char **argv) {
     register_economy_contracts_tests();
     register_save_persistence_tests();
     register_save_format_tests();
-    register_economy_furnace_tests();
     register_construction_modules_tests();
     register_economy_contract3_tests();
     register_economy_pricing_tests();

--- a/src/tests/test_bug_regression.c
+++ b/src/tests/test_bug_regression.c
@@ -164,20 +164,6 @@ TEST(test_bug16_npc_target_bounds_checked) {
     ASSERT(w.npc_ships[0].target_asteroid < MAX_ASTEROIDS || w.npc_ships[0].target_asteroid == -1);
 }
 
-TEST(test_bug17_no_duplicate_refinery) {
-    /* economy.c exports step_refinery_production for tests and client use.
-     * game_sim.c has its own static copy for the server.  Both must produce
-     * consistent results — verify economy.c's version works correctly. */
-    station_t stations[MAX_STATIONS];
-    memset(stations, 0, sizeof(stations));
-    stations[0].modules[stations[0].module_count++] = (station_module_t){ .type = MODULE_FURNACE };
-    stations[0].inventory[COMMODITY_FERRITE_ORE] = 10.0f;
-    step_refinery_production(stations, MAX_STATIONS, 1.0f);
-    /* Ore should be consumed and inventory produced. */
-    ASSERT(stations[0].inventory[COMMODITY_FERRITE_ORE] < 10.0f);
-    ASSERT(stations[0].inventory[COMMODITY_FERRITE_INGOT] > 0.0f);
-}
-
 TEST(test_bug18_emergency_recover_nearest_station) {
     WORLD_DECL;
     world_reset(&w);
@@ -1333,7 +1319,6 @@ void register_bug_regression_batch2_tests(void) {
     RUN(test_bug14_player_ship_syncs_all_cargo);
     RUN(test_bug15_state_size_symmetric);
     RUN(test_bug16_npc_target_bounds_checked);
-    RUN(test_bug17_no_duplicate_refinery);
     RUN(test_bug18_emergency_recover_nearest_station);
     RUN(test_bug19_feedback_in_world);
     RUN(test_bug20_player_ship_checks_id);

--- a/src/tests/test_economy.c
+++ b/src/tests/test_economy.c
@@ -1,29 +1,5 @@
 #include "tests/test_harness.h"
 
-TEST(test_refinery_production_smelts_ore) {
-    station_t station = {0};
-    station.modules[station.module_count++] = (station_module_t){ .type = MODULE_FURNACE };
-    station.inventory[COMMODITY_FERRITE_ORE] = 10.0f;
-    step_refinery_production(&station, 1, 1.0f);
-    ASSERT(station.inventory[COMMODITY_FERRITE_ORE] < 10.0f);
-    ASSERT(station.inventory[COMMODITY_FERRITE_INGOT] > 0.0f);
-}
-
-TEST(test_refinery_production_empty_buffer_noop) {
-    station_t station = {0};
-    station.modules[station.module_count++] = (station_module_t){ .type = MODULE_FURNACE };
-    step_refinery_production(&station, 1, 1.0f);
-    ASSERT_EQ_FLOAT(station.inventory[COMMODITY_FERRITE_INGOT], 0.0f, 0.001f);
-}
-
-TEST(test_refinery_skips_non_refinery) {
-    station_t station = {0};
-    station.modules[station.module_count++] = (station_module_t){ .type = MODULE_FRAME_PRESS };
-    station.inventory[COMMODITY_FERRITE_ORE] = 10.0f;
-    step_refinery_production(&station, 1, 1.0f);
-    ASSERT_EQ_FLOAT(station.inventory[COMMODITY_FERRITE_ORE], 10.0f, 0.001f);
-}
-
 TEST(test_station_production_yard_makes_frames) {
     station_t station = {0};
     station.modules[station.module_count++] = (station_module_t){ .type = MODULE_FRAME_PRESS };
@@ -218,47 +194,6 @@ TEST(test_hauler_fills_highest_value_contract) {
     world_sim_step(&w, SIM_DT);
     /* Hauler should target station 2 (higher value contract) */
     ASSERT(hauler->dest_station == 2);
-}
-
-TEST(test_furnace_only_smelts_ferrite) {
-    station_t st = {0};
-    st.modules[st.module_count++] = (station_module_t){ .type = MODULE_FURNACE };
-    st.inventory[COMMODITY_FERRITE_ORE] = 50.0f;
-    st.inventory[COMMODITY_CUPRITE_ORE] = 50.0f;
-    st.inventory[COMMODITY_CRYSTAL_ORE] = 50.0f;
-    step_refinery_production(&st, 1, 1.0f);
-    ASSERT(st.inventory[COMMODITY_FERRITE_ORE] < 50.0f);  /* smelted */
-    ASSERT_EQ_FLOAT(st.inventory[COMMODITY_CUPRITE_ORE], 50.0f, 0.01f);  /* untouched */
-    ASSERT_EQ_FLOAT(st.inventory[COMMODITY_CRYSTAL_ORE], 50.0f, 0.01f);  /* untouched */
-    ASSERT(st.inventory[COMMODITY_FERRITE_INGOT] > 0.0f);
-}
-
-TEST(test_furnace_cu_smelts_cuprite) {
-    station_t st = {0};
-    st.modules[st.module_count++] = (station_module_t){ .type = MODULE_FURNACE_CU };
-    st.inventory[COMMODITY_FERRITE_ORE] = 50.0f;
-    st.inventory[COMMODITY_CUPRITE_ORE] = 50.0f;
-    step_refinery_production(&st, 1, 1.0f);
-    ASSERT_EQ_FLOAT(st.inventory[COMMODITY_FERRITE_ORE], 50.0f, 0.01f);  /* no FE furnace */
-    ASSERT(st.inventory[COMMODITY_CUPRITE_ORE] < 50.0f);
-    ASSERT(st.inventory[COMMODITY_CUPRITE_INGOT] > 0.0f);
-}
-
-TEST(test_furnace_cr_smelts_crystal) {
-    station_t st = {0};
-    st.modules[st.module_count++] = (station_module_t){ .type = MODULE_FURNACE_CR };
-    st.inventory[COMMODITY_CRYSTAL_ORE] = 50.0f;
-    step_refinery_production(&st, 1, 1.0f);
-    ASSERT(st.inventory[COMMODITY_CRYSTAL_ORE] < 50.0f);
-    ASSERT(st.inventory[COMMODITY_CRYSTAL_INGOT] > 0.0f);
-}
-
-TEST(test_no_furnace_no_smelting) {
-    station_t st = {0};
-    st.modules[st.module_count++] = (station_module_t){ .type = MODULE_FRAME_PRESS };
-    st.inventory[COMMODITY_FERRITE_ORE] = 50.0f;
-    step_refinery_production(&st, 1, 1.0f);
-    ASSERT_EQ_FLOAT(st.inventory[COMMODITY_FERRITE_ORE], 50.0f, 0.01f);
 }
 
 TEST(test_one_contract_per_station) {
@@ -494,9 +429,6 @@ TEST(test_furnace_without_adjacent_hopper_smelts) {
 
 void register_economy_basic_tests(void) {
     TEST_SECTION("\nEconomy tests:\n");
-    RUN(test_refinery_production_smelts_ore);
-    RUN(test_refinery_production_empty_buffer_noop);
-    RUN(test_refinery_skips_non_refinery);
     RUN(test_station_production_yard_makes_frames);
     RUN(test_station_production_beamworks_makes_modules);
     RUN(test_station_repair_cost_no_damage);
@@ -513,14 +445,6 @@ void register_economy_contracts_tests(void) {
     RUN(test_contract_closes_when_deficit_filled);
     RUN(test_sell_price_uses_contract_price);
     RUN(test_hauler_fills_highest_value_contract);
-}
-
-void register_economy_furnace_tests(void) {
-    TEST_SECTION("\nRefinery tiers:\n");
-    RUN(test_furnace_only_smelts_ferrite);
-    RUN(test_furnace_cu_smelts_cuprite);
-    RUN(test_furnace_cr_smelts_crystal);
-    RUN(test_no_furnace_no_smelting);
 }
 
 void register_economy_contract3_tests(void) {


### PR DESCRIPTION
## Summary
- Delete `src/economy.c` `step_refinery_production()` / `can_smelt_ore()` — client-side mirror of the server's `sim_step_refinery_production`. The client doesn't run sim, so this was test-only deadweight. Drops 8 tests that exclusively exercised it (`test_economy.c` "Refinery tiers" group + 3 in "Economy tests" + `test_bug17`).
- Collapse `hail_find_or_issue_contract`'s `if (has_payload)` branch to always-FRACTURE. Post-#259 (physical ore towing) the delivery loop at `game_sim.c:898` explicitly skips raw-ore commodities, making the issued ore TRACTOR contract unfulfillable.
- Document ore `base_price` as the smelt-payout floor (read by `station_buy_price()` in the beam-smelt payout when no TRACTOR contract is active). First-pass tried to delete the seeds as dead, which broke `test_scenario_full_mining_cycle`. Restored with explanatory comments.

Net: 7 files, +26 / -183.

## Test plan
- [x] `make test` — 314/314 pass
- [x] Native build (cmake `signal` + `signal_server` targets)
- [x] WASM build (`signal.html`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)