### PR TITLE
Repair kits as cargo: BUY at shipyards, SELL/install at consumer docks

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -1029,31 +1029,53 @@ static void try_repair_ship(world_t *w, server_player_t *sp) {
     float missing = fmaxf(0.0f, max_hull - sp->ship.hull);
     if (missing <= 0.0f) return;
 
-    /* Each repair-kit restores 1 HP. If the station has no kits the
-     * dock can't repair — the demand for kits is what closes the
-     * production loop. Partial repair is allowed: heal as many HP as
-     * kits are on hand. */
-    int kits_avail = (int)floorf(st->inventory[COMMODITY_REPAIR_KIT] + 0.0001f);
-    int hp_needed  = (int)ceilf(missing);
-    int hp_apply   = kits_avail < hp_needed ? kits_avail : hp_needed;
+    /* 1 kit = 1 HP. Source priority: ship cargo first (kits the player
+     * brought along — already paid for), then station inventory at
+     * station retail. Shipyards charge no labor (you paid station
+     * retail already if buying here); any other dock charges
+     * LABOR_FEE_PER_HP for the install. Partial repair is allowed if
+     * neither source has enough kits. */
+    int kits_in_cargo  = (int)floorf(sp->ship.cargo[COMMODITY_REPAIR_KIT] + 0.0001f);
+    int kits_at_station = (int)floorf(st->inventory[COMMODITY_REPAIR_KIT] + 0.0001f);
+    int hp_needed       = (int)ceilf(missing);
+    int hp_apply        = hp_needed;
+    if (hp_apply > kits_in_cargo + kits_at_station)
+        hp_apply = kits_in_cargo + kits_at_station;
     if (hp_apply <= 0) return;
 
-    /* Drain kits from float + manifest in lockstep. */
-    st->inventory[COMMODITY_REPAIR_KIT] -= (float)hp_apply;
-    if (st->inventory[COMMODITY_REPAIR_KIT] < 0.0f)
-        st->inventory[COMMODITY_REPAIR_KIT] = 0.0f;
-    manifest_consume_by_commodity(&st->manifest, COMMODITY_REPAIR_KIT, hp_apply);
-    st->named_ingots_dirty = true;
+    int from_cargo   = (hp_apply < kits_in_cargo) ? hp_apply : kits_in_cargo;
+    int from_station = hp_apply - from_cargo;
 
-    /* Credit cost still applies — kits are the physical input, credits
-     * are the labor. Cost scales with HP actually applied so a partial
-     * repair charges only for the partial heal. */
-    float cost = ceilf((float)hp_apply * STATION_REPAIR_COST_PER_HULL);
-    ledger_force_debit(st, sp->session_token, cost, &sp->ship);
+    /* Drain ship cargo + ship manifest. */
+    if (from_cargo > 0) {
+        sp->ship.cargo[COMMODITY_REPAIR_KIT] -= (float)from_cargo;
+        if (sp->ship.cargo[COMMODITY_REPAIR_KIT] < 0.0f)
+            sp->ship.cargo[COMMODITY_REPAIR_KIT] = 0.0f;
+        manifest_consume_by_commodity(&sp->ship.manifest,
+                                      COMMODITY_REPAIR_KIT, from_cargo);
+    }
+
+    /* Drain station inventory + station manifest for the fallback. */
+    if (from_station > 0) {
+        st->inventory[COMMODITY_REPAIR_KIT] -= (float)from_station;
+        if (st->inventory[COMMODITY_REPAIR_KIT] < 0.0f)
+            st->inventory[COMMODITY_REPAIR_KIT] = 0.0f;
+        manifest_consume_by_commodity(&st->manifest,
+                                      COMMODITY_REPAIR_KIT, from_station);
+        st->named_ingots_dirty = true;
+    }
+
+    /* Cost = station retail on station-sourced kits + labor at non-shipyard. */
+    float station_kit_cost = (float)from_station
+                           * station_sell_price(st, COMMODITY_REPAIR_KIT);
+    bool is_shipyard = station_has_module(st, MODULE_SHIPYARD);
+    float labor_cost = is_shipyard ? 0.0f : (float)hp_apply * LABOR_FEE_PER_HP;
+    float cost = ceilf(station_kit_cost + labor_cost);
+    if (cost > 0.0f) ledger_force_debit(st, sp->session_token, cost, &sp->ship);
 
     sp->ship.hull = fminf(max_hull, sp->ship.hull + (float)hp_apply);
-    SIM_LOG("[sim] player %d repaired %d HP (%d kits, %.0f cr)\n",
-            sp->id, hp_apply, hp_apply, cost);
+    SIM_LOG("[sim] player %d repaired %d HP (%d cargo + %d station kits, %.0f cr)\n",
+            sp->id, hp_apply, from_cargo, from_station, cost);
     emit_event(w, (sim_event_t){.type = SIM_EVENT_REPAIR, .player_id = sp->id});
 }
 
