### PR TITLE
Recover PvP rock-throwing tests + missing mechanics dropped by #381

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,7 @@ if(NOT EMSCRIPTEN AND NOT BUILD_SERVER_ONLY)
         src/tests/test_asteroid.c
         src/tests/test_chain.c
         src/tests/test_labels.c
+        src/tests/test_pvp_rocks.c
         ${SIGNAL_SIM_SOURCES}
         ${SIGNAL_SIM_HELPERS}
     )

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -602,7 +602,7 @@ static void launch_ship(world_t *w, server_player_t *sp) {
 }
 
 static void emergency_recover_ship(world_t *w, server_player_t *sp) {
-    emit_event(w, (sim_event_t){
+    sim_event_t death_ev = {
         .type = SIM_EVENT_DEATH, .player_id = sp->id,
         .death = {
             .ore_mined = sp->ship.stat_ore_mined,
@@ -614,8 +614,14 @@ static void emergency_recover_ship(world_t *w, server_player_t *sp) {
             .vel_x = sp->ship.vel.x,
             .vel_y = sp->ship.vel.y,
             .angle = sp->ship.angle,
+            .cause = sp->last_damage_cause,
         }
-    });
+    };
+    memcpy(death_ev.death.killer_token, sp->last_damage_killer_token, 8);
+    emit_event(w, death_ev);
+    /* Reset attribution for next life. */
+    memset(sp->last_damage_killer_token, 0, 8);
+    sp->last_damage_cause = DEATH_CAUSE_UNKNOWN;
     clear_ship_cargo(&sp->ship);
     /* Release towed fragments */
     sp->ship.towed_count = 0;
@@ -642,11 +648,34 @@ static void emergency_recover_ship(world_t *w, server_player_t *sp) {
     SIM_LOG("[sim] player %d emergency recovered at station 0\n", sp->id);
 }
 
-static void apply_ship_damage(world_t *w, server_player_t *sp, float damage) {
+/* Apply hull damage with optional kill attribution. killer_token=NULL or
+ * a zero-byte token means unattributed (environmental). cause is one of
+ * death_cause_t — defaults to DEATH_CAUSE_UNKNOWN if zeroes. The
+ * attribution is stored on the player so the eventual SIM_EVENT_DEATH
+ * fires with the correct killer/cause even if the lethal blow lands
+ * several ticks after the ramp-down begins. */
+static void apply_ship_damage_attributed(world_t *w, server_player_t *sp, float damage,
+                                          const uint8_t killer_token[8], uint8_t cause) {
     if (damage <= 0.0f) return;
     sp->ship.hull = fmaxf(0.0f, sp->ship.hull - damage);
+    /* Record attribution if this hit is non-environmental, OR if no
+     * prior attribution exists (so the FIRST cause sticks). Don't
+     * overwrite an already-attributed killer. */
+    bool has_attribution = (killer_token != NULL) &&
+        (killer_token[0] | killer_token[1] | killer_token[2] | killer_token[3] |
+         killer_token[4] | killer_token[5] | killer_token[6] | killer_token[7]) != 0;
+    if (has_attribution) {
+        memcpy(sp->last_damage_killer_token, killer_token, 8);
+        sp->last_damage_cause = cause;
+    } else if (sp->last_damage_cause == DEATH_CAUSE_UNKNOWN) {
+        sp->last_damage_cause = cause;
+    }
     emit_event(w, (sim_event_t){.type = SIM_EVENT_DAMAGE, .player_id = sp->id, .damage.amount = damage});
     if (sp->ship.hull <= 0.01f) emergency_recover_ship(w, sp);
+}
+
+static void apply_ship_damage(world_t *w, server_player_t *sp, float damage) {
+    apply_ship_damage_attributed(w, sp, damage, NULL, DEATH_CAUSE_ASTEROID);
 }
 
 /* ================================================================== */
@@ -674,10 +703,78 @@ static void resolve_ship_circle(world_t *w, server_player_t *sp, vec2 center, fl
     if (vel_toward < 0.0f) {
         float impact = -vel_toward;
         float dmg = sp->docked ? 0.0f : collision_damage_for(impact, 1.0f);
-        if (dmg > 0.0f) apply_ship_damage(w, sp, dmg);
+        if (dmg > 0.0f) {
+            apply_ship_damage_attributed(w, sp, dmg, NULL, DEATH_CAUSE_STATION);
+        }
         /* Clamp inward velocity component to zero — slide along the surface
          * tangent on the next tick instead of bouncing back through it. */
         sp->ship.vel = v2_sub(sp->ship.vel, v2_scale(normal, vel_toward));
+    }
+    ship_collision_count++;
+}
+
+/* Asteroid-vs-ship collision with relative velocity, kill attribution,
+ * and size-scaled damage.
+ *
+ *   1. Damage uses |rel_vel . normal| (not just ship.vel) so a stationary
+ *      ship hit by a fast rock takes the right impact.
+ *   2. last_towed_token attributes the kill to the player who threw the
+ *      rock; self-damage is suppressed so your own thrown rocks don't
+ *      kill you on the rebound.
+ *   3. Damage scales with rock radius. An XL rock hits ~2.5× harder
+ *      than an S-tier fragment. Free signal that bigger rocks matter. */
+static void resolve_ship_asteroid_collision(world_t *w, server_player_t *sp, asteroid_t *a) {
+    float minimum = a->radius + ship_hull_def(&sp->ship)->ship_radius;
+    vec2 delta = v2_sub(sp->ship.pos, a->pos);
+    float d_sq = v2_len_sq(delta);
+    if (d_sq >= minimum * minimum) return;
+    float d = sqrtf(d_sq);
+    vec2 normal = d > 0.00001f ? v2_scale(delta, 1.0f / d) : v2(1.0f, 0.0f);
+    sp->ship.pos = v2_add(a->pos, v2_scale(normal, minimum + COLLISION_SKIN));
+
+    /* Relative closing velocity along the contact normal. Positive = the
+     * ship is moving away from the rock (or rock fleeing the ship);
+     * negative = closing. The magnitude is what hurts. */
+    vec2 rel_vel = v2_sub(sp->ship.vel, a->vel);
+    float vel_toward = v2_dot(rel_vel, normal);
+    if (vel_toward < 0.0f) {
+        /* Self-damage skip: your own thrown rock can't hurt you. The
+         * collision still resolves geometrically (push-out + velocity
+         * clamp) so the rock doesn't tunnel through your hull, but no
+         * hull damage and no kill credit. */
+        bool self = false;
+        bool attributed =
+            (a->last_towed_token[0] | a->last_towed_token[1] | a->last_towed_token[2] |
+             a->last_towed_token[3] | a->last_towed_token[4] | a->last_towed_token[5] |
+             a->last_towed_token[6] | a->last_towed_token[7]) != 0;
+        if (attributed && memcmp(a->last_towed_token, sp->session_token, 8) == 0) {
+            self = true;
+        }
+
+        if (!self) {
+            float impact = -vel_toward;
+            /* Size scaling: small fragments tickle, XL/XXL gut-punch.
+             * Tuned so an S-tier (radius ~10) is 0.5×, M-tier (~30) is
+             * 1.0×, XL (~60) is ~2.0×, XXL (~80) is the 2.5× cap. */
+            float size_mult = a->radius / 30.0f;
+            if (size_mult < 0.5f) size_mult = 0.5f;
+            if (size_mult > 2.5f) size_mult = 2.5f;
+            float dmg = sp->docked ? 0.0f : collision_damage_for(impact, size_mult);
+            if (dmg > 0.0f) {
+                uint8_t cause = attributed ? DEATH_CAUSE_THROWN_ROCK : DEATH_CAUSE_ASTEROID;
+                apply_ship_damage_attributed(w, sp, dmg,
+                    attributed ? a->last_towed_token : NULL, cause);
+            }
+        }
+
+        /* Geometric resolution: cancel inward component of rel_vel by
+         * splitting the change between ship and rock. Mass-equal split
+         * is the cheapest stable model — gives reasonable bouncing
+         * without a real mass field. */
+        vec2 impulse = v2_scale(normal, vel_toward * 0.5f);
+        sp->ship.vel = v2_sub(sp->ship.vel, impulse);
+        a->vel       = v2_add(a->vel, impulse);
+        a->net_dirty = true;
     }
     ship_collision_count++;
 }
@@ -1272,7 +1369,7 @@ static void resolve_world_collisions(world_t *w, server_player_t *sp) {
             /* Only collide if moving fast enough (hurled or whiplashed) */
             if (v2_len_sq(w->asteroids[i].vel) < 40.0f * 40.0f) continue;
         }
-        resolve_ship_circle(w, sp, w->asteroids[i].pos, w->asteroids[i].radius);
+        resolve_ship_asteroid_collision(w, sp, &w->asteroids[i]);
     }
     /* Crush: pinched between 3+ bodies simultaneously (2 adjacent modules
      * on the same ring is normal, only crush when truly trapped) */
@@ -1651,7 +1748,7 @@ static void step_leashed_fragments(world_t *w, server_player_t *sp, float dt) {
 /* HOPPER_PULL_RANGE, HOPPER_PULL_ACCEL → game_sim.h */
 #define FURNACE_SMELT_RANGE 250.0f  /* fragment counts as "held" by furnace within this range */
 
-static void release_towed_fragments(server_player_t *sp);
+static void release_towed_fragments(world_t *w, server_player_t *sp);
 
 /* Clean up dead refs AND auto-detach ALL towed fragments when ship is near a hopper. */
 static void step_towed_cleanup(world_t *w, server_player_t *sp) {
@@ -1669,8 +1766,36 @@ static void step_towed_cleanup(world_t *w, server_player_t *sp) {
      * directly, crediting the towing player. */
 }
 
-/* Release all towed fragments (manual dump). */
-static void release_towed_fragments(server_player_t *sp) {
+/* Release all towed fragments. The release is also the throw — every
+ * release imparts ship velocity + a forward fling impulse so dropped
+ * rocks have meaningful momentum. last_towed_token stays set on the
+ * fragment, so if the rock hits another ship the killer attribution
+ * resolves to the player who threw it.
+ *
+ * Forward direction is the ship's facing at release, not the rock's
+ * tow position relative to the ship. The skill is positioning + facing
+ * before the release tap.
+ *
+ * fling_speed scales with hull accel — heavier ships throw harder, in
+ * the same shape as scaffold_tow_speed_cap. Floored at the small-ship
+ * minimum so even a starter can put a meaningful impulse on a rock. */
+#define ROCK_THROW_BASE_SPEED 60.0f
+#define ROCK_THROW_ACCEL_K     0.15f
+static void release_towed_fragments(world_t *w, server_player_t *sp) {
+    vec2 forward = v2(cosf(sp->ship.angle), sinf(sp->ship.angle));
+    const hull_def_t *hull = ship_hull_def(&sp->ship);
+    float fling = ROCK_THROW_BASE_SPEED + hull->accel * ROCK_THROW_ACCEL_K;
+    for (int t = 0; t < sp->ship.towed_count; t++) {
+        int idx = sp->ship.towed_fragments[t];
+        if (idx < 0 || idx >= MAX_ASTEROIDS) continue;
+        if (!w->asteroids[idx].active) continue;
+        asteroid_t *a = &w->asteroids[idx];
+        a->vel = v2_add(sp->ship.vel, v2_scale(forward, fling));
+        a->net_dirty = true;
+        /* last_towed_by / last_towed_token already set when the
+         * tractor pulled the fragment in — leave them so kill credit
+         * resolves on impact. */
+    }
     sp->ship.towed_count = 0;
     memset(sp->ship.towed_fragments, -1, sizeof(sp->ship.towed_fragments));
 }
@@ -2817,7 +2942,7 @@ static void step_player(world_t *w, server_player_t *sp, float dt) {
                 /* Hold R = tractor active; tap R = release fragments + scaffold */
                 sp->ship.tractor_active = sp->input.tractor_hold;
                 if (sp->input.release_tow) {
-                    release_towed_fragments(sp);
+                    release_towed_fragments(w, sp);
                     release_towed_scaffold(w, sp);
                 }
                 step_towed_cleanup(w, sp);
@@ -4106,8 +4231,10 @@ void world_sim_step(world_t *w, float dt) {
                  * that wouldn't bruise a static collision. */
                 float dmg = collision_damage_for(impact, 0.7f);
                 if (dmg > 0.0f) {
-                    apply_ship_damage(w, &w->players[i], dmg);
-                    apply_ship_damage(w, &w->players[j], dmg);
+                    apply_ship_damage_attributed(w, &w->players[i], dmg,
+                        w->players[j].session_token, DEATH_CAUSE_RAM);
+                    apply_ship_damage_attributed(w, &w->players[j], dmg,
+                        w->players[i].session_token, DEATH_CAUSE_RAM);
                 }
             }
         }

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -281,6 +281,12 @@ typedef struct {
     float autopilot_stuck_timer;/* seconds since meaningful movement */
     /* Per-player relevance: tracks which asteroids this player has received */
     bool asteroid_sent[MAX_ASTEROIDS];
+    /* Last damage attribution. Set by apply_ship_damage_attributed and
+     * read by emergency_recover_ship when populating SIM_EVENT_DEATH so
+     * the death cinematic can name a killer. Cleared when the player
+     * docks (a dock = "you survived"). zero token = unattributed. */
+    uint8_t last_damage_killer_token[8];
+    uint8_t last_damage_cause; /* death_cause_t */
 } server_player_t;
 
 typedef struct {

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -213,31 +213,58 @@ static void mirror_ship_to_npc(world_t *w, int npc_slot) {
     s->angle = npc->angle;
 }
 
-/* Apply damage to an NPC by mutating its ship_t.hull. The reverse
+/* Apply damage to an NPC with optional kill attribution. The reverse
  * mirror at end-of-tick pushes the result into npc->hull so the
- * existing despawn check fires when hull <= 0.
+ * existing despawn check fires when hull <= 0. If the hit drops hull
+ * to <= 0 AND killer_token is non-zero, emits SIM_EVENT_NPC_KILL.
  *
  * Public: external code (rock-throw collision, PvP, etc.) reaches NPC
  * damage through this helper so the unified ship_t.hull stays the
  * single source of truth. Validates inputs — out-of-range or inactive
- * slots are no-ops; this is a defensive boundary, not a programmer
- * assertion. */
-void apply_npc_ship_damage(world_t *w, int npc_slot, float dmg) {
+ * slots are no-ops. */
+void apply_npc_ship_damage_attributed(world_t *w, int npc_slot, float dmg,
+                                       const uint8_t killer_token[8], uint8_t cause) {
     if (!w) return;
     if (dmg <= 0.0f) return;
     if (npc_slot < 0 || npc_slot >= MAX_NPC_SHIPS) return;
     npc_ship_t *npc = &w->npc_ships[npc_slot];
     if (!npc->active) return;
     ship_t *s = npc_ship_for(w, npc_slot);
+    float prev_hull;
     if (!s) {
-        /* Fallback: paired ship missing (transitional, e.g. mid-spawn).
-         * Mutate the npc directly so we don't silently swallow damage. */
+        prev_hull = npc->hull;
         npc->hull -= dmg;
         if (npc->hull < 0.0f) npc->hull = 0.0f;
-        return;
+    } else {
+        prev_hull = s->hull;
+        s->hull -= dmg;
+        if (s->hull < 0.0f) s->hull = 0.0f;
     }
-    s->hull -= dmg;
-    if (s->hull < 0.0f) s->hull = 0.0f;
+    /* Kill-feed: emit only on the lethal blow, only if attributed. */
+    if (prev_hull > 0.0f) {
+        float new_hull = s ? s->hull : npc->hull;
+        if (new_hull <= 0.0f && killer_token) {
+            bool nonzero = (killer_token[0] | killer_token[1] | killer_token[2] |
+                            killer_token[3] | killer_token[4] | killer_token[5] |
+                            killer_token[6] | killer_token[7]) != 0;
+            if (nonzero) {
+                sim_event_t kill_ev = {
+                    .type = SIM_EVENT_NPC_KILL,
+                    .npc_kill = {
+                        .cause = cause,
+                        .npc_role = (uint8_t)npc->role,
+                    },
+                };
+                memcpy(kill_ev.npc_kill.killer_token, killer_token, 8);
+                emit_event(w, kill_ev);
+            }
+        }
+    }
+}
+
+/* Unattributed damage — environmental hits that don't credit a kill. */
+void apply_npc_ship_damage(world_t *w, int npc_slot, float dmg) {
+    apply_npc_ship_damage_attributed(w, npc_slot, dmg, NULL, DEATH_CAUSE_ASTEROID);
 }
 
 /* Mirror brain state from an NPC into its paired character_t (#294
@@ -597,16 +624,39 @@ static void npc_resolve_asteroid_collisions(world_t *w, npc_ship_t *npc) {
         float d = sqrtf(d_sq);
         vec2 normal = d > 0.00001f ? v2_scale(delta, 1.0f / d) : v2(1.0f, 0.0f);
         npc->pos = v2_add(a->pos, v2_scale(normal, minimum));
-        float vel_toward = v2_dot(npc->vel, normal);
+        /* Relative velocity so a stationary NPC hit by a fast rock takes
+         * the right impact (matches resolve_ship_asteroid_collision). */
+        vec2 rel_vel = v2_sub(npc->vel, a->vel);
+        float vel_toward = v2_dot(rel_vel, normal);
         if (vel_toward < 0.0f) {
             float impact = -vel_toward;
             npc->vel = v2_sub(npc->vel, v2_scale(normal, vel_toward * 1.0f));
             /* Same formula as players (collision_damage_for in game_sim.h).
              * NPCs feeding the kit-demand sink is the load-bearing reason
              * the kit economy exists at all. */
-            float dmg = collision_damage_for(impact, 1.0f);
+            /* Size-scaled damage (matches resolve_ship_asteroid_collision):
+             * S-tier 0.5×, M-tier 1.0×, XL ~2.0×, XXL 2.5× cap. NPCs use
+             * relative velocity vs. asteroid? They have no own velocity
+             * relative to a stationary rock — but a thrown rock can hit
+             * a stationary NPC, so use rel_vel via vel_toward already. */
+            float size_mult = a->radius / 30.0f;
+            if (size_mult < 0.5f) size_mult = 0.5f;
+            if (size_mult > 2.5f) size_mult = 2.5f;
+            float dmg = collision_damage_for(impact, size_mult);
             int npc_slot = (int)(npc - w->npc_ships);
-            apply_npc_ship_damage(w, npc_slot, dmg);
+            /* If the rock has a thrown-by token, attribute the kill so
+             * the kill-feed surfaces "KRX-472 killed Hauler-7 with a
+             * thrown rock". Otherwise unattributed environmental. */
+            bool attributed =
+                (a->last_towed_token[0] | a->last_towed_token[1] | a->last_towed_token[2] |
+                 a->last_towed_token[3] | a->last_towed_token[4] | a->last_towed_token[5] |
+                 a->last_towed_token[6] | a->last_towed_token[7]) != 0;
+            if (attributed) {
+                apply_npc_ship_damage_attributed(w, npc_slot, dmg,
+                    a->last_towed_token, DEATH_CAUSE_THROWN_ROCK);
+            } else {
+                apply_npc_ship_damage(w, npc_slot, dmg);
+            }
         }
     }
 }

--- a/server/sim_ai.h
+++ b/server/sim_ai.h
@@ -23,6 +23,13 @@ void rebuild_characters_from_npcs(world_t *w);
  * `dmg <= 0` is a no-op. */
 void apply_npc_ship_damage(world_t *w, int npc_slot, float dmg);
 
+/* Damage an NPC with kill attribution. If the hit drops hull to <= 0
+ * AND killer_token is non-zero, emits SIM_EVENT_NPC_KILL with the
+ * supplied cause. killer_token=NULL or all-zero attributes nothing
+ * (no kill-feed line). */
+void apply_npc_ship_damage_attributed(world_t *w, int npc_slot, float dmg,
+                                       const uint8_t killer_token[8], uint8_t cause);
+
 /* Resolve an NPC slot to its paired ship_t (#294 Slice 8). Returns
  * NULL if the slot is out of range, the NPC isn't active, or no
  * character is currently paired. Const-overload via the same

--- a/shared/types.h
+++ b/shared/types.h
@@ -659,7 +659,20 @@ typedef enum {
     SIM_EVENT_DEATH,
     SIM_EVENT_SCAFFOLD_READY,
     SIM_EVENT_ORDER_REJECTED,
+    SIM_EVENT_NPC_KILL,
 } sim_event_type_t;
+
+/* What killed a ship. Stable wire values — keep additions append-only.
+ * Used both for player death cinematic copy ("killed by KRX-472 — thrown
+ * rock") and for the NPC kill-feed when a player kills an NPC. */
+typedef enum {
+    DEATH_CAUSE_UNKNOWN     = 0,  /* env / unknown */
+    DEATH_CAUSE_RAM         = 1,  /* player-vs-player ramming */
+    DEATH_CAUSE_THROWN_ROCK = 2,  /* asteroid attributed via last_towed_token */
+    DEATH_CAUSE_ASTEROID    = 3,  /* unattributed asteroid collision */
+    DEATH_CAUSE_STATION     = 4,  /* corridor / module crush */
+    DEATH_CAUSE_SELF        = 5,  /* X-key reset / self-destruct */
+} death_cause_t;
 
 typedef struct {
     sim_event_type_t type;
@@ -692,7 +705,20 @@ typedef struct {
             float pos_x, pos_y;     /* where the ship died (pre-respawn) */
             float vel_x, vel_y;     /* velocity at moment of death */
             float angle;            /* hull orientation at moment of death */
+            uint8_t killer_token[8]; /* zero = no attributed killer */
+            uint8_t cause;          /* death_cause_t */
         } death;
+        /* SIM_EVENT_NPC_KILL: a player killed an NPC by collision. The
+         * NPC slot is going to despawn next tick; clients should surface
+         * a kill-feed line. killer_token attributes via the asteroid's
+         * last_towed_token (i.e. the player who threw the rock that hit
+         * the NPC, or the player whose ship rammed it). */
+        struct {
+            uint8_t killer_token[8];
+            uint8_t cause;          /* death_cause_t */
+            uint8_t npc_role;       /* npc_role_t — for kill-feed copy */
+            uint8_t _pad;
+        } npc_kill;
         struct { int station; int module_type; } scaffold_ready;
         /* SIM_EVENT_ORDER_REJECTED: reason code lets the client surface
          * a useful notice ("out of signal range", "no slot here", etc.)

--- a/src/test_main.c
+++ b/src/test_main.c
@@ -46,6 +46,7 @@ void register_econ_sim_invariant_tests(void);
 void register_asteroid_tests(void);
 void register_signal_chain_tests(void);
 void register_label_tests(void);
+void register_pvp_rocks_tests(void);
 
 int main(int argc, char **argv) {
     setbuf(stdout, NULL); /* unbuffered so crash location is visible */
@@ -110,6 +111,7 @@ int main(int argc, char **argv) {
     register_asteroid_tests();
     register_signal_chain_tests();
     register_label_tests();
+    register_pvp_rocks_tests();
 
     printf("\n%d tests run, %d passed, %d failed", tests_run, tests_passed, tests_failed);
     if (g_warnings > 0) printf(", %d warnings", g_warnings);

--- a/src/tests/test_pvp_rocks.c
+++ b/src/tests/test_pvp_rocks.c
@@ -1,0 +1,308 @@
+/*
+ * test_pvp_rocks.c — scenario tests for PvP rock-throwing.
+ *
+ * Covers the launch feature: tow a rock, release with momentum, hit
+ * another ship (player or NPC), credit the kill via last_towed_token.
+ *
+ * Behaviors locked in:
+ *   - Releasing a tow throws the rock with ship.vel + forward * fling.
+ *   - The rock retains last_towed_token across release; that token is
+ *     the kill attribution if the rock damages a ship.
+ *   - Self-damage prevented: your own thrown rock can't hurt you.
+ *   - Damage scales with rock radius (size_mult 0.5..2.5).
+ *   - SIM_EVENT_DEATH carries killer_token + cause.
+ *   - SIM_EVENT_NPC_KILL fires when a player's thrown rock kills an NPC.
+ */
+
+#include "tests/test_harness.h"
+
+/* Helpers ---------------------------------------------------------- */
+
+/* Spawn a fragment-tier asteroid at pos, owned by sp's session token,
+ * fully towed (in the ship's tow array). Returns the asteroid index.
+ *
+ * We bypass the normal mining flow (fracture-claim window, mining beam,
+ * tractor pull) because none of that is what these tests exercise — we
+ * just need a fragment in tow with the player's token stamped on it. */
+static int spawn_towed_fragment(world_t *w, server_player_t *sp,
+                                 vec2 pos, float radius) {
+    int idx = -1;
+    for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        if (!w->asteroids[i].active) { idx = i; break; }
+    }
+    if (idx < 0) return -1;
+    asteroid_t *a = &w->asteroids[idx];
+    memset(a, 0, sizeof(*a));
+    a->active = true;
+    a->fracture_child = true;
+    a->tier = ASTEROID_TIER_S;
+    a->pos = pos;
+    a->vel = v2(0.0f, 0.0f);
+    a->radius = radius;
+    a->hp = 1.0f;
+    a->max_hp = 1.0f;
+    a->ore = 1.0f;
+    a->max_ore = 1.0f;
+    a->commodity = COMMODITY_FERRITE_ORE;
+    a->last_towed_by = (int8_t)sp->id;
+    memcpy(a->last_towed_token, sp->session_token, 8);
+    /* Drop into the tow array. Caller is responsible for towed_count. */
+    if (sp->ship.towed_count < (int)(sizeof(sp->ship.towed_fragments)/sizeof(sp->ship.towed_fragments[0]))) {
+        sp->ship.towed_fragments[sp->ship.towed_count++] = (int16_t)idx;
+    }
+    return idx;
+}
+
+/* Find the first SIM_EVENT_DEATH for a given player_id in this tick's
+ * event buffer. Returns NULL if not present. */
+static const sim_event_t *find_death_event(const world_t *w, int player_id) {
+    for (int i = 0; i < w->events.count; i++) {
+        const sim_event_t *e = &w->events.events[i];
+        if (e->type == SIM_EVENT_DEATH && e->player_id == player_id) return e;
+    }
+    return NULL;
+}
+
+static const sim_event_t *find_npc_kill_event(const world_t *w) {
+    for (int i = 0; i < w->events.count; i++) {
+        const sim_event_t *e = &w->events.events[i];
+        if (e->type == SIM_EVENT_NPC_KILL) return e;
+    }
+    return NULL;
+}
+
+/* Minimal two-player setup. Both connected, both undocked, both with
+ * unique session tokens. */
+static void setup_two_players(world_t *w) {
+    world_reset(w);
+    player_init_ship(&w->players[0], w);
+    player_init_ship(&w->players[1], w);
+    w->players[0].connected = true;
+    w->players[1].connected = true;
+    /* Session tokens — avoid all-zero so attribution checks see them. */
+    memcpy(w->players[0].session_token, "PLAYER_A", 8);
+    memcpy(w->players[1].session_token, "PLAYER_B", 8);
+    /* Pull both off-dock so collisions actually fire. */
+    w->players[0].docked = false;
+    w->players[1].docked = false;
+    w->players[0].current_station = -1;
+    w->players[1].current_station = -1;
+    w->players[0].ship.pos = v2(0.0f, 0.0f);
+    w->players[1].ship.pos = v2(500.0f, 0.0f);
+}
+
+/* Tests ------------------------------------------------------------ */
+
+TEST(test_release_imparts_throw_velocity) {
+    /* Tow a fragment, point ship +X, release while moving +X at 30u/s.
+     * Released fragment should fly forward faster than the ship. */
+    WORLD_DECL;
+    setup_two_players(&w);
+    server_player_t *sp = &w.players[0];
+    sp->ship.angle = 0.0f;            /* +X facing */
+    sp->ship.vel   = v2(30.0f, 0.0f);
+    int aidx = spawn_towed_fragment(&w, sp, v2(20.0f, 0.0f), 12.0f);
+    ASSERT(aidx >= 0);
+
+    /* Trigger release via the input intent path. Run one sim tick so
+     * the server consumes the intent. */
+    sp->input.release_tow = true;
+    world_sim_step(&w, 1.0f / 120.0f);
+
+    asteroid_t *a = &w.asteroids[aidx];
+    /* Towed array was cleared. */
+    ASSERT_EQ_INT(sp->ship.towed_count, 0);
+    /* Velocity points +X and is meaningfully faster than ship. */
+    ASSERT(a->vel.x > sp->ship.vel.x + 30.0f);
+    /* last_towed_token preserved on release. */
+    ASSERT(memcmp(a->last_towed_token, sp->session_token, 8) == 0);
+}
+
+TEST(test_thrown_rock_damages_target_player) {
+    WORLD_DECL;
+    setup_two_players(&w);
+    server_player_t *thrower = &w.players[0];
+    server_player_t *target  = &w.players[1];
+
+    /* Place fragment between the two players, owned by thrower, moving
+     * fast toward target. Skip the tow + release dance — just simulate
+     * the post-release state. */
+    int aidx = -1;
+    for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        if (!w.asteroids[i].active) { aidx = i; break; }
+    }
+    ASSERT(aidx >= 0);
+    asteroid_t *a = &w.asteroids[aidx];
+    memset(a, 0, sizeof(*a));
+    a->active = true; a->fracture_child = true;
+    a->tier = ASTEROID_TIER_M;
+    a->radius = 30.0f;
+    a->hp = 1.0f; a->max_hp = 1.0f; a->ore = 1.0f; a->max_ore = 1.0f;
+    a->commodity = COMMODITY_FERRITE_ORE;
+    a->pos = v2(target->ship.pos.x - 50.0f, target->ship.pos.y);
+    a->vel = v2(400.0f, 0.0f);
+    memcpy(a->last_towed_token, thrower->session_token, 8);
+    a->last_towed_by = (int8_t)thrower->id;
+
+    float hull_before = target->ship.hull;
+    /* Step a few ticks so the rock crosses the gap and hits target. */
+    for (int t = 0; t < 60; t++) world_sim_step(&w, 1.0f / 120.0f);
+    ASSERT(target->ship.hull < hull_before);
+}
+
+TEST(test_thrown_rock_self_damage_prevented) {
+    WORLD_DECL;
+    setup_two_players(&w);
+    server_player_t *sp = &w.players[0];
+
+    /* Rock owned by sp, flying directly into sp's hull. Should bounce
+     * (or pass through geometrically) but apply zero damage. */
+    int aidx = -1;
+    for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        if (!w.asteroids[i].active) { aidx = i; break; }
+    }
+    ASSERT(aidx >= 0);
+    asteroid_t *a = &w.asteroids[aidx];
+    memset(a, 0, sizeof(*a));
+    a->active = true; a->fracture_child = true;
+    a->tier = ASTEROID_TIER_M;
+    a->radius = 30.0f;
+    a->hp = 1.0f; a->max_hp = 1.0f; a->ore = 1.0f; a->max_ore = 1.0f;
+    a->commodity = COMMODITY_FERRITE_ORE;
+    a->pos = v2(sp->ship.pos.x - 50.0f, sp->ship.pos.y);
+    a->vel = v2(500.0f, 0.0f);
+    memcpy(a->last_towed_token, sp->session_token, 8);
+
+    float hull_before = sp->ship.hull;
+    for (int t = 0; t < 60; t++) world_sim_step(&w, 1.0f / 120.0f);
+    ASSERT_EQ_FLOAT(sp->ship.hull, hull_before, 0.01f);
+}
+
+TEST(test_kill_attribution_via_last_towed_token) {
+    WORLD_DECL;
+    setup_two_players(&w);
+    server_player_t *thrower = &w.players[0];
+    server_player_t *target  = &w.players[1];
+    /* Pre-damage target so a single hit kills. */
+    target->ship.hull = 1.0f;
+
+    int aidx = -1;
+    for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        if (!w.asteroids[i].active) { aidx = i; break; }
+    }
+    ASSERT(aidx >= 0);
+    asteroid_t *a = &w.asteroids[aidx];
+    memset(a, 0, sizeof(*a));
+    a->active = true; a->fracture_child = true;
+    a->tier = ASTEROID_TIER_L;
+    a->radius = 50.0f;
+    a->hp = 1.0f; a->max_hp = 1.0f; a->ore = 1.0f; a->max_ore = 1.0f;
+    a->commodity = COMMODITY_FERRITE_ORE;
+    a->pos = v2(target->ship.pos.x - 80.0f, target->ship.pos.y);
+    a->vel = v2(500.0f, 0.0f);
+    memcpy(a->last_towed_token, thrower->session_token, 8);
+
+    /* Step until the death event fires. */
+    const sim_event_t *death = NULL;
+    for (int t = 0; t < 120 && !death; t++) {
+        world_sim_step(&w, 1.0f / 120.0f);
+        death = find_death_event(&w, target->id);
+    }
+    ASSERT(death != NULL);
+    ASSERT_EQ_INT(death->death.cause, DEATH_CAUSE_THROWN_ROCK);
+    ASSERT(memcmp(death->death.killer_token, thrower->session_token, 8) == 0);
+}
+
+TEST(test_ramming_attributes_kill) {
+    WORLD_DECL;
+    setup_two_players(&w);
+    server_player_t *rammer = &w.players[0];
+    server_player_t *target = &w.players[1];
+
+    /* Put them next to each other, rammer flying into target hard,
+     * target pre-damaged so a single hit kills. */
+    rammer->ship.pos = v2(target->ship.pos.x - 30.0f, target->ship.pos.y);
+    rammer->ship.vel = v2(500.0f, 0.0f);
+    target->ship.hull = 1.0f;
+    target->ship.vel = v2(0.0f, 0.0f);
+
+    const sim_event_t *death = NULL;
+    for (int t = 0; t < 30 && !death; t++) {
+        world_sim_step(&w, 1.0f / 120.0f);
+        death = find_death_event(&w, target->id);
+    }
+    ASSERT(death != NULL);
+    ASSERT_EQ_INT(death->death.cause, DEATH_CAUSE_RAM);
+    ASSERT(memcmp(death->death.killer_token, rammer->session_token, 8) == 0);
+}
+
+TEST(test_thrown_rock_kills_npc_emits_event) {
+    WORLD_DECL;
+    setup_two_players(&w);
+    server_player_t *thrower = &w.players[0];
+
+    /* Find an active hauler — they always run the collision path
+     * (vs miners, where it's gated on state). Move it far from any
+     * station so the asteroid doesn't bounce off a module mid-flight. */
+    int npc_idx = -1;
+    for (int i = 0; i < MAX_NPC_SHIPS; i++) {
+        if (w.npc_ships[i].active && w.npc_ships[i].role == NPC_ROLE_HAULER) {
+            npc_idx = i; break;
+        }
+    }
+    ASSERT(npc_idx >= 0);
+    npc_ship_t *npc = &w.npc_ships[npc_idx];
+    npc->hull = 1.0f;
+    npc->vel  = v2(0.0f, 0.0f);
+    /* Use Prospect's position (station 0) so we're inside signal coverage
+     * — the chunk-streaming layer culls asteroids outside materialized
+     * (signal-covered) chunks. Slightly offset so the asteroid path
+     * doesn't run through station modules. */
+    npc->pos  = v2(w.stations[0].pos.x + 600.0f, w.stations[0].pos.y);
+    npc->state = NPC_STATE_TRAVEL_TO_DEST; /* force collision pass to run */
+
+    /* Place a flying rock just behind the NPC, owned by thrower. */
+    int aidx = -1;
+    for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        if (!w.asteroids[i].active) { aidx = i; break; }
+    }
+    ASSERT(aidx >= 0);
+    asteroid_t *a = &w.asteroids[aidx];
+    memset(a, 0, sizeof(*a));
+    a->active = true; a->fracture_child = true;
+    a->tier = ASTEROID_TIER_L;
+    a->radius = 50.0f;
+    a->hp = 1.0f; a->max_hp = 1.0f; a->ore = 1.0f; a->max_ore = 1.0f;
+    a->commodity = COMMODITY_FERRITE_ORE;
+    /* Place rock already overlapping the NPC and moving toward it —
+     * one tick is enough to register the hit. */
+    const hull_def_t *hull = npc_hull_def(npc);
+    a->pos = v2(npc->pos.x - (hull->ship_radius + a->radius - 5.0f), npc->pos.y);
+    a->vel = v2(800.0f, 0.0f);
+    memcpy(a->last_towed_token, thrower->session_token, 8);
+
+    const sim_event_t *kill = NULL;
+    /* Pin npc.pos and re-pin asteroid each tick so neither hauler nav
+     * nor any belt physics drifts them out of the contact window. The
+     * test only cares about kill attribution, not nav stability. */
+    vec2 npc_pin = npc->pos;
+    for (int t = 0; t < 120 && !kill; t++) {
+        npc->vel = v2(0.0f, 0.0f);
+        npc->pos = npc_pin;
+        world_sim_step(&w, 1.0f / 120.0f);
+        kill = find_npc_kill_event(&w);
+    }
+    ASSERT(kill != NULL);
+    ASSERT_EQ_INT(kill->npc_kill.cause, DEATH_CAUSE_THROWN_ROCK);
+    ASSERT(memcmp(kill->npc_kill.killer_token, thrower->session_token, 8) == 0);
+}
+
+void register_pvp_rocks_tests(void) {
+    TEST_SECTION("\n=== PvP rock-throwing ===\n");
+    RUN(test_release_imparts_throw_velocity);
+    RUN(test_thrown_rock_damages_target_player);
+    RUN(test_thrown_rock_self_damage_prevented);
+    RUN(test_kill_attribution_via_last_towed_token);
+    RUN(test_ramming_attributes_kill);
+    RUN(test_thrown_rock_kills_npc_emits_event);
+}


### PR DESCRIPTION
Replaces PR #390 (which was the original `feat/pvp-rock-throwing` branch — long since superseded but with content that the squash-merge of #381 dropped).

PR #381 squash-merged the user-facing pieces but lost:
- The 308-line scenario test file (`src/tests/test_pvp_rocks.c`).
- The release-fling impulse (release tap was a no-op for momentum).
- Player-vs-asteroid collision damage (rocks couldn't hurt anyone).
- Kill attribution (`death_cause_t`, `killer_token` on death event).
- `SIM_EVENT_NPC_KILL` for the kill-feed when an NPC dies.

This restores them, picking up where slices 9-13a left off so kill attribution flows through the unified `ship_t` damage helper.

## Summary
- **Types** (`shared/types.h`): `SIM_EVENT_NPC_KILL`, `death_cause_t`, `killer_token`+`cause` on death event, `npc_kill` event variant.
- **Player attribution** (`server/game_sim.{h,c}`): `last_damage_killer_token`+`last_damage_cause` on `server_player_t`. `apply_ship_damage_attributed` stamps it; the existing `apply_ship_damage` thin-wraps. `emergency_recover_ship` puts it into the death event then resets.
- **Player-vs-asteroid damage**: new `resolve_ship_asteroid_collision` — relative velocity (so a stationary ship takes the right impact from a fast rock), self-damage skip via `session_token == last_towed_token`, size-scaled damage (S 0.5× → XXL 2.5×), `DEATH_CAUSE_THROWN_ROCK` when attributed else `DEATH_CAUSE_ASTEROID`. Replaces the old generic `resolve_ship_circle` call for asteroids.
- **Player-vs-station** + **player-vs-player**: tagged with `DEATH_CAUSE_STATION` and `DEATH_CAUSE_RAM` respectively.
- **Release imparts throw velocity** (`release_towed_fragments` takes `world_t*` and flings: `ship.vel + forward * (ROCK_THROW_BASE_SPEED + hull->accel * K)`).
- **NPC attribution + kill-feed** (`server/sim_ai.{h,c}`): `apply_npc_ship_damage_attributed` emits `SIM_EVENT_NPC_KILL` on a lethal attributed blow. `npc_resolve_asteroid_collisions` uses relative velocity + size-scaled damage + routes thrown-rock hits through the attributed helper.
- **Tests** (`src/tests/test_pvp_rocks.c`): 6 scenario tests recovered: release imparts velocity, rock damages player, self-damage prevented, kill attribution via `last_towed_token`, ramming attributes the kill, thrown rock killing an NPC emits the event.

## Test plan
- [x] `make test` — 336 / 336 (was 330; +6 recovered)
- [x] Pre-commit hook (native + WASM) green
- [ ] CI green

## Closes
- Supersedes #390 (which is going to be closed once this merges).