### PR TITLE
Delete dead station_has_service / station_upgrade_service

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -435,8 +435,6 @@ const station_t* nearby_station_ptr(void);
 int nearest_station_index(vec2 pos);
 int nearest_signal_station(vec2 pos);
 const station_t* navigation_station_ptr(void);
-bool station_has_service(uint32_t service);
-uint32_t station_upgrade_service(ship_upgrade_t upgrade);
 
 /* (Old MARKET / STATUS formatter helpers retired in the docked-UI
  * redesign — the verb-list view computes its rows inline from station

--- a/src/main.c
+++ b/src/main.c
@@ -67,7 +67,6 @@ static void mix_external_audio(float *buffer, int frames, int channels, void *us
 /* format_ingot_stock_line: see station_ui.c */
 /* station_at ... navigation_station_ptr: see station_ui.c */
 /* station_role_name, station_role_short_name: see station_ui.c */
-/* station_has_service, station_upgrade_service: see station_ui.c */
 /* build_station_ui_state, format_station_* helpers: see station_ui.c */
 /* station_role_hub_label, station_role_market_title, station_role_fit_title: see station_ui.c */
 /* station_role_color: see station_ui.c */

--- a/src/station_ui.c
+++ b/src/station_ui.c
@@ -168,29 +168,6 @@ void station_role_color(const station_t* station, float* r, float* g0, float* b)
 }
 
 /* ------------------------------------------------------------------ */
-/* Station service / upgrade helpers                                   */
-/* ------------------------------------------------------------------ */
-
-bool station_has_service(uint32_t service) {
-    const station_t* station = current_station_ptr();
-    return (station != NULL) && ((station->services & service) != 0);
-}
-
-uint32_t station_upgrade_service(ship_upgrade_t upgrade) {
-    switch (upgrade) {
-        case SHIP_UPGRADE_MINING:
-            return STATION_SERVICE_UPGRADE_LASER;
-        case SHIP_UPGRADE_HOLD:
-            return STATION_SERVICE_UPGRADE_HOLD;
-        case SHIP_UPGRADE_TRACTOR:
-            return STATION_SERVICE_UPGRADE_TRACTOR;
-        case SHIP_UPGRADE_COUNT:
-        default:
-            return 0;
-    }
-}
-
-/* ------------------------------------------------------------------ */
 /* Formatting helpers                                                  */
 /* ------------------------------------------------------------------ */
 


### PR DESCRIPTION
## Summary

Both helpers became dead code in #388 when the upgrade flow dropped the `STATION_SERVICE_UPGRADE_*` gate (any-dock, cargo-first model). Confirmed zero live callers across \`src/\`, \`server/\`, \`shared/\`.

Removed:
- \`src/station_ui.c::station_has_service\`
- \`src/station_ui.c::station_upgrade_service\`
- \`src/client.h\` declarations for both
- Stale \"see station_ui.c\" comment in \`src/main.c\`

Net: -26 lines.

## Out of scope

\`STATION_SERVICE_UPGRADE_LASER/HOLD/TRACTOR\` are still set in \`rebuild_station_services()\` and declared on \`MODULE_SCHEMA\` entries. Retained deliberately — they're still informational schema metadata even though no consumer reads them. Trimming them is a larger schema pass that should land separately if at all.

## Test plan

- [x] \`make test\` — 328 passed locally
- [x] Native build green
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)