### PR TITLE
Slice 10 of ship/NPC unify: expose apply_npc_ship_damage

### DIFF
--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -171,7 +171,10 @@ static ship_t *npc_ship_for(world_t *w, int npc_slot) {
 
 /* Reverse mirror: push ship.hull back into npc.hull at the end of an
  * NPC's tick. Lets damage written through the ship layer (the player
- * path's substrate) flow into the npc's despawn check next tick. */
+ * path's substrate) flow into the npc's despawn check next tick.
+ * Physics fields stay npc-authoritative for now — dispatch writes
+ * pos/vel/angle on the npc side and the top-of-tick mirror keeps the
+ * ship in sync; flipping dispatch onto ship_t is a later slice. */
 static void mirror_ship_to_npc(world_t *w, int npc_slot) {
     const ship_t *s = npc_ship_for(w, npc_slot);
     if (!s) return;
@@ -181,8 +184,12 @@ static void mirror_ship_to_npc(world_t *w, int npc_slot) {
 
 /* Apply damage to an NPC by mutating its ship_t.hull. The reverse
  * mirror at end-of-tick pushes the result into npc->hull so the
- * existing despawn check fires when hull <= 0. */
-static void apply_npc_ship_damage(world_t *w, int npc_slot, float dmg) {
+ * existing despawn check fires when hull <= 0.
+ *
+ * Public: external code (rock-throw collision, PvP, etc.) reaches NPC
+ * damage through this helper so the unified ship_t.hull stays the
+ * single source of truth. */
+void apply_npc_ship_damage(world_t *w, int npc_slot, float dmg) {
     if (dmg <= 0.0f) return;
     ship_t *s = npc_ship_for(w, npc_slot);
     if (!s) {

--- a/server/sim_ai.h
+++ b/server/sim_ai.h
@@ -16,4 +16,11 @@ const hull_def_t *npc_hull_def(const npc_ship_t *npc);
  * pool stays in sync with NPC lifecycle (#294 Slice 6). */
 void rebuild_characters_from_npcs(world_t *w);
 
+/* Damage an NPC through its paired ship_t (#294 Slice 9 + 10). The
+ * reverse mirror at end of the NPC's tick pushes the result into
+ * npc->hull so the existing despawn check still fires. Safe to call
+ * even if the NPC has no paired ship (falls back to npc->hull).
+ * `dmg <= 0` is a no-op. */
+void apply_npc_ship_damage(world_t *w, int npc_slot, float dmg);
+
 #endif /* SIM_AI_H */


### PR DESCRIPTION
Continues #294 after #397.

## Summary
Make `apply_npc_ship_damage` public so external damage callers (rock-throw collision in #382 / #384, PvP in #381) can hit NPCs through their paired `ship_t.hull` instead of poking `npc->hull` directly. The reverse mirror at end of the NPC's tick already pushes the result into `npc->hull` so the existing `hull <= 0` despawn check keeps firing.

- `server/sim_ai.h` — declare `apply_npc_ship_damage(world_t*, int npc_slot, float dmg)`.
- `server/sim_ai.c` — drop the `static` qualifier; tighten the comment.

(I tried piggy-backing a physics reverse-mirror in this slice — push `ship.pos/vel/angle` back to the npc — but it clobbered the dispatch's in-tick npc-side writes. Three NPC-collision/tow tests caught it. That flip belongs in a later slice that also moves the dispatch's physics writes onto `ship_t`. Reverted.)

No behavior change.

## Test plan
- [x] `make test` — 328 / 328
- [x] Pre-commit hook (native + WASM) green
- [ ] CI green