@@ -2405,7 +2427,9 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
             float available = (c >= COMMODITY_RAW_ORE_COUNT)
                 ? (float)manifest_count_by_commodity(&docked_st->manifest, c)
                 : docked_st->inventory[c];
-            float space = ship_cargo_capacity(&sp->ship) - ship_total_cargo(&sp->ship);
+            float free_volume = ship_cargo_capacity(&sp->ship) - ship_total_cargo(&sp->ship);
+            float vol = commodity_volume(c);
+            float space = (vol > FLOAT_EPSILON) ? (free_volume / vol) : free_volume;
             float price_base = station_sell_price(docked_st, c);
             /* Grade-aware pricing: if the client picked a specific-grade row
              * in TRADE the row's displayed price was base * grade_multiplier,

--- a/shared/economy_const.h
+++ b/shared/economy_const.h
@@ -25,16 +25,27 @@ static const float STATION_REPAIR_COST_PER_HULL = 5.0f;
 static const float MAX_PRODUCT_STOCK = 120.0f;
 static const float HAULER_RESERVE = 24.0f;  /* keep 20% stock for player purchases */
 
-/* --- Dock repair-kit fab --- */
-/* A station with MODULE_DOCK consumes 1 frame + 1 laser + 1 tractor and
- * produces REPAIR_KIT_PER_BATCH kits every REPAIR_KIT_FAB_PERIOD seconds.
- * Slow cadence is intentional — each batch heavily pulls on three
- * production chains; faster would saturate Kepler/Helios output and
- * starve outpost construction of its inputs. The cap is large because
- * kits get consumed 1-per-HP, not 1-per-ship-visit. */
+/* --- Shipyard repair-kit fab --- */
+/* A station with MODULE_SHIPYARD consumes 1 frame + 1 laser + 1 tractor
+ * and produces REPAIR_KIT_PER_BATCH kits every REPAIR_KIT_FAB_PERIOD
+ * seconds. Slow cadence is intentional — each batch heavily pulls on
+ * three production chains; faster would saturate Kepler/Helios output
+ * and starve outpost construction of its inputs. The cap is large
+ * because kits get consumed 1-per-HP, not 1-per-ship-visit. */
 static const float REPAIR_KIT_FAB_PERIOD  = 30.0f;
 static const float REPAIR_KIT_PER_BATCH   = 100.0f;
 static const float REPAIR_KIT_STOCK_CAP   = 1000.0f;
+
+/* Kits are dense cargo: 10 kits per cargo unit. A 100-HP repair (= 100
+ * kits) costs 10 cargo slots, which fits in any starter ship's hold.
+ * commodity_volume() returns this for REPAIR_KIT, 1.0 for everything
+ * else. */
+static const float REPAIR_KIT_CARGO_DENSITY = 0.1f;
+
+/* Per-HP labor fee charged at non-shipyard docks (where the kits were
+ * fabricated elsewhere). Shipyards charge 0 labor — you already paid
+ * full station retail when you bought the kits there. */
+static const float LABOR_FEE_PER_HP = 1.0f;
 
 /* --- Outpost construction --- */
 static const float SCAFFOLD_MATERIAL_NEEDED = 60.0f;   /* total frames needed */

