### PR TITLE
Repair-kit economy fix + ship-upgrade rework + render polish

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ option(BUILD_TESTS_ONLY  "Only build the test executable"       OFF)
 option(BUILD_SERVER_ONLY "Only build the headless game server"  OFF)
 
 # --- GIT_HASH baked into binaries for /health and client mismatch checks ---
+# Captured at configure time. To refresh after a commit/pull without
+# nuking the cache, re-run `cmake -S . -B <build_dir> -DGIT_HASH=$(git
+# rev-parse --short HEAD)`. Otherwise the value sticks across rebuilds
+# and the browser-visible /health version drifts behind HEAD.
 if(NOT DEFINED GIT_HASH)
     execute_process(COMMAND git rev-parse --short HEAD
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
@@ -54,6 +58,9 @@ set(SIGNAL_SIM_HELPERS
     src/economy.c
     src/asteroid.c
     src/rng.c
+    shared/belt.c
+    shared/module_schema.c
+    shared/station_util.c
 )
 
 # Client-only: rendering, input, HUD, audio, network plumbing. Not
@@ -258,6 +265,14 @@ if(EMSCRIPTEN)
         "SHELL:-sEXPORTED_RUNTIME_METHODS=['ccall','cwrap']"
         "SHELL:--shell-file ${CMAKE_CURRENT_SOURCE_DIR}/web/shell.html"
         "SHELL:-lwebsocket.js"
+    )
+    # Copy play.html into the build-web output dir so it's reachable
+    # from the SimpleHTTP server (and so docker bind-mounts of build-web
+    # serve it without needing the image's COPY layer).
+    add_custom_command(TARGET signal POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_CURRENT_SOURCE_DIR}/web/play.html
+            ${CMAKE_CURRENT_BINARY_DIR}/play.html
     )
 elseif(APPLE)
     target_link_libraries(signal PRIVATE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,13 @@ services:
       - "9091:9091"   # signal_server websocket + health endpoint
     volumes:
       - ./data:/app/data
+      # Bind-mount the local wasm bundle so `cmake --build build-web` is
+      # picked up by the running container without a `docker compose
+      # --build` (which recreates the container and occasionally
+      # corrupts podman's storage layer on macOS). For server-side
+      # changes still rebuild the image; for client-side, just rebuild
+      # the wasm and hard-refresh.
+      - ./build-web:/app/build-web
     environment:
       - PORT=9091
       # - SIGNAL_API_TOKEN=devtoken  # set to enable the REST API surface

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -475,16 +475,16 @@ static void generate_outpost_name(char *out, size_t out_size, vec2 pos, int slot
 /* ================================================================== */
 
 static void clear_ship_cargo(ship_t *s) {
+    /* Wipe both the float side and the manifest. Without the manifest
+     * reset, an emergency-recover would leave phantom cargo_unit_t
+     * entries on the ship — the TRADE picker reads the manifest and
+     * would still surface "SELL Iron ingot" rows even though cargo[]
+     * was zero, so [3]/[4] would resolve to a row that produced
+     * nothing on the server. */
     memset(s->cargo, 0, sizeof(s->cargo));
-}
-
-static uint32_t station_upgrade_service(ship_upgrade_t upgrade) {
-    switch (upgrade) {
-    case SHIP_UPGRADE_MINING:  return STATION_SERVICE_UPGRADE_LASER;
-    case SHIP_UPGRADE_HOLD:    return STATION_SERVICE_UPGRADE_HOLD;
-    case SHIP_UPGRADE_TRACTOR: return STATION_SERVICE_UPGRADE_TRACTOR;
-    default: return 0;
-    }
+    s->manifest.count = 0;
+    if (s->manifest.units && s->manifest.cap > 0)
+        memset(s->manifest.units, 0, s->manifest.cap * sizeof(cargo_unit_t));
 }
 
 /* ================================================================== */
@@ -497,10 +497,6 @@ static int station_berth_count(const station_t *st);
 static vec2 dock_berth_pos(const station_t *st, int berth);
 static float dock_berth_angle(const station_t *st, int berth);
 static int find_best_berth(const world_t *w, const station_t *st, int station_idx, vec2 ship_pos);
-
-static bool station_has_service(const station_t *station, uint32_t service) {
-    return station && ((station->services & service) != 0);
-}
 
 /* Repair pricing now lives inline in try_repair_ship — kept around in
  * case future callers need a quote. */
@@ -1084,16 +1080,43 @@ static void try_repair_ship(world_t *w, server_player_t *sp) {
 
 static void try_apply_ship_upgrade(world_t *w, server_player_t *sp, ship_upgrade_t upgrade) {
     station_t *st = &w->stations[sp->current_station];
-    uint32_t req_svc = station_upgrade_service(upgrade);
-    if (!station_has_service(st, req_svc)) return;
+    /* Any dock installs the upgrade — the modules themselves are the
+     * gate. No more FAB-module service requirement; the recipe input
+     * (frame/laser/tractor) has to come from cargo or the dock's
+     * inventory and that's what limits the action. Mirrors the
+     * repair-kit "any dock" model from #373. */
     if (ship_upgrade_maxed(&sp->ship, upgrade)) return;
 
+    /* Real cost = the modules themselves (frames / lasers / tractors).
+     * Cargo first; if short, dock fills the gap from station inventory
+     * at retail price. No flat credit upgrade fee anymore — the credit
+     * cost is purely the per-unit retail on dock-sourced units. Mirrors
+     * try_repair_ship's cargo-first / dock-fallback pattern. */
     product_t required = upgrade_required_product(upgrade);
-    float pcost = upgrade_product_cost(&sp->ship, upgrade);
-    if (st->inventory[COMMODITY_FRAME + required] < pcost - 0.01f) return;
-    int cost = ship_upgrade_cost(&sp->ship, upgrade);
-    if (!ledger_spend(st, sp->session_token, (float)cost, &sp->ship)) return;
-    st->inventory[COMMODITY_FRAME + required] -= pcost;
+    commodity_t comm = (commodity_t)(COMMODITY_FRAME + required);
+    int units_needed = (int)ceilf(upgrade_product_cost(&sp->ship, upgrade));
+    int in_cargo  = (int)floorf(sp->ship.cargo[comm] + 0.0001f);
+    int at_station = (int)floorf(st->inventory[comm] + 0.0001f);
+    if (in_cargo + at_station < units_needed) return;
+
+    int from_cargo   = (units_needed < in_cargo) ? units_needed : in_cargo;
+    int from_station = units_needed - from_cargo;
+
+    float credit_cost = (float)from_station * station_sell_price(st, comm);
+    if (credit_cost > 0.0f && !ledger_spend(st, sp->session_token, credit_cost, &sp->ship))
+        return;
+
+    if (from_cargo > 0) {
+        sp->ship.cargo[comm] -= (float)from_cargo;
+        if (sp->ship.cargo[comm] < 0.0f) sp->ship.cargo[comm] = 0.0f;
+        manifest_consume_by_commodity(&sp->ship.manifest, comm, from_cargo);
+    }
+    if (from_station > 0) {
+        st->inventory[comm] -= (float)from_station;
+        if (st->inventory[comm] < 0.0f) st->inventory[comm] = 0.0f;
+        manifest_consume_by_commodity(&st->manifest, comm, from_station);
+        st->named_ingots_dirty = true;
+    }
 
     switch (upgrade) {
     case SHIP_UPGRADE_MINING:  sp->ship.mining_level++;  break;
@@ -1101,8 +1124,9 @@ static void try_apply_ship_upgrade(world_t *w, server_player_t *sp, ship_upgrade
     case SHIP_UPGRADE_TRACTOR: sp->ship.tractor_level++; break;
     default: break;
     }
-    SIM_LOG("[sim] player %d upgraded %d to level %d\n", sp->id, (int)upgrade,
-           ship_upgrade_level(&sp->ship, upgrade));
+    SIM_LOG("[sim] player %d upgraded %d to level %d (%d cargo + %d dock kits, %.0f cr)\n",
+           sp->id, (int)upgrade, ship_upgrade_level(&sp->ship, upgrade),
+           from_cargo, from_station, credit_cost);
     emit_event(w, (sim_event_t){.type = SIM_EVENT_UPGRADE, .player_id = sp->id, .upgrade.upgrade = upgrade});
 }
 
@@ -2450,7 +2474,14 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
              * an explicit `buy_quantity` intent if/when needed. */
             float bal = ledger_balance(docked_st, sp->session_token);
             float afford = (price_per > 0.01f) ? floorf(bal / price_per) : 0.0f;
-            float amount = fminf(fminf(fminf(available, space), afford), 1.0f);
+            /* Per-press unit cap scales by commodity density: standard
+             * goods (vol = 1.0) buy 1 per press; dense goods like
+             * repair kits (vol = 0.1) buy 10 per press so a single
+             * keystroke fills one cargo unit's worth. */
+            int per_press_cap = (vol > FLOAT_EPSILON)
+                ? (int)lroundf(1.0f / vol) : 1;
+            if (per_press_cap < 1) per_press_cap = 1;
+            float amount = fminf(fminf(fminf(available, space), afford), (float)per_press_cap);
             float total_cost = amount * price_per;
             SIM_LOG("[buy] avail=%.2f space=%.2f price/u=%.2f bal=%.2f afford=%.0f amount=%.2f\n",
                     available, space, price_per, bal, afford, amount);
@@ -3128,17 +3159,31 @@ static void step_contracts(world_t *w, float dt) {
         station_t *st = &w->stations[s];
         if (!station_exists(st)) continue;
 
-        /* Check which contract types this station already has */
+        /* Check which contract types this station already has. The
+         * kit-input slot tracks shipyard imports of frame / laser /
+         * tractor commodities separately from the ingot / scaffold
+         * production slot, so a shipyard that's already importing
+         * ingots for its own fabs can ALSO be importing frames for
+         * its kit fab. Without this split, Helios (which always has
+         * some CU/CR ingot deficit) would never get a chance to ask
+         * for frames — kit fab silently starved. */
         bool has_ore_contract = false;
         bool has_production_contract = false;
+        bool has_kit_input_contract = false;
         for (int k = 0; k < MAX_CONTRACTS; k++) {
             if (!w->contracts[k].active || w->contracts[k].station_index != s) continue;
-            if (w->contracts[k].commodity < COMMODITY_RAW_ORE_COUNT)
+            commodity_t cc = w->contracts[k].commodity;
+            if (cc < COMMODITY_RAW_ORE_COUNT) {
                 has_ore_contract = true;
-            else
+            } else if (cc == COMMODITY_FRAME ||
+                       cc == COMMODITY_LASER_MODULE ||
+                       cc == COMMODITY_TRACTOR_MODULE) {
+                has_kit_input_contract = true;
+            } else {
                 has_production_contract = true;
+            }
         }
-        if (has_ore_contract && has_production_contract) continue;
+        if (has_ore_contract && has_production_contract && has_kit_input_contract) continue;
 
         /* Skip contract generation if station is nearly broke */
         if (st->credit_pool < 100.0f) continue;
@@ -3247,13 +3292,14 @@ static void step_contracts(world_t *w, float dt) {
             }
         }
 
-        /* Priority 5: shipyard kit-fab inputs. Every shipyard needs
-         * frames + lasers + tractor modules to mint repair kits, but the
-         * upstream production contracts (above) come first so they don't
-         * starve. Only fires when the station's own ingot/scaffold
-         * pipeline is satisfied, ensuring kit fab gets fed without
-         * cannibalising the chain that produces its inputs. */
-        if (!need.active && !has_production_contract && station_has_module(st, MODULE_SHIPYARD)) {
+        /* Priority 5: shipyard kit-fab inputs. Lives in its own slot
+         * so an ongoing ingot/scaffold contract doesn't starve it.
+         * Helios always has some CU/CR ingot deficit; without this
+         * split, the frame contract for kit-fab never gets posted. */
+        contract_t kit_need = {0};
+        kit_need.target_index = -1;
+        kit_need.claimed_by = -1;
+        if (!has_kit_input_contract && station_has_module(st, MODULE_SHIPYARD)) {
             const struct { commodity_t c; module_type_t producer; } kit_inputs[] = {
                 { COMMODITY_FRAME,          MODULE_FRAME_PRESS  },
                 { COMMODITY_LASER_MODULE,   MODULE_LASER_FAB    },
@@ -3269,7 +3315,7 @@ static void step_contracts(world_t *w, float dt) {
             }
             if (worst_idx >= 0) {
                 commodity_t mat = kit_inputs[worst_idx].c;
-                need = (contract_t){
+                kit_need = (contract_t){
                     .active = true, .action = CONTRACT_TRACTOR,
                     .station_index = (uint8_t)s,
                     .commodity = mat,
@@ -3308,11 +3354,17 @@ static void step_contracts(world_t *w, float dt) {
             }
         }
 
-        /* Post the contract if we found a need */
-        if (need.active) {
+        /* Post any contract we found a need for. `need` and `kit_need`
+         * occupy separate slots, so a shipyard can simultaneously be
+         * importing ingots for its fabs AND frames for its kit fab. */
+        contract_t *to_post[2] = { NULL, NULL };
+        int post_count = 0;
+        if (need.active)     to_post[post_count++] = &need;
+        if (kit_need.active) to_post[post_count++] = &kit_need;
+        for (int p = 0; p < post_count; p++) {
             for (int k = 0; k < MAX_CONTRACTS; k++) {
                 if (!w->contracts[k].active) {
-                    w->contracts[k] = need;
+                    w->contracts[k] = *to_post[p];
                     break;
                 }
             }

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -498,13 +498,10 @@ static vec2 dock_berth_pos(const station_t *st, int berth);
 static float dock_berth_angle(const station_t *st, int berth);
 static int find_best_berth(const world_t *w, const station_t *st, int station_idx, vec2 ship_pos);
 
-/* Repair pricing now lives inline in try_repair_ship — kept around in
- * case future callers need a quote. */
-__attribute__((unused))
-static float sim_station_repair_cost(const ship_t *s) {
-    float missing = fmaxf(0.0f, ship_max_hull(s) - s->hull);
-    return ceilf(missing * STATION_REPAIR_COST_PER_HULL);
-}
+/* Repair pricing lives inline in try_repair_ship now. The standalone
+ * helper used to be kept around speculatively but it's dead in every
+ * TU and MSVC chokes on __attribute__((unused)) — drop it. Bring it
+ * back as a real function the moment a caller materializes. */
 
 /* Asteroid lifecycle, dynamics, fracture → sim_asteroid.c
  * sim_can_smelt_ore, sim_step_refinery_production, sim_step_station_production,

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -3274,6 +3274,12 @@ static void step_contracts(world_t *w, float dt) {
             int worst_idx = -1;
             for (int j = 0; j < 3; j++) {
                 if (!checks[j].needed) continue;
+                /* Don't import what we make ourselves. Helios has both
+                 * FURNACE_CU and LASER_FAB, so the local furnace feeds
+                 * the local fab — posting an import contract for the
+                 * same ingot duplicates supply and shows up to players
+                 * as "asking for what's already on the shelf". */
+                if (station_produces(st, checks[j].ingot)) continue;
                 float deficit = MAX_PRODUCT_STOCK * 0.5f - st->inventory[checks[j].ingot];
                 if (deficit > worst_deficit) { worst_deficit = deficit; worst_idx = j; }
             }

--- a/server/main.c
+++ b/server/main.c
@@ -513,8 +513,11 @@ static void handle_station_state(struct mg_connection *c, int sid) {
     static const char *cnames[] = {
         "ferrite_ore","cuprite_ore","crystal_ore",
         "ferrite_ingot","cuprite_ingot","crystal_ingot",
-        "frame","laser_module","tractor_module"
+        "frame","laser_module","tractor_module",
+        "repair_kit",
     };
+    _Static_assert(sizeof(cnames)/sizeof(cnames[0]) == COMMODITY_COUNT,
+                   "cnames must stay in sync with commodity_t");
     for (int i = 0; i < COMMODITY_COUNT; i++) {
         if (i > 0) BUF_APPEND(pos, buf, BUFSZ, ",");
         BUF_APPEND(pos, buf, BUFSZ,

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -426,6 +426,16 @@ void step_furnace_smelting(world_t *w, float dt) {
                                || (st->modules[m].type == MODULE_FURNACE_CR);
                 if (!is_furnace) continue;
 
+                /* Furnaces only smelt their own ore type. Without this
+                 * gate, Prospect's ferrite furnace would pull cuprite
+                 * and crystal fragments into its beam (and produce
+                 * inventory drift in either direction depending on
+                 * commodity_refined_form behavior). The fragment stays
+                 * free so the player can route it to the matching
+                 * smelter. */
+                commodity_t furnace_ore = furnace_ore_type(st->modules[m].type);
+                if ((int)furnace_ore < 0 || a->commodity != furnace_ore) continue;
+
                 /* Output cap: refuse to engage the beam if the station's
                  * ingot stockpile is already full. Without this, smelts
                  * silently overflow (the inventory float clamps at
@@ -435,12 +445,9 @@ void step_furnace_smelting(world_t *w, float dt) {
                  * player gets visible feedback that this station can't
                  * accept it (no tractor pull, no smelt) and can route
                  * to a station with room. */
-                commodity_t furnace_ore = furnace_ore_type(st->modules[m].type);
-                if ((int)furnace_ore >= 0 && a->commodity == furnace_ore) {
-                    commodity_t furnace_ingot = commodity_refined_form(furnace_ore);
-                    if (st->inventory[furnace_ingot] + a->ore > MAX_PRODUCT_STOCK)
-                        continue;  /* hopper full — skip this furnace */
-                }
+                commodity_t furnace_ingot = commodity_refined_form(furnace_ore);
+                if (st->inventory[furnace_ingot] + a->ore > MAX_PRODUCT_STOCK)
+                    continue;  /* hopper full — skip this furnace */
 
                 int ring = st->modules[m].ring;
                 vec2 furnace_pos = module_world_pos_ring(st, ring, st->modules[m].slot);

--- a/shared/belt.c
+++ b/shared/belt.c
@@ -1,0 +1,133 @@
+/*
+ * belt.c — implementations for the asteroid belt density field.
+ *
+ * Split from belt.h so editing the noise/density/ore math doesn't
+ * recompile every TU that includes belt.h. Callers were doing call-
+ * site inlining via `static inline`; the cost of an out-of-line call
+ * here is negligible compared with the 40+ TU recompile fan-out.
+ */
+#include <math.h>
+#include "belt.h"
+
+/* ------------------------------------------------------------------ */
+/* Permutation-based Perlin noise (2D)                                */
+/* ------------------------------------------------------------------ */
+
+void noise2d_init(noise2d_t *n, uint32_t seed) {
+    /* Fisher-Yates shuffle with xorshift RNG */
+    for (int i = 0; i < 256; i++) n->perm[i] = (uint8_t)i;
+    uint32_t s = seed ? seed : 1;
+    for (int i = 255; i > 0; i--) {
+        s ^= s << 13; s ^= s >> 17; s ^= s << 5;
+        int j = (int)(s % (uint32_t)(i + 1));
+        uint8_t tmp = n->perm[i];
+        n->perm[i] = n->perm[j];
+        n->perm[j] = tmp;
+    }
+    for (int i = 0; i < 256; i++) n->perm[256 + i] = n->perm[i];
+}
+
+static inline float noise2d_fade(float t) {
+    return t * t * t * (t * (t * 6.0f - 15.0f) + 10.0f);
+}
+
+static inline float noise2d_grad(int hash, float x, float y) {
+    int h = hash & 7;
+    float u = h < 4 ? x : y;
+    float v = h < 4 ? y : x;
+    return ((h & 1) ? -u : u) + ((h & 2) ? -v : v);
+}
+
+float noise2d_eval(const noise2d_t *n, float x, float y) {
+    int xi = (int)floorf(x) & 255;
+    int yi = (int)floorf(y) & 255;
+    float xf = x - floorf(x);
+    float yf = y - floorf(y);
+    float u = noise2d_fade(xf);
+    float v = noise2d_fade(yf);
+    int aa = n->perm[n->perm[xi] + yi];
+    int ab = n->perm[n->perm[xi] + yi + 1];
+    int ba = n->perm[n->perm[xi + 1] + yi];
+    int bb = n->perm[n->perm[xi + 1] + yi + 1];
+    float g_aa = noise2d_grad(aa, xf, yf);
+    float g_ba = noise2d_grad(ba, xf - 1.0f, yf);
+    float g_ab = noise2d_grad(ab, xf, yf - 1.0f);
+    float g_bb = noise2d_grad(bb, xf - 1.0f, yf - 1.0f);
+    float l1 = g_aa + u * (g_ba - g_aa);
+    float l2 = g_ab + u * (g_bb - g_ab);
+    return l1 + v * (l2 - l1);
+}
+
+/* ------------------------------------------------------------------ */
+/* Belt density field                                                  */
+/* ------------------------------------------------------------------ */
+
+void belt_field_init(belt_field_t *bf, uint32_t seed, float world_scale) {
+    noise2d_init(&bf->n1, seed);
+    noise2d_init(&bf->n2, seed + 7919u);
+    noise2d_init(&bf->n3, seed + 31337u);
+    noise2d_init(&bf->n4, seed + 65537u);
+    noise2d_init(&bf->n5, seed + 99991u);
+    bf->world_scale = world_scale;
+}
+
+/*
+ * Layers:
+ *   - Ridged noise for sharp belt centers (rivers)
+ *   - Pool noise for filled areas (lakes)
+ *   - Regional bias for large-scale ocean/desert (continents)
+ *   - Fine grain for cluster variation
+ *   - Hard floor threshold for truly empty lanes
+ */
+float belt_density_at(const belt_field_t *bf, float x, float y) {
+    float nx = x / bf->world_scale;
+    float ny = y / bf->world_scale;
+
+    /* Ridged noise: belt structure */
+    float r = 1.0f - fabsf(noise2d_eval(&bf->n1, nx * 3.0f, ny * 3.0f));
+    r = r * r;  /* sharpen ridges */
+
+    /* Pool noise: medium variation */
+    float p = noise2d_eval(&bf->n2, nx * 7.0f, ny * 7.0f);
+    p = fminf(fmaxf((p + 0.3f) * 0.8f, 0.0f), 1.0f);
+
+    /* Fine grain */
+    float g = noise2d_eval(&bf->n1, nx * 18.0f, ny * 18.0f) * 0.15f;
+
+    /* Regional bias */
+    float rb = noise2d_eval(&bf->n2, nx * 1.2f, ny * 1.2f);
+    rb = fminf(fmaxf((rb + 0.2f) * 0.7f, 0.0f), 1.0f);
+
+    /* Combine */
+    float d = r * 0.6f + p * 0.3f + g;
+    d = d * (0.4f + rb * 0.6f);
+
+    /* Hard floor: empty lanes */
+    d = fminf(fmaxf(d, 0.0f), 1.0f);
+    if (d < 0.15f) return 0.0f;
+    d = (d - 0.15f) / 0.85f;
+
+    /* Slight boost to mid-range */
+    d = powf(d, 0.7f);
+    return fminf(fmaxf(d, 0.0f), 1.0f);
+}
+
+/*
+ * Returns the dominant ore commodity at world position (x, y).
+ * Each ore reads its own noise field so pockets are geographically
+ * distinct. Additive biases give ~80% Fe / 4% Cu / 16% Cr globally.
+ */
+commodity_t belt_ore_at(const belt_field_t *bf, float x, float y) {
+    float nx = x / bf->world_scale;
+    float ny = y / bf->world_scale;
+
+    /* Target: ~60% ferrite, ~24% crystal, ~16% cuprite (i.e. 60/40 of
+     * the non-ferrite split, with crystal taking the larger share). */
+    float fe = noise2d_eval(&bf->n3, nx * 4.0f, ny * 4.0f) + 0.15f;
+    float cu = noise2d_eval(&bf->n4, nx * 4.0f, ny * 4.0f) - 0.55f;
+    float cr = noise2d_eval(&bf->n5, nx * 4.0f, ny * 4.0f) - 0.05f;
+
+    if (fe >= cu && fe >= cr) return COMMODITY_FERRITE_ORE;
+    if (cr >= cu) return COMMODITY_CRYSTAL_ORE;
+    return COMMODITY_CUPRITE_ORE;
+}

--- a/shared/belt.h
+++ b/shared/belt.h
@@ -2,11 +2,14 @@
  * belt.h — Procedural asteroid belt density field.
  * Evaluates noise-based density and ore bias at any world position.
  * Deterministic from seed. No pre-generated data.
+ *
+ * Implementations live in belt.c so editing the noise/density/ore math
+ * doesn't trigger a recompile of every TU that touches the belt struct
+ * (which used to fan out to ~40 .o files).
  */
 #ifndef BELT_H
 #define BELT_H
 
-#include <math.h>
 #include <stdint.h>
 #include "types.h"
 
@@ -18,52 +21,8 @@ typedef struct {
     uint8_t perm[512];
 } noise2d_t;
 
-static inline void noise2d_init(noise2d_t *n, uint32_t seed) {
-    /* Fisher-Yates shuffle with xorshift RNG */
-    for (int i = 0; i < 256; i++) n->perm[i] = (uint8_t)i;
-    uint32_t s = seed ? seed : 1;
-    for (int i = 255; i > 0; i--) {
-        s ^= s << 13; s ^= s >> 17; s ^= s << 5;
-        int j = (int)(s % (uint32_t)(i + 1));
-        uint8_t tmp = n->perm[i];
-        n->perm[i] = n->perm[j];
-        n->perm[j] = tmp;
-    }
-    for (int i = 0; i < 256; i++) n->perm[256 + i] = n->perm[i];
-}
-
-static inline float noise2d_fade(float t) {
-    return t * t * t * (t * (t * 6.0f - 15.0f) + 10.0f);
-}
-
-static inline float noise2d_grad(int hash, float x, float y) {
-    int h = hash & 7;
-    float u = h < 4 ? x : y;
-    float v = h < 4 ? y : x;
-    return ((h & 1) ? -u : u) + ((h & 2) ? -v : v);
-}
-
-static inline float noise2d_eval(const noise2d_t *n, float x, float y) {
-    int xi = (int)floorf(x) & 255;
-    int yi = (int)floorf(y) & 255;
-    float xf = x - floorf(x);
-    float yf = y - floorf(y);
-    float u = noise2d_fade(xf);
-    float v = noise2d_fade(yf);
-    int aa = n->perm[n->perm[xi] + yi];
-    int ab = n->perm[n->perm[xi] + yi + 1];
-    int ba = n->perm[n->perm[xi + 1] + yi];
-    int bb = n->perm[n->perm[xi + 1] + yi + 1];
-    float x1 = aa + (ba - aa) * 0.0f; /* suppress warning */
-    (void)x1;
-    float g_aa = noise2d_grad(aa, xf, yf);
-    float g_ba = noise2d_grad(ba, xf - 1.0f, yf);
-    float g_ab = noise2d_grad(ab, xf, yf - 1.0f);
-    float g_bb = noise2d_grad(bb, xf - 1.0f, yf - 1.0f);
-    float l1 = g_aa + u * (g_ba - g_aa);
-    float l2 = g_ab + u * (g_bb - g_ab);
-    return l1 + v * (l2 - l1);
-}
+void  noise2d_init(noise2d_t *n, uint32_t seed);
+float noise2d_eval(const noise2d_t *n, float x, float y);
 
 /* ------------------------------------------------------------------ */
 /* Belt density field                                                  */
@@ -78,77 +37,13 @@ typedef struct {
     float world_scale;
 } belt_field_t;
 
-static inline void belt_field_init(belt_field_t *bf, uint32_t seed, float world_scale) {
-    noise2d_init(&bf->n1, seed);
-    noise2d_init(&bf->n2, seed + 7919u);
-    noise2d_init(&bf->n3, seed + 31337u);
-    noise2d_init(&bf->n4, seed + 65537u);
-    noise2d_init(&bf->n5, seed + 99991u);
-    bf->world_scale = world_scale;
-}
+void        belt_field_init(belt_field_t *bf, uint32_t seed, float world_scale);
 
-/*
- * Returns asteroid density at world position (x, y).
- * 0.0 = empty space, 1.0 = dense ocean of rock.
- *
- * Layers:
- *   - Ridged noise for sharp belt centers (rivers)
- *   - Pool noise for filled areas (lakes)
- *   - Regional bias for large-scale ocean/desert (continents)
- *   - Fine grain for cluster variation
- *   - Hard floor threshold for truly empty lanes
- */
-static inline float belt_density_at(const belt_field_t *bf, float x, float y) {
-    float nx = x / bf->world_scale;
-    float ny = y / bf->world_scale;
+/* Returns asteroid density at world position (x, y).
+ * 0.0 = empty space, 1.0 = dense ocean of rock. */
+float       belt_density_at(const belt_field_t *bf, float x, float y);
 
-    /* Ridged noise: belt structure */
-    float r = 1.0f - fabsf(noise2d_eval(&bf->n1, nx * 3.0f, ny * 3.0f));
-    r = r * r;  /* sharpen ridges */
-
-    /* Pool noise: medium variation */
-    float p = noise2d_eval(&bf->n2, nx * 7.0f, ny * 7.0f);
-    p = fminf(fmaxf((p + 0.3f) * 0.8f, 0.0f), 1.0f);
-
-    /* Fine grain */
-    float g = noise2d_eval(&bf->n1, nx * 18.0f, ny * 18.0f) * 0.15f;
-
-    /* Regional bias */
-    float rb = noise2d_eval(&bf->n2, nx * 1.2f, ny * 1.2f);
-    rb = fminf(fmaxf((rb + 0.2f) * 0.7f, 0.0f), 1.0f);
-
-    /* Combine */
-    float d = r * 0.6f + p * 0.3f + g;
-    d = d * (0.4f + rb * 0.6f);
-
-    /* Hard floor: empty lanes */
-    d = fminf(fmaxf(d, 0.0f), 1.0f);
-    if (d < 0.15f) return 0.0f;
-    d = (d - 0.15f) / 0.85f;
-
-    /* Slight boost to mid-range */
-    d = powf(d, 0.7f);
-    return fminf(fmaxf(d, 0.0f), 1.0f);
-}
-
-/*
- * Returns the dominant ore commodity at world position (x, y).
- * Uses separate noise layers so ore zones are geographically distinct.
- */
-static inline commodity_t belt_ore_at(const belt_field_t *bf, float x, float y) {
-    float nx = x / bf->world_scale;
-    float ny = y / bf->world_scale;
-
-    /* Rarity: ferrite 80%, crystal 16%, cuprite 4%.
-     * Bias noise weights so ferrite dominates most of the map,
-     * crystal appears in moderate pockets, cuprite is rare. */
-    float fe = fmaxf(noise2d_eval(&bf->n3, nx * 4.0f, ny * 4.0f) + 0.5f, 0.1f) * 4.0f;
-    float cu = fmaxf(noise2d_eval(&bf->n4, nx * 4.0f, ny * 4.0f) + 0.5f, 0.1f) * 0.2f;
-    float cr = fmaxf(noise2d_eval(&bf->n5, nx * 4.0f, ny * 4.0f) + 0.5f, 0.1f) * 0.8f;
-
-    if (fe >= cu && fe >= cr) return COMMODITY_FERRITE_ORE;
-    if (cr >= cu) return COMMODITY_CRYSTAL_ORE;
-    return COMMODITY_CUPRITE_ORE;
-}
+/* Returns the dominant ore commodity at world position (x, y). */
+commodity_t belt_ore_at(const belt_field_t *bf, float x, float y);
 
 #endif /* BELT_H */

--- a/shared/module_schema.c
+++ b/shared/module_schema.c
@@ -1,0 +1,261 @@
+/*
+ * module_schema.c — table + lookups for station module behavior.
+ *
+ * Split from module_schema.h so editing the schema (frequent during
+ * gameplay tuning) doesn't recompile every TU that includes types.h.
+ *
+ * The table is defined here once and referenced by every caller via
+ * the lookup helpers. Callers pay one extra indirect call per query
+ * (was an inline-resolved table read); none of these lookups are in
+ * inner loops, so the cost is invisible.
+ */
+#include "types.h"
+#include "module_schema.h"
+
+const module_schema_t MODULE_SCHEMA[MODULE_COUNT] = {
+    [MODULE_DOCK] = {
+        .name = "Dock",
+        .kind = MODULE_KIND_SERVICE,
+        .input = COMMODITY_COUNT, .output = COMMODITY_COUNT,
+        .rate = 0.0f, .buffer_capacity = 0.0f,
+        .build_material = 20.0f, .build_commodity = COMMODITY_FRAME,
+        .order_fee = 25, /* 100/4 */
+        .services = 0,
+        .valid_rings = MODULE_RINGS_ANY,
+        .variant_count = 0,
+        .prerequisite = MODULE_SIGNAL_RELAY, /* tier 1 */
+    },
+    [MODULE_HOPPER] = {
+        .name = "Hopper", /* ore intake + beam anchor for furnaces */
+        .kind = MODULE_KIND_STORAGE,
+        .input = COMMODITY_FERRITE_ORE, /* primary; accepts all ore types */
+        .output = COMMODITY_COUNT,
+        .rate = 0.0f, .buffer_capacity = 30.0f,
+        .build_material = 40.0f, .build_commodity = COMMODITY_FRAME,
+        .order_fee = 37, /* 150/4 */
+        .services = 0,
+        .valid_rings = MODULE_RINGS_OUTER,
+        .variant_count = 0,
+        .prerequisite = MODULE_SIGNAL_RELAY, /* tier 1 */
+    },
+    [MODULE_FURNACE] = {
+        .name = "Iron Furnace",
+        .kind = MODULE_KIND_PRODUCER,
+        .input = COMMODITY_FERRITE_ORE,
+        .output = COMMODITY_FERRITE_INGOT,
+        .rate = 1.0f, .buffer_capacity = 12.0f,
+        .build_material = 60.0f, .build_commodity = COMMODITY_FRAME,
+        .order_fee = 50, /* 200/4 */
+        .services = 0,
+        .valid_rings = MODULE_RINGS_OUTER,
+        .variant_count = 0,
+        .prerequisite = MODULE_HOPPER, /* tier 2 — needs hopper */
+    },
+    [MODULE_FURNACE_CU] = {
+        .name = "Copper Furnace",
+        .kind = MODULE_KIND_PRODUCER,
+        .input = COMMODITY_CUPRITE_ORE,
+        .output = COMMODITY_CUPRITE_INGOT,
+        .rate = 0.8f, .buffer_capacity = 12.0f,
+        .build_material = 120.0f, .build_commodity = COMMODITY_FRAME,
+        .order_fee = 100,
+        .services = 0,
+        .valid_rings = MODULE_RINGS_OUTER,
+        .variant_count = 0,
+        .prerequisite = MODULE_FRAME_PRESS, /* tier 4 — needs frames */
+    },
+    [MODULE_FURNACE_CR] = {
+        .name = "Crystal Furnace",
+        .kind = MODULE_KIND_PRODUCER,
+        .input = COMMODITY_CRYSTAL_ORE,
+        .output = COMMODITY_CRYSTAL_INGOT,
+        .rate = 0.6f, .buffer_capacity = 12.0f,
+        .build_material = 160.0f, .build_commodity = COMMODITY_FRAME,
+        .order_fee = 125,
+        .services = 0,
+        .valid_rings = MODULE_RINGS_OUTER,
+        .variant_count = 0,
+        .prerequisite = MODULE_FRAME_PRESS, /* tier 4 */
+    },
+    [MODULE_REPAIR_BAY] = {
+        .name = "Repair Bay",
+        .kind = MODULE_KIND_SERVICE,
+        .input = COMMODITY_COUNT, .output = COMMODITY_COUNT,
+        .rate = 0.0f, .buffer_capacity = 0.0f,
+        .build_material = 30.0f, .build_commodity = COMMODITY_FRAME,
+        .order_fee = 50,
+        .services = STATION_SERVICE_REPAIR,
+        .valid_rings = MODULE_RINGS_OUTER,
+        .variant_count = 0,
+        .prerequisite = MODULE_DOCK, /* tier 2 — needs ships docking first */
+    },
+    [MODULE_SIGNAL_RELAY] = {
+        .name = "Signal Relay",
+        .kind = MODULE_KIND_SERVICE,
+        .input = COMMODITY_COUNT, .output = COMMODITY_COUNT,
+        .rate = 0.0f, .buffer_capacity = 0.0f,
+        .build_material = 40.0f, .build_commodity = COMMODITY_FRAME,
+        .order_fee = 37, /* 150/4 */
+        .services = 0,
+        .valid_rings = MODULE_RINGS_ANY,
+        .variant_count = 0,
+        .prerequisite = MODULE_COUNT, /* root — always available */
+    },
+    [MODULE_FRAME_PRESS] = {
+        .name = "Frame Press",
+        .kind = MODULE_KIND_PRODUCER,
+        .input = COMMODITY_FERRITE_INGOT,
+        .output = COMMODITY_FRAME,
+        .rate = 1.0f, .buffer_capacity = 12.0f,
+        .build_material = 80.0f, .build_commodity = COMMODITY_FRAME,
+        .order_fee = 75,
+        .services = 0,
+        .valid_rings = MODULE_RINGS_INDUSTRIAL,
+        .variant_count = 0,
+        .prerequisite = MODULE_FURNACE, /* tier 3 — needs ingots */
+    },
+    [MODULE_LASER_FAB] = {
+        .name = "Laser Fab",
+        .kind = MODULE_KIND_PRODUCER,
+        .input = COMMODITY_CUPRITE_INGOT, /* plus crystal ingots */
+        .output = COMMODITY_LASER_MODULE,
+        .rate = 0.5f, .buffer_capacity = 12.0f,
+        .build_material = 80.0f, .build_commodity = COMMODITY_CUPRITE_INGOT,
+        .order_fee = 100,
+        .services = STATION_SERVICE_UPGRADE_LASER,
+        .valid_rings = MODULE_RINGS_INDUSTRIAL,
+        .variant_count = 0,
+        .prerequisite = MODULE_FURNACE_CU, /* tier 5 — needs cu ingots */
+    },
+    [MODULE_TRACTOR_FAB] = {
+        .name = "Tractor Fab",
+        .kind = MODULE_KIND_PRODUCER,
+        .input = COMMODITY_CUPRITE_INGOT,
+        .output = COMMODITY_TRACTOR_MODULE,
+        .rate = 0.5f, .buffer_capacity = 12.0f,
+        .build_material = 80.0f, .build_commodity = COMMODITY_CRYSTAL_INGOT,
+        .order_fee = 100,
+        .services = STATION_SERVICE_UPGRADE_TRACTOR,
+        .valid_rings = MODULE_RINGS_INDUSTRIAL,
+        .variant_count = 0,
+        .prerequisite = MODULE_FURNACE_CR, /* tier 5 — needs cr ingots */
+    },
+    [MODULE_ORE_SILO] = {
+        .name = "Ore Silo",
+        .kind = MODULE_KIND_STORAGE,
+        .input = COMMODITY_FERRITE_ORE, /* primary; accepts all ore */
+        .output = COMMODITY_COUNT,
+        .rate = 0.0f, .buffer_capacity = 60.0f, /* big buffer */
+        .build_material = 30.0f, .build_commodity = COMMODITY_FRAME,
+        .order_fee = 25,
+        .services = 0,
+        .valid_rings = MODULE_RINGS_OUTER,
+        .variant_count = 0,
+        .prerequisite = MODULE_FURNACE, /* tier 3 — overflow storage */
+    },
+    [MODULE_SHIPYARD] = {
+        .name = "Shipyard",
+        .kind = MODULE_KIND_SHIPYARD,
+        .input = COMMODITY_FRAME, /* default; consumes whatever the order needs */
+        .output = COMMODITY_COUNT,
+        .rate = 0.0f, .buffer_capacity = 60.0f,
+        .build_material = 120.0f, .build_commodity = COMMODITY_FRAME,
+        .order_fee = 125,
+        .services = 0,
+        .valid_rings = MODULE_RINGS_INDUSTRIAL,
+        .variant_count = 0,
+        .prerequisite = MODULE_FRAME_PRESS, /* tier 4 — needs frames */
+    },
+    [MODULE_CARGO_BAY] = {
+        .name = "Cargo Bay",
+        .kind = MODULE_KIND_STORAGE,
+        .input = COMMODITY_FERRITE_INGOT, /* generic — accepts any commodity in flow graph */
+        .output = COMMODITY_COUNT,
+        .rate = 0.0f, .buffer_capacity = 120.0f, /* large storage */
+        .build_material = 60.0f, .build_commodity = COMMODITY_FRAME,
+        .order_fee = 60,
+        .services = 0,
+        .valid_rings = MODULE_RINGS_OUTER,
+        .variant_count = 0,
+        .prerequisite = MODULE_FURNACE, /* tier 3 — needs production to store */
+    },
+};
+
+/* ----- Lookup helpers ----- */
+
+const module_schema_t *module_schema(module_type_t type) {
+    if ((unsigned)type >= MODULE_COUNT) return &MODULE_SCHEMA[MODULE_DOCK];
+    return &MODULE_SCHEMA[type];
+}
+
+module_kind_t module_kind(module_type_t type) {
+    return module_schema(type)->kind;
+}
+
+bool module_is_producer(module_type_t type) { return module_kind(type) == MODULE_KIND_PRODUCER; }
+bool module_is_service (module_type_t type) { return module_kind(type) == MODULE_KIND_SERVICE; }
+bool module_is_storage (module_type_t type) { return module_kind(type) == MODULE_KIND_STORAGE; }
+bool module_is_shipyard(module_type_t type) { return module_kind(type) == MODULE_KIND_SHIPYARD; }
+bool module_is_dead    (module_type_t type) { return module_kind(type) == MODULE_KIND_NONE; }
+
+commodity_t module_schema_input (module_type_t type) { return module_schema(type)->input; }
+commodity_t module_schema_output(module_type_t type) { return module_schema(type)->output; }
+float       module_production_rate(module_type_t type) { return module_schema(type)->rate; }
+float       module_buffer_capacity(module_type_t type) { return module_schema(type)->buffer_capacity; }
+
+bool module_valid_on_ring(module_type_t type, int ring) {
+    if (ring < 0 || ring > 3) return false;
+    return (module_schema(type)->valid_rings & (1u << ring)) != 0;
+}
+
+bool module_unlocked_for_player(uint32_t unlocked_mask, module_type_t type) {
+    int prereq = module_schema(type)->prerequisite;
+    if (prereq < 0 || prereq >= MODULE_COUNT) return true;
+    return (unlocked_mask & (1u << prereq)) != 0;
+}
+
+const char *module_type_name(module_type_t type) {
+    return module_schema(type)->name;
+}
+
+commodity_t module_build_material_lookup(module_type_t type) {
+    return module_schema(type)->build_commodity;
+}
+
+float module_build_cost_lookup(module_type_t type) {
+    return module_schema(type)->build_material;
+}
+
+int scaffold_order_fee(module_type_t type) {
+    return module_schema(type)->order_fee;
+}
+
+module_build_state_t module_build_state(const station_module_t *m) {
+    if (!m->scaffold) return MODULE_BUILD_COMPLETE;
+    if (m->build_progress < 1.0f) return MODULE_BUILD_AWAITING_SUPPLY;
+    return MODULE_BUILD_BUILDING;
+}
+
+bool module_is_complete(const station_module_t *m) {
+    return !m->scaffold;
+}
+
+bool module_is_fully_supplied(const station_module_t *m) {
+    return !m->scaffold || m->build_progress >= 1.0f;
+}
+
+float module_supply_fraction(const station_module_t *m) {
+    if (!m->scaffold) return 1.0f;
+    float p = m->build_progress;
+    if (p > 1.0f) p = 1.0f;
+    if (p < 0.0f) p = 0.0f;
+    return p;
+}
+
+float module_build_timer_fraction(const station_module_t *m) {
+    if (!m->scaffold) return 1.0f;
+    float t = m->build_progress - 1.0f;
+    if (t < 0.0f) return 0.0f;
+    if (t > 1.0f) return 1.0f;
+    return t;
+}

--- a/shared/module_schema.h
+++ b/shared/module_schema.h
@@ -5,12 +5,9 @@
  * producer / storage / shipyard), input/output commodities, build cost,
  * order fee, valid rings, and provided services.
  *
- * Production code, plan-mode UI, the order menu, and the material flow
- * graph all read from this table. Adding a new module type means one
- * entry here, not edits across five files.
- *
- * Header-only — included by types.h. Inline functions for lookups so
- * client and server share without a separate .c file.
+ * Implementations + the table itself live in module_schema.c. The header
+ * is declarations + small structs only, so editing the table doesn't
+ * fan out to every TU that includes types.h.
  *
  * Variant question (#280): commodity-specialized producers (furnaces
  * MODULE_FURNACE / _CU / _CR, fabs MODULE_FRAME_PRESS / _LASER_FAB /
@@ -23,9 +20,6 @@
  *     furnace as prerequisite); the enum is the natural foreign key.
  *   - On-disk and on-wire representations already serialize the enum;
  *     collapsing would force a save/wire bump for no behavioral win.
- * If a future module gets more than ~4 variants we can revisit, but
- * for the current 6 commodity-specialized producers, the enum scales
- * fine. Don't add `variant_count` writers for these types.
  */
 #ifndef MODULE_SCHEMA_H
 #define MODULE_SCHEMA_H
@@ -68,260 +62,33 @@ typedef struct {
                                      * (MODULE_COUNT = no prerequisite, root) */
 } module_schema_t;
 
-/* The schema table. Indexed by module_type_t.
- * NONE entries are deleted/dead enum values that still exist for
- * backward compatibility but should not be used in new code. */
-static const module_schema_t MODULE_SCHEMA[MODULE_COUNT] = {
-    [MODULE_DOCK] = {
-        .name = "Dock",
-        .kind = MODULE_KIND_SERVICE,
-        .input = COMMODITY_COUNT, .output = COMMODITY_COUNT,
-        .rate = 0.0f, .buffer_capacity = 0.0f,
-        .build_material = 20.0f, .build_commodity = COMMODITY_FRAME,
-        .order_fee = 25, /* 100/4 */
-        .services = 0,
-        .valid_rings = MODULE_RINGS_ANY,
-        .variant_count = 0,
-        .prerequisite = MODULE_SIGNAL_RELAY, /* tier 1 */
-    },
-    [MODULE_HOPPER] = {
-        .name = "Hopper", /* ore intake + beam anchor for furnaces */
-        .kind = MODULE_KIND_STORAGE,
-        .input = COMMODITY_FERRITE_ORE, /* primary; accepts all ore types */
-        .output = COMMODITY_COUNT,
-        .rate = 0.0f, .buffer_capacity = 30.0f,
-        .build_material = 40.0f, .build_commodity = COMMODITY_FRAME,
-        .order_fee = 37, /* 150/4 */
-        .services = 0,
-        .valid_rings = MODULE_RINGS_OUTER,
-        .variant_count = 0,
-        .prerequisite = MODULE_SIGNAL_RELAY, /* tier 1 */
-    },
-    [MODULE_FURNACE] = {
-        .name = "Iron Furnace",
-        .kind = MODULE_KIND_PRODUCER,
-        .input = COMMODITY_FERRITE_ORE,
-        .output = COMMODITY_FERRITE_INGOT,
-        .rate = 1.0f, .buffer_capacity = 12.0f,
-        .build_material = 60.0f, .build_commodity = COMMODITY_FRAME,
-        .order_fee = 50, /* 200/4 */
-        .services = 0,
-        .valid_rings = MODULE_RINGS_OUTER,
-        .variant_count = 0,
-        .prerequisite = MODULE_HOPPER, /* tier 2 — needs hopper */
-    },
-    [MODULE_FURNACE_CU] = {
-        .name = "Copper Furnace",
-        .kind = MODULE_KIND_PRODUCER,
-        .input = COMMODITY_CUPRITE_ORE,
-        .output = COMMODITY_CUPRITE_INGOT,
-        .rate = 0.8f, .buffer_capacity = 12.0f,
-        .build_material = 120.0f, .build_commodity = COMMODITY_FRAME,
-        .order_fee = 100,
-        .services = 0,
-        .valid_rings = MODULE_RINGS_OUTER,
-        .variant_count = 0,
-        .prerequisite = MODULE_FRAME_PRESS, /* tier 4 — needs frames */
-    },
-    [MODULE_FURNACE_CR] = {
-        .name = "Crystal Furnace",
-        .kind = MODULE_KIND_PRODUCER,
-        .input = COMMODITY_CRYSTAL_ORE,
-        .output = COMMODITY_CRYSTAL_INGOT,
-        .rate = 0.6f, .buffer_capacity = 12.0f,
-        .build_material = 160.0f, .build_commodity = COMMODITY_FRAME,
-        .order_fee = 125,
-        .services = 0,
-        .valid_rings = MODULE_RINGS_OUTER,
-        .variant_count = 0,
-        .prerequisite = MODULE_FRAME_PRESS, /* tier 4 */
-    },
-    [MODULE_REPAIR_BAY] = {
-        .name = "Repair Bay",
-        .kind = MODULE_KIND_SERVICE,
-        .input = COMMODITY_COUNT, .output = COMMODITY_COUNT,
-        .rate = 0.0f, .buffer_capacity = 0.0f,
-        .build_material = 30.0f, .build_commodity = COMMODITY_FRAME,
-        .order_fee = 50,
-        .services = STATION_SERVICE_REPAIR,
-        .valid_rings = MODULE_RINGS_OUTER,
-        .variant_count = 0,
-        .prerequisite = MODULE_DOCK, /* tier 2 — needs ships docking first */
-    },
-    [MODULE_SIGNAL_RELAY] = {
-        .name = "Signal Relay",
-        .kind = MODULE_KIND_SERVICE,
-        .input = COMMODITY_COUNT, .output = COMMODITY_COUNT,
-        .rate = 0.0f, .buffer_capacity = 0.0f,
-        .build_material = 40.0f, .build_commodity = COMMODITY_FRAME,
-        .order_fee = 37, /* 150/4 */
-        .services = 0,
-        .valid_rings = MODULE_RINGS_ANY,
-        .variant_count = 0,
-        .prerequisite = MODULE_COUNT, /* root — always available */
-    },
-    [MODULE_FRAME_PRESS] = {
-        .name = "Frame Press",
-        .kind = MODULE_KIND_PRODUCER,
-        .input = COMMODITY_FERRITE_INGOT,
-        .output = COMMODITY_FRAME,
-        .rate = 1.0f, .buffer_capacity = 12.0f,
-        .build_material = 80.0f, .build_commodity = COMMODITY_FRAME,
-        .order_fee = 75,
-        .services = 0,
-        .valid_rings = MODULE_RINGS_INDUSTRIAL,
-        .variant_count = 0,
-        .prerequisite = MODULE_FURNACE, /* tier 3 — needs ingots */
-    },
-    [MODULE_LASER_FAB] = {
-        .name = "Laser Fab",
-        .kind = MODULE_KIND_PRODUCER,
-        .input = COMMODITY_CUPRITE_INGOT, /* plus crystal ingots */
-        .output = COMMODITY_LASER_MODULE,
-        .rate = 0.5f, .buffer_capacity = 12.0f,
-        .build_material = 80.0f, .build_commodity = COMMODITY_CUPRITE_INGOT,
-        .order_fee = 100,
-        .services = STATION_SERVICE_UPGRADE_LASER,
-        .valid_rings = MODULE_RINGS_INDUSTRIAL,
-        .variant_count = 0,
-        .prerequisite = MODULE_FURNACE_CU, /* tier 5 — needs cu ingots */
-    },
-    [MODULE_TRACTOR_FAB] = {
-        .name = "Tractor Fab",
-        .kind = MODULE_KIND_PRODUCER,
-        .input = COMMODITY_CUPRITE_INGOT,
-        .output = COMMODITY_TRACTOR_MODULE,
-        .rate = 0.5f, .buffer_capacity = 12.0f,
-        .build_material = 80.0f, .build_commodity = COMMODITY_CRYSTAL_INGOT,
-        .order_fee = 100,
-        .services = STATION_SERVICE_UPGRADE_TRACTOR,
-        .valid_rings = MODULE_RINGS_INDUSTRIAL,
-        .variant_count = 0,
-        .prerequisite = MODULE_FURNACE_CR, /* tier 5 — needs cr ingots */
-    },
-    [MODULE_ORE_SILO] = {
-        .name = "Ore Silo",
-        .kind = MODULE_KIND_STORAGE,
-        .input = COMMODITY_FERRITE_ORE, /* primary; accepts all ore */
-        .output = COMMODITY_COUNT,
-        .rate = 0.0f, .buffer_capacity = 60.0f, /* big buffer */
-        .build_material = 30.0f, .build_commodity = COMMODITY_FRAME,
-        .order_fee = 25,
-        .services = 0,
-        .valid_rings = MODULE_RINGS_OUTER,
-        .variant_count = 0,
-        .prerequisite = MODULE_FURNACE, /* tier 3 — overflow storage */
-    },
-    [MODULE_SHIPYARD] = {
-        .name = "Shipyard",
-        .kind = MODULE_KIND_SHIPYARD,
-        .input = COMMODITY_FRAME, /* default; consumes whatever the order needs */
-        .output = COMMODITY_COUNT,
-        .rate = 0.0f, .buffer_capacity = 60.0f,
-        .build_material = 120.0f, .build_commodity = COMMODITY_FRAME,
-        .order_fee = 125,
-        .services = 0,
-        .valid_rings = MODULE_RINGS_INDUSTRIAL,
-        .variant_count = 0,
-        .prerequisite = MODULE_FRAME_PRESS, /* tier 4 — needs frames */
-    },
-    [MODULE_CARGO_BAY] = {
-        .name = "Cargo Bay",
-        .kind = MODULE_KIND_STORAGE,
-        .input = COMMODITY_FERRITE_INGOT, /* generic — accepts any commodity in flow graph */
-        .output = COMMODITY_COUNT,
-        .rate = 0.0f, .buffer_capacity = 120.0f, /* large storage */
-        .build_material = 60.0f, .build_commodity = COMMODITY_FRAME,
-        .order_fee = 60,
-        .services = 0,
-        .valid_rings = MODULE_RINGS_OUTER,
-        .variant_count = 0,
-        .prerequisite = MODULE_FURNACE, /* tier 3 — needs production to store */
-    },
-};
+/* The schema table — defined in module_schema.c. */
+extern const module_schema_t MODULE_SCHEMA[MODULE_COUNT];
 
-/* ----- Lookup helpers -----
- * All return safe defaults for out-of-range or NONE entries. */
+/* ----- Lookup helpers — all return safe defaults for OOR / NONE ----- */
+const module_schema_t *module_schema(module_type_t type);
+module_kind_t          module_kind(module_type_t type);
+bool                   module_is_producer(module_type_t type);
+bool                   module_is_service (module_type_t type);
+bool                   module_is_storage (module_type_t type);
+bool                   module_is_shipyard(module_type_t type);
+bool                   module_is_dead    (module_type_t type);
+commodity_t            module_schema_input (module_type_t type);
+commodity_t            module_schema_output(module_type_t type);
+float                  module_production_rate(module_type_t type);
+float                  module_buffer_capacity(module_type_t type);
+bool                   module_valid_on_ring(module_type_t type, int ring);
 
-static inline const module_schema_t *module_schema(module_type_t type) {
-    if ((unsigned)type >= MODULE_COUNT) return &MODULE_SCHEMA[MODULE_DOCK];
-    return &MODULE_SCHEMA[type];
-}
+/* Tech-tree gate: a module is unlocked when its prerequisite has been
+ * built at least once. Roots (prerequisite = MODULE_COUNT) are always
+ * available. */
+bool                   module_unlocked_for_player(uint32_t unlocked_mask, module_type_t type);
 
-static inline module_kind_t module_kind(module_type_t type) {
-    return module_schema(type)->kind;
-}
-
-static inline bool module_is_producer(module_type_t type) {
-    return module_kind(type) == MODULE_KIND_PRODUCER;
-}
-
-static inline bool module_is_service(module_type_t type) {
-    return module_kind(type) == MODULE_KIND_SERVICE;
-}
-
-static inline bool module_is_storage(module_type_t type) {
-    return module_kind(type) == MODULE_KIND_STORAGE;
-}
-
-static inline bool module_is_shipyard(module_type_t type) {
-    return module_kind(type) == MODULE_KIND_SHIPYARD;
-}
-
-static inline bool module_is_dead(module_type_t type) {
-    return module_kind(type) == MODULE_KIND_NONE;
-}
-
-static inline commodity_t module_schema_input(module_type_t type) {
-    return module_schema(type)->input;
-}
-
-static inline commodity_t module_schema_output(module_type_t type) {
-    return module_schema(type)->output;
-}
-
-static inline float module_production_rate(module_type_t type) {
-    return module_schema(type)->rate;
-}
-
-static inline float module_buffer_capacity(module_type_t type) {
-    return module_schema(type)->buffer_capacity;
-}
-
-/* True if this module type can be placed on the given ring (1..3 or 0=core) */
-static inline bool module_valid_on_ring(module_type_t type, int ring) {
-    if (ring < 0 || ring > 3) return false;
-    return (module_schema(type)->valid_rings & (1u << ring)) != 0;
-}
-
-/* Tech-tree gate: a module is unlocked for a player when they have
- * built (ordered) its prerequisite at least once. Root modules
- * (prerequisite = MODULE_COUNT) are always available. */
-static inline bool module_unlocked_for_player(uint32_t unlocked_mask, module_type_t type) {
-    int prereq = module_schema(type)->prerequisite;
-    if (prereq < 0 || prereq >= MODULE_COUNT) return true; /* root */
-    return (unlocked_mask & (1u << prereq)) != 0;
-}
-
-/* Display name for a module type — single source of truth. */
-static inline const char *module_type_name(module_type_t type) {
-    return module_schema(type)->name;
-}
-
-/* ----- Legacy lookup helpers (now schema-backed) -----
- * Used by client UI and onboarding. Internally delegate to the schema. */
-
-static inline commodity_t module_build_material_lookup(module_type_t type) {
-    return module_schema(type)->build_commodity;
-}
-
-static inline float module_build_cost_lookup(module_type_t type) {
-    return module_schema(type)->build_material;
-}
-
-static inline int scaffold_order_fee(module_type_t type) {
-    return module_schema(type)->order_fee;
-}
+/* Display name + legacy lookup wrappers. */
+const char            *module_type_name(module_type_t type);
+commodity_t            module_build_material_lookup(module_type_t type);
+float                  module_build_cost_lookup(module_type_t type);
+int                    scaffold_order_fee(module_type_t type);
 
 /* ----- Module build lifecycle (#307) -----
  *
@@ -331,12 +98,6 @@ static inline int scaffold_order_fee(module_type_t type) {
  *   scaffold=true,  0.0 <= build_progress < 1.0  : awaiting supply
  *   scaffold=true,  1.0 <= build_progress < 2.0  : supplied, build timer running
  *   scaffold=false, build_progress == 1.0        : complete
- *
- * Direct comparisons against 1.0 / 2.0 are deprecated; readers should use
- * the helpers below so the convention stays internal to the construction
- * stepper. The on-disk and on-wire representation remains a single float
- * for now — splitting into separate fields will ride along with the
- * unified `ship_t` save bump (#294) so we don't migrate twice.
  */
 typedef enum {
     MODULE_BUILD_AWAITING_SUPPLY = 0,
@@ -347,38 +108,10 @@ typedef enum {
 /* Wall-clock seconds between full supply and module activation. */
 #define MODULE_BUILD_TIME_SEC 10.0f
 
-static inline module_build_state_t module_build_state(const station_module_t *m) {
-    if (!m->scaffold) return MODULE_BUILD_COMPLETE;
-    if (m->build_progress < 1.0f) return MODULE_BUILD_AWAITING_SUPPLY;
-    return MODULE_BUILD_BUILDING;
-}
-
-static inline bool module_is_complete(const station_module_t *m) {
-    return !m->scaffold;
-}
-
-static inline bool module_is_fully_supplied(const station_module_t *m) {
-    return !m->scaffold || m->build_progress >= 1.0f;
-}
-
-/* 0.0 .. 1.0 — fraction of build material delivered.
- * Reads as 1.0 once supply phase ends (regardless of build-timer phase). */
-static inline float module_supply_fraction(const station_module_t *m) {
-    if (!m->scaffold) return 1.0f;
-    float p = m->build_progress;
-    if (p > 1.0f) p = 1.0f;
-    if (p < 0.0f) p = 0.0f;
-    return p;
-}
-
-/* 0.0 .. 1.0 — fraction of build timer elapsed since full supply.
- * Reads as 0.0 in AWAITING_SUPPLY, 1.0 in COMPLETE. */
-static inline float module_build_timer_fraction(const station_module_t *m) {
-    if (!m->scaffold) return 1.0f;
-    float t = m->build_progress - 1.0f;
-    if (t < 0.0f) return 0.0f;
-    if (t > 1.0f) return 1.0f;
-    return t;
-}
+module_build_state_t   module_build_state(const station_module_t *m);
+bool                   module_is_complete(const station_module_t *m);
+bool                   module_is_fully_supplied(const station_module_t *m);
+float                  module_supply_fraction(const station_module_t *m);
+float                  module_build_timer_fraction(const station_module_t *m);
 
 #endif /* MODULE_SCHEMA_H */

--- a/shared/station_util.c
+++ b/shared/station_util.c
@@ -1,0 +1,202 @@
+/*
+ * station_util.c — implementations for station_util.h queries.
+ *
+ * Split out from the header so editing these helpers (frequent during
+ * gameplay tuning — modules, primary-trade derivations, ring math)
+ * doesn't recompile every TU that pulls station_t through types.h.
+ */
+#include <math.h>
+#include "types.h"
+#include "station_util.h"
+
+bool station_exists(const station_t *st) {
+    return st->signal_range > 0.0f || st->scaffold || st->planned || st->dock_radius > 0.0f;
+}
+
+bool station_is_active(const station_t *st) {
+    return st->signal_range > 0.0f && !st->scaffold && !st->planned;
+}
+
+bool station_provides_docking(const station_t *st) {
+    return st->dock_radius > 0.0f && !st->planned;
+}
+
+bool station_provides_signal(const station_t *st) {
+    return st->signal_range > 0.0f && st->signal_connected && !st->planned;
+}
+
+bool station_collides(const station_t *st) {
+    return st->radius > 0.0f && !st->planned;
+}
+
+bool station_has_module(const station_t *st, module_type_t type) {
+    for (int i = 0; i < st->module_count; i++)
+        if (st->modules[i].type == type && !st->modules[i].scaffold) return true;
+    return false;
+}
+
+int station_max_ring(const station_t *st) {
+    int max = 1;
+    for (int i = 0; i < st->module_count; i++) {
+        if (st->modules[i].scaffold) continue;
+        int r = (int)st->modules[i].ring;
+        if (r > max && r <= STATION_NUM_RINGS) max = r;
+    }
+    return max;
+}
+
+int station_spawn_fee(const station_t *st) {
+    switch (station_max_ring(st)) {
+        case 1:  return 50;
+        case 2:  return 100;
+        case 3:  return 300;
+        default: return 50;
+    }
+}
+
+bool station_consumes(const station_t *st, commodity_t c) {
+    /* Shipyards consume frame + laser + tractor as kit-fab inputs.
+     * Without this branch, a player who fills a frame contract at
+     * Helios and has leftover frames can't sell them — Helios's frame
+     * press doesn't exist locally, so the fallback skipped, even
+     * though the kit fab will happily eat any extras. */
+    bool is_shipyard = station_has_module(st, MODULE_SHIPYARD);
+    switch (c) {
+        case COMMODITY_FERRITE_ORE:   return station_has_module(st, MODULE_FURNACE);
+        case COMMODITY_CUPRITE_ORE:   return station_has_module(st, MODULE_FURNACE_CU);
+        case COMMODITY_CRYSTAL_ORE:   return station_has_module(st, MODULE_FURNACE_CR);
+        case COMMODITY_FERRITE_INGOT: return station_has_module(st, MODULE_FRAME_PRESS);
+        case COMMODITY_CUPRITE_INGOT:
+            return station_has_module(st, MODULE_LASER_FAB) ||
+                   station_has_module(st, MODULE_TRACTOR_FAB);
+        case COMMODITY_CRYSTAL_INGOT:
+            return station_has_module(st, MODULE_LASER_FAB);
+        case COMMODITY_FRAME:         return is_shipyard;
+        case COMMODITY_LASER_MODULE:  return is_shipyard;
+        case COMMODITY_TRACTOR_MODULE:return is_shipyard;
+        case COMMODITY_REPAIR_KIT:
+            return station_has_module(st, MODULE_DOCK) && !is_shipyard;
+        default: return false;
+    }
+}
+
+bool station_produces(const station_t *st, commodity_t c) {
+    switch (c) {
+        case COMMODITY_FERRITE_INGOT: return station_has_module(st, MODULE_FURNACE);
+        case COMMODITY_CUPRITE_INGOT: return station_has_module(st, MODULE_FURNACE_CU);
+        case COMMODITY_CRYSTAL_INGOT: return station_has_module(st, MODULE_FURNACE_CR);
+        case COMMODITY_FRAME:         return station_has_module(st, MODULE_FRAME_PRESS);
+        case COMMODITY_LASER_MODULE:  return station_has_module(st, MODULE_LASER_FAB);
+        case COMMODITY_TRACTOR_MODULE:return station_has_module(st, MODULE_TRACTOR_FAB);
+        case COMMODITY_REPAIR_KIT:    return station_has_module(st, MODULE_SHIPYARD);
+        default: return false;
+    }
+}
+
+void rebuild_station_services(station_t *st) {
+    st->services = 0;
+    for (int i = 0; i < st->module_count; i++) {
+        if (st->modules[i].scaffold) continue;
+        switch (st->modules[i].type) {
+            case MODULE_REPAIR_BAY:     st->services |= STATION_SERVICE_REPAIR; break;
+            case MODULE_LASER_FAB:      st->services |= STATION_SERVICE_UPGRADE_LASER; break;
+            case MODULE_TRACTOR_FAB:    st->services |= STATION_SERVICE_UPGRADE_TRACTOR; break;
+            case MODULE_FRAME_PRESS:    st->services |= STATION_SERVICE_UPGRADE_HOLD; break;
+            default: break;
+        }
+    }
+}
+
+module_type_t station_dominant_module(const station_t *st) {
+    static const module_type_t priority[] = {
+        MODULE_FURNACE_CU, MODULE_FURNACE_CR, MODULE_FURNACE,
+        MODULE_FRAME_PRESS, MODULE_LASER_FAB,
+        MODULE_TRACTOR_FAB, MODULE_SIGNAL_RELAY, MODULE_HOPPER,
+    };
+    for (int p = 0; p < (int)(sizeof(priority) / sizeof(priority[0])); p++) {
+        for (int i = 0; i < st->module_count; i++) {
+            if (st->modules[i].type == priority[p]) return priority[p];
+        }
+    }
+    return MODULE_DOCK;
+}
+
+commodity_t station_primary_buy(const station_t *st) {
+    module_type_t dom = station_dominant_module(st);
+    switch (dom) {
+        case MODULE_FRAME_PRESS: return COMMODITY_FERRITE_INGOT;
+        case MODULE_LASER_FAB:   return COMMODITY_CUPRITE_INGOT;
+        case MODULE_TRACTOR_FAB: return COMMODITY_CUPRITE_INGOT;
+        default: break;
+    }
+    return (commodity_t)-1;
+}
+
+commodity_t station_primary_sell(const station_t *st) {
+    module_type_t dom = station_dominant_module(st);
+    switch (dom) {
+        case MODULE_FURNACE:     return COMMODITY_FERRITE_INGOT;
+        case MODULE_FURNACE_CU:  return COMMODITY_CUPRITE_INGOT;
+        case MODULE_FURNACE_CR:  return COMMODITY_CRYSTAL_INGOT;
+        case MODULE_FRAME_PRESS: return COMMODITY_FRAME;
+        case MODULE_LASER_FAB:   return COMMODITY_LASER_MODULE;
+        case MODULE_TRACTOR_FAB: return COMMODITY_TRACTOR_MODULE;
+        default: break;
+    }
+    return (commodity_t)-1;
+}
+
+/* ------------------------------------------------------------------ */
+/* Ring rotation / module world geometry                               */
+/* ------------------------------------------------------------------ */
+
+float station_ring_rotation(const station_t *st, int ring) {
+    if (ring < 1 || ring > STATION_NUM_RINGS) return 0.0f;
+    int idx = ring - 1;
+    if (idx < MAX_ARMS) return st->arm_rotation[idx] + st->ring_offset[idx];
+    return 0.0f;
+}
+
+vec2 module_world_pos_ring(const station_t *st, int ring, int slot) {
+    if (ring < 1 || ring > STATION_NUM_RINGS) return st->pos;
+    int slots = STATION_RING_SLOTS[ring];
+    float angle = TWO_PI_F * (float)slot / (float)slots + station_ring_rotation(st, ring);
+    float r = STATION_RING_RADIUS[ring];
+    return v2_add(st->pos, v2(cosf(angle) * r, sinf(angle) * r));
+}
+
+float module_angle_ring(const station_t *st, int ring, int slot) {
+    if (ring < 1 || ring > STATION_NUM_RINGS) return 0.0f;
+    int slots = STATION_RING_SLOTS[ring];
+    return TWO_PI_F * (float)slot / (float)slots + station_ring_rotation(st, ring);
+}
+
+int ring_module_count(const station_t *st, int ring) {
+    int count = 0;
+    for (int i = 0; i < st->module_count; i++)
+        if (st->modules[i].ring == ring) count++;
+    return count;
+}
+
+bool station_has_ring(const station_t *st, int ring) {
+    for (int i = 0; i < st->module_count; i++)
+        if (st->modules[i].ring == ring) return true;
+    return false;
+}
+
+bool ring_has_dock(const station_t *st, int ring) {
+    for (int i = 0; i < st->module_count; i++)
+        if (st->modules[i].ring == ring && st->modules[i].type == MODULE_DOCK && !st->modules[i].scaffold)
+            return true;
+    return false;
+}
+
+int station_ring_free_slot(const station_t *st, int ring, int port_count) {
+    for (int slot = 0; slot < port_count; slot++) {
+        bool taken = false;
+        for (int i = 0; i < st->module_count; i++)
+            if (st->modules[i].ring == ring && st->modules[i].slot == slot) { taken = true; break; }
+        if (!taken) return slot;
+    }
+    return -1;
+}

--- a/shared/station_util.h
+++ b/shared/station_util.h
@@ -1,11 +1,9 @@
 /*
- * station_util.h — Inline helpers for querying and computing station
- * state. Extracted from types.h (#273) so changes to a helper don't
- * recompile every translation unit that just needs a struct definition.
+ * station_util.h — Helpers for querying and computing station state.
+ * Implementations live in station_util.c.
  *
- * Includes: lifecycle predicates, module queries, dominant-module /
- * primary-trade derivations, ring rotation, module world position, and
- * ring-slot accounting.
+ * Lifecycle predicates, module queries, dominant-module / primary-trade
+ * derivations, ring rotation, module world position, ring-slot accounting.
  */
 #ifndef STATION_UTIL_H
 #define STATION_UTIL_H
@@ -16,230 +14,33 @@
  * STATION_NUM_RINGS / STATION_RING_RADIUS / STATION_RING_SLOTS constants
  * are available from the includer. Same pattern as station_geom.h. */
 
-/* ------------------------------------------------------------------ */
-/* Lifecycle predicates                                                */
-/* ------------------------------------------------------------------ */
+/* ----- Lifecycle predicates ----- */
+bool          station_exists(const station_t *st);
+bool          station_is_active(const station_t *st);
+bool          station_provides_docking(const station_t *st);
+bool          station_provides_signal(const station_t *st);
+bool          station_collides(const station_t *st);
 
-/* A station slot is in use if it has signal range, is under construction,
- * is planned, or has a dock radius. Empty/zeroed slots return false. */
-static inline bool station_exists(const station_t *st) {
-    return st->signal_range > 0.0f || st->scaffold || st->planned || st->dock_radius > 0.0f;
-}
+/* ----- Module queries ----- */
+bool          station_has_module(const station_t *st, module_type_t type);
+int           station_max_ring(const station_t *st);
+int           station_spawn_fee(const station_t *st);
+bool          station_consumes(const station_t *st, commodity_t c);
+bool          station_produces(const station_t *st, commodity_t c);
+void          rebuild_station_services(station_t *st);
 
-/* A station is active (fully built and operational). */
-static inline bool station_is_active(const station_t *st) {
-    return st->signal_range > 0.0f && !st->scaffold && !st->planned;
-}
+/* Display / trade derivations from the dominant module. */
+module_type_t station_dominant_module(const station_t *st);
+commodity_t   station_primary_buy(const station_t *st);
+commodity_t   station_primary_sell(const station_t *st);
 
-/* Should this station provide a dock ring? */
-static inline bool station_provides_docking(const station_t *st) {
-    return st->dock_radius > 0.0f && !st->planned;
-}
-
-/* Should this station contribute to signal coverage? */
-static inline bool station_provides_signal(const station_t *st) {
-    return st->signal_range > 0.0f && st->signal_connected && !st->planned;
-}
-
-/* Should this station participate in collision? */
-static inline bool station_collides(const station_t *st) {
-    return st->radius > 0.0f && !st->planned;
-}
-
-/* ------------------------------------------------------------------ */
-/* Module queries                                                      */
-/* ------------------------------------------------------------------ */
-
-static inline bool station_has_module(const station_t *st, module_type_t type) {
-    for (int i = 0; i < st->module_count; i++)
-        if (st->modules[i].type == type && !st->modules[i].scaffold) return true;
-    return false;
-}
-
-/* How many rings of the station are populated with active modules?
- * Returns 1..STATION_NUM_RINGS. Empty stations report 1 (the inner
- * dock ring is always assumed to exist). Used to scale the docking
- * spawn fee — bigger stations charge more. */
-static inline int station_max_ring(const station_t *st) {
-    int max = 1;
-    for (int i = 0; i < st->module_count; i++) {
-        if (st->modules[i].scaffold) continue;
-        int r = (int)st->modules[i].ring;
-        if (r > max && r <= STATION_NUM_RINGS) max = r;
-    }
-    return max;
-}
-
-/* Spawn / re-dock fee charged when a player first establishes a
- * ledger entry at this station. Scales with ring count: tier-1
- * outposts are cheap, full 3-ring hubs are premium. The fee is
- * debited even if the player has no balance, putting them into
- * debt — earn it back by working. */
-static inline int station_spawn_fee(const station_t *st) {
-    switch (station_max_ring(st)) {
-        case 1:  return 50;
-        case 2:  return 100;
-        case 3:  return 300;
-        default: return 50;
-    }
-}
-
-/* Returns true if the station consumes this commodity as production input. */
-static inline bool station_consumes(const station_t *st, commodity_t c) {
-    switch (c) {
-        case COMMODITY_FERRITE_ORE:   return station_has_module(st, MODULE_FURNACE);
-        case COMMODITY_CUPRITE_ORE:   return station_has_module(st, MODULE_FURNACE_CU);
-        case COMMODITY_CRYSTAL_ORE:   return station_has_module(st, MODULE_FURNACE_CR);
-        case COMMODITY_FERRITE_INGOT: return station_has_module(st, MODULE_FRAME_PRESS);
-        case COMMODITY_CUPRITE_INGOT:
-            return station_has_module(st, MODULE_LASER_FAB) ||
-                   station_has_module(st, MODULE_TRACTOR_FAB);
-        case COMMODITY_CRYSTAL_INGOT:
-            return station_has_module(st, MODULE_LASER_FAB);
-        /* Consumer-only docks (no shipyard) buy kits hauled in from
-         * shipyards — that's how Prospect's repair stockpile gets fed.
-         * Shipyards make their own and never buy them back. */
-        case COMMODITY_REPAIR_KIT:
-            return station_has_module(st, MODULE_DOCK)
-                   && !station_has_module(st, MODULE_SHIPYARD);
-        default: return false;
-    }
-}
-
-/* Returns true if the station produces this commodity (has the right module). */
-static inline bool station_produces(const station_t *st, commodity_t c) {
-    switch (c) {
-        case COMMODITY_FERRITE_INGOT: return station_has_module(st, MODULE_FURNACE);
-        case COMMODITY_CUPRITE_INGOT: return station_has_module(st, MODULE_FURNACE_CU);
-        case COMMODITY_CRYSTAL_INGOT: return station_has_module(st, MODULE_FURNACE_CR);
-        case COMMODITY_FRAME:         return station_has_module(st, MODULE_FRAME_PRESS);
-        case COMMODITY_LASER_MODULE:  return station_has_module(st, MODULE_LASER_FAB);
-        case COMMODITY_TRACTOR_MODULE:return station_has_module(st, MODULE_TRACTOR_FAB);
-        case COMMODITY_REPAIR_KIT:    return station_has_module(st, MODULE_SHIPYARD);
-        default: return false;
-    }
-}
-
-static inline void rebuild_station_services(station_t *st) {
-    st->services = 0;
-    for (int i = 0; i < st->module_count; i++) {
-        if (st->modules[i].scaffold) continue;
-        switch (st->modules[i].type) {
-            case MODULE_REPAIR_BAY:     st->services |= STATION_SERVICE_REPAIR; break;
-            case MODULE_LASER_FAB:      st->services |= STATION_SERVICE_UPGRADE_LASER; break;
-            case MODULE_TRACTOR_FAB:    st->services |= STATION_SERVICE_UPGRADE_TRACTOR; break;
-            case MODULE_FRAME_PRESS:    st->services |= STATION_SERVICE_UPGRADE_HOLD; break;
-            default: break;
-        }
-    }
-}
-
-/* Return the dominant module type for display purposes (name, color, visual).
- * Priority: FURNACE > FRAME_PRESS > LASER_FAB > TRACTOR_FAB > SIGNAL_RELAY > others.
- * Returns MODULE_DOCK as fallback. */
-static inline module_type_t station_dominant_module(const station_t *st) {
-    static const module_type_t priority[] = {
-        MODULE_FURNACE_CU, MODULE_FURNACE_CR, MODULE_FURNACE,
-        MODULE_FRAME_PRESS, MODULE_LASER_FAB,
-        MODULE_TRACTOR_FAB, MODULE_SIGNAL_RELAY, MODULE_HOPPER,
-    };
-    for (int p = 0; p < (int)(sizeof(priority) / sizeof(priority[0])); p++) {
-        for (int i = 0; i < st->module_count; i++) {
-            if (st->modules[i].type == priority[p]) return priority[p];
-        }
-    }
-    return MODULE_DOCK;
-}
-
-/* Primary trade slot: the one commodity this station buys from players.
- * Furnaces don't buy from players (ore arrives via fragment smelting).
- * Returns -1 if no player trade. */
-static inline commodity_t station_primary_buy(const station_t *st) {
-    module_type_t dom = station_dominant_module(st);
-    switch (dom) {
-        case MODULE_FRAME_PRESS: return COMMODITY_FERRITE_INGOT;
-        case MODULE_LASER_FAB:   return COMMODITY_CUPRITE_INGOT;
-        case MODULE_TRACTOR_FAB: return COMMODITY_CUPRITE_INGOT;
-        default: break;
-    }
-    return (commodity_t)-1;
-}
-
-/* Primary trade slot: the one commodity this station sells to players.
- * Derived from the dominant production module. Returns -1 if none. */
-static inline commodity_t station_primary_sell(const station_t *st) {
-    module_type_t dom = station_dominant_module(st);
-    switch (dom) {
-        case MODULE_FURNACE:     return COMMODITY_FERRITE_INGOT;
-        case MODULE_FURNACE_CU:  return COMMODITY_CUPRITE_INGOT;
-        case MODULE_FURNACE_CR:  return COMMODITY_CRYSTAL_INGOT;
-        case MODULE_FRAME_PRESS: return COMMODITY_FRAME;
-        case MODULE_LASER_FAB:   return COMMODITY_LASER_MODULE;
-        case MODULE_TRACTOR_FAB: return COMMODITY_TRACTOR_MODULE;
-        default: break;
-    }
-    return (commodity_t)-1;
-}
-
-/* ------------------------------------------------------------------ */
-/* Ring rotation / module world geometry                               */
-/* ------------------------------------------------------------------ */
-
-/* Per-ring rotation: ring 1 fastest, outer rings slower. */
-static inline float station_ring_rotation(const station_t *st, int ring) {
-    if (ring < 1 || ring > STATION_NUM_RINGS) return 0.0f;
-    int idx = ring - 1;
-    if (idx < MAX_ARMS) return st->arm_rotation[idx] + st->ring_offset[idx];
-    return 0.0f;
-}
-
-/* World-space position of a module: ring determines radius,
- * slot determines angle. Each ring rotates independently. */
-static inline vec2 module_world_pos_ring(const station_t *st, int ring, int slot) {
-    if (ring < 1 || ring > STATION_NUM_RINGS) return st->pos;
-    int slots = STATION_RING_SLOTS[ring];
-    float angle = TWO_PI_F * (float)slot / (float)slots + station_ring_rotation(st, ring);
-    float r = STATION_RING_RADIUS[ring];
-    return v2_add(st->pos, v2(cosf(angle) * r, sinf(angle) * r));
-}
-
-static inline float module_angle_ring(const station_t *st, int ring, int slot) {
-    if (ring < 1 || ring > STATION_NUM_RINGS) return 0.0f;
-    int slots = STATION_RING_SLOTS[ring];
-    return TWO_PI_F * (float)slot / (float)slots + station_ring_rotation(st, ring);
-}
-
-/* Count modules on a given ring. */
-static inline int ring_module_count(const station_t *st, int ring) {
-    int count = 0;
-    for (int i = 0; i < st->module_count; i++)
-        if (st->modules[i].ring == ring) count++;
-    return count;
-}
-
-static inline bool station_has_ring(const station_t *st, int ring) {
-    /* A ring "exists" if any module is placed on it */
-    for (int i = 0; i < st->module_count; i++)
-        if (st->modules[i].ring == ring) return true;
-    return false;
-}
-
-/* A ring has a completed dock module — gates construction of the next ring. */
-static inline bool ring_has_dock(const station_t *st, int ring) {
-    for (int i = 0; i < st->module_count; i++)
-        if (st->modules[i].ring == ring && st->modules[i].type == MODULE_DOCK && !st->modules[i].scaffold)
-            return true;
-    return false;
-}
-
-static inline int station_ring_free_slot(const station_t *st, int ring, int port_count) {
-    for (int slot = 0; slot < port_count; slot++) {
-        bool taken = false;
-        for (int i = 0; i < st->module_count; i++)
-            if (st->modules[i].ring == ring && st->modules[i].slot == slot) { taken = true; break; }
-        if (!taken) return slot;
-    }
-    return -1;
-}
+/* ----- Ring rotation / module world geometry ----- */
+float         station_ring_rotation(const station_t *st, int ring);
+vec2          module_world_pos_ring(const station_t *st, int ring, int slot);
+float         module_angle_ring   (const station_t *st, int ring, int slot);
+int           ring_module_count(const station_t *st, int ring);
+bool          station_has_ring(const station_t *st, int ring);
+bool          ring_has_dock(const station_t *st, int ring);
+int           station_ring_free_slot(const station_t *st, int ring, int port_count);
 
 #endif

--- a/src/client.h
+++ b/src/client.h
@@ -57,9 +57,13 @@ typedef struct {
     int hull_now;
     int hull_max;
     int repair_cost;
-    int mining_cost;
-    int hold_cost;
-    int tractor_cost;
+    /* Per-upgrade module accounting. Real cost is the modules
+     * themselves; credit_cost is what the dock charges to fill the
+     * gap from its inventory. units_in_cargo + units_at_station
+     * must be >= units_needed for the upgrade to fire. */
+    int mining_units_needed, mining_units_in_cargo, mining_units_at_station, mining_credit_cost;
+    int hold_units_needed,   hold_units_in_cargo,   hold_units_at_station,   hold_credit_cost;
+    int tractor_units_needed,tractor_units_in_cargo,tractor_units_at_station,tractor_credit_cost;
     bool can_repair;
     bool can_upgrade_mining;
     bool can_upgrade_hold;

--- a/src/economy.c
+++ b/src/economy.c
@@ -107,10 +107,22 @@ float station_repair_cost(const ship_t* ship, const station_t* station) {
     return damage * (kit_price + labor);
 }
 
-bool can_afford_upgrade(const station_t* station, const ship_t* ship, ship_upgrade_t upgrade, uint32_t service, int credit_cost, float balance) {
-    if (!station || !(station->services & service)) return false;
+bool can_afford_upgrade(const station_t* station, const ship_t* ship, ship_upgrade_t upgrade, float balance) {
+    /* Any dock can install upgrades; the FAB-module gate is gone.
+     * Modules (cargo or dock inventory) are the limiter, mirroring
+     * the repair-kit "any dock" model from #373. */
+    if (!station) return false;
     if (ship_upgrade_maxed(ship, upgrade)) return false;
-    if (balance + FLOAT_EPSILON < (float)credit_cost) return false;
-    if (station->inventory[COMMODITY_FRAME + upgrade_required_product(upgrade)] + FLOAT_EPSILON < upgrade_product_cost(ship, upgrade)) return false;
+    /* Cargo first, dock fallback at retail. Mirror the server logic so
+     * the UI's "can afford?" matches what try_apply_ship_upgrade will
+     * actually accept. */
+    commodity_t comm = (commodity_t)(COMMODITY_FRAME + upgrade_required_product(upgrade));
+    int units_needed = (int)ceilf(upgrade_product_cost(ship, upgrade));
+    int in_cargo  = (int)floorf(ship->cargo[comm] + 0.0001f);
+    int at_station = (int)floorf(station->inventory[comm] + 0.0001f);
+    if (in_cargo + at_station < units_needed) return false;
+    int from_station = units_needed - (units_needed < in_cargo ? units_needed : in_cargo);
+    float credit_cost = (float)from_station * station_sell_price(station, comm);
+    if (balance + FLOAT_EPSILON < credit_cost) return false;
     return true;
 }

--- a/src/economy.h
+++ b/src/economy.h
@@ -8,6 +8,6 @@
 void step_station_production(station_t* stations, int count, float dt);
 
 float station_repair_cost(const ship_t* ship, const station_t* station);
-bool can_afford_upgrade(const station_t* station, const ship_t* ship, ship_upgrade_t upgrade, uint32_t service, int credit_cost, float balance);
+bool can_afford_upgrade(const station_t* station, const ship_t* ship, ship_upgrade_t upgrade, float balance);
 
 #endif

--- a/src/input.c
+++ b/src/input.c
@@ -415,7 +415,19 @@ input_intent_t sample_input_intent(void) {
          *   [M] upgrade mining laser
          *   [H] upgrade hold capacity
          *   [T] upgrade tractor */
-        intent.service_repair = is_key_pressed(SAPP_KEYCODE_R);
+        if (is_key_pressed(SAPP_KEYCODE_R)) {
+            const station_t *st = current_station_ptr();
+            int kits_avail =
+                (int)floorf(LOCAL_PLAYER.ship.cargo[COMMODITY_REPAIR_KIT] + 0.0001f) +
+                (st ? (int)floorf(st->inventory[COMMODITY_REPAIR_KIT] + 0.0001f) : 0);
+            float max_hull = ship_max_hull(&LOCAL_PLAYER.ship);
+            bool needs_repair = LOCAL_PLAYER.ship.hull < max_hull;
+            if (needs_repair && kits_avail <= 0) {
+                set_notice("No repair kits available.");
+            } else {
+                intent.service_repair = true;
+            }
+        }
         intent.upgrade_mining = is_key_pressed(SAPP_KEYCODE_M);
         intent.upgrade_hold   = is_key_pressed(SAPP_KEYCODE_H);
         intent.upgrade_tractor= is_key_pressed(SAPP_KEYCODE_T);
@@ -514,6 +526,10 @@ input_intent_t sample_input_intent(void) {
                 float price = station_sell_price(st, row_c) * mining_payout_multiplier(row_g);
                 float free_volume = ship_cargo_capacity(ship) - ship_total_cargo(ship);
                 float vol = commodity_volume(row_c);
+                /* Match server: dense goods buy multi-per-press so a
+                 * single keystroke fills one cargo unit. */
+                int per_press = (vol > FLOAT_EPSILON) ? (int)lroundf(1.0f / vol) : 1;
+                if (per_press < 1) per_press = 1;
                 if (free_volume + FLOAT_EPSILON < vol) {
                     set_notice("Hold full.");
                 } else if (player_current_balance() < price) {
@@ -522,18 +538,20 @@ input_intent_t sample_input_intent(void) {
                     intent.buy_product = true;
                     intent.buy_commodity = row_c;
                     intent.buy_grade = row_g;
-                    LOCAL_PLAYER.ship.cargo[row_c] += 1.0f;
+                    LOCAL_PLAYER.ship.cargo[row_c] += (float)per_press;
                     if (!g.multiplayer_enabled) {
                         station_t *mst = &g.world.stations[LOCAL_PLAYER.current_station];
+                        float total = price * (float)per_press;
                         for (int li = 0; li < mst->ledger_count; li++)
-                            if (mst->ledger[li].balance >= price) {
-                                mst->ledger[li].balance -= price;
+                            if (mst->ledger[li].balance >= total) {
+                                mst->ledger[li].balance -= total;
                                 break;
                             }
                     }
-                    set_notice("-$%d  %s %s",
-                               (int)lroundf(price), mining_grade_label(row_g),
-                               commodity_short_name(row_c));
+                    set_notice("-$%d  %s %s x%d",
+                               (int)lroundf(price * (float)per_press),
+                               mining_grade_label(row_g),
+                               commodity_short_name(row_c), per_press);
                 }
             } else if (row_kind == 1) {
                 /* SELL action — routes through the existing per-commodity

--- a/src/main.c
+++ b/src/main.c
@@ -1199,6 +1199,14 @@ static void render_world(void) {
             body_b = body_b + (0.2f - body_b) * sp * 0.3f;
         }
 
+        sgl_c4f(body_r, body_g, body_b, 1.0f);
+        if (a->commodity == COMMODITY_CRYSTAL_ORE) {
+            /* Crystals are constructed from explicit rectangles — no
+             * polar profile, no segment smoothing. */
+            draw_crystal_asteroid_fill(a);
+            continue;
+        }
+
         int base_segs = 18;
         switch (a->tier) {
             case ASTEROID_TIER_XXL: base_segs = 28; break;
@@ -1210,7 +1218,6 @@ static void render_world(void) {
         }
         int segments = lod_segments(base_segs, a->radius);
 
-        sgl_c4f(body_r, body_g, body_b, 1.0f);
         float step = TWO_PI_F / (float)segments;
         float a0 = a->rotation;
         float r0 = asteroid_profile(a, a0);
@@ -1242,30 +1249,33 @@ static void render_world(void) {
         float body_r, body_g, body_b;
         asteroid_body_color(a->tier, a->commodity, progress_ratio, &body_r, &body_g, &body_b);
 
-        int base_segs = 18;
-        switch (a->tier) {
-            case ASTEROID_TIER_XXL: base_segs = 28; break;
-            case ASTEROID_TIER_XL:  base_segs = 22; break;
-            case ASTEROID_TIER_L:   base_segs = 18; break;
-            case ASTEROID_TIER_M:   base_segs = 15; break;
-            case ASTEROID_TIER_S:   base_segs = 12; break;
-            default: break;
-        }
-        int segments = lod_segments(base_segs, a->radius);
-
         float rim_r = is_target ? (ineffective ? 1.0f : 0.45f) : (body_r * 0.85f);
         float rim_g = is_target ? (ineffective ? 0.15f : 0.94f) : (body_g * 0.95f);
         float rim_b = is_target ? (ineffective ? 0.1f : 1.0f) : fminf(1.0f, body_b * 1.2f);
         float rim_a = is_target ? 1.0f : 0.8f;
 
-        sgl_c4f(rim_r, rim_g, rim_b, rim_a);
-        sgl_begin_line_strip();
-        for (int j = 0; j <= segments; j++) {
-            float angle = a->rotation + ((float)j / (float)segments) * TWO_PI_F;
-            float radius = asteroid_profile(a, angle);
-            sgl_v2f(a->pos.x + cosf(angle) * radius, a->pos.y + sinf(angle) * radius);
+        if (a->commodity == COMMODITY_CRYSTAL_ORE) {
+            draw_crystal_asteroid_outline(a, rim_r, rim_g, rim_b, rim_a);
+        } else {
+            int base_segs = 18;
+            switch (a->tier) {
+                case ASTEROID_TIER_XXL: base_segs = 28; break;
+                case ASTEROID_TIER_XL:  base_segs = 22; break;
+                case ASTEROID_TIER_L:   base_segs = 18; break;
+                case ASTEROID_TIER_M:   base_segs = 15; break;
+                case ASTEROID_TIER_S:   base_segs = 12; break;
+                default: break;
+            }
+            int segments = lod_segments(base_segs, a->radius);
+            sgl_c4f(rim_r, rim_g, rim_b, rim_a);
+            sgl_begin_line_strip();
+            for (int j = 0; j <= segments; j++) {
+                float angle = a->rotation + ((float)j / (float)segments) * TWO_PI_F;
+                float radius = asteroid_profile(a, angle);
+                sgl_v2f(a->pos.x + cosf(angle) * radius, a->pos.y + sinf(angle) * radius);
+            }
+            sgl_end();
         }
-        sgl_end();
 
         /* Glow core (the "dot"). Common fragments keep the original
          * muted commodity tint — the belt should look mostly the

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -277,7 +277,19 @@ bool station_copy(station_t *dst, const station_t *src) {
 }
 
 bool manifest_push(manifest_t *manifest, const cargo_unit_t *unit) {
-    if (!manifest || !unit || manifest->count >= manifest->cap || !manifest->units) return false;
+    if (!manifest || !unit) return false;
+    /* Grow on demand. Without this, a ship that's accumulated 32 manifest
+     * entries (the default ship cap) would silently reject every BUY of a
+     * finished good — the picker would advertise stock, the player would
+     * press F, and the transfer would fail because dst was full while
+     * the float side suggested cargo room. Doubling keeps the realloc
+     * cost amortized O(1). */
+    if (manifest->count >= manifest->cap) {
+        uint16_t new_cap = manifest->cap > 0 ? (uint16_t)(manifest->cap * 2u) : 32;
+        if (new_cap <= manifest->cap) return false; /* uint16 overflow */
+        if (!manifest_reserve(manifest, new_cap)) return false;
+    }
+    if (!manifest->units) return false;
     manifest->units[manifest->count++] = *unit;
     return true;
 }

--- a/src/station_ui.c
+++ b/src/station_ui.c
@@ -1065,7 +1065,8 @@ static void draw_verbs_view(const station_ui_state_t *ui,
         if (kits_needed < 0) kits_needed = 0;
         if (ui->hull_now >= ui->hull_max) {
             left_rgb = COL_DIM;
-            snprintf(right_buf, sizeof(right_buf), "hull full");
+            snprintf(right_buf, sizeof(right_buf), "kits [ %d / 0 ]",
+                     kits_avail);
         } else if (kits_avail <= 0) {
             left_rgb = COL_DIM;
             snprintf(right_buf, sizeof(right_buf), "no kits available");

--- a/src/station_ui.c
+++ b/src/station_ui.c
@@ -310,9 +310,35 @@ void build_station_ui_state(station_ui_state_t* ui) {
     ui->hull_max = (int)lroundf(ship_max_hull(&LOCAL_PLAYER.ship));
     float repair = station_repair_cost(&LOCAL_PLAYER.ship, current_station_ptr());
     ui->repair_cost = (int)lroundf(repair);
-    ui->mining_cost = ship_upgrade_cost(&LOCAL_PLAYER.ship,SHIP_UPGRADE_MINING);
-    ui->hold_cost = ship_upgrade_cost(&LOCAL_PLAYER.ship,SHIP_UPGRADE_HOLD);
-    ui->tractor_cost = ship_upgrade_cost(&LOCAL_PLAYER.ship,SHIP_UPGRADE_TRACTOR);
+
+    /* Compute per-upgrade module accounting (cargo first, dock fallback). */
+    struct { ship_upgrade_t up; int *needed, *cargo, *atstation, *credit; } slots[3] = {
+        { SHIP_UPGRADE_MINING,
+          &ui->mining_units_needed,  &ui->mining_units_in_cargo,
+          &ui->mining_units_at_station, &ui->mining_credit_cost },
+        { SHIP_UPGRADE_HOLD,
+          &ui->hold_units_needed,    &ui->hold_units_in_cargo,
+          &ui->hold_units_at_station,   &ui->hold_credit_cost },
+        { SHIP_UPGRADE_TRACTOR,
+          &ui->tractor_units_needed, &ui->tractor_units_in_cargo,
+          &ui->tractor_units_at_station,&ui->tractor_credit_cost },
+    };
+    for (int i = 0; i < 3; i++) {
+        commodity_t c = (commodity_t)(COMMODITY_FRAME +
+                        upgrade_required_product(slots[i].up));
+        int need = (int)ceilf(upgrade_product_cost(&LOCAL_PLAYER.ship, slots[i].up));
+        int in_cargo  = (int)floorf(LOCAL_PLAYER.ship.cargo[c] + 0.0001f);
+        int at_station = ui->station
+            ? (int)floorf(ui->station->inventory[c] + 0.0001f) : 0;
+        int from_station = need - (need < in_cargo ? need : in_cargo);
+        if (from_station < 0) from_station = 0;
+        float credit = ui->station
+            ? (float)from_station * station_sell_price(ui->station, c) : 0.0f;
+        *slots[i].needed    = need;
+        *slots[i].cargo     = in_cargo;
+        *slots[i].atstation = at_station;
+        *slots[i].credit    = (int)lroundf(credit);
+    }
     /* Any dock installs kits — gate is whether there are kits available
      * (computed below) and whether the quoted cost is affordable. */
     ui->can_repair = (repair > 0.0f) && (player_current_balance() + FLOAT_EPSILON >= repair);
@@ -329,9 +355,9 @@ void build_station_ui_state(station_ui_state_t* ui) {
     int kits_avail = ui->ship_kits + ui->station_kits;
     ui->kits_short_by = (hp_needed > kits_avail) ? (hp_needed - kits_avail) : 0;
     float bal = player_current_balance();
-    ui->can_upgrade_mining = can_afford_upgrade(ui->station, &LOCAL_PLAYER.ship, SHIP_UPGRADE_MINING, STATION_SERVICE_UPGRADE_LASER, ui->mining_cost, bal);
-    ui->can_upgrade_hold = can_afford_upgrade(ui->station, &LOCAL_PLAYER.ship, SHIP_UPGRADE_HOLD, STATION_SERVICE_UPGRADE_HOLD, ui->hold_cost, bal);
-    ui->can_upgrade_tractor = can_afford_upgrade(ui->station, &LOCAL_PLAYER.ship, SHIP_UPGRADE_TRACTOR, STATION_SERVICE_UPGRADE_TRACTOR, ui->tractor_cost, bal);
+    ui->can_upgrade_mining = can_afford_upgrade(ui->station, &LOCAL_PLAYER.ship, SHIP_UPGRADE_MINING, bal);
+    ui->can_upgrade_hold = can_afford_upgrade(ui->station, &LOCAL_PLAYER.ship, SHIP_UPGRADE_HOLD, bal);
+    ui->can_upgrade_tractor = can_afford_upgrade(ui->station, &LOCAL_PLAYER.ship, SHIP_UPGRADE_TRACTOR, bal);
 }
 
 /* ------------------------------------------------------------------ */
@@ -715,13 +741,22 @@ static void draw_trade_view(const station_ui_state_t *ui,
     const uint8_t COL_FADED[3] = { PAL_TEXT_FADED };
     const uint8_t COL_TEXT[3]  = { PAL_TEXT_SECONDARY };
 
-    my += draw_section_header(cx, my, inner_right, "MARKET", HDR_TRADE);
+    my += draw_section_header(cx, my, inner_right, "TRADE", HDR_TRADE);
 
-    /* Supply strip — six commodity slots showing this station's stock.
-     * Each cell is colored by the commodity when the station has the
-     * matching producing module; gray when it doesn't. The number is
-     * floored stock. Lets the player scan a station's tier role at a
-     * glance ("Helios is making lasers + tractors but no frames"). */
+    /* Supply strip — six commodity slots showing this station's chain
+     * STATUS, not raw counts. The picker rows below carry the actual
+     * stock + price; this row is a flow badge.
+     *
+     * Three nested stripes per cell — empty/=/==/=== — each higher
+     * level implies the lower:
+     *   ===  on the shelf  (manifest > 0 && sell_price > 0)
+     *   ==-  in flow       (inventory or any module buffer carrying c)
+     *   =--  in the system (station has the producing module)
+     *   ---  not produced here
+     *
+     * Color = commodity hue, brightness rises with the level so a
+     * station at a glance reads as "alive ferrite line" vs "starved
+     * laser line". */
     {
         struct { commodity_t c; module_type_t producer; const char *code; } slots[6] = {
             { COMMODITY_FERRITE_INGOT,  MODULE_FURNACE,      "FE" },
@@ -732,41 +767,74 @@ static void draw_trade_view(const station_ui_state_t *ui,
             { COMMODITY_TRACTOR_MODULE, MODULE_TRACTOR_FAB,  "TM" },
         };
         const float cell_w = 8.0f;
-        const float slot_w = cell_w * 7.0f; /* "FEx99 " = 6 chars + sep */
+        const float slot_w = cell_w * 7.0f;
         for (int i = 0; i < 6; i++) {
             float sx = cx + (float)i * slot_w;
-            /* Manifest is the truth for finished goods. Use the
-             * client-side summary so SP and MP both work — st->manifest
-             * itself is the SERVER's local copy in SP but is empty for
-             * remote stations in MP (the wire only carries summaries,
-             * not full units). The picker rows go through the same
-             * summary helper, so strip + rows can never disagree. */
-            int stock = 0;
+            commodity_t c = slots[i].c;
+
+            /* Level 1: producer module present? */
+            bool in_system = station_produces(st, c);
+
+            /* Level 2: any concrete supply at this station — float
+             * inventory OR module buffers carrying this commodity.
+             * Module buffers are tagged by the recipe of the host
+             * module: input buffer carries the recipe's input;
+             * output buffer carries the recipe's output. STORAGE
+             * modules don't have a fixed commodity, so we count any
+             * non-empty storage output as "in flow" for any
+             * commodity the station produces (best the data lets us
+             * do without per-tick commodity tags). */
+            bool in_flow = (st->inventory[c] > 0.01f);
+            if (!in_flow) {
+                for (int m = 0; m < st->module_count; m++) {
+                    module_type_t mt = st->modules[m].type;
+                    if (st->modules[m].scaffold) continue;
+                    if (module_schema_input(mt) == c && st->module_input[m] > 0.01f) {
+                        in_flow = true; break;
+                    }
+                    if (module_schema_output(mt) == c && st->module_output[m] > 0.01f) {
+                        in_flow = true; break;
+                    }
+                }
+            }
+
+            /* Level 3: stock the player can buy now (same condition
+             * the BUY rows in the picker use). */
+            int manifest_stock = 0;
             for (int gi = 0; gi < MINING_GRADE_COUNT; gi++)
-                stock += station_manifest_count_cg(st, slots[i].c, (mining_grade_t)gi);
-            bool has_module = station_has_module(st, slots[i].producer);
+                manifest_stock += station_manifest_count_cg(st, c, (mining_grade_t)gi);
+            bool sellable = in_system && (manifest_stock > 0)
+                          && (station_sell_price(st, c) > FLOAT_EPSILON);
+
+            int level = 0;
+            if (in_system) level = 1;
+            if (in_system && in_flow) level = 2;
+            if (sellable) level = 3;
+
             uint8_t r, g, b;
-            if (!has_module) {
-                /* No producing module: dark gray label, em-dash for stock. */
+            if (level == 0) {
                 r = 90; g = 90; b = 90;
-            } else if (stock <= 0) {
-                /* Module present but bone dry: faded commodity color. */
-                commodity_color_u8(slots[i].c, &r, &g, &b);
-                r = (uint8_t)(r / 3); g = (uint8_t)(g / 3); b = (uint8_t)(b / 3);
             } else {
-                /* In stock: full commodity color. */
-                commodity_color_u8(slots[i].c, &r, &g, &b);
+                commodity_color_u8(c, &r, &g, &b);
+                /* Three brightness tiers: 1/3 / 2/3 / full. */
+                int num = level;
+                r = (uint8_t)((int)r * num / 3);
+                g = (uint8_t)((int)g * num / 3);
+                b = (uint8_t)((int)b * num / 3);
             }
             sdtx_color3b(r, g, b);
             sdtx_pos(ui_text_pos(sx), ui_text_pos(my));
+
+            /* Density glyph per level — one character that grows in
+             * weight as the chain ascends from idle to sellable.
+             * Level 3 uses oric font byte 0xA0 (full block, verified
+             * 8×0xFF in vendor/sokol/sokol_debugtext.h). */
+            const char *glyph =
+                (level == 3) ? "\xA0" :
+                (level == 2) ? "=" :
+                (level == 1) ? "-" : " ";
             char cell[8];
-            if (!has_module) {
-                snprintf(cell, sizeof(cell), "%s --", slots[i].code);
-            } else if (stock > 99) {
-                snprintf(cell, sizeof(cell), "%s99+", slots[i].code);
-            } else {
-                snprintf(cell, sizeof(cell), "%s %2d", slots[i].code, stock);
-            }
+            snprintf(cell, sizeof(cell), "%s %s", slots[i].code, glyph);
             sdtx_puts(cell);
         }
         my += row_h;
@@ -842,7 +910,7 @@ static void draw_trade_view(const station_ui_state_t *ui,
         snprintf(pg, sizeof(pg), "page %d/%d   [F] next",
                  page + 1, total_pages);
         const uint8_t COL_ACTIVE[3] = { 130, 210, 255 };
-        draw_row_lr(cx, my, inner_right, COL_ACTIVE, "MARKET", COL_FADED, pg);
+        draw_row_lr(cx, my, inner_right, COL_ACTIVE, "TRADE", COL_FADED, pg);
         my += row_h;
     }
 
@@ -985,27 +1053,33 @@ static void draw_verbs_view(const station_ui_state_t *ui,
     /* -------- SERVICES (always visible; rows always show their status) -------- */
     my += draw_section_header(cx, my, inner_right, "SERVICES", HDR_SERVICE);
 
-    /* [R] repair hull — shows kit availability ("X ship / Y dock") and
-     * flags partial repair when neither source has enough kits. */
+    /* [R] repair hull — same grammar as the upgrade rows:
+     *   kits [ have / need ]  -N cr
+     * "have" = ship cargo + dock inventory; "need" = HP missing (1
+     * kit per HP). Append the credit cost when actionable. */
     {
         const uint8_t *left_rgb = COL_AMBER;
         char right_buf[64];
+        int kits_avail = ui->ship_kits + ui->station_kits;
+        int kits_needed = ui->hull_max - ui->hull_now;
+        if (kits_needed < 0) kits_needed = 0;
         if (ui->hull_now >= ui->hull_max) {
             left_rgb = COL_DIM;
             snprintf(right_buf, sizeof(right_buf), "hull full");
-        } else if (ui->can_repair && ui->kits_short_by == 0) {
-            snprintf(right_buf, sizeof(right_buf), "-%d %s  %d/%d kits",
-                     ui->repair_cost, ui_station_currency(st),
-                     ui->ship_kits, ui->station_kits);
-        } else if (ui->can_repair && ui->kits_short_by > 0) {
-            /* Partial heal — money is fine, kits are short. */
-            snprintf(right_buf, sizeof(right_buf), "-%d %s  short %d kits",
-                     ui->repair_cost, ui_station_currency(st),
-                     ui->kits_short_by);
-        } else if (ui->repair_cost > 0) {
+        } else if (kits_avail <= 0) {
             left_rgb = COL_DIM;
-            snprintf(right_buf, sizeof(right_buf), "need %d %s",
-                     ui->repair_cost, ui_station_currency(st));
+            snprintf(right_buf, sizeof(right_buf), "no kits available");
+        } else if (ui->can_repair && ui->repair_cost > 0) {
+            snprintf(right_buf, sizeof(right_buf), "kits [ %d / %d ]  -%d cr",
+                     kits_avail, kits_needed, ui->repair_cost);
+        } else if (ui->can_repair) {
+            snprintf(right_buf, sizeof(right_buf), "kits [ %d / %d ]",
+                     kits_avail, kits_needed);
+        } else if (ui->repair_cost > 0) {
+            /* Affordability blocks; module supply is fine. */
+            left_rgb = COL_DIM;
+            snprintf(right_buf, sizeof(right_buf), "kits [ %d / %d ]  need %d cr",
+                     kits_avail, kits_needed, ui->repair_cost);
         } else {
             left_rgb = COL_DIM;
             snprintf(right_buf, sizeof(right_buf), "unavailable here");
@@ -1015,32 +1089,57 @@ static void draw_verbs_view(const station_ui_state_t *ui,
         my += row_h;
     }
 
-    /* [M] tune laser, [H] expand hold, [T] tune tractor — same grammar. */
-    struct { const char *left; module_type_t gate; int cost; bool can;
-             bool maxed; } refit[3] = {
-        { "[M] tune laser",   MODULE_LASER_FAB,   ui->mining_cost,  ui->can_upgrade_mining,
+    /* [M] tune laser, [H] expand hold, [T] tune tractor — same grammar.
+     * Real cost is the modules themselves (frames / lasers / tractors
+     * pulled from cargo). If cargo is short, the dock fills the gap
+     * from its own inventory at retail. Any dock can install — module
+     * supply is the only gate. */
+    struct { const char *left; const char *unit_singular; const char *unit_plural;
+             int needed, in_cargo, at_station, credit; bool can; bool maxed; } refit[3] = {
+        { "[M] tune laser",   "laser module",   "laser modules",
+          ui->mining_units_needed, ui->mining_units_in_cargo,
+          ui->mining_units_at_station, ui->mining_credit_cost,
+          ui->can_upgrade_mining,
           ship_upgrade_maxed(ship, SHIP_UPGRADE_MINING) },
-        { "[H] expand hold",  MODULE_FRAME_PRESS, ui->hold_cost,    ui->can_upgrade_hold,
+        { "[H] expand hold",  "frame", "frames",
+          ui->hold_units_needed, ui->hold_units_in_cargo,
+          ui->hold_units_at_station, ui->hold_credit_cost,
+          ui->can_upgrade_hold,
           ship_upgrade_maxed(ship, SHIP_UPGRADE_HOLD) },
-        { "[T] tune tractor", MODULE_TRACTOR_FAB, ui->tractor_cost, ui->can_upgrade_tractor,
+        { "[T] tune tractor", "tractor module", "tractor modules",
+          ui->tractor_units_needed, ui->tractor_units_in_cargo,
+          ui->tractor_units_at_station, ui->tractor_credit_cost,
+          ui->can_upgrade_tractor,
           ship_upgrade_maxed(ship, SHIP_UPGRADE_TRACTOR) },
     };
     for (int i = 0; i < 3; i++) {
         const uint8_t *left_rgb = COL_NAV;
-        char right_buf[48];
+        char right_buf[80];
+        int avail  = refit[i].in_cargo + refit[i].at_station;
+        int needed = refit[i].needed;
+        const char *plural = refit[i].unit_plural;
         if (refit[i].maxed) {
             left_rgb = COL_DIM;
             snprintf(right_buf, sizeof(right_buf), "maxed");
-        } else if (!station_has_module(st, refit[i].gate)) {
+        } else if (avail <= 0) {
+            /* Mirrors the [R] repair-hull row: nothing in cargo or at
+             * the dock, no way to install. */
             left_rgb = COL_DIM;
-            snprintf(right_buf, sizeof(right_buf), "unavailable here");
-        } else if (refit[i].can) {
-            snprintf(right_buf, sizeof(right_buf), "-%d %s",
-                     refit[i].cost, ui_station_currency(st));
+            snprintf(right_buf, sizeof(right_buf), "no %s available", plural);
         } else {
-            left_rgb = COL_DIM;
-            snprintf(right_buf, sizeof(right_buf), "need %d %s",
-                     refit[i].cost, ui_station_currency(st));
+            if (!refit[i].can) left_rgb = COL_DIM;
+            /* Always: "<plural> [ have / need ]". If the row is
+             * actionable AND the dock is filling some of the gap from
+             * its inventory, append the credit cost the player will pay
+             * at retail. */
+            if (refit[i].can && refit[i].credit > 0) {
+                snprintf(right_buf, sizeof(right_buf), "%s [ %d / %d ]  -%d cr",
+                         plural, avail, needed,
+                         refit[i].credit);
+            } else {
+                snprintf(right_buf, sizeof(right_buf), "%s [ %d / %d ]",
+                         plural, avail, needed);
+            }
         }
         draw_row_lr(cx, my, inner_right, left_rgb, refit[i].left,
                     (left_rgb == COL_NAV) ? COL_TEXT : COL_FADED, right_buf);
@@ -1166,14 +1265,11 @@ static void draw_jobs_view(const station_ui_state_t *ui,
         } else {
             int qty = slot_fulfillable[s] ? slot_held[s]
                                           : (int)lroundf(ct->quantity_needed);
-            /* Include the required grade inline so the job row reads
-             * "Ferrite rare x12" — the whole cell gets tinted to the
-             * grade color below, so the player sees at a glance which
-             * grade will satisfy this contract. */
-            snprintf(cargo_buf, sizeof(cargo_buf), "%s %s x%d",
-                     commodity_short_name(ct->commodity),
-                     mining_grade_label((mining_grade_t)ct->required_grade),
-                     qty);
+            /* Drop the grade word — color encodes rarity for the whole
+             * row (see the grade-tint override below). Keeps the cargo
+             * cell short so payout doesn't collide with it. */
+            snprintf(cargo_buf, sizeof(cargo_buf), "%s x%d",
+                     commodity_short_name(ct->commodity), qty);
         }
 
         const station_t *dest = (ct->station_index < MAX_STATIONS)
@@ -1194,13 +1290,23 @@ static void draw_jobs_view(const station_ui_state_t *ui,
         }
 
         const uint8_t *info_rgb = (row_rgb == COL_DIM) ? COL_FADED : COL_TEXT;
-        /* Grade tint for the cargo cell (fracture contracts keep the
-         * neutral info color since they're not commodity-scoped). */
+        /* Grade tint for the entire row when the contract is for a
+         * rare grade. Common grade keeps the neutral row color so the
+         * board doesn't constantly look "lit up". Selected/tracked
+         * states already override row_rgb above, so those states win
+         * over the grade tint (color is the action signal first,
+         * rarity second). */
         uint8_t ggr, ggg, ggb;
         mining_grade_rgb((mining_grade_t)ct->required_grade, &ggr, &ggg, &ggb);
         uint8_t grade_rgb[3] = { ggr, ggg, ggb };
+        bool rare_grade = ct->action != CONTRACT_FRACTURE
+                       && ct->required_grade > (uint8_t)MINING_GRADE_COMMON;
+        if (rare_grade && !selected && !tracked) {
+            row_rgb = grade_rgb;
+        }
         const uint8_t *cargo_rgb = (ct->action == CONTRACT_FRACTURE)
-            ? info_rgb : grade_rgb;
+            ? info_rgb
+            : (rare_grade ? grade_rgb : info_rgb);
         if (compact) {
             cell_t top[] = {
                 {  0, key_buf,   row_rgb },

--- a/src/tests/test_economy.c
+++ b/src/tests/test_economy.c
@@ -42,34 +42,51 @@ TEST(test_station_repair_cost_with_damage) {
     ASSERT(cost > 0.0f);
 }
 
-TEST(test_can_afford_upgrade_all_conditions) {
+TEST(test_can_afford_upgrade_dock_fallback) {
+    /* Empty cargo, but station stocks the modules and player has
+     * credits — dock fills the gap from inventory at retail. */
     ship_t ship = {0};
     ship.hull_class = HULL_CLASS_MINER;
     station_t station = {0};
     station.services = STATION_SERVICE_UPGRADE_HOLD;
     station.inventory[COMMODITY_FRAME] = 100.0f;
-    int cost = ship_upgrade_cost(&ship, SHIP_UPGRADE_HOLD);
-    ASSERT(can_afford_upgrade(&station, &ship, SHIP_UPGRADE_HOLD, STATION_SERVICE_UPGRADE_HOLD, cost, 10000.0f));
+    station.base_price[COMMODITY_FRAME] = 22.0f;
+    ASSERT(can_afford_upgrade(&station, &ship, SHIP_UPGRADE_HOLD,10000.0f));
 }
 
-TEST(test_can_afford_upgrade_no_credits) {
+TEST(test_can_afford_upgrade_no_credits_for_dock_fallback) {
+    /* Empty cargo, station has modules, balance zero — fallback
+     * needs credits, so this must be rejected. */
     ship_t ship = {0};
     ship.hull_class = HULL_CLASS_MINER;
     station_t station = {0};
     station.services = STATION_SERVICE_UPGRADE_HOLD;
     station.inventory[COMMODITY_FRAME] = 100.0f;
-    int cost = ship_upgrade_cost(&ship, SHIP_UPGRADE_HOLD);
-    ASSERT(!can_afford_upgrade(&station, &ship, SHIP_UPGRADE_HOLD, STATION_SERVICE_UPGRADE_HOLD, cost, 0.0f));
+    station.base_price[COMMODITY_FRAME] = 22.0f;
+    ASSERT(!can_afford_upgrade(&station, &ship, SHIP_UPGRADE_HOLD,0.0f));
 }
 
-TEST(test_can_afford_upgrade_no_product) {
+TEST(test_can_afford_upgrade_no_product_anywhere) {
+    /* Empty cargo, empty station inventory — no modules to install. */
     ship_t ship = {0};
     ship.hull_class = HULL_CLASS_MINER;
     station_t station = {0};
     station.services = STATION_SERVICE_UPGRADE_HOLD;
     station.inventory[COMMODITY_FRAME] = 0.0f;
-    int cost = ship_upgrade_cost(&ship, SHIP_UPGRADE_HOLD);
-    ASSERT(!can_afford_upgrade(&station, &ship, SHIP_UPGRADE_HOLD, STATION_SERVICE_UPGRADE_HOLD, cost, 10000.0f));
+    ASSERT(!can_afford_upgrade(&station, &ship, SHIP_UPGRADE_HOLD,10000.0f));
+}
+
+TEST(test_can_afford_upgrade_cargo_only_no_credits_needed) {
+    /* Ship cargo covers the full module cost — credit balance is
+     * irrelevant since the dock has nothing to sell. */
+    ship_t ship = {0};
+    ship.hull_class = HULL_CLASS_MINER;
+    station_t station = {0};
+    station.services = STATION_SERVICE_UPGRADE_HOLD;
+    /* Empty dock inventory; ship carries enough frames itself. */
+    int need = (int)ceilf(upgrade_product_cost(&ship, SHIP_UPGRADE_HOLD));
+    ship.cargo[COMMODITY_FRAME] = (float)need;
+    ASSERT(can_afford_upgrade(&station, &ship, SHIP_UPGRADE_HOLD,0.0f));
 }
 
 TEST(test_contract_generated_from_hopper_deficit) {
@@ -359,19 +376,20 @@ TEST(test_mixed_cargo_sell_and_deliver) {
 }
 
 TEST(test_no_delivery_without_matching_contract) {
-    /* Cargo with no matching contract or production sink should not be delivered */
+    /* Cargo with no matching contract AND no consuming module on the
+     * station should stay in the hold. Use Prospect (no shipyard,
+     * no fab) so a tractor-module load has nowhere to land. */
     WORLD_DECL;
     world_reset(&w);
     player_init_ship(&w.players[0], &w);
     w.players[0].connected = true;
-    /* Player carries a finished module — stations don't buy this via
-     * fallback input delivery. */
     w.players[0].ship.cargo[COMMODITY_TRACTOR_MODULE] = 20.0f;
-    /* Clear all contracts */
     for (int k = 0; k < MAX_CONTRACTS; k++) w.contracts[k].active = false;
-    /* Dock at yard and try to sell */
+    /* Prospect Refinery (station 0): DOCK + SIGNAL_RELAY + FURNACE +
+     * ORE_SILO. No SHIPYARD, no TRACTOR_FAB → station_consumes returns
+     * false for tractor modules, so the SELL fallback should skip. */
     w.players[0].docked = true;
-    w.players[0].current_station = 1;
+    w.players[0].current_station = 0;
     w.players[0].input.service_sell = true;
     world_sim_step(&w, SIM_DT);
     ASSERT_EQ_FLOAT(w.players[0].ship.cargo[COMMODITY_TRACTOR_MODULE], 20.0f, 0.01f);
@@ -652,9 +670,10 @@ void register_economy_basic_tests(void) {
     RUN(test_station_production_beamworks_makes_modules);
     RUN(test_station_repair_cost_no_damage);
     RUN(test_station_repair_cost_with_damage);
-    RUN(test_can_afford_upgrade_all_conditions);
-    RUN(test_can_afford_upgrade_no_credits);
-    RUN(test_can_afford_upgrade_no_product);
+    RUN(test_can_afford_upgrade_dock_fallback);
+    RUN(test_can_afford_upgrade_no_credits_for_dock_fallback);
+    RUN(test_can_afford_upgrade_no_product_anywhere);
+    RUN(test_can_afford_upgrade_cargo_only_no_credits_needed);
     RUN(test_commodity_volume_kit_dense);
     RUN(test_ship_total_cargo_kit_density);
 }

--- a/src/tests/test_world_sim.c
+++ b/src/tests/test_world_sim.c
@@ -1061,11 +1061,17 @@ TEST(test_belt_ore_distribution) {
         else if (ore == COMMODITY_CUPRITE_ORE) cu++;
         else if (ore == COMMODITY_CRYSTAL_ORE) cr++;
     }
-    /* Ferrite should dominate, cuprite rare, crystal moderate */
-    ASSERT(fe > 500);   /* majority ferrite */
-    ASSERT(cu < 200);   /* cuprite is rare */
-    ASSERT(cr > 20);    /* crystal exists */
-    ASSERT(cr < fe);    /* less than ferrite */
+    /* Target mix ~60/16/24 (Fe/Cu/Cr). Cuprite >0 is load-bearing:
+     * laser modules + tractor coils + repair kits all need cuprite
+     * ingots. The bounds are loose to absorb tuning drift; tighten
+     * them in a follow-up if a real regression slips past. */
+    printf("    belt mix: fe=%d cu=%d cr=%d (target ~60/16/24)\n", fe, cu, cr);
+    ASSERT(fe > 500);     /* ferrite still dominant */
+    ASSERT(cu > 50);      /* cuprite reliably present */
+    ASSERT(cu < 250);     /* but still the rarest of three */
+    ASSERT(cr > 100);     /* crystal at least mid-share */
+    ASSERT(cr < fe);      /* less than ferrite */
+    ASSERT(cu < cr);      /* cuprite rarer than crystal */
 }
 
 TEST(test_chunk_determinism) {

--- a/src/world_draw.c
+++ b/src/world_draw.c
@@ -57,11 +57,115 @@ void grade_tint(uint8_t grade, float *r, float *g, float *b) {
 }
 
 float asteroid_profile(const asteroid_t* asteroid, float angle) {
-    float bump1 = sinf(angle * 3.0f + asteroid->seed);
-    float bump2 = sinf(angle * 7.0f + asteroid->seed * 1.71f);
-    float bump3 = cosf(angle * 5.0f + asteroid->seed * 0.63f);
-    float profile = 1.0f + (bump1 * 0.08f) + (bump2 * 0.06f) + (bump3 * 0.04f);
+    /* Polar-profile silhouettes for ferrite (lumpy round) and cuprite
+     * (six-sided hex crystal). Crystal-ore asteroids do NOT use this
+     * path — see draw_crystal_asteroid_*; they're built from explicit
+     * rotated rectangles because real straight crystal edges can't
+     * survive a per-angle radius sample. */
+    float profile;
+    switch (asteroid->commodity) {
+    case COMMODITY_CUPRITE_ORE: {
+        /* Hex crystal — six dominant lobes, light high-freq texture. */
+        float hex     = sinf(6.0f * angle + asteroid->seed);
+        float texture = sinf(angle * 11.0f + asteroid->seed * 1.31f) * 0.025f;
+        profile = 1.0f + hex * 0.12f + texture;
+        break;
+    }
+    case COMMODITY_FERRITE_ORE:
+    default: {
+        /* Lumpy round — original profile, retained for ferrite + any
+         * non-ore (debris, fragments without a commodity tag). */
+        float bump1 = sinf(angle * 3.0f + asteroid->seed);
+        float bump2 = sinf(angle * 7.0f + asteroid->seed * 1.71f);
+        float bump3 = cosf(angle * 5.0f + asteroid->seed * 0.63f);
+        profile = 1.0f + (bump1 * 0.08f) + (bump2 * 0.06f) + (bump3 * 0.04f);
+        break;
+    }
+    }
     return asteroid->radius * profile;
+}
+
+/* ------------------------------------------------------------------ */
+/* Crystal asteroids — built from explicit rectangles                  */
+/* ------------------------------------------------------------------ */
+
+int crystal_spike_count(const asteroid_t *a) {
+    /* Larger rocks read as 5-spike druzes, smaller fragments as 3.
+     * S-tier fragments use 3 too — a single bar would look pasted-on
+     * next to its 3-spike parents. */
+    switch (a->tier) {
+    case ASTEROID_TIER_XXL:
+    case ASTEROID_TIER_XL:
+    case ASTEROID_TIER_L:
+        return 5;
+    case ASTEROID_TIER_M:
+    case ASTEROID_TIER_S:
+    default:
+        return 3;
+    }
+}
+
+/* Build the four world-space corners of one crystal spike (a rotated
+ * rectangle anchored at the asteroid center, extending outward by
+ * `length` along `dir`, `width` thick). Out-corners are CCW from the
+ * inner-left so the caller can fan-triangulate as (0,1,2)+(0,2,3). */
+static void crystal_spike_corners(const asteroid_t *a, int i, int n,
+                                   float out_x[4], float out_y[4])
+{
+    /* Spread spikes around the full circle but perturb each one by a
+     * seed-derived offset so they're never perfectly symmetric. */
+    float spacing = TWO_PI_F / (float)n;
+    float dir = a->rotation + (float)i * spacing
+              + a->seed * 0.5f
+              + sinf(a->seed * 1.7f + (float)i * 2.13f) * 0.18f;
+
+    /* Per-spike length + width jitter — keeps individual spikes
+     * looking like distinct broken pieces of one larger crystal.
+     * Width is set wide enough that adjacent spikes overlap near
+     * the asteroid core, so the silhouette reads as a tightly
+     * packed cluster (no big furrows between bars) instead of a
+     * thin starburst. */
+    float length = a->radius * (1.00f + 0.15f * sinf(a->seed + (float)i * 1.71f));
+    float width  = a->radius * (0.42f + 0.10f * cosf(a->seed * 1.3f + (float)i * 1.31f));
+
+    float c = cosf(dir), s = sinf(dir);
+    /* Local frame: x along the spike axis (0..length), y perpendicular
+     * (-width..+width). Order: inner-left, tip-left, tip-right,
+     * inner-right. CCW. */
+    float lx[4] = { 0.0f,    length, length,  0.0f   };
+    float ly[4] = { -width,  -width, +width,  +width };
+    for (int k = 0; k < 4; k++) {
+        out_x[k] = a->pos.x + lx[k] * c - ly[k] * s;
+        out_y[k] = a->pos.y + lx[k] * s + ly[k] * c;
+    }
+}
+
+void draw_crystal_asteroid_fill(const asteroid_t *a) {
+    int n = crystal_spike_count(a);
+    for (int i = 0; i < n; i++) {
+        float wx[4], wy[4];
+        crystal_spike_corners(a, i, n, wx, wy);
+        /* Two CCW triangles cover the rectangle. Caller has already
+         * pushed the body color and opened sgl_begin_triangles. */
+        sgl_v2f(wx[0], wy[0]); sgl_v2f(wx[1], wy[1]); sgl_v2f(wx[2], wy[2]);
+        sgl_v2f(wx[0], wy[0]); sgl_v2f(wx[2], wy[2]); sgl_v2f(wx[3], wy[3]);
+    }
+}
+
+void draw_crystal_asteroid_outline(const asteroid_t *a, float r, float g, float b, float alpha) {
+    int n = crystal_spike_count(a);
+    sgl_c4f(r, g, b, alpha);
+    sgl_begin_lines();
+    for (int i = 0; i < n; i++) {
+        float wx[4], wy[4];
+        crystal_spike_corners(a, i, n, wx, wy);
+        for (int k = 0; k < 4; k++) {
+            int next = (k + 1) % 4;
+            sgl_v2f(wx[k],    wy[k]);
+            sgl_v2f(wx[next], wy[next]);
+        }
+    }
+    sgl_end();
 }
 
 void draw_background(vec2 camera) {

--- a/src/world_draw.h
+++ b/src/world_draw.h
@@ -22,6 +22,19 @@ float cam_bottom(void);
 /* --- Asteroid helpers --- */
 float asteroid_profile(const asteroid_t* asteroid, float angle);
 
+/* Crystal-ore asteroids use constructed rectangle geometry instead of
+ * the polar profile path (rectangles can't be expressed as a single
+ * radius-per-angle without rounding the corners). The fill helper is
+ * called inside an open sgl_begin_triangles() / sgl_end() batch; the
+ * outline helper opens its own sgl_begin_lines/end. */
+void draw_crystal_asteroid_fill(const asteroid_t *a);
+void draw_crystal_asteroid_outline(const asteroid_t *a, float r, float g, float b, float alpha);
+
+/* Number of rectangle "spikes" a crystal asteroid renders with — 3 for
+ * fragments and small clusters, 5 for the larger ones. Same math is
+ * used by the AABB / hit-test code if any. */
+int  crystal_spike_count(const asteroid_t *a);
+
 /* Float-RGB grade tint for sokol_gl callers. Delegates to the canonical
  * mining_grade_rgb in shared/mining.h. UI code should call that directly
  * instead of routing grade colors through world_draw. */


### PR DESCRIPTION
## Summary

- **Unblocks main CI** — adds the missing `repair_kit` entry to `cnames[]` in `server/main.c` so Linux GCC stops failing on `-Werror=aggressive-loop-optimizations`. Adds a `_Static_assert` so the next bump fails with a clear message.
- **Fixes the broken repair-kit production loop** — cuprite ore was never spawning because `belt_ore_at`'s multiplicative bias made cuprite max (~0.24) lower than ferrite min (~0.40), so cuprite never won the dominant-ore selection. Reworked to additive bias.
- **Furnace ore-type gate** moved earlier in `step_furnace_smelting` so a ferrite furnace can't pull cuprite/crystal fragments.
- **Ship upgrades reworked** to mirror #373's any-dock pattern: cargo-first, dock-fallback at retail, no flat upgrade fee, drops the `STATION_SERVICE_UPGRADE_*` gate.
- **Manifest fixes**: `manifest_push` grows on demand; `clear_ship_cargo` wipes the manifest too (previously phantom `cargo_unit_t` entries survived emergency recovery and surfaced as ghost SELL rows).
- **Header → .c extractions** for `belt`, `module_schema`, `station_util` so editing the schema table or noise math doesn't fan out a 40-TU recompile.
- **Crystal asteroid visual rework** (rectangles instead of polar profile) + cuprite hex silhouette.
- **TRADE picker** rename + nested-stripe flow status (`===`/`==-`/`=--`/`---`) replacing raw counts.
- **Per-press buy multiplier** for dense goods so 100 kits doesn't take 100 keystrokes.
- **Build/dev-loop**: docker-compose bind-mount of `build-web`, CMake copy of `web/play.html`.

Bundles ~9 separate concerns into one PR per request — see commit body for the full breakdown.

## Test plan

- [x] `make test` — 328 passed, 0 failed locally
- [x] Native build green (Apple/Metal)
- [ ] CI passes on Linux (the cnames fix is specifically what was breaking it)
- [ ] WASM build green
- [ ] Manual smoke: Prospect → mine cuprite (should now exist) → return → repair-kit fab runs at any dock with FE + LASER inventory
- [ ] Manual smoke: dock at any station → upgrade installs from cargo first, then dock inventory at retail; balance no longer charged a flat fee
- [ ] Manual smoke: TRADE picker shows nested-stripe flow status that reads correctly across the 3 starter stations
- [ ] Manual smoke: F-press on repair kits buys 10/keystroke; F on frames/ingots still buys 1

## Notes

The `STATION_SERVICE_UPGRADE_*` flags + `station_has_service` / `station_upgrade_service` helpers are now dead-code-equivalent (set by station_util but read by nothing). Left in place this PR; should be deleted in a follow-up cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)