### PR TITLE
Repair kits: gate fab on shipyards, auto-import to consumer docks

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -3193,13 +3193,13 @@ static void step_contracts(world_t *w, float dt) {
             }
         }
 
-        /* Priority 5: dock kit-fab inputs. Last-resort: every dock needs
+        /* Priority 5: shipyard kit-fab inputs. Every shipyard needs
          * frames + lasers + tractor modules to mint repair kits, but the
          * upstream production contracts (above) come first so they don't
          * starve. Only fires when the station's own ingot/scaffold
          * pipeline is satisfied, ensuring kit fab gets fed without
          * cannibalising the chain that produces its inputs. */
-        if (!need.active && !has_production_contract && station_has_module(st, MODULE_DOCK)) {
+        if (!need.active && !has_production_contract && station_has_module(st, MODULE_SHIPYARD)) {
             const struct { commodity_t c; module_type_t producer; } kit_inputs[] = {
                 { COMMODITY_FRAME,          MODULE_FRAME_PRESS  },
                 { COMMODITY_LASER_MODULE,   MODULE_LASER_FAB    },
@@ -3223,6 +3223,32 @@ static void step_contracts(world_t *w, float dt) {
                     .base_price = st->base_price[mat] > 0.0f
                                   ? st->base_price[mat] * 1.25f * pool_factor
                                   : 28.0f * pool_factor,
+                    .target_index = -1, .claimed_by = -1,
+                };
+            }
+        }
+
+        /* Priority 6: kit imports at consumer-only stations. A station
+         * with a dock but no shipyard (Prospect, future outposts) can't
+         * mint kits — it needs them hauled in. Issue a TRACTOR contract
+         * for REPAIR_KIT when the station's kit inventory falls below
+         * 25% of cap. Players and NPC haulers can fulfill via the same
+         * delivery loop that handles ingot/frame deliveries. */
+        if (!need.active && !has_production_contract
+            && station_has_module(st, MODULE_DOCK)
+            && !station_has_module(st, MODULE_SHIPYARD)) {
+            const float kit_import_threshold = REPAIR_KIT_STOCK_CAP * 0.25f;
+            if (st->inventory[COMMODITY_REPAIR_KIT] < kit_import_threshold) {
+                float deficit = REPAIR_KIT_STOCK_CAP - st->inventory[COMMODITY_REPAIR_KIT];
+                float seed = st->base_price[COMMODITY_REPAIR_KIT] > 0.0f
+                             ? st->base_price[COMMODITY_REPAIR_KIT]
+                             : 6.0f;
+                need = (contract_t){
+                    .active = true, .action = CONTRACT_TRACTOR,
+                    .station_index = (uint8_t)s,
+                    .commodity = COMMODITY_REPAIR_KIT,
+                    .quantity_needed = deficit,
+                    .base_price = seed * 1.5f * pool_factor,
                     .target_index = -1, .claimed_by = -1,
                 };
             }

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -954,25 +954,24 @@ void step_module_delivery(world_t *w, station_t *st, int station_idx,
 }
 
 /* ------------------------------------------------------------------ */
-/* Dock repair-kit fabrication                                         */
+/* Shipyard repair-kit fabrication                                     */
 /* ------------------------------------------------------------------ */
-/* Every station with a MODULE_DOCK runs an assembly bench that turns
- * 1 frame + 1 laser + 1 tractor module into REPAIR_KIT_PER_BATCH (100)
- * repair kits, on a slow cadence (REPAIR_KIT_FAB_PERIOD seconds per
- * batch). One kit restores 1 HP at the dock's repair service.
+/* Every station with a MODULE_SHIPYARD runs an assembly bench that
+ * turns 1 frame + 1 laser + 1 tractor module into REPAIR_KIT_PER_BATCH
+ * (100) repair kits, on a slow cadence (REPAIR_KIT_FAB_PERIOD seconds
+ * per batch). Kits are commodities — bought as cargo at the shipyard,
+ * carried, and consumed at any dock during repair.
  *
- * Inputs come from the same station's inventory + manifest (so the
- * three Helios/Kepler outputs flow naturally to docks via NPC haulers
- * or player delivery, and from there into kits the ships consume).
- * The triple-input recipe is the load-bearing demand sink that closes
- * the production loop — every smelter, every fab has a downstream
- * consumer, instead of saturating at the cap. */
+ * Stations with a dock but no shipyard (e.g. Prospect) don't make
+ * kits; they import them via the kit-deficit TRACTOR contract issued
+ * by step_contracts. The triple-input recipe remains the load-bearing
+ * demand sink that closes the production loop. */
 void step_dock_repair_kit_fab(world_t *w, float dt) {
     if (!w) return;
     for (int s = 0; s < MAX_STATIONS; s++) {
         station_t *st = &w->stations[s];
         if (!station_exists(st)) continue;
-        if (!station_has_module(st, MODULE_DOCK)) continue;
+        if (!station_has_module(st, MODULE_SHIPYARD)) continue;
         if (st->inventory[COMMODITY_REPAIR_KIT] >= REPAIR_KIT_STOCK_CAP) continue;
 
         st->repair_kit_fab_timer += dt;
@@ -1022,7 +1021,7 @@ void step_dock_repair_kit_fab(world_t *w, float dt) {
             st->named_ingots_dirty = true;
         }
         st->repair_kit_fab_timer = 0.0f;
-        SIM_LOG("[dock-fab] station %d minted %d kits (1 frame + 1 laser + 1 tractor consumed)\n",
+        SIM_LOG("[shipyard-fab] station %d minted %d kits (1 frame + 1 laser + 1 tractor consumed)\n",
                 s, int_minted);
     }
 }

--- a/src/tests/test_economy.c
+++ b/src/tests/test_economy.c
@@ -408,6 +408,78 @@ TEST(test_refinery_smelts_ore_in_inventory) {
     ASSERT(ingots > 0.0f);
 }
 
+TEST(test_kit_fab_requires_shipyard) {
+    /* After the shipyard-fab redesign, only stations with MODULE_SHIPYARD
+     * mint repair kits. A station with only a dock + the three input
+     * commodities should never produce kits. */
+    WORLD_DECL;
+    world_reset(&w);
+    /* Prospect (station 0) has a dock but no shipyard. Kepler (station 1)
+     * has both. Pre-fill both with kit-fab inputs. */
+    ASSERT(station_has_module(&w.stations[0], MODULE_DOCK));
+    ASSERT(!station_has_module(&w.stations[0], MODULE_SHIPYARD));
+    ASSERT(station_has_module(&w.stations[1], MODULE_SHIPYARD));
+    for (int s = 0; s < 2; s++) {
+        w.stations[s].inventory[COMMODITY_FRAME]          = 5.0f;
+        w.stations[s].inventory[COMMODITY_LASER_MODULE]   = 5.0f;
+        w.stations[s].inventory[COMMODITY_TRACTOR_MODULE] = 5.0f;
+        w.stations[s].inventory[COMMODITY_REPAIR_KIT]     = 0.0f;
+        w.stations[s].repair_kit_fab_timer = 0.0f;
+    }
+    /* Run long enough for at least one fab cycle (REPAIR_KIT_FAB_PERIOD = 30s). */
+    for (int i = 0; i < (int)(35.0f / SIM_DT); i++)
+        world_sim_step(&w, SIM_DT);
+    /* Shipyard station produces kits; dock-only station does not. */
+    ASSERT(w.stations[1].inventory[COMMODITY_REPAIR_KIT] > 0.0f);
+    ASSERT_EQ_FLOAT(w.stations[0].inventory[COMMODITY_REPAIR_KIT], 0.0f, 0.01f);
+}
+
+TEST(test_kit_import_contract_at_consumer_station) {
+    /* A station with a dock but no shipyard should issue a TRACTOR
+     * contract for REPAIR_KIT when its kit inventory drops below the
+     * import threshold. Players or NPC haulers fulfill via the same
+     * delivery loop that handles ingots. */
+    WORLD_DECL;
+    world_reset(&w);
+    ASSERT(station_has_module(&w.stations[0], MODULE_DOCK));
+    ASSERT(!station_has_module(&w.stations[0], MODULE_SHIPYARD));
+    /* Drain Prospect's kit inventory to force the deficit. */
+    w.stations[0].inventory[COMMODITY_REPAIR_KIT] = 0.0f;
+    /* Run a few seconds for the contract step to fire. */
+    for (int i = 0; i < 120; i++) world_sim_step(&w, SIM_DT);
+    bool found = false;
+    for (int k = 0; k < MAX_CONTRACTS; k++) {
+        contract_t *c = &w.contracts[k];
+        if (c->active && c->action == CONTRACT_TRACTOR
+            && c->station_index == 0
+            && c->commodity == COMMODITY_REPAIR_KIT) {
+            found = true;
+            ASSERT(c->base_price > 0.0f);
+            ASSERT(c->quantity_needed > 0.0f);
+            break;
+        }
+    }
+    ASSERT(found);
+}
+
+TEST(test_kit_import_contract_skips_shipyard_stations) {
+    /* A shipyard station mints its own kits; the import contract should
+     * not fire there even with kit inventory at zero. */
+    WORLD_DECL;
+    world_reset(&w);
+    ASSERT(station_has_module(&w.stations[1], MODULE_SHIPYARD));
+    w.stations[1].inventory[COMMODITY_REPAIR_KIT] = 0.0f;
+    for (int i = 0; i < 120; i++) world_sim_step(&w, SIM_DT);
+    for (int k = 0; k < MAX_CONTRACTS; k++) {
+        contract_t *c = &w.contracts[k];
+        if (c->active && c->action == CONTRACT_TRACTOR
+            && c->station_index == 1
+            && c->commodity == COMMODITY_REPAIR_KIT) {
+            ASSERT(false); /* shouldn't reach here */
+        }
+    }
+}
+
 TEST(test_furnace_without_adjacent_hopper_smelts) {
     /* Furnaces smelt from station inventory regardless of adjacency. */
     WORLD_DECL;
@@ -445,6 +517,9 @@ void register_economy_contracts_tests(void) {
     RUN(test_contract_closes_when_deficit_filled);
     RUN(test_sell_price_uses_contract_price);
     RUN(test_hauler_fills_highest_value_contract);
+    RUN(test_kit_fab_requires_shipyard);
+    RUN(test_kit_import_contract_at_consumer_station);
+    RUN(test_kit_import_contract_skips_shipyard_stations);
 }
 
 void register_economy_contract3_tests(void) {


### PR DESCRIPTION
## Summary
Step 1 of the repair-kits-as-cargo redesign. Splits production from consumption so the existing commodity flow handles distribution.

- Kit fab now requires `MODULE_SHIPYARD` (was: any `MODULE_DOCK`). Kepler and Helios stay producers; Prospect stops fabricating.
- Existing Priority 5 contract (kit-fab inputs: frames/lasers/tractors) now gates on shipyard. Helios still imports frames it can't make; Prospect stops asking for inputs it has no use for.
- New Priority 6 contract: dock-only stations (no shipyard) auto-issue `CONTRACT_TRACTOR` for `REPAIR_KIT` when inventory drops below 25% of cap. Players and NPCs fulfill via the existing delivery loop — no new fulfillment code.

This is server-side scaffolding only. The kits-as-cargo behavior flip and the cargo-first repair logic land in the next PR — for now repair still consumes from station inventory in-place.

## Test plan
- [x] `make test` — 317/317 pass (3 new)
- [x] Native build green
- [x] WASM build green
- [x] New tests:
  - `test_kit_fab_requires_shipyard` — Prospect (dock-only) doesn't mint kits even with all inputs; Kepler does.
  - `test_kit_import_contract_at_consumer_station` — Prospect with empty kit inventory auto-issues a `REPAIR_KIT` TRACTOR contract.
  - `test_kit_import_contract_skips_shipyard_stations` — shipyard stations don't issue kit-import contracts (they make their own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)