### PR TITLE
Slice 8 of ship/NPC unify: unified ships[] pool for NPCs

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -4125,6 +4125,8 @@ void world_sim_step_player_only(world_t *w, int player_idx, float dt) {
 void world_cleanup(world_t *w) {
     for (int i = 0; i < MAX_PLAYERS; i++)
         ship_cleanup(&w->players[i].ship);
+    for (int i = 0; i < MAX_SHIPS; i++)
+        ship_cleanup(&w->ships[i]);
     for (int i = 0; i < MAX_STATIONS; i++)
         station_cleanup(&w->stations[i]);
     free(w->signal_cache.strength);
@@ -4153,6 +4155,8 @@ void world_reset(world_t *w) {
     sparse_cell_entry_t *grid_entries = w->asteroid_grid.entries;
     for (int i = 0; i < MAX_PLAYERS; i++)
         ship_cleanup(&w->players[i].ship);
+    for (int i = 0; i < MAX_SHIPS; i++)
+        ship_cleanup(&w->ships[i]);
     for (int i = 0; i < MAX_STATIONS; i++)
         station_cleanup(&w->stations[i]);
     free(grid_entries);

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -25,6 +25,9 @@
 
 enum {
     MAX_PLAYERS = 32,
+    /* #294 Slice 8: unified NPC ship_t pool. Sized for NPCs only today;
+     * widening to include players is a later slice. */
+    MAX_SHIPS = MAX_NPC_SHIPS,
 };
 
 static const float WORLD_RADIUS = 50000.0f;  /* safety net; gameplay bounded by station signal_range */
@@ -294,8 +297,14 @@ typedef struct {
         bool from_chunk;   /* true = terrain, false = fracture child */
     } asteroid_origin[MAX_ASTEROIDS];
     npc_ship_t npc_ships[MAX_NPC_SHIPS];
-    /* #294 Slice 1: empty controller pool. Nothing populates this yet —
-     * MINER migration (Slice 3a) will be the first writer. Sized to the
+    /* #294 Slice 8: unified ship_t pool. Each active NPC owns a slot
+     * here; the paired character_t.ship_idx points to it. Players still
+     * carry an inline ship_t in server_player_t — converging is a later
+     * slice. Manifest lifecycle: bootstrap on alloc, ship_cleanup on
+     * free and on world_cleanup/world_reset. */
+    ship_t ships[MAX_SHIPS];
+    /* Controller pool. Each entry pairs an active NPC (today) or a
+     * player (later) to a ship slot via ship_idx. Sized to the
      * NPC + player union so later slices don't need a flag-day resize. */
     character_t characters[MAX_PLAYERS + MAX_NPC_SHIPS];
     scaffold_t scaffolds[MAX_SCAFFOLDS];

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -75,7 +75,41 @@ static character_kind_t character_kind_from_role(npc_role_t role) {
     }
 }
 
+/* Find a free ships[] slot — one not pointed to by any active character.
+ * Returns -1 if the pool is full. */
+static int ship_pool_alloc_slot(const world_t *w) {
+    int cap = (int)(sizeof(w->characters) / sizeof(w->characters[0]));
+    for (int s = 0; s < MAX_SHIPS; s++) {
+        bool taken = false;
+        for (int i = 0; i < cap; i++) {
+            if (w->characters[i].active && w->characters[i].ship_idx == s) {
+                taken = true;
+                break;
+            }
+        }
+        if (!taken) return s;
+    }
+    return -1;
+}
+
+/* Initialize a ships[] slot from an NPC's snapshot. Frees any prior
+ * manifest the slot was holding so this is safe for a slot that was
+ * previously occupied (e.g. after rebuild_characters_from_npcs). */
+static void ship_pool_init_from_npc(ship_t *ship, const npc_ship_t *npc) {
+    ship_cleanup(ship);
+    memset(ship, 0, sizeof(*ship));
+    (void)ship_manifest_bootstrap(ship);
+    ship->pos = npc->pos;
+    ship->vel = npc->vel;
+    ship->angle = npc->angle;
+    ship->hull_class = npc->hull_class;
+    ship->hull = npc->hull;
+}
+
 static int character_alloc_for_npc(world_t *w, int npc_slot, const npc_ship_t *npc) {
+    (void)npc_slot; /* ship_idx now points to the unified ships[] pool, not npc_slot. */
+    int ship_slot = ship_pool_alloc_slot(w);
+    if (ship_slot < 0) return -1;
     int cap = (int)(sizeof(w->characters) / sizeof(w->characters[0]));
     for (int i = 0; i < cap; i++) {
         if (w->characters[i].active) continue;
@@ -83,7 +117,7 @@ static int character_alloc_for_npc(world_t *w, int npc_slot, const npc_ship_t *n
         memset(c, 0, sizeof(*c));
         c->active = true;
         c->kind = character_kind_from_role(npc->role);
-        c->ship_idx = npc_slot;
+        c->ship_idx = ship_slot;
         c->state = npc->state;
         c->target_asteroid = npc->target_asteroid;
         c->home_station = npc->home_station;
@@ -91,8 +125,11 @@ static int character_alloc_for_npc(world_t *w, int npc_slot, const npc_ship_t *n
         c->state_timer = npc->state_timer;
         c->towed_fragment = npc->towed_fragment;
         c->towed_scaffold = npc->towed_scaffold;
+        ship_pool_init_from_npc(&w->ships[ship_slot], npc);
         return i;
     }
+    /* No free character slot; release the ship slot we reserved. */
+    ship_cleanup(&w->ships[ship_slot]);
     return -1;
 }
 
@@ -113,12 +150,19 @@ static int character_for_npc_slot(const world_t *w, int npc_slot) {
 
 static void character_free_for_npc(world_t *w, int npc_slot) {
     int idx = character_for_npc_slot(w, npc_slot);
-    if (idx >= 0) w->characters[idx].active = false;
+    if (idx < 0) return;
+    int ship_slot = w->characters[idx].ship_idx;
+    if (ship_slot >= 0 && ship_slot < MAX_SHIPS) {
+        ship_cleanup(&w->ships[ship_slot]);
+        memset(&w->ships[ship_slot], 0, sizeof(w->ships[ship_slot]));
+    }
+    w->characters[idx].active = false;
 }
 
 /* Mirror brain state from an NPC into its paired character_t (#294
- * Slice 7). Called at the top of each NPC's tick so future readers can
- * trust the controller layer; the npc-side fields remain the source of
+ * Slice 7) AND physics state into its paired ship_t (#294 Slice 8).
+ * Called at the top of each NPC's tick so future readers can trust the
+ * controller + ship layer; the npc-side fields remain the source of
  * truth that the dispatch switch writes back to. */
 static void mirror_npc_to_character(world_t *w, int npc_slot) {
     int idx = character_for_npc_slot(w, npc_slot);
@@ -132,6 +176,14 @@ static void mirror_npc_to_character(world_t *w, int npc_slot) {
     c->state_timer = npc->state_timer;
     c->towed_fragment = npc->towed_fragment;
     c->towed_scaffold = npc->towed_scaffold;
+    if (c->ship_idx >= 0 && c->ship_idx < MAX_SHIPS) {
+        ship_t *s = &w->ships[c->ship_idx];
+        s->pos = npc->pos;
+        s->vel = npc->vel;
+        s->angle = npc->angle;
+        s->hull = npc->hull;
+        s->hull_class = npc->hull_class;
+    }
 }
 
 void rebuild_characters_from_npcs(world_t *w) {
@@ -209,30 +261,31 @@ static bool npc_target_valid(const world_t *w, const npc_ship_t *npc) {
 }
 
 /* Asteroid-already-taken check, reading from the controller layer
- * (#294 Slice 7): scan characters[] for any other MINER targeting
+ * (#294 Slice 7+8): scan characters[] for any other MINER targeting
  * `target_idx`. The mirror at top of tick keeps character.target_asteroid
- * in sync with npc.target_asteroid. `self_npc_slot` is excluded so the
+ * in sync with npc.target_asteroid. `self_char_idx` is excluded so the
  * caller doesn't see itself as a competitor. */
-static bool miner_target_taken(const world_t *w, int target_idx, int self_npc_slot) {
+static bool miner_target_taken(const world_t *w, int target_idx, int self_char_idx) {
     int cap = (int)(sizeof(w->characters) / sizeof(w->characters[0]));
     for (int i = 0; i < cap; i++) {
+        if (i == self_char_idx) continue;
         const character_t *c = &w->characters[i];
         if (!c->active || c->kind != CHARACTER_KIND_NPC_MINER) continue;
-        if (c->ship_idx == self_npc_slot) continue;
         if (c->target_asteroid == target_idx) return true;
     }
     return false;
 }
 
 static int npc_find_mineable_asteroid(const world_t *w, const npc_ship_t *npc) {
-    int self_slot = (int)(npc - w->npc_ships);
+    int self_npc_slot = (int)(npc - w->npc_ships);
+    int self_char = character_for_npc_slot(w, self_npc_slot);
 
     /* Priority: DESTROY contract targets first */
     for (int k = 0; k < MAX_CONTRACTS; k++) {
         if (!w->contracts[k].active || w->contracts[k].action != CONTRACT_FRACTURE) continue;
         int idx = w->contracts[k].target_index;
         if (idx < 0 || idx >= MAX_ASTEROIDS || !w->asteroids[idx].active) continue;
-        if (!miner_target_taken(w, idx, self_slot)) return idx;
+        if (!miner_target_taken(w, idx, self_char)) return idx;
     }
 
     /* Normal: find nearest mineable asteroid */
@@ -242,7 +295,7 @@ static int npc_find_mineable_asteroid(const world_t *w, const npc_ship_t *npc) {
         const asteroid_t *a = &w->asteroids[i];
         if (!a->active || a->tier == ASTEROID_TIER_S) continue;
         if (signal_npc_confidence(signal_strength_at(w, a->pos)) < 0.1f) continue;
-        if (miner_target_taken(w, i, self_slot)) continue;
+        if (miner_target_taken(w, i, self_char)) continue;
         float d = v2_dist_sq(npc->pos, a->pos);
         if (d < best_d) { best_d = d; best = i; }
     }


### PR DESCRIPTION
Continues #294 after #395.

## Summary
Each active NPC now owns a real `ship_t` in `world.ships[]`, pointed to by the paired `character_t.ship_idx`. Manifest lifecycle is bootstrap on alloc, `ship_cleanup` on free + on `world_cleanup` / `world_reset`.

Players still carry an inline `ship_t` in `server_player_t` — converging the player side is a later slice.

- `MAX_SHIPS = MAX_NPC_SHIPS` (NPC-only pool today).
- `world.ships[MAX_SHIPS]`; `world_cleanup` / `world_reset` ship_cleanup each slot alongside players.
- `ship_pool_alloc_slot` finds a free slot via "no character points here" — no parallel active flag needed.
- `ship_pool_init_from_npc` is cleanup-first so a slot whose previous occupant left a heap manifest behind is safe.
- `character_alloc_for_npc` reserves a ships[] slot before claiming a character; `character.ship_idx` now points into ships[] (no longer the NPC slot).
- `mirror_npc_to_character` pushes pos/vel/angle/hull/hull_class into the paired ship each tick.
- `miner_target_taken` self-exclusion is now by character index — the old `ship_idx == npc_slot` assumption is gone.

Mirror direction is npc → ship/character only. The NPC remains the source of truth; future slices flip individual write sites onto the ship/character so eventually `ship_t` becomes authoritative and `npc_ship_t` shrinks toward a wire-only mirror.

No behavior change.

## Test plan
- [x] `make test` — 328 / 328
- [x] Pre-commit hook (native + WASM) green
- [ ] CI green