--- a/shared/station_util.h
+++ b/shared/station_util.h
@@ -96,6 +96,12 @@ static inline bool station_consumes(const station_t *st, commodity_t c) {
                    station_has_module(st, MODULE_TRACTOR_FAB);
         case COMMODITY_CRYSTAL_INGOT:
             return station_has_module(st, MODULE_LASER_FAB);
+        /* Consumer-only docks (no shipyard) buy kits hauled in from
+         * shipyards — that's how Prospect's repair stockpile gets fed.
+         * Shipyards make their own and never buy them back. */
+        case COMMODITY_REPAIR_KIT:
+            return station_has_module(st, MODULE_DOCK)
+                   && !station_has_module(st, MODULE_SHIPYARD);
         default: return false;
     }
 }
@@ -109,7 +115,7 @@ static inline bool station_produces(const station_t *st, commodity_t c) {
         case COMMODITY_FRAME:         return station_has_module(st, MODULE_FRAME_PRESS);
         case COMMODITY_LASER_MODULE:  return station_has_module(st, MODULE_LASER_FAB);
         case COMMODITY_TRACTOR_MODULE:return station_has_module(st, MODULE_TRACTOR_FAB);
-        case COMMODITY_REPAIR_KIT:    return station_has_module(st, MODULE_DOCK);
+        case COMMODITY_REPAIR_KIT:    return station_has_module(st, MODULE_SHIPYARD);
         default: return false;
     }
 }

--- a/src/commodity.c
+++ b/src/commodity.c
@@ -143,10 +143,15 @@ const char* commodity_short_name(commodity_t commodity) {
     }
 }
 
+float commodity_volume(commodity_t commodity) {
+    if (commodity == COMMODITY_REPAIR_KIT) return REPAIR_KIT_CARGO_DENSITY;
+    return 1.0f;
+}
+
 float ship_total_cargo(const ship_t* ship) {
     float total = 0.0f;
     for (int i = 0; i < COMMODITY_COUNT; i++) {
-        total += ship->cargo[i];
+        total += ship->cargo[i] * commodity_volume((commodity_t)i);
     }
     return total;
 }

