### PR TITLE
Slice 13a of ship/NPC unify: parity invariant + mirror closure

### DIFF
--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -173,17 +173,44 @@ static ship_t *npc_ship_for(world_t *w, int npc_slot) {
     return &w->ships[s];
 }
 
-/* Reverse mirror: push ship.hull back into npc.hull at the end of an
- * NPC's tick. Lets damage written through the ship layer (the player
- * path's substrate) flow into the npc's despawn check next tick.
- * Physics fields stay npc-authoritative for now — dispatch writes
- * pos/vel/angle on the npc side and the top-of-tick mirror keeps the
- * ship in sync; flipping dispatch onto ship_t is a later slice. */
+/* Public wrapper: rejects NULL world and out-of-range / inactive
+ * slots. Used by tests and external readers that want to inspect or
+ * mutate an NPC's paired ship_t. */
+ship_t *world_npc_ship_for(world_t *w, int npc_slot) {
+    if (!w) return NULL;
+    if (npc_slot < 0 || npc_slot >= MAX_NPC_SHIPS) return NULL;
+    if (!w->npc_ships[npc_slot].active) return NULL;
+    return npc_ship_for(w, npc_slot);
+}
+
+/* End-of-tick paired-pool sync. Each field flows in the direction of
+ * its current authority:
+ *
+ *   - hull is ship-authoritative since Slice 9/11 (apply_npc_ship_damage,
+ *     hauler dock auto-repair both write ship.hull). Push ship -> npc
+ *     so the npc-side despawn check reads a fresh value next tick.
+ *   - pos / vel / angle / thrusting are still npc-authoritative — the
+ *     dispatch writes them on the npc side. Push npc -> ship so the
+ *     ship is a faithful end-of-tick snapshot. Required for the
+ *     parity invariant (test_npc_ship_physics_in_sync_each_tick) and
+ *     for any external reader that takes ship_t as the canonical
+ *     view. Slice 13 flips these to ship-authoritative; this function
+ *     becomes ship -> npc only at that point.
+ *
+ * Caveat for the npc-authoritative direction: external code that
+ * mutates ship.pos/vel/angle *between* two ticks will have its
+ * change overwritten here at the next end-of-tick. That's the bug
+ * Slice 13 fixes. Until then, external physics writes don't survive
+ * this transitional sync — only damage does (via the ship-authoritative
+ * hull path). */
 static void mirror_ship_to_npc(world_t *w, int npc_slot) {
-    const ship_t *s = npc_ship_for(w, npc_slot);
+    ship_t *s = npc_ship_for(w, npc_slot);
     if (!s) return;
     npc_ship_t *npc = &w->npc_ships[npc_slot];
     npc->hull = s->hull;
+    s->pos = npc->pos;
+    s->vel = npc->vel;
+    s->angle = npc->angle;
 }
 
 /* Apply damage to an NPC by mutating its ship_t.hull. The reverse

--- a/server/sim_ai.h
+++ b/server/sim_ai.h
@@ -23,4 +23,11 @@ void rebuild_characters_from_npcs(world_t *w);
  * `dmg <= 0` is a no-op. */
 void apply_npc_ship_damage(world_t *w, int npc_slot, float dmg);
 
+/* Resolve an NPC slot to its paired ship_t (#294 Slice 8). Returns
+ * NULL if the slot is out of range, the NPC isn't active, or no
+ * character is currently paired. Const-overload via the same
+ * underlying lookup is unnecessary today; tests and external readers
+ * can take the non-const pointer. */
+ship_t *world_npc_ship_for(world_t *w, int npc_slot);
+
 #endif /* SIM_AI_H */

--- a/src/tests/test_save.c
+++ b/src/tests/test_save.c
@@ -50,6 +50,35 @@ TEST(test_world_save_load_preserves_npcs) {
     remove("/tmp/test_npcs.sav");
 }
 
+TEST(test_npc_ship_physics_in_sync_each_tick) {
+    /* Tripwire for the Slice 13 physics flip and any future mirror
+     * direction change: at the end of every sim step, every active
+     * NPC's paired ship_t must agree with its npc_ship_t on hull,
+     * hull_class, pos, vel, and angle. A missed write site lasts at
+     * most one tick before the reverse mirror washes it out, so
+     * behavioral tests don't catch it — this one does, immediately.
+     * Runs for 10 sim seconds (1200 ticks @ 120 Hz) to cover spawn,
+     * mine, dock, hauler-in-transit, and at least one despawn cycle. */
+    WORLD_HEAP w = calloc(1, sizeof(world_t));
+    world_reset(w);
+    for (int t = 0; t < 1200; t++) {
+        world_sim_step(w, SIM_DT);
+        for (int n = 0; n < MAX_NPC_SHIPS; n++) {
+            const npc_ship_t *npc = &w->npc_ships[n];
+            if (!npc->active) continue;
+            const ship_t *s = world_npc_ship_for(w, n);
+            ASSERT(s != NULL);
+            ASSERT_EQ_FLOAT(s->hull, npc->hull, 0.001f);
+            ASSERT(s->hull_class == npc->hull_class);
+            ASSERT_EQ_FLOAT(s->pos.x, npc->pos.x, 0.001f);
+            ASSERT_EQ_FLOAT(s->pos.y, npc->pos.y, 0.001f);
+            ASSERT_EQ_FLOAT(s->vel.x, npc->vel.x, 0.001f);
+            ASSERT_EQ_FLOAT(s->vel.y, npc->vel.y, 0.001f);
+            ASSERT_EQ_FLOAT(s->angle, npc->angle, 0.001f);
+        }
+    }
+}
+
 TEST(test_world_load_rebuilds_character_pool) {
     /* world_load only restores npc_ships[]; the paired character_t /
      * ships[] pools are server-side transient and have to be rebuilt
@@ -642,6 +671,7 @@ void register_save_persistence_tests(void) {
     RUN(test_player_save_load_roundtrip);
     RUN(test_world_save_load_preserves_stations);
     RUN(test_world_save_load_preserves_npcs);
+    RUN(test_npc_ship_physics_in_sync_each_tick);
     RUN(test_world_load_rebuilds_character_pool);
     RUN(test_world_save_load_preserves_fracture_children);
     RUN(test_world_load_preserves_fracture_claim_dedupe_identity);


### PR DESCRIPTION
Pre-Slice-13 tripwire. Adds the tooling to prove the physics flip lands cleanly when it happens.

## Summary
- `src/tests/test_save.c` — new `test_npc_ship_physics_in_sync_each_tick`: at the end of every sim step, every active NPC's `ship_t` and `npc_ship_t` must agree on hull, hull_class, pos, vel, angle. A missed write site lasts at most one tick before the reverse mirror washes it out, so behavioral tests miss it; this one fails immediately. 1200 ticks (10s) covers spawn / mine / dock / hauler-in-transit.
- `server/sim_ai.h` — public `world_npc_ship_for(world, npc_slot)` resolves an NPC slot to its paired `ship_t*` with bounds + active validation.
- `server/sim_ai.c` — `mirror_ship_to_npc` grew the complementary `npc -> ship` physics push so end-of-tick state is consistent. Each field flows in its current authority direction (hull: ship → npc; pos/vel/angle: npc → ship). When Slice 13 flips physics writes onto `ship_t`, this collapses to ship → npc only. Comment block records the transition plan.

## Test plan
- [x] `make test` — 330 / 330 (one new)
- [x] Pre-commit hook (native + WASM) green
- [ ] CI green