### PR TITLE
Remove passive dock heal; autopilot drives kit-based repair

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -1363,11 +1363,9 @@ static void update_docking_state(world_t *w, server_player_t *sp, float dt) {
         sp->ship.pos = dock_berth_pos(&w->stations[sp->current_station], sp->dock_berth);
         sp->ship.angle = dock_berth_angle(&w->stations[sp->current_station], sp->dock_berth);
         sp->ship.vel = v2(0.0f, 0.0f);
-        /* Passive hull repair while docked */
-        float max_hull = ship_max_hull(&sp->ship);
-        if (sp->ship.hull < max_hull) {
-            sp->ship.hull = fminf(max_hull, sp->ship.hull + 8.0f * dt);
-        }
+        /* No passive heal: all repair goes through kits via try_repair_ship.
+         * Press R to spend kits + credits, or carry kits in cargo and let
+         * the autopilot trigger the repair on dock. */
         return;
     }
 

--- a/server/sim_autopilot.c
+++ b/server/sim_autopilot.c
@@ -486,26 +486,29 @@ void step_autopilot(world_t *w, server_player_t *sp, float dt) {
             sp->autopilot_state = AUTOPILOT_STEP_RETURN_TO_REFINERY;
             break;
         }
-        /* Phase 1 (first ~0.6s): trigger sell + repair, then hold while
-         * the docked passive heal brings hull back up. The 0.6s gives
-         * the sim a few sub-steps to process the sell action and the
-         * repair action before we start checking hull. */
-        if (sp->autopilot_timer < 0.6f) {
-            sp->input.service_sell = true;
-            sp->input.service_sell_only = COMMODITY_COUNT;
-            /* If a repair bay exists at this station, also pay for an
-             * instant repair. Falls back to passive heal if not. */
-            sp->input.service_repair = true;
+        /* Repeatedly trigger sell + repair while docked. service_repair
+         * is harmless when hull is already full; with kit-based repair
+         * it consumes one kit per HP every tick the action fires. */
+        sp->input.service_sell = true;
+        sp->input.service_sell_only = COMMODITY_COUNT;
+        sp->input.service_repair = true;
+        if (sp->autopilot_timer < 0.6f) break;
+
+        /* Wait until either hull is full OR no kits are available
+         * anywhere (cargo + this station's inventory). The latter
+         * prevents an infinite wait when the supply chain hasn't
+         * delivered kits to this dock and the player isn't carrying
+         * any — better to launch with damage than to idle forever. */
+        const station_t *st = &w->stations[sp->current_station];
+        float ship_kits = sp->ship.cargo[COMMODITY_REPAIR_KIT];
+        float station_kits = st->inventory[COMMODITY_REPAIR_KIT];
+        bool any_kits = (ship_kits + station_kits) > 0.5f;
+        if (!autopilot_hull_full(&sp->ship) && any_kits) {
+            /* Stay docked; repair will keep ticking from cargo first
+             * then station inventory. */
             break;
         }
-        /* Phase 2: wait until hull is full before launching. The dock
-         * passive heal is 8 hp/sec — even from 0%, that's <15s for the
-         * miner hull (100 max). The autopilot just sits in dock. */
-        if (!autopilot_hull_full(&sp->ship)) {
-            /* Stay docked, no action needed. Loop again next tick. */
-            break;
-        }
-        /* Hull repaired AND cargo sold — launch back into the field. */
+        /* Hull repaired (or unrepairable) AND cargo sold — launch. */
         sp->input.interact = true;
         sp->autopilot_state = AUTOPILOT_STEP_LAUNCH;
         sp->autopilot_timer = 0.0f;

--- a/src/tests/test_bug_regression.c
+++ b/src/tests/test_bug_regression.c
@@ -1024,17 +1024,14 @@ TEST(test_bug52_server_repair_cost_no_service_check) {
     ledger_earn(&w.stations[0], w.players[0].session_token, 1000.0f);
     float bal_before = ledger_balance(&w.stations[0],
                                       w.players[0].session_token);
-    /* Damage past passive-repair recovery so we can read intent precisely. */
     w.players[0].ship.hull = 50.0f;
     w.players[0].input.service_repair = true;
     world_sim_step(&w, SIM_DT);
-    /* Passive heal still applies (~0.067 HP per tick at 8 HP/sec * SIM_DT)
-     * but the kit-based heal must not have fired — no charge to the ledger. */
+    /* No kits = no heal, no charge. Passive heal was removed. */
     float bal_after = ledger_balance(&w.stations[0],
                                      w.players[0].session_token);
     ASSERT_EQ_FLOAT(bal_after, bal_before, 0.01f);
-    /* Hull may rise by < 1 HP from passive heal — that's expected. */
-    ASSERT(w.players[0].ship.hull < 51.0f);
+    ASSERT_EQ_FLOAT(w.players[0].ship.hull, 50.0f, 0.01f);
 }
 
 TEST(test_bug53_npc_cargo_commodity_bounds) {

--- a/src/tests/test_economy.c
+++ b/src/tests/test_economy.c
@@ -377,21 +377,21 @@ TEST(test_no_delivery_without_matching_contract) {
     ASSERT_EQ_FLOAT(w.players[0].ship.cargo[COMMODITY_TRACTOR_MODULE], 20.0f, 0.01f);
 }
 
-TEST(test_259_passive_repair_at_any_station) {
-    /* Passive repair (8 hp/s) runs at ANY station while docked,
-     * regardless of STATION_SERVICE_REPAIR flag. */
+TEST(test_no_passive_heal_without_kits) {
+    /* Passive heal was removed: docking alone never repairs. With both
+     * ship cargo and station inventory empty, damaged hull stays
+     * damaged — repair requires kits. */
     WORLD_DECL;
     world_reset(&w);
     player_init_ship(&w.players[0], &w);
     w.players[0].connected = true;
-    w.players[0].ship.hull = 50.0f; /* damaged */
-    /* Dock at station 0 (no REPAIR_BAY module) */
+    w.players[0].ship.hull = 50.0f;
     w.players[0].docked = true;
     w.players[0].current_station = 0;
-    ASSERT(!(w.stations[0].services & STATION_SERVICE_REPAIR));
-    /* Run a few ticks — hull should increase from passive repair */
+    w.stations[0].inventory[COMMODITY_REPAIR_KIT] = 0.0f;
+    w.players[0].ship.cargo[COMMODITY_REPAIR_KIT] = 0.0f;
     for (int i = 0; i < 120; i++) world_sim_step(&w, SIM_DT);
-    ASSERT(w.players[0].ship.hull > 50.0f);
+    ASSERT_EQ_FLOAT(w.players[0].ship.hull, 50.0f, 0.01f);
 }
 
 TEST(test_refinery_smelts_ore_in_inventory) {
@@ -597,21 +597,16 @@ TEST(test_repair_partial_when_kits_short) {
     w.players[0].docked = true;
     w.players[0].current_station = 0;
 
-    w.stations[0].services |= STATION_SERVICE_REPAIR;
     w.stations[0].inventory[COMMODITY_REPAIR_KIT] = 0.0f;
     w.players[0].ship.cargo[COMMODITY_REPAIR_KIT] = 0.0f;
     float max_hull = ship_max_hull(&w.players[0].ship);
-    /* Damage by 20, then forcibly clear the docked passive heal so we
-     * can measure precisely. Approach: run only one tick where dock
-     * passive adds 8*dt = 8/120 ≈ 0.067 HP; tolerance covers it. */
     w.players[0].ship.hull = max_hull - 20.0f;
 
     w.players[0].input.service_repair = true;
     world_sim_step(&w, SIM_DT);
 
-    /* Hull should be roughly unchanged (only the passive 8 HP/sec
-     * applies for one tick = 0.067 HP). */
-    ASSERT(w.players[0].ship.hull < max_hull - 19.0f);
+    /* No kits anywhere = no heal at all (passive heal removed). */
+    ASSERT_EQ_FLOAT(w.players[0].ship.hull, max_hull - 20.0f, 0.01f);
 }
 
 TEST(test_furnace_without_adjacent_hopper_smelts) {
@@ -702,7 +697,7 @@ void register_economy_mixed_cargo_tests(void) {
 
 void register_economy_service259_tests(void) {
     TEST_SECTION("\nStation service semantics (#259):\n");
-    RUN(test_259_passive_repair_at_any_station);
+    RUN(test_no_passive_heal_without_kits);
 }
 
 void register_economy_refinery_smelt_tests(void) {


### PR DESCRIPTION
## Summary
PR #5 of the repair-kits redesign — closes the demand-sink loop. All hull restoration now requires kits; docking alone no longer heals.

- `step_player_dock`: drops the 8 HP/sec passive heal.
- `AUTOPILOT_STEP_SELL`: re-issues `service_repair` every tick (kit-fed) and exits the wait loop when no kits are available anywhere, so the autopilot never hangs at a kit-dry dock.

This is what makes the kit economy actually fire on a damaged ship that returns to dock — before this, passive heal subsumed every demand the kit chain was designed to satisfy.

## Test plan
- [x] `make test` — 323/323 pass
- [x] Native + WASM builds green
- Updated `test_259_passive_repair_at_any_station` → `test_no_passive_heal_without_kits` (empty supply leaves hull damaged).
- Tightened `test_repair_partial_when_kits_short` and `test_bug52` to exact-equal asserts now that passive trickle is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)