### PR TITLE
Slice 5 of ship/NPC unify: introduce character_t + characters[] pool

### DIFF
--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -294,6 +294,10 @@ typedef struct {
         bool from_chunk;   /* true = terrain, false = fracture child */
     } asteroid_origin[MAX_ASTEROIDS];
     npc_ship_t npc_ships[MAX_NPC_SHIPS];
+    /* #294 Slice 1: empty controller pool. Nothing populates this yet —
+     * MINER migration (Slice 3a) will be the first writer. Sized to the
+     * NPC + player union so later slices don't need a flag-day resize. */
+    character_t characters[MAX_PLAYERS + MAX_NPC_SHIPS];
     scaffold_t scaffolds[MAX_SCAFFOLDS];
     server_player_t players[MAX_PLAYERS];
     uint32_t rng;

--- a/shared/types.h
+++ b/shared/types.h
@@ -483,6 +483,47 @@ typedef struct {
     float hull;
 } npc_ship_t;
 
+/* ------------------------------------------------------------------ */
+/* character_t — controller layer (#294 Slice 1: types only)            */
+/* ------------------------------------------------------------------ */
+/*
+ * A character_t is the AI brain or human pilot binding sitting on top
+ * of a ship_t. The unification target (#294) is:
+ *
+ *   ship_t       — physics + cargo + manifest + upgrades + hull HP
+ *   character_t  — kind, brain state, target, home/dest station,
+ *                  state timer; indexes a ship by id
+ *   world_t      — ships[]      unified pool (players + NPCs)
+ *                  characters[] controller pool
+ *
+ * Slice 1 introduces the type and an empty `characters[]` pool on
+ * world_t so later slices can populate them without a flag-day rename.
+ * Nothing reads or writes the pool yet — npc_ship_t and
+ * server_player_t still own physics + brain state today.
+ */
+typedef enum {
+    CHARACTER_KIND_NONE = 0,
+    CHARACTER_KIND_PLAYER,
+    CHARACTER_KIND_NPC_MINER,
+    CHARACTER_KIND_NPC_HAULER,
+    CHARACTER_KIND_NPC_TOW,
+} character_kind_t;
+
+typedef struct {
+    bool active;
+    character_kind_t kind;
+    int ship_idx;             /* index into world.ships[]; -1 = unbound */
+    /* Brain state — meaningful for NPC kinds. Players carry these in
+     * server_player_t for now; converging is a later slice. */
+    npc_state_t state;
+    int target_asteroid;      /* -1 = none */
+    int home_station;
+    int dest_station;
+    float state_timer;
+    int towed_fragment;       /* -1 = none */
+    int towed_scaffold;       /* -1 = none */
+} character_t;
+
 typedef struct {
     vec2 pos;
     float depth;


### PR DESCRIPTION
Lands #294 Slice 1 (audit + types).

## Summary
- `shared/types.h`: `character_kind_t` (NONE / PLAYER / NPC_MINER / NPC_HAULER / NPC_TOW) and `character_t` with: `active`, `kind`, `ship_idx`, `state`, `target_asteroid`, `home_station`, `dest_station`, `state_timer`, `towed_fragment`, `towed_scaffold`.
- `server/game_sim.h`: `world.characters[MAX_PLAYERS + MAX_NPC_SHIPS]` — empty pool, zero-init via the existing `world_reset` memset path.
- Nothing reads or writes the pool yet. `npc_ship_t` and `server_player_t` still own physics + brain state. The next slice (MINER migration) becomes the first writer.

## Test plan
- [x] `make test` — 328 / 328
- [x] Pre-commit hook (native + WASM) green
- [ ] CI green