### PR TITLE
Slice 11 of ship/NPC unify: stop clobbering ship.hull at top of tick

### DIFF
--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -225,8 +225,13 @@ static void mirror_npc_to_character(world_t *w, int npc_slot) {
         s->pos = npc->pos;
         s->vel = npc->vel;
         s->angle = npc->angle;
-        s->hull = npc->hull;
         s->hull_class = npc->hull_class;
+        /* Don't mirror hull npc->ship here: ship.hull is authoritative
+         * (Slice 9 + 10). External callers — apply_npc_ship_damage and
+         * future rock/PvP impact paths — may have mutated ship.hull
+         * between this NPC's last tick and now; mirroring npc.hull
+         * over it would lose that damage/repair. The end-of-tick
+         * reverse mirror (mirror_ship_to_npc) keeps npc.hull in sync. */
     }
 }
 

--- a/src/tests/test_econ_sim.c
+++ b/src/tests/test_econ_sim.c
@@ -575,16 +575,22 @@ TEST(test_e2e_npc_dock_auto_repair_drains_kits) {
     /* Pick the first hauler that's currently homed at the shipyard,
      * wound it, and drop it just outside the dock approach radius. */
     npc_ship_t *hauler = NULL;
+    int hauler_slot = -1;
     for (int n = 0; n < MAX_NPC_SHIPS; n++) {
         if (!w->npc_ships[n].active) continue;
         if (w->npc_ships[n].role != NPC_ROLE_HAULER) continue;
         w->npc_ships[n].home_station = shipyard;
         hauler = &w->npc_ships[n];
+        hauler_slot = n;
         break;
     }
     ASSERT(hauler != NULL);
     float max_h = npc_max_hull(hauler);
-    hauler->hull  = max_h - 20.0f; /* 20 HP damage */
+    /* Damage through the public ship-layer helper so ship.hull stays
+     * authoritative (#294 Slice 11). Writing hauler->hull directly
+     * would leave ship.hull at max_h and the auto-repair would see
+     * nothing to fix. */
+    apply_npc_ship_damage(w, hauler_slot, 20.0f);
     hauler->state = NPC_STATE_RETURN_TO_STATION;
     /* Drop the hauler well inside the home station's dock approach
      * radius so the next sim_step's RETURN_TO_STATION branch trips

--- a/src/tests/test_harness.h
+++ b/src/tests/test_harness.h
@@ -22,6 +22,7 @@
 #include "sim_nav.h"
 #include "sim_autopilot.h"
 #include "sim_flight.h"
+#include "sim_ai.h"
 #include "chunk.h"
 #include "net_protocol.h"
 #include "mining.h"


### PR DESCRIPTION
Continues #294 after #398.

## Summary
`ship.hull` is authoritative as of Slice 9 + 10, but `mirror_npc_to_character` was still copying `npc.hull -> ship.hull` at the top of every NPC tick. That mirror would silently lose any external mutation of `ship.hull` between two ticks (the first real consumer being `apply_npc_ship_damage` called from rock-throw / PvP impact paths once those land).

- `server/sim_ai.c` — drop the `npc.hull -> ship.hull` line from `mirror_npc_to_character`. Other physics fields (pos, vel, angle, hull_class) keep mirroring because the dispatch still writes them on the NPC side; flipping those onto `ship_t` is a later slice.
- `src/tests/test_econ_sim.c` — `test_e2e_npc_dock_auto_repair_drains_kits` damages the hauler via `apply_npc_ship_damage` instead of poking `hauler->hull` directly. Tests/external code that mutate `npc.hull` no longer have their changes reflected on the ship side; the public helper exists for exactly this reason.
- `src/tests/test_harness.h` — include `sim_ai.h` so tests pick up the public damage helper.

No runtime behavior change.

## Test plan
- [x] `make test` — 328 / 328
- [x] Pre-commit hook (native + WASM) green
- [ ] CI green