### PR TITLE
Ship/NPC unify, slice 2: collision damage formula

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -669,8 +669,8 @@ static void resolve_ship_circle(world_t *w, server_player_t *sp, vec2 center, fl
     float vel_toward = v2_dot(sp->ship.vel, normal);
     if (vel_toward < 0.0f) {
         float impact = -vel_toward;
-        if (!sp->docked && impact > SHIP_COLLISION_DAMAGE_THRESHOLD)
-            apply_ship_damage(w, sp, (impact - SHIP_COLLISION_DAMAGE_THRESHOLD) * SHIP_COLLISION_DAMAGE_SCALE);
+        float dmg = sp->docked ? 0.0f : collision_damage_for(impact, 1.0f);
+        if (dmg > 0.0f) apply_ship_damage(w, sp, dmg);
         /* Clamp inward velocity component to zero — slide along the surface
          * tangent on the next tick instead of bouncing back through it. */
         sp->ship.vel = v2_sub(sp->ship.vel, v2_scale(normal, vel_toward));
@@ -724,8 +724,8 @@ static void resolve_ship_annular_sector(world_t *w, server_player_t *sp,
     float vel_toward = v2_dot(sp->ship.vel, push_normal);
     if (vel_toward < 0.0f) {
         float impact = -vel_toward;
-        if (!sp->docked && impact > SHIP_COLLISION_DAMAGE_THRESHOLD)
-            apply_ship_damage(w, sp, (impact - SHIP_COLLISION_DAMAGE_THRESHOLD) * SHIP_COLLISION_DAMAGE_SCALE);
+        float dmg = sp->docked ? 0.0f : collision_damage_for(impact, 1.0f);
+        if (dmg > 0.0f) apply_ship_damage(w, sp, dmg);
         sp->ship.vel = v2_sub(sp->ship.vel, v2_scale(push_normal, vel_toward * 1.0f));
     }
 }
@@ -4006,9 +4006,11 @@ void world_sim_step(world_t *w, float dt) {
                 vec2 impulse = v2_scale(normal, rel_vel * 0.6f);
                 w->players[i].ship.vel = v2_sub(w->players[i].ship.vel, impulse);
                 w->players[j].ship.vel = v2_add(w->players[j].ship.vel, impulse);
-                /* Ramming damage — both ships take damage based on impact speed */
-                if (impact > SHIP_COLLISION_DAMAGE_THRESHOLD * 0.7f) {
-                    float dmg = (impact - SHIP_COLLISION_DAMAGE_THRESHOLD * 0.7f) * SHIP_COLLISION_DAMAGE_SCALE;
+                /* Ramming damage — both ships take damage based on impact speed.
+                 * Threshold mult 0.7× makes deliberate rams sting at speeds
+                 * that wouldn't bruise a static collision. */
+                float dmg = collision_damage_for(impact, 0.7f);
+                if (dmg > 0.0f) {
                     apply_ship_damage(w, &w->players[i], dmg);
                     apply_ship_damage(w, &w->players[j], dmg);
                 }

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -55,6 +55,16 @@ static const float FRACTURE_CHILD_CLEANUP_DISTANCE = 4000.0f;
 static const float STATION_DOCK_APPROACH_OFFSET = 34.0f;
 static const float SHIP_COLLISION_DAMAGE_THRESHOLD = 115.0f;
 static const float SHIP_COLLISION_DAMAGE_SCALE = 0.12f;
+
+/* Soft impact -> hull damage. Returns 0 below the (possibly scaled)
+ * threshold; otherwise (impact - threshold) * SCALE. Player and NPC
+ * collision sites both call this so the formula stays in one place.
+ * threshold_mult lets ship-vs-ship ramming cut the bar (0.7×) to make
+ * deliberate ramming actually hurt. */
+static inline float collision_damage_for(float impact, float threshold_mult) {
+    float t = SHIP_COLLISION_DAMAGE_THRESHOLD * threshold_mult;
+    return (impact > t) ? (impact - t) * SHIP_COLLISION_DAMAGE_SCALE : 0.0f;
+}
 static const float NPC_DOCK_TIME = 3.0f;
 static const float HAULER_DOCK_TIME = 4.0f;
 static const float HAULER_LOAD_TIME = 2.0f;

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -336,12 +336,11 @@ static void npc_resolve_asteroid_collisions(world_t *w, npc_ship_t *npc) {
         if (vel_toward < 0.0f) {
             float impact = -vel_toward;
             npc->vel = v2_sub(npc->vel, v2_scale(normal, vel_toward * 1.0f));
-            /* Hull damage scaled the same way as players (game_sim.c
-             * apply_ship_damage uses SHIP_COLLISION_DAMAGE_THRESHOLD /
-             * _SCALE). NPCs feeding the kit-demand sink is the load-
-             * bearing reason we have a kit economy at all. */
-            if (impact > SHIP_COLLISION_DAMAGE_THRESHOLD) {
-                float dmg = (impact - SHIP_COLLISION_DAMAGE_THRESHOLD) * SHIP_COLLISION_DAMAGE_SCALE;
+            /* Same formula as players (collision_damage_for in game_sim.h).
+             * NPCs feeding the kit-demand sink is the load-bearing reason
+             * the kit economy exists at all. */
+            float dmg = collision_damage_for(impact, 1.0f);
+            if (dmg > 0.0f) {
                 npc->hull -= dmg;
                 if (npc->hull < 0.0f) npc->hull = 0.0f;
             }


### PR DESCRIPTION
## Summary
Second slice of ship/NPC unification. Pulls four copies of the impact → hull damage arithmetic into a single inline helper.

- `collision_damage_for(impact, threshold_mult)` in `game_sim.h`. Returns 0 below the (possibly scaled) threshold; otherwise `(impact - t) * SCALE`.
- Player paths still call `apply_ship_damage` for event emission and clamping; only the formula moves. NPC path inlines the hull decrement (no events; sim_ai despawns on hull <= 0 next tick — same as before).
- `threshold_mult` keeps ship-vs-ship 0.7× ramming intact. Behavior byte-identical.

Sites consolidated: `resolve_ship_circle` (player vs station sphere), `resolve_ship_annular_sector` (player vs corridor), `resolve_ship_collisions` (ship-vs-ship ram), `npc_resolve_asteroid_collisions` (NPC vs asteroid).

## Test plan
- [x] `make test` — 323/323 pass
- [x] Native + WASM builds green
- No new tests; behavior identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)