### PR TITLE
Ship/NPC unify, slice 1: hull-class helper consolidation

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -22,6 +22,7 @@
  */
 #include "game_sim.h"
 #include "manifest.h"
+#include "ship.h"
 #include "sim_ai.h"
 #include "sim_autopilot.h"
 #include "sim_nav.h"
@@ -2043,7 +2044,7 @@ static bool find_scan_target(world_t *w, server_player_t *sp, vec2 muzzle, vec2 
         if (!npc->active) continue;
         vec2 to_npc = v2_sub(npc->pos, muzzle);
         float proj = v2_dot(to_npc, forward);
-        float npc_r = HULL_DEFS[npc->hull_class].render_scale * 16.0f;
+        float npc_r = npc_hull_def(npc)->render_scale * 16.0f;
         if (proj > 0.0f && proj < best_dist) {
             vec2 closest = v2_add(muzzle, v2_scale(forward, proj));
             float perp = v2_len(v2_sub(closest, npc->pos));
@@ -2063,7 +2064,7 @@ static bool find_scan_target(world_t *w, server_player_t *sp, vec2 muzzle, vec2 
         if (!other->connected || other->id == sp->id) continue;
         vec2 to_p = v2_sub(other->ship.pos, muzzle);
         float proj = v2_dot(to_p, forward);
-        float pr = HULL_DEFS[other->ship.hull_class].ship_radius;
+        float pr = ship_hull_def(&other->ship)->ship_radius;
         if (proj > 0.0f && proj < best_dist) {
             vec2 closest = v2_add(muzzle, v2_scale(forward, proj));
             float perp = v2_len(v2_sub(closest, other->ship.pos));
@@ -4256,7 +4257,7 @@ void player_init_ship(server_player_t *sp, world_t *w) {
     memset(&sp->ship, 0, sizeof(sp->ship));
     (void)ship_manifest_bootstrap(&sp->ship);
     sp->ship.hull_class = HULL_CLASS_MINER;
-    sp->ship.hull       = HULL_DEFS[HULL_CLASS_MINER].max_hull;
+    sp->ship.hull       = hull_max_for_class(HULL_CLASS_MINER);
     sp->ship.angle      = PI_F * 0.5f;
     memset(sp->ship.towed_fragments, -1, sizeof(sp->ship.towed_fragments));
     sp->ship.towed_scaffold = -1;

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -79,7 +79,7 @@ int spawn_npc(world_t *w, int station_idx, npc_role_t role) {
     npc->role = role;
     npc->hull_class = hc;
     npc->state = NPC_STATE_DOCKED;
-    npc->pos = v2_add(st->pos, v2(30.0f * (float)(slot % 3 - 1), -(st->radius + HULL_DEFS[hc].ship_radius + 50.0f)));
+    npc->pos = v2_add(st->pos, v2(30.0f * (float)(slot % 3 - 1), -(st->radius + hull_def_for_class(hc)->ship_radius + 50.0f)));
     npc->angle = PI_F * 0.5f;
     npc->target_asteroid = -1;
     npc->towed_fragment = -1;

--- a/src/ship.c
+++ b/src/ship.c
@@ -1,11 +1,19 @@
 #include "ship.h"
 
+const hull_def_t* hull_def_for_class(hull_class_t hc) {
+    return &HULL_DEFS[hc];
+}
+
+float hull_max_for_class(hull_class_t hc) {
+    return HULL_DEFS[hc].max_hull;
+}
+
 const hull_def_t* ship_hull_def(const ship_t* ship) {
-    return &HULL_DEFS[ship->hull_class];
+    return hull_def_for_class(ship->hull_class);
 }
 
 const hull_def_t* npc_hull_def(const npc_ship_t* npc) {
-    return &HULL_DEFS[npc->hull_class];
+    return hull_def_for_class(npc->hull_class);
 }
 
 vec2 ship_forward(float angle) {
@@ -18,11 +26,11 @@ vec2 ship_muzzle(vec2 pos, float angle, const ship_t* ship) {
 }
 
 float ship_max_hull(const ship_t* ship) {
-    return ship_hull_def(ship)->max_hull;
+    return hull_max_for_class(ship->hull_class);
 }
 
 float npc_max_hull(const npc_ship_t* npc) {
-    return npc_hull_def(npc)->max_hull;
+    return hull_max_for_class(npc->hull_class);
 }
 
 float ship_cargo_capacity(const ship_t* ship) {

--- a/src/ship.h
+++ b/src/ship.h
@@ -3,6 +3,12 @@
 
 #include "types.h"
 
+/* Hull-class lookups. The class accessor is the source of truth; the
+ * ship/npc-typed wrappers are kept so existing callsites compile and
+ * intent stays readable at the use site. Slice 1 of ship/NPC unify. */
+const hull_def_t* hull_def_for_class(hull_class_t hc);
+float             hull_max_for_class(hull_class_t hc);
+
 const hull_def_t* ship_hull_def(const ship_t* ship);
 const hull_def_t* npc_hull_def(const npc_ship_t* npc);
 


### PR DESCRIPTION
## Summary
First slice of the long-dreaded ship/NPC unification — pure mechanical refactor with no behavior change. Sets up later slices without committing to them.

- Adds `hull_def_for_class(hull_class_t)` and `hull_max_for_class(hull_class_t)` as the source of truth.
- `ship_hull_def` / `npc_hull_def` / `ship_max_hull` / `npc_max_hull` become thin wrappers.
- Production sites that were indexing `HULL_DEFS[]` directly now go through the helper:
  - `game_sim.c` scan-target NPC/player radius lookups
  - `game_sim.c` `player_init_ship` hull seed
  - `sim_ai.c` `spawn_npc` berth offset

Test fixtures still index `HULL_DEFS` directly — left alone, the refactor win is killing the indexes in sim code, not in test setup.

## Why this slice first
Of the five slices identified in the unification analysis, this is the only zero-risk one. It establishes the pattern (class-keyed accessor) that later slices (collision consolidation, composition refactor) can lean on. If the rest of the unification work never happens, this PR still leaves the codebase slightly cleaner.

## Test plan
- [x] `make test` — 323/323 pass
- [x] Native + WASM builds green
- No new tests; behavior is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)