--- a/src/commodity.h
+++ b/src/commodity.h
@@ -18,6 +18,11 @@ void commodity_color_u8(commodity_t commodity, uint8_t *r, uint8_t *g, uint8_t *
 float ship_total_cargo(const ship_t* ship);
 float ship_cargo_amount(const ship_t* ship, commodity_t commodity);
 
+/* Cargo space taken by one unit of commodity. 1.0 for most goods;
+ * REPAIR_KIT is dense at REPAIR_KIT_CARGO_DENSITY. Used by space
+ * checks so a ship can carry many kits in a small hold. */
+float commodity_volume(commodity_t commodity);
+
 /* Station buys from player at this price (lower when overstocked) */
 float station_buy_price(const station_t* station, commodity_t commodity);
 /* Station sells to player at this price (higher when understocked) */

--- a/src/economy.c
+++ b/src/economy.c
@@ -97,7 +97,14 @@ float station_repair_cost(const ship_t* ship, const station_t* station) {
     if (!(station->services & STATION_SERVICE_REPAIR)) return 0.0f;
     float damage = ship_max_hull(ship) - ship->hull;
     if (damage <= 0.0f) return 0.0f;
-    return damage * STATION_REPAIR_COST_PER_HULL;
+
+    /* Quote: assume station-sourced kits (worst case for the player —
+     * the actual repair will be cheaper if they brought their own).
+     * Labor fee is zero at shipyards, LABOR_FEE_PER_HP elsewhere. */
+    float kit_price = station_sell_price(station, COMMODITY_REPAIR_KIT);
+    bool is_shipyard = station_has_module(station, MODULE_SHIPYARD);
+    float labor = is_shipyard ? 0.0f : LABOR_FEE_PER_HP;
+    return damage * (kit_price + labor);
 }
 
 bool can_afford_upgrade(const station_t* station, const ship_t* ship, ship_upgrade_t upgrade, uint32_t service, int credit_cost, float balance) {

--- a/src/input.c
+++ b/src/input.c
@@ -512,8 +512,9 @@ input_intent_t sample_input_intent(void) {
             if (row_kind == 0) {
                 /* BUY action */
                 float price = station_sell_price(st, row_c) * mining_payout_multiplier(row_g);
-                float space = ship_cargo_capacity(ship) - ship_total_cargo(ship);
-                if (space < 0.5f) {
+                float free_volume = ship_cargo_capacity(ship) - ship_total_cargo(ship);
+                float vol = commodity_volume(row_c);
+                if (free_volume + FLOAT_EPSILON < vol) {
                     set_notice("Hold full.");
                 } else if (player_current_balance() < price) {
                     set_notice("Need $%d.", (int)lroundf(price));

--- a/src/station_ui.c
+++ b/src/station_ui.c
@@ -763,7 +763,7 @@ static void draw_trade_view(const station_ui_state_t *ui,
     trade_row_t rows[TRADE_MAX_ROWS];
     int row_count = 0;
 
-    float space   = ship_cargo_capacity(ship) - ship_total_cargo(ship);
+    float free_volume = ship_cargo_capacity(ship) - ship_total_cargo(ship);
     float credits = player_current_balance();
 
     /* BUY rows — one per (commodity, grade) where the station has
@@ -782,7 +782,8 @@ static void draw_trade_view(const station_ui_state_t *ui,
             if (stock <= 0) continue;
             int price = (int)lroundf(price_base
                     * mining_payout_multiplier((mining_grade_t)gi));
-            bool can = (space >= 0.5f) && (credits >= (float)price);
+            float vol = commodity_volume((commodity_t)c);
+            bool can = (free_volume + FLOAT_EPSILON >= vol) && (credits >= (float)price);
             rows[row_count++] = (trade_row_t){
                 .kind = 0, .commodity = (commodity_t)c, .grade = (mining_grade_t)gi,
                 .stock = stock, .unit_price = price,

--- a/src/tests/test_bug_regression.c
+++ b/src/tests/test_bug_regression.c
@@ -53,8 +53,10 @@ TEST(test_bug7_player_slot_mismatch) {
 }
 
 TEST(test_bug9_repair_cost_consistent) {
-    /* This one should PASS — verifying the economy.c version works.
-     * The real bug is a name collision with game_sim.c's static version. */
+    /* Quote scales with the per-HP cost at this station: kit retail
+     * (station_sell_price) + labor fee (zero at shipyard, otherwise
+     * LABOR_FEE_PER_HP). With kits at 6 cr/unit and no shipyard, a
+     * 20 HP repair quotes 20 * (6 + 1) = 140 cr. */
     ship_t ship;
     memset(&ship, 0, sizeof(ship));
     ship.hull_class = HULL_CLASS_MINER;
@@ -62,9 +64,10 @@ TEST(test_bug9_repair_cost_consistent) {
     station_t st;
     memset(&st, 0, sizeof(st));
     st.services = STATION_SERVICE_REPAIR;
+    st.base_price[COMMODITY_REPAIR_KIT] = 6.0f;
+    st.inventory[COMMODITY_REPAIR_KIT]  = MAX_PRODUCT_STOCK; /* full → 1× base */
     float cost = station_repair_cost(&ship, &st);
-    /* (max 100 - hull 80) * 5.0 cr/HP = 100 cr (#299 raised the rate). */
-    ASSERT_EQ_FLOAT(cost, 100.0f, 0.01f);
+    ASSERT_EQ_FLOAT(cost, 20.0f * (6.0f + LABOR_FEE_PER_HP), 0.01f);
 }
 
 TEST(test_bug10_damage_event_has_amount) {

--- a/src/tests/test_economy.c
+++ b/src/tests/test_economy.c
@@ -480,6 +480,138 @@ TEST(test_kit_import_contract_skips_shipyard_stations) {
     }
 }
 
+TEST(test_repair_drains_ship_cargo_first) {
+    /* Player docked at a station with a repair service. Ship carries
+     * 50 kits in cargo, station has 100 kits in inventory. A 30 HP
+     * repair drains 30 kits from ship cargo, leaves station inventory
+     * untouched, and charges only the labor fee (no station retail
+     * since no kits sourced from station). */
+    WORLD_DECL;
+    world_reset(&w);
+    player_init_ship(&w.players[0], &w);
+    w.players[0].connected = true;
+    w.players[0].session_ready = true;
+    memset(w.players[0].session_token, 0x01, 8);
+    w.players[0].docked = true;
+    w.players[0].current_station = 0;
+
+    /* Force the repair service (default Prospect lacks REPAIR_BAY). */
+    w.stations[0].services |= STATION_SERVICE_REPAIR;
+    w.stations[0].inventory[COMMODITY_REPAIR_KIT] = 100.0f;
+    w.players[0].ship.cargo[COMMODITY_REPAIR_KIT] = 50.0f;
+    float max_hull = ship_max_hull(&w.players[0].ship);
+    w.players[0].ship.hull = max_hull - 30.0f; /* 30 HP missing */
+
+    float bal_before = ledger_balance(&w.stations[0],
+                                      w.players[0].session_token);
+    w.players[0].input.service_repair = true;
+    world_sim_step(&w, SIM_DT);
+
+    /* Hull restored, ship cargo drained, station inventory untouched. */
+    ASSERT_EQ_FLOAT(w.players[0].ship.hull, max_hull, 0.5f);
+    ASSERT_EQ_FLOAT(w.players[0].ship.cargo[COMMODITY_REPAIR_KIT], 20.0f, 0.5f);
+    ASSERT_EQ_FLOAT(w.stations[0].inventory[COMMODITY_REPAIR_KIT], 100.0f, 0.5f);
+
+    /* Charge: only labor (no station retail). 30 HP * 1 cr/HP. */
+    float bal_after = ledger_balance(&w.stations[0],
+                                     w.players[0].session_token);
+    float charged = bal_before - bal_after;
+    ASSERT_EQ_FLOAT(charged, 30.0f * LABOR_FEE_PER_HP, 0.5f);
+}
+
+TEST(test_repair_falls_back_to_station_inventory) {
+    /* Player has no kits in cargo; station inventory covers it. Repair
+     * charges retail (station_sell_price) + labor since not a shipyard. */
+    WORLD_DECL;
+    world_reset(&w);
+    player_init_ship(&w.players[0], &w);
+    w.players[0].connected = true;
+    w.players[0].session_ready = true;
+    memset(w.players[0].session_token, 0x01, 8);
+    w.players[0].docked = true;
+    w.players[0].current_station = 0;
+
+    w.stations[0].services |= STATION_SERVICE_REPAIR;
+    w.stations[0].base_price[COMMODITY_REPAIR_KIT] = 6.0f;
+    w.stations[0].inventory[COMMODITY_REPAIR_KIT]  = MAX_PRODUCT_STOCK; /* full → 1× */
+    w.players[0].ship.cargo[COMMODITY_REPAIR_KIT]  = 0.0f;
+    float max_hull = ship_max_hull(&w.players[0].ship);
+    w.players[0].ship.hull = max_hull - 10.0f;
+
+    float bal_before = ledger_balance(&w.stations[0],
+                                      w.players[0].session_token);
+    w.players[0].input.service_repair = true;
+    world_sim_step(&w, SIM_DT);
+
+    /* 10 HP from station: 10 kits drained, charge = 10 * (6 + 1) = 70 cr. */
+    ASSERT_EQ_FLOAT(w.players[0].ship.hull, max_hull, 0.5f);
+    ASSERT_EQ_FLOAT(w.stations[0].inventory[COMMODITY_REPAIR_KIT],
+                    MAX_PRODUCT_STOCK - 10.0f, 0.5f);
+    float charged = bal_before - ledger_balance(&w.stations[0],
+                                                w.players[0].session_token);
+    ASSERT_EQ_FLOAT(charged, 10.0f * (6.0f + LABOR_FEE_PER_HP), 1.0f);
+}
+
+TEST(test_repair_at_shipyard_no_labor_fee) {
+    /* At a shipyard the labor fee is zero — you already paid retail
+     * when you bought the kits there. */
+    WORLD_DECL;
+    world_reset(&w);
+    player_init_ship(&w.players[0], &w);
+    w.players[0].connected = true;
+    w.players[0].session_ready = true;
+    memset(w.players[0].session_token, 0x02, 8);
+    w.players[0].docked = true;
+    w.players[0].current_station = 1; /* Kepler has shipyard */
+    ASSERT(station_has_module(&w.stations[1], MODULE_SHIPYARD));
+
+    w.stations[1].services |= STATION_SERVICE_REPAIR;
+    w.stations[1].base_price[COMMODITY_REPAIR_KIT] = 6.0f;
+    w.stations[1].inventory[COMMODITY_REPAIR_KIT]  = MAX_PRODUCT_STOCK;
+    w.players[0].ship.cargo[COMMODITY_REPAIR_KIT]  = 0.0f;
+    float max_hull = ship_max_hull(&w.players[0].ship);
+    w.players[0].ship.hull = max_hull - 10.0f;
+
+    float bal_before = ledger_balance(&w.stations[1],
+                                      w.players[0].session_token);
+    w.players[0].input.service_repair = true;
+    world_sim_step(&w, SIM_DT);
+
+    /* 10 HP from station: charge = 10 * (6 + 0) = 60 cr (no labor). */
+    float charged = bal_before - ledger_balance(&w.stations[1],
+                                                w.players[0].session_token);
+    ASSERT_EQ_FLOAT(charged, 10.0f * 6.0f, 1.0f);
+}
+
+TEST(test_repair_partial_when_kits_short) {
+    /* Both ship cargo and station inventory empty: repair does nothing
+     * (no partial heal because no kits to consume). */
+    WORLD_DECL;
+    world_reset(&w);
+    player_init_ship(&w.players[0], &w);
+    w.players[0].connected = true;
+    w.players[0].session_ready = true;
+    memset(w.players[0].session_token, 0x03, 8);
+    w.players[0].docked = true;
+    w.players[0].current_station = 0;
+
+    w.stations[0].services |= STATION_SERVICE_REPAIR;
+    w.stations[0].inventory[COMMODITY_REPAIR_KIT] = 0.0f;
+    w.players[0].ship.cargo[COMMODITY_REPAIR_KIT] = 0.0f;
+    float max_hull = ship_max_hull(&w.players[0].ship);
+    /* Damage by 20, then forcibly clear the docked passive heal so we
+     * can measure precisely. Approach: run only one tick where dock
+     * passive adds 8*dt = 8/120 ≈ 0.067 HP; tolerance covers it. */
+    w.players[0].ship.hull = max_hull - 20.0f;
+
+    w.players[0].input.service_repair = true;
+    world_sim_step(&w, SIM_DT);
+
+    /* Hull should be roughly unchanged (only the passive 8 HP/sec
+     * applies for one tick = 0.067 HP). */
+    ASSERT(w.players[0].ship.hull < max_hull - 19.0f);
+}
+
 TEST(test_furnace_without_adjacent_hopper_smelts) {
     /* Furnaces smelt from station inventory regardless of adjacency. */
     WORLD_DECL;
@@ -499,6 +631,24 @@ TEST(test_furnace_without_adjacent_hopper_smelts) {
     ASSERT(w.stations[0].inventory[COMMODITY_FERRITE_INGOT] > initial_ingots);
 }
 
+TEST(test_commodity_volume_kit_dense) {
+    /* Kits take REPAIR_KIT_CARGO_DENSITY units of cargo each; everything
+     * else is 1.0. */
+    ASSERT_EQ_FLOAT(commodity_volume(COMMODITY_REPAIR_KIT),
+                    REPAIR_KIT_CARGO_DENSITY, 0.001f);
+    ASSERT_EQ_FLOAT(commodity_volume(COMMODITY_FRAME), 1.0f, 0.001f);
+    ASSERT_EQ_FLOAT(commodity_volume(COMMODITY_FERRITE_INGOT), 1.0f, 0.001f);
+}
+
+TEST(test_ship_total_cargo_kit_density) {
+    /* 100 kits + 5 frames = 100 * 0.1 + 5 * 1.0 = 15 cargo units. */
+    ship_t ship = {0};
+    ship.cargo[COMMODITY_REPAIR_KIT] = 100.0f;
+    ship.cargo[COMMODITY_FRAME] = 5.0f;
+    ASSERT_EQ_FLOAT(ship_total_cargo(&ship),
+                    100.0f * REPAIR_KIT_CARGO_DENSITY + 5.0f, 0.001f);
+}
+
 void register_economy_basic_tests(void) {
     TEST_SECTION("\nEconomy tests:\n");
     RUN(test_station_production_yard_makes_frames);
@@ -508,6 +658,8 @@ void register_economy_basic_tests(void) {
     RUN(test_can_afford_upgrade_all_conditions);
     RUN(test_can_afford_upgrade_no_credits);
     RUN(test_can_afford_upgrade_no_product);
+    RUN(test_commodity_volume_kit_dense);
+    RUN(test_ship_total_cargo_kit_density);
 }
 
 void register_economy_contracts_tests(void) {
@@ -520,6 +672,10 @@ void register_economy_contracts_tests(void) {
     RUN(test_kit_fab_requires_shipyard);
     RUN(test_kit_import_contract_at_consumer_station);
     RUN(test_kit_import_contract_skips_shipyard_stations);
+    RUN(test_repair_drains_ship_cargo_first);
+    RUN(test_repair_falls_back_to_station_inventory);
+    RUN(test_repair_at_shipyard_no_labor_fee);
+    RUN(test_repair_partial_when_kits_short);
 }
 
 void register_economy_contract3_tests(void) {


### PR DESCRIPTION
## Summary
Step 2 of the repair-kits-as-cargo redesign. Kits now flow through the existing commodity pipeline rather than being consumed in-place at the dock.

- `station_produces(REPAIR_KIT)` → `MODULE_SHIPYARD` (was: `MODULE_DOCK`). Kepler/Helios surface kits as a BUY row.
- `station_consumes(REPAIR_KIT)` → `MODULE_DOCK && !MODULE_SHIPYARD`. Consumer-only docks (Prospect, future outposts) advertise a SELL row; hauler delivery against the import contract from PR #370 closes the loop.
- `commodity_volume()` introduced: kits take `REPAIR_KIT_CARGO_DENSITY = 0.1` cargo units each; everything else 1.0. `ship_total_cargo` and BUY space checks now divide by volume so 100 kits fit in 10 cargo slots.
- `try_repair_ship` rewritten:
  - Drain ship cargo first, station inventory fallback.
  - Charge `station_sell_price(REPAIR_KIT)` on station-sourced kits.
  - `LABOR_FEE_PER_HP = 1.0` at non-shipyard docks; zero at shipyards (you paid retail when you bought the kits there).
- `station_repair_cost` UI quote reflects the same model — worst-case station-sourced quote.

## Test plan
- [x] `make test` — 323/323 pass (6 new)
- [x] Native build green
- [x] WASM build green
- [x] New tests:
  - `test_commodity_volume_kit_dense`, `test_ship_total_cargo_kit_density` — volume math.
  - `test_repair_drains_ship_cargo_first` — cargo first, station untouched, only labor charged.
  - `test_repair_falls_back_to_station_inventory` — station drained, retail + labor charged.
  - `test_repair_at_shipyard_no_labor_fee` — Kepler charges retail only.
  - `test_repair_partial_when_kits_short` — both sources empty, no heal beyond docked passive.
- [x] `test_bug9_repair_cost_consistent` updated for the new per-station cost model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)