### PR TITLE
CCN reduction: process_sim_events, sample_input_intent, server main, draw_hud (partial)

### DIFF
--- a/server/main.c
+++ b/server/main.c
@@ -1143,30 +1143,170 @@ static void broadcast_ship_states(void) {
     }
 }
 
-/* ------------------------------------------------------------------ */
-/* Main                                                               */
-/* ------------------------------------------------------------------ */
+/* ================================================================== */
+/* sim_event handlers — per-event broadcast logic invoked inside the   */
+/* main sim loop. Each takes the live event by const pointer.          */
+/* ================================================================== */
 
-int main(void) {
-    /* Line-buffer stdout and unbuffer stderr so `docker compose logs`
-     * sees server output in real time. Without this, fully-buffered
-     * stdout holds [server] printf lines until a 4KB page fills,
-     * which in practice means we never see startup/death logs. */
-    setvbuf(stdout, NULL, _IOLBF, 0);
-    setvbuf(stderr, NULL, _IONBF, 0);
-    signal(SIGINT, signal_handler);
-    signal(SIGTERM, signal_handler);
+static void srv_on_outpost_placed(const sim_event_t *ev) {
+    int slot = ev->outpost_placed.slot;
+    uint8_t id_buf[STATION_IDENTITY_SIZE + 4];
+    int id_len = serialize_station_identity(id_buf, slot, &world.stations[slot]);
+    broadcast(id_buf, (size_t)id_len);
+    station_identity_dirty[slot] = true;
+    station_econ_dirty = true;
+    contracts_dirty = true;
+}
 
+/* SELL / REPAIR / UPGRADE / DOCK / LAUNCH all need the player's ship +
+ * current-station record pushed immediately so cargo / credits / hull /
+ * dock status don't sit stale for the SHIP_TICK_MS window. */
+static void srv_on_player_state_change(const sim_event_t *ev) {
+    int pid = ev->player_id;
+    if (pid < 0 || pid >= MAX_PLAYERS) return;
+    server_player_t *sp = &world.players[pid];
+    if (!sp->connected || !sp->conn) {
+        station_econ_dirty = true;
+        contracts_dirty = true;
+        return;
+    }
+    uint8_t buf[PLAYER_SHIP_SIZE + 4];
+    int len = send_player_ship(buf, (uint8_t)pid, sp);
+    ws_send(sp->conn, buf, (size_t)len);
+
+    int st_idx = sp->current_station;
+    if (st_idx >= 0 && st_idx < MAX_STATIONS) {
+        uint8_t sbuf[2 + STATION_RECORD_SIZE];
+        sbuf[0] = NET_MSG_WORLD_STATIONS;
+        sbuf[1] = 1;
+        uint8_t *p = &sbuf[2];
+        p[0] = (uint8_t)st_idx;
+        for (int c = 0; c < COMMODITY_COUNT; c++)
+            write_f32_le(&p[1 + c * 4], world.stations[st_idx].inventory[c]);
+        ws_send(sp->conn, sbuf, (size_t)(2 + STATION_RECORD_SIZE));
+    }
+    station_econ_dirty = true;
+    contracts_dirty = true;
+}
+
+/* SIM_EVENT_DEATH: highscore submission + per-player death packet
+ * (carries pos/vel/stats so the client cinematic anchors at the
+ * wreckage before the server respawn moves the ship) + fresh ship
+ * state so the post-respawn hull/dock is visible immediately. */
+static void srv_on_death(const sim_event_t *ev) {
+    int pid = ev->player_id;
+    if (pid < 0 || pid >= MAX_PLAYERS) return;
+    server_player_t *sp = &world.players[pid];
+    if (!sp->connected) return;
+
+    const char *cs = sp->callsign;
+    bool qualified = highscore_submit(&highscores, cs, ev->death.credits_earned);
+    printf("[server] death pid=%d cs=%s earned=%.0f cr -> %s (top=%d)\n",
+           pid, cs[0] ? cs : "?", ev->death.credits_earned,
+           qualified ? "qualified" : "skipped", highscores.count);
+    if (qualified) highscores_dirty = true;
+
+    if (!sp->conn) return;
+
+    /* Death packet: [type:1][pid:1][px:f32][py:f32][vx:f32][vy:f32]
+     * [ang:f32][ore:f32][earned:f32][spent:f32][asteroids:f32] = 38 bytes */
+    uint8_t msg[38];
+    msg[0] = NET_MSG_DEATH;
+    msg[1] = (uint8_t)pid;
+    write_f32_le(&msg[2],  ev->death.pos_x);
+    write_f32_le(&msg[6],  ev->death.pos_y);
+    write_f32_le(&msg[10], ev->death.vel_x);
+    write_f32_le(&msg[14], ev->death.vel_y);
+    write_f32_le(&msg[18], ev->death.angle);
+    write_f32_le(&msg[22], ev->death.ore_mined);
+    write_f32_le(&msg[26], ev->death.credits_earned);
+    write_f32_le(&msg[30], ev->death.credits_spent);
+    write_f32_le(&msg[34], (float)ev->death.asteroids_fractured);
+    ws_send(sp->conn, msg, sizeof(msg));
+
+    uint8_t buf[PLAYER_SHIP_SIZE + 4];
+    int len = send_player_ship(buf, (uint8_t)pid, sp);
+    ws_send(sp->conn, buf, (size_t)len);
+}
+
+static void srv_on_contract_complete(const sim_event_t *ev) {
+    (void)ev;
+    station_econ_dirty = true;
+    contracts_dirty = true;
+}
+
+static void srv_on_hail_response(const sim_event_t *ev) {
+    int pid = ev->player_id;
+    if (pid < 0 || pid >= MAX_PLAYERS) return;
+    server_player_t *sp = &world.players[pid];
+    if (!sp->connected || !sp->conn) return;
+
+    uint8_t msg[7];
+    msg[0] = NET_MSG_HAIL_RESPONSE;
+    msg[1] = (uint8_t)ev->hail_response.station;
+    write_f32_le(&msg[2], ev->hail_response.credits);
+    int ci = ev->hail_response.contract_index;
+    msg[6] = (ci >= 0 && ci < MAX_CONTRACTS) ? (uint8_t)ci : 0xFF;
+    ws_send(sp->conn, msg, sizeof(msg));
+
+    contracts_dirty = true;
+    /* Push fresh ship state so the credit bump is visible immediately. */
+    uint8_t buf[PLAYER_SHIP_SIZE + 4];
+    int len = send_player_ship(buf, (uint8_t)pid, sp);
+    ws_send(sp->conn, buf, (size_t)len);
+}
+
+/* OUTPOST_PLACED / OUTPOST_ACTIVATED / MODULE_ACTIVATED / SCAFFOLD_READY
+ * all need station identity refreshed so the client sees updated
+ * module / pending lists. */
+static void srv_mark_all_stations_identity_dirty(void) {
+    for (int s = 0; s < MAX_STATIONS; s++) station_identity_dirty[s] = true;
+}
+
+/* Fan a single sim event out to its per-type broadcaster(s). Multiple
+ * "if" branches on event type (rather than a switch) so events that
+ * fall into more than one bucket — OUTPOST_PLACED touches both
+ * srv_on_outpost_placed AND the structure-event identity refresh —
+ * all run. */
+static void srv_dispatch_sim_event(const sim_event_t *ev) {
+    if (ev->type == SIM_EVENT_OUTPOST_PLACED) srv_on_outpost_placed(ev);
+    if (ev->type == SIM_EVENT_SELL ||
+        ev->type == SIM_EVENT_REPAIR ||
+        ev->type == SIM_EVENT_UPGRADE ||
+        ev->type == SIM_EVENT_DOCK ||
+        ev->type == SIM_EVENT_LAUNCH) {
+        srv_on_player_state_change(ev);
+    }
+    if (ev->type == SIM_EVENT_DEATH)              srv_on_death(ev);
+    if (ev->type == SIM_EVENT_CONTRACT_COMPLETE)  srv_on_contract_complete(ev);
+    if (ev->type == SIM_EVENT_HAIL_RESPONSE)      srv_on_hail_response(ev);
+    if (ev->type == SIM_EVENT_OUTPOST_PLACED ||
+        ev->type == SIM_EVENT_OUTPOST_ACTIVATED ||
+        ev->type == SIM_EVENT_MODULE_ACTIVATED ||
+        ev->type == SIM_EVENT_SCAFFOLD_READY) {
+        srv_mark_all_stations_identity_dirty();
+    }
+}
+
+/* ================================================================== */
+/* Bootstrap helpers — pulled out of main() for clarity.               */
+/* ================================================================== */
+
+/* Read PORT, SIGNAL_API_TOKEN, SIGNAL_ALLOWED_ORIGIN, SIGNAL_REQUIRE_API_TOKEN
+ * env vars and stamp the listen URL + CORS headers. Returns false (and
+ * caller should exit nonzero) if SIGNAL_REQUIRE_API_TOKEN is set without
+ * a token. listen_url is sized by the caller. */
+static bool read_env_config(char *listen_url, size_t listen_url_size) {
     const char *port = getenv("PORT");
     if (!port) port = "8080";
     api_token = getenv("SIGNAL_API_TOKEN");
-    if (api_token && api_token[0] != '\0')
+    if (api_token && api_token[0] != '\0') {
         printf("[server] Station API enabled (token set)\n");
-    else {
+    } else {
         fprintf(stderr, "[WARN] SIGNAL_API_TOKEN is unset -- REST API will reject all requests\n");
         if (getenv("SIGNAL_REQUIRE_API_TOKEN")) {
             fprintf(stderr, "[FATAL] SIGNAL_REQUIRE_API_TOKEN set but no token provided\n");
-            return 1;
+            return false;
         }
     }
     allowed_origin = getenv("SIGNAL_ALLOWED_ORIGIN");
@@ -1177,10 +1317,11 @@ int main(void) {
         "X-Content-Type-Options: nosniff\r\n"
         "Cache-Control: no-store\r\n", allowed_origin);
     printf("[server] CORS origin: %s\n", allowed_origin);
-    char listen_url[64];
-    snprintf(listen_url, sizeof(listen_url), "http://0.0.0.0:%s", port);
+    snprintf(listen_url, listen_url_size, "http://0.0.0.0:%s", port);
+    return true;
+}
 
-    /* Ensure persistence directories exist. */
+static void ensure_persistence_dirs(void) {
 #ifdef _WIN32
     _mkdir(PLAYER_SAVE_DIR);
     _mkdir(STATION_CATALOG_DIR);
@@ -1188,12 +1329,14 @@ int main(void) {
     mkdir(PLAYER_SAVE_DIR, 0755);
     mkdir(STATION_CATALOG_DIR, 0755);
 #endif
+}
 
-    /* Initialise world — layered persistence (#314):
-     * 1. world_reset() seeds starter stations + belt field
-     * 2. Catalog overwrites identity for any persisted stations
-     * 3. Session snapshot overlays economy state (inventories, NPCs, contracts)
-     * 4. Rebuild derived structures */
+/* Layered persistence (#314):
+ *   1. world_reset() seeds starter stations + belt field
+ *   2. Catalog overwrites identity for any persisted stations
+ *   3. Session snapshot overlays economy state
+ *   4. Rebuild derived structures (signal chain, station nav, hash chain) */
+static void load_world_state(void) {
     world_reset(&world);
 
     int catalog_count = station_catalog_load_all(world.stations, MAX_STATIONS,
@@ -1204,8 +1347,7 @@ int main(void) {
     if (world_load(&world, SAVE_PATH)) {
         printf("[server] loaded session from %s\n", SAVE_PATH);
     } else {
-        printf("[server] no session save — fresh economy\n");
-        /* If catalog exists but session doesn't, seed economy for active stations */
+        printf("[server] no session save -- fresh economy\n");
         if (catalog_count > 0) {
             for (int i = 0; i < MAX_STATIONS; i++) {
                 if (station_exists(&world.stations[i]) && world.stations[i].credit_pool == 0.0f)
@@ -1215,33 +1357,27 @@ int main(void) {
         world_seed_station_manifests(&world);
     }
 
-    /* Assign stable IDs to any stations loaded from v1 catalogs (id == 0) */
+    /* Assign stable IDs to any stations loaded from v1 catalogs (id == 0). */
     if (world.next_station_id == 0) world.next_station_id = 1;
     for (int i = 0; i < MAX_STATIONS; i++) {
         if (station_exists(&world.stations[i]) && world.stations[i].id == 0)
             world.stations[i].id = world.next_station_id++;
     }
 
-    /* The station catalog format doesn't persist currency_name (yet) and
-     * the catalog loader memsets the whole struct, so the defaults set
-     * by world_reset() get wiped. Re-stamp the names for the three
-     * starter stations whenever they come back empty so WORK rows show
-     * "+N prospect vouchers" / "kepler bonds" / "helios credits"
-     * instead of the bare "cr" fallback. */
-    {
-        const char *defaults[3] = {
-            "prospect vouchers",
-            "kepler bonds",
-            "helios credits",
-        };
-        for (int i = 0; i < 3 && i < MAX_STATIONS; i++) {
-            if (!station_exists(&world.stations[i])) continue;
-            if (world.stations[i].currency_name[0] == '\0') {
-                snprintf(world.stations[i].currency_name,
-                         sizeof(world.stations[i].currency_name),
-                         "%s", defaults[i]);
-                station_identity_dirty[i] = true;
-            }
+    /* The station catalog format doesn't persist currency_name (yet)
+     * and the catalog loader memsets the whole struct, so the defaults
+     * set by world_reset() get wiped. Re-stamp the names for the three
+     * starter stations whenever they come back empty. */
+    static const char *defaults[3] = {
+        "prospect vouchers", "kepler bonds", "helios credits",
+    };
+    for (int i = 0; i < 3 && i < MAX_STATIONS; i++) {
+        if (!station_exists(&world.stations[i])) continue;
+        if (world.stations[i].currency_name[0] == '\0') {
+            snprintf(world.stations[i].currency_name,
+                     sizeof(world.stations[i].currency_name),
+                     "%s", defaults[i]);
+            station_identity_dirty[i] = true;
         }
     }
 
@@ -1258,6 +1394,122 @@ int main(void) {
     if (highscores.count > 0)
         printf("[server] loaded %d highscore(s) from %s\n",
                highscores.count, HIGHSCORE_PATH);
+}
+
+/* Run as many fixed-step sim ticks as `sim_accum` covers, up to
+ * MAX_SIM_STEPS, broadcasting per-event side effects after each tick.
+ * Caller passes the running accumulator + the elapsed-since-last-call
+ * seconds. Returns when steps run out or the accumulator is empty. */
+static void run_sim_ticks(float *sim_accum, float elapsed) {
+    *sim_accum += elapsed;
+    int steps = 0;
+    while (*sim_accum >= SIM_DT && steps < MAX_SIM_STEPS) {
+        world_sim_step(&world, SIM_DT);
+        for (int e = 0; e < world.events.count; e++)
+            srv_dispatch_sim_event(&world.events.events[e]);
+        if (world.events.count > 0) {
+            uint8_t ebuf[2 + SIM_MAX_EVENTS * NET_EVENT_RECORD_SIZE];
+            int elen = serialize_events(ebuf, &world.events);
+            if (elen > 2) broadcast(ebuf, (size_t)elen);
+        }
+        broadcast_fracture_updates();
+        *sim_accum -= SIM_DT;
+        steps++;
+    }
+    if (*sim_accum > SIM_DT) *sim_accum = 0.0f; /* prevent spiral */
+}
+
+/* Tick down per-player grace timers and session-auth timeouts. */
+static void tick_session_timers(void) {
+    for (int i = 0; i < MAX_PLAYERS; i++) {
+        server_player_t *sp = &world.players[i];
+        if (sp->connected && sp->grace_period) {
+            sp->grace_timer -= (float)SIM_TICK_MS / 1000.0f;
+            if (sp->grace_timer <= 0.0f) {
+                sp->connected = false;
+                sp->grace_period = false;
+                uint8_t leave_msg[] = { NET_MSG_LEAVE, (uint8_t)i };
+                broadcast(leave_msg, 2);
+                printf("[server] player %d grace expired, fully disconnected\n", i);
+            }
+        }
+        /* Kick clients that never sent SESSION within the auth window. */
+        if (sp->connected && !sp->session_ready && !sp->grace_period) {
+            sp->grace_timer -= (float)SIM_TICK_MS / 1000.0f;
+            if (sp->grace_timer <= 0.0f) {
+                printf("[server] player %d: session timeout, disconnecting\n", i);
+                mg_ws_send(sp->conn, NULL, 0, WEBSOCKET_OP_CLOSE);
+                sp->connected = false;
+                sp->conn = NULL;
+                uint8_t leave_msg[] = { NET_MSG_LEAVE, (uint8_t)i };
+                broadcast(leave_msg, 2);
+            }
+        }
+    }
+}
+
+/* WORLD_TICK_MS broadcast: dirty station identities + named-ingot
+ * stockpiles + manifest summaries. */
+static void broadcast_dirty_station_data(uint64_t now, uint64_t *last_station_identity_p) {
+    if (now - *last_station_identity_p >= STATION_IDENTITY_FALLBACK_MS) {
+        for (int s = 0; s < MAX_STATIONS; s++) station_identity_dirty[s] = true;
+        *last_station_identity_p = now;
+    }
+    /* Re-broadcast dirty station identities only to players in signal range. */
+    for (int s = 0; s < MAX_STATIONS; s++) {
+        if (!station_identity_dirty[s]) continue;
+        if (!station_exists(&world.stations[s])) continue;
+        uint8_t id_buf[STATION_IDENTITY_SIZE + 4];
+        int id_len = serialize_station_identity(id_buf, s, &world.stations[s]);
+        float sr_sq = world.stations[s].signal_range * world.stations[s].signal_range;
+        for (int p = 0; p < MAX_PLAYERS; p++) {
+            if (!world.players[p].connected || !world.players[p].conn) continue;
+            if (v2_dist_sq(world.players[p].ship.pos, world.stations[s].pos) <= sr_sq)
+                ws_send(world.players[p].conn, id_buf, (size_t)id_len);
+        }
+        station_identity_dirty[s] = false;
+    }
+    /* RATi v2: named-ingot stockpile + per-(commodity, grade) manifest
+     * summary. Smaller payload than identity (~3KB worst case) so we
+     * send to everyone regardless of signal range — MARKET is global. */
+    for (int s = 0; s < MAX_STATIONS; s++) {
+        if (!world.stations[s].named_ingots_dirty) continue;
+        if (!station_exists(&world.stations[s])) continue;
+        uint8_t buf[STATION_INGOTS_HEADER + STATION_NAMED_INGOTS_MAX * NAMED_INGOT_RECORD_SIZE];
+        int len = serialize_station_ingots(buf, s, &world.stations[s]);
+        for (int p = 0; p < MAX_PLAYERS; p++) {
+            if (!world.players[p].connected || !world.players[p].conn) continue;
+            ws_send(world.players[p].conn, buf, (size_t)len);
+        }
+        uint8_t mbuf[STATION_MANIFEST_HEADER +
+                     COMMODITY_COUNT * MINING_GRADE_COUNT * STATION_MANIFEST_ENTRY];
+        int mlen = serialize_station_manifest(mbuf, s, &world.stations[s]);
+        for (int p = 0; p < MAX_PLAYERS; p++) {
+            if (!world.players[p].connected || !world.players[p].conn) continue;
+            ws_send(world.players[p].conn, mbuf, (size_t)mlen);
+        }
+        world.stations[s].named_ingots_dirty = false;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Main                                                               */
+/* ------------------------------------------------------------------ */
+
+int main(void) {
+    /* Line-buffer stdout and unbuffer stderr so `docker compose logs`
+     * sees server output in real time. Without this, fully-buffered
+     * stdout holds [server] printf lines until a 4KB page fills. */
+    setvbuf(stdout, NULL, _IOLBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
+    signal(SIGINT, signal_handler);
+    signal(SIGTERM, signal_handler);
+
+    char listen_url[64];
+    if (!read_env_config(listen_url, sizeof(listen_url))) return 1;
+
+    ensure_persistence_dirs();
+    load_world_state();
 
     struct mg_mgr mgr;
     mg_mgr_init(&mgr);
@@ -1267,7 +1519,7 @@ int main(void) {
 #else
     printf("[server] SIGNAL alpha on %s\n", listen_url);
 #endif
-    printf("[server] ALPHA BUILD — world may reset without notice\n");
+    printf("[server] ALPHA BUILD -- world may reset without notice\n");
 
     uint64_t last_sim = 0, last_state = 0, last_world = 0, last_ship = 0, last_save = 0;
     uint64_t last_econ_dirty = 0;
@@ -1280,221 +1532,22 @@ int main(void) {
         if (now - last_sim >= SIM_TICK_MS) {
             float elapsed = (float)(now - last_sim) / 1000.0f;
             last_sim = now;
-            sim_accum += elapsed;
-            int steps = 0;
-            while (sim_accum >= SIM_DT && steps < MAX_SIM_STEPS) {
-                world_sim_step(&world, SIM_DT);
-                /* Immediate broadcasts triggered by sim events. */
-                for (int e = 0; e < world.events.count; e++) {
-                    sim_event_t *ev = &world.events.events[e];
-                    if (ev->type == SIM_EVENT_OUTPOST_PLACED) {
-                        int slot = ev->outpost_placed.slot;
-                        uint8_t id_buf[STATION_IDENTITY_SIZE + 4];
-                        int id_len = serialize_station_identity(id_buf, slot, &world.stations[slot]);
-                        broadcast(id_buf, (size_t)id_len);
-                        station_identity_dirty[slot] = true;
-                        station_econ_dirty = true;
-                        contracts_dirty = true;
-                    }
-                    /* Send immediate ship + station state after actions that
-                     * change cargo, credits, hull, or dock status — eliminates
-                     * the 250ms stale window from SHIP_TICK_MS cadence. */
-                    if (ev->type == SIM_EVENT_SELL || ev->type == SIM_EVENT_REPAIR ||
-                        ev->type == SIM_EVENT_UPGRADE || ev->type == SIM_EVENT_DOCK ||
-                        ev->type == SIM_EVENT_LAUNCH) {
-                        int pid = ev->player_id;
-                        if (pid >= 0 && pid < MAX_PLAYERS && world.players[pid].connected && world.players[pid].conn) {
-                            uint8_t buf[PLAYER_SHIP_SIZE + 4];
-                            int len = send_player_ship(buf, (uint8_t)pid, &world.players[pid]);
-                            ws_send(world.players[pid].conn, buf, (size_t)len);
-                            /* Send only the station the player is at, not all stations */
-                            int st_idx = world.players[pid].current_station;
-                            if (st_idx >= 0 && st_idx < MAX_STATIONS) {
-                                uint8_t sbuf[2 + STATION_RECORD_SIZE];
-                                sbuf[0] = NET_MSG_WORLD_STATIONS;
-                                sbuf[1] = 1;
-                                uint8_t *p = &sbuf[2];
-                                p[0] = (uint8_t)st_idx;
-                                for (int c = 0; c < COMMODITY_COUNT; c++)
-                                    write_f32_le(&p[1 + c * 4], world.stations[st_idx].inventory[c]);
-                                ws_send(world.players[pid].conn, sbuf, (size_t)(2 + STATION_RECORD_SIZE));
-                            }
-                        }
-                        station_econ_dirty = true;
-                        contracts_dirty = true;
-                    }
-                    if (ev->type == SIM_EVENT_DEATH) {
-                        int pid = ev->player_id;
-                        /* Submit the run to the global leaderboard. Runs that
-                         * don't qualify for top-N return false and no-op. */
-                        if (pid >= 0 && pid < MAX_PLAYERS && world.players[pid].connected) {
-                            const char *cs = world.players[pid].callsign;
-                            bool qualified = highscore_submit(
-                                &highscores, cs, ev->death.credits_earned);
-                            printf("[server] death pid=%d cs=%s earned=%.0f cr → %s (top=%d)\n",
-                                   pid, cs[0] ? cs : "?", ev->death.credits_earned,
-                                   qualified ? "qualified" : "skipped",
-                                   highscores.count);
-                            if (qualified) highscores_dirty = true;
-                        }
-                        if (pid >= 0 && pid < MAX_PLAYERS && world.players[pid].connected && world.players[pid].conn) {
-                            /* Death packet now carries position + stats so
-                             * the client cinematic anchors at the wreckage
-                             * before the server-side respawn moves the
-                             * ship. Layout:
-                             * [type:1][pid:1][px:f32][py:f32][vx:f32][vy:f32]
-                             * [ang:f32][ore:f32][earned:f32][spent:f32]
-                             * [asteroids:f32] = 38 bytes */
-                            uint8_t msg[38];
-                            msg[0] = NET_MSG_DEATH;
-                            msg[1] = (uint8_t)pid;
-                            write_f32_le(&msg[2],  ev->death.pos_x);
-                            write_f32_le(&msg[6],  ev->death.pos_y);
-                            write_f32_le(&msg[10], ev->death.vel_x);
-                            write_f32_le(&msg[14], ev->death.vel_y);
-                            write_f32_le(&msg[18], ev->death.angle);
-                            write_f32_le(&msg[22], ev->death.ore_mined);
-                            write_f32_le(&msg[26], ev->death.credits_earned);
-                            write_f32_le(&msg[30], ev->death.credits_spent);
-                            write_f32_le(&msg[34], (float)ev->death.asteroids_fractured);
-                            ws_send(world.players[pid].conn, msg, sizeof(msg));
-                            /* Also send updated ship state (hull restored, docked) */
-                            uint8_t buf[PLAYER_SHIP_SIZE + 4];
-                            int len = send_player_ship(buf, (uint8_t)pid, &world.players[pid]);
-                            ws_send(world.players[pid].conn, buf, (size_t)len);
-                        }
-                    }
-                    if (ev->type == SIM_EVENT_CONTRACT_COMPLETE) {
-                        station_econ_dirty = true;
-                        contracts_dirty = true;
-                    }
-                    if (ev->type == SIM_EVENT_HAIL_RESPONSE) {
-                        int pid = ev->player_id;
-                        if (pid >= 0 && pid < MAX_PLAYERS && world.players[pid].connected && world.players[pid].conn) {
-                            uint8_t msg[7];
-                            msg[0] = NET_MSG_HAIL_RESPONSE;
-                            msg[1] = (uint8_t)ev->hail_response.station;
-                            write_f32_le(&msg[2], ev->hail_response.credits);
-                            int ci = ev->hail_response.contract_index;
-                            msg[6] = (ci >= 0 && ci < MAX_CONTRACTS) ? (uint8_t)ci : 0xFF;
-                            ws_send(world.players[pid].conn, msg, sizeof(msg));
-                            /* Contracts table changed — push fresh list. */
-                            contracts_dirty = true;
-                            /* Push fresh ship state so the credit bump is visible immediately */
-                            uint8_t buf[PLAYER_SHIP_SIZE + 4];
-                            int len = send_player_ship(buf, (uint8_t)pid, &world.players[pid]);
-                            ws_send(world.players[pid].conn, buf, (size_t)len);
-                        }
-                    }
-                    if (ev->type == SIM_EVENT_OUTPOST_PLACED ||
-                        ev->type == SIM_EVENT_OUTPOST_ACTIVATED ||
-                        ev->type == SIM_EVENT_MODULE_ACTIVATED ||
-                        ev->type == SIM_EVENT_SCAFFOLD_READY) {
-                        /* Any structure event needs the station identity refreshed
-                         * so the client sees the updated module/pending list. */
-                        for (int s = 0; s < MAX_STATIONS; s++)
-                            station_identity_dirty[s] = true;
-                    }
-                }
-                /* Broadcast all events to clients for audio + UI */
-                if (world.events.count > 0) {
-                    uint8_t ebuf[2 + SIM_MAX_EVENTS * NET_EVENT_RECORD_SIZE];
-                    int elen = serialize_events(ebuf, &world.events);
-                    if (elen > 2) broadcast(ebuf, (size_t)elen);
-                }
-                broadcast_fracture_updates();
-                sim_accum -= SIM_DT;
-                steps++;
-            }
-            if (sim_accum > SIM_DT) sim_accum = 0.0f; /* prevent spiral */
-            /* Mark econ dirty every ~1s as fallback for production changes */
+            run_sim_ticks(&sim_accum, elapsed);
+            /* Mark econ dirty every ~1s as fallback for production changes. */
             if (now - last_econ_dirty >= 1000) {
                 station_econ_dirty = true;
                 contracts_dirty = true;
                 last_econ_dirty = now;
             }
         }
-        /* Tick down reconnect grace timers and session auth timeouts */
-        for (int i = 0; i < MAX_PLAYERS; i++) {
-            server_player_t *sp = &world.players[i];
-            if (sp->connected && sp->grace_period) {
-                sp->grace_timer -= (float)SIM_TICK_MS / 1000.0f;
-                if (sp->grace_timer <= 0.0f) {
-                    sp->connected = false;
-                    sp->grace_period = false;
-                    uint8_t leave_msg[] = { NET_MSG_LEAVE, (uint8_t)i };
-                    broadcast(leave_msg, 2);
-                    printf("[server] player %d grace expired, fully disconnected\n", i);
-                }
-            }
-            /* Kick clients that never sent SESSION within the auth window */
-            if (sp->connected && !sp->session_ready && !sp->grace_period) {
-                sp->grace_timer -= (float)SIM_TICK_MS / 1000.0f;
-                if (sp->grace_timer <= 0.0f) {
-                    printf("[server] player %d: session timeout, disconnecting\n", i);
-                    mg_ws_send(sp->conn, NULL, 0, WEBSOCKET_OP_CLOSE);
-                    sp->connected = false;
-                    sp->conn = NULL;
-                    uint8_t leave_msg[] = { NET_MSG_LEAVE, (uint8_t)i };
-                    broadcast(leave_msg, 2);
-                }
-            }
-        }
+        tick_session_timers();
         if (now - last_state >= STATE_TICK_MS) {
             broadcast_player_states();
             last_state = now;
         }
         if (now - last_world >= WORLD_TICK_MS) {
             broadcast_world();
-            /* Periodic fallback re-sync for scaffold progress */
-            if (now - last_station_identity >= STATION_IDENTITY_FALLBACK_MS) {
-                for (int s = 0; s < MAX_STATIONS; s++) station_identity_dirty[s] = true;
-                last_station_identity = now;
-            }
-            /* Re-broadcast dirty station identities only to players in signal range */
-            for (int s = 0; s < MAX_STATIONS; s++) {
-                if (!station_identity_dirty[s]) continue;
-                if (!station_exists(&world.stations[s])) continue;
-                uint8_t id_buf[STATION_IDENTITY_SIZE + 4];
-                int id_len = serialize_station_identity(id_buf, s, &world.stations[s]);
-                float sr_sq = world.stations[s].signal_range * world.stations[s].signal_range;
-                for (int p = 0; p < MAX_PLAYERS; p++) {
-                    if (!world.players[p].connected || !world.players[p].conn) continue;
-                    if (v2_dist_sq(world.players[p].ship.pos, world.stations[s].pos) <= sr_sq)
-                        ws_send(world.players[p].conn, id_buf, (size_t)id_len);
-                }
-                station_identity_dirty[s] = false;
-            }
-
-            /* RATi v2: re-broadcast dirty named-ingot stockpiles to all
-             * connected players. Smaller payload than identity (~3KB
-             * worst case for a full stockpile) so we send to everyone
-             * regardless of signal range — the MARKET tab is global. */
-            for (int s = 0; s < MAX_STATIONS; s++) {
-                if (!world.stations[s].named_ingots_dirty) continue;
-                if (!station_exists(&world.stations[s])) continue;
-                uint8_t buf[STATION_INGOTS_HEADER + STATION_NAMED_INGOTS_MAX * NAMED_INGOT_RECORD_SIZE];
-                int len = serialize_station_ingots(buf, s, &world.stations[s]);
-                for (int p = 0; p < MAX_PLAYERS; p++) {
-                    if (!world.players[p].connected || !world.players[p].conn) continue;
-                    ws_send(world.players[p].conn, buf, (size_t)len);
-                }
-                /* Phase 2: same dirty flag is a good proxy for "manifest
-                 * changed" — smelt sets it when it mints a new unit, and
-                 * buy/sell flip it via named_ingots rotation. Broadcast
-                 * the per-(commodity, grade) summary so clients can
-                 * render TRADE rows correctly in multiplayer. */
-                {
-                    uint8_t mbuf[STATION_MANIFEST_HEADER +
-                                 COMMODITY_COUNT * MINING_GRADE_COUNT * STATION_MANIFEST_ENTRY];
-                    int mlen = serialize_station_manifest(mbuf, s, &world.stations[s]);
-                    for (int p = 0; p < MAX_PLAYERS; p++) {
-                        if (!world.players[p].connected || !world.players[p].conn) continue;
-                        ws_send(world.players[p].conn, mbuf, (size_t)mlen);
-                    }
-                }
-                world.stations[s].named_ingots_dirty = false;
-            }
+            broadcast_dirty_station_data(now, &last_station_identity);
             last_world = now;
         }
         if (now - last_ship >= SHIP_TICK_MS) {

--- a/shared/types.h
+++ b/shared/types.h
@@ -660,6 +660,7 @@ typedef enum {
     SIM_EVENT_SCAFFOLD_READY,
     SIM_EVENT_ORDER_REJECTED,
     SIM_EVENT_NPC_KILL,
+    SIM_EVENT_COUNT,        /* sentinel — keep last; sized for dispatch tables */
 } sim_event_type_t;
 
 /* What killed a ship. Stable wire values — keep additions append-only.

--- a/src/hud.c
+++ b/src/hud.c
@@ -748,78 +748,76 @@ void draw_hud_panels(void) {
 /* draw_hud -- the main HUD text layer                                 */
 /* ------------------------------------------------------------------ */
 
-void draw_hud(void) {
-    float screen_w = ui_screen_width();
-    float screen_h = ui_screen_height();
+/* Death-screen overlay — full-screen scrim + stats + leaderboard +
+ * "[E] launch" prompt. Returns true if the overlay drew (caller skips
+ * the regular flight HUD), false otherwise. */
+static bool draw_death_overlay(float screen_w, float screen_h) {
+    if (!g.death_cinematic.active && g.death_cinematic.menu_alpha <= 0.001f)
+        return false;
 
-    /* --- Death screen overlay (driven by the death cinematic) --- */
-    if (g.death_cinematic.active || g.death_cinematic.menu_alpha > 0.001f) {
-        float menu_alpha = g.death_cinematic.menu_alpha;
-        if (menu_alpha < 0.0f) menu_alpha = 0.0f;
-        if (menu_alpha > 1.0f) menu_alpha = 1.0f;
-        float scrim = 0.55f * menu_alpha;
+    float menu_alpha = g.death_cinematic.menu_alpha;
+    if (menu_alpha < 0.0f) menu_alpha = 0.0f;
+    if (menu_alpha > 1.0f) menu_alpha = 1.0f;
+    float scrim = 0.55f * menu_alpha;
 
-        /* Dark scrim under the menu */
-        sgl_begin_quads();
-        sgl_c4f(0.0f, 0.0f, 0.0f, scrim);
-        sgl_v2f(0.0f, 0.0f);
-        sgl_v2f(screen_w, 0.0f);
-        sgl_v2f(screen_w, screen_h);
-        sgl_v2f(0.0f, screen_h);
-        sgl_end();
-        float alpha = menu_alpha;
+    /* Dark scrim under the menu. */
+    sgl_begin_quads();
+    sgl_c4f(0.0f, 0.0f, 0.0f, scrim);
+    sgl_v2f(0.0f, 0.0f);
+    sgl_v2f(screen_w, 0.0f);
+    sgl_v2f(screen_w, screen_h);
+    sgl_v2f(0.0f, screen_h);
+    sgl_end();
+    float alpha = menu_alpha;
 
-        /* Use 1:1 canvas so text fills the screen */
-        sdtx_canvas(screen_w, screen_h);
-        sdtx_origin(0.0f, 0.0f);
-        float cx = screen_w * 0.5f;
-        float cy = screen_h * 0.5f;
-        float cell = 8.0f;
-        uint8_t a8 = (uint8_t)(alpha * 255.0f);
+    /* 1:1 canvas so text fills the screen. */
+    sdtx_canvas(screen_w, screen_h);
+    sdtx_origin(0.0f, 0.0f);
+    float cx = screen_w * 0.5f;
+    float cy = screen_h * 0.5f;
+    float cell = 8.0f;
+    uint8_t a8 = (uint8_t)(alpha * 255.0f);
 
-        /* Title */
-        const char *title = "SHIP DESTROYED";
-        float title_w = (float)strlen(title) * cell;
-        sdtx_pos((cx - title_w * 0.5f) / cell, (cy - 60.0f) / cell);
-        sdtx_color4b(PAL_DEATH_TITLE, a8);
-        sdtx_puts(title);
+    /* Title. */
+    const char *title = "SHIP DESTROYED";
+    float title_w = (float)strlen(title) * cell;
+    sdtx_pos((cx - title_w * 0.5f) / cell, (cy - 60.0f) / cell);
+    sdtx_color4b(PAL_DEATH_TITLE, a8);
+    sdtx_puts(title);
 
-        /* Stats */
-        float row = (cy - 16.0f) / cell;
-        float left = fmaxf(1.0f, (cx - 110.0f) / cell);
+    /* Stats. */
+    float row = (cy - 16.0f) / cell;
+    float left = fmaxf(1.0f, (cx - 110.0f) / cell);
+    sdtx_color4b(PAL_NOTICE, a8);
+
+    sdtx_pos(left, row);
+    sdtx_printf("Ore smelted:   %8.0f", g.death_ore_mined);
+    row += 2.5f;
+    sdtx_pos(left, row);
+    sdtx_printf("Rocks broken:  %8d", g.death_asteroids_fractured);
+    row += 2.5f;
+    sdtx_pos(left, row);
+    sdtx_color4b(PAL_DEATH_EARNED, a8);
+    sdtx_printf("Credits earned:%8.0f", g.death_credits_earned);
+    row += 2.5f;
+    sdtx_pos(left, row);
+    sdtx_color4b(PAL_DEATH_SPENT, a8);
+    sdtx_printf("Credits spent: %8.0f", g.death_credits_spent);
+    row += 3.0f;
+
+    /* Global highscores — top runs broadcast by the server. The
+     * player's just-submitted run is highlighted in the death-earned
+     * color so they can spot where they landed. Always render the
+     * header so the player knows the leaderboard exists even when
+     * empty (first run on a fresh server) or before the server's
+     * post-death broadcast has arrived. */
+    {
+        const char *lb = "-- TOP RUNS --";
+        float lb_w = (float)strlen(lb) * cell;
+        sdtx_pos((cx - lb_w * 0.5f) / cell, row);
         sdtx_color4b(PAL_NOTICE, a8);
-
-        sdtx_pos(left, row);
-        sdtx_printf("Ore smelted:   %8.0f", g.death_ore_mined);
-        row += 2.5f;
-
-        sdtx_pos(left, row);
-        sdtx_printf("Rocks broken:  %8d", g.death_asteroids_fractured);
-        row += 2.5f;
-
-        sdtx_pos(left, row);
-        sdtx_color4b(PAL_DEATH_EARNED, a8);
-        sdtx_printf("Credits earned:%8.0f", g.death_credits_earned);
-        row += 2.5f;
-
-        sdtx_pos(left, row);
-        sdtx_color4b(PAL_DEATH_SPENT, a8);
-        sdtx_printf("Credits spent: %8.0f", g.death_credits_spent);
-        row += 3.0f;
-
-        /* Global highscores — top runs broadcast by the server. The
-         * player's just-submitted run is highlighted in the death-earned
-         * color so they can spot where they landed. Always render the
-         * header so the player knows the leaderboard exists even when
-         * empty (first run on a fresh server) or before the server's
-         * post-death broadcast has arrived. */
-        {
-            const char *lb = "-- TOP RUNS --";
-            float lb_w = (float)strlen(lb) * cell;
-            sdtx_pos((cx - lb_w * 0.5f) / cell, row);
-            sdtx_color4b(PAL_NOTICE, a8);
-            sdtx_puts(lb);
-            row += 1.6f;
+        sdtx_puts(lb);
+        row += 1.6f;
             if (g.highscore_count > 0) {
                 int show = (g.highscore_count > 8) ? 8 : g.highscore_count;
                 for (int i = 0; i < show; i++) {
@@ -844,17 +842,25 @@ void draw_hud(void) {
             row += 1.0f;
         }
 
-        /* Prompt — RED, hard FLASH on/off */
-        float flash = (sinf(g.world.time * 7.0f) > 0.0f) ? 1.0f : 0.25f;
-        uint8_t pa = (uint8_t)(flash * (float)a8);
-        sdtx_color4b(PAL_DEATH_PROMPT, pa);
-        const char *prompt = "[ E ] launch";
-        float prompt_w = (float)strlen(prompt) * cell;
-        sdtx_pos((cx - prompt_w * 0.5f) / cell, row);
-        sdtx_puts(prompt);
+    /* Prompt — RED, hard FLASH on/off */
+    float flash = (sinf(g.world.time * 7.0f) > 0.0f) ? 1.0f : 0.25f;
+    uint8_t pa = (uint8_t)(flash * (float)a8);
+    sdtx_color4b(PAL_DEATH_PROMPT, pa);
+    const char *prompt = "[ E ] launch";
+    float prompt_w = (float)strlen(prompt) * cell;
+    sdtx_pos((cx - prompt_w * 0.5f) / cell, row);
+    sdtx_puts(prompt);
 
-        return; /* skip normal HUD */
-    }
+    return true;
+}
+
+void draw_hud(void) {
+    float screen_w = ui_screen_width();
+    float screen_h = ui_screen_height();
+
+    /* Death-screen overlay short-circuits the rest of the HUD. */
+    if (draw_death_overlay(screen_w, screen_h)) return;
+
     bool compact = ui_is_compact();
     float top_x = 0.0f;
     float top_y = 0.0f;

--- a/src/input.c
+++ b/src/input.c
@@ -157,82 +157,75 @@ static int collect_reticle_targets(vec2 pos, reticle_target_t *out, int max) {
     return count;
 }
 
-input_intent_t sample_input_intent(void) {
-    input_intent_t intent = { 0 };
-    /* Default buy_grade to "any" (sentinel = MINING_GRADE_COUNT) so
-     * manifest-first transfers don't accidentally prefer COMMON just
-     * because the zero-init lands there. UI wires a real grade when a
-     * grade-picker is added. */
-    intent.buy_grade = MINING_GRADE_COUNT;
-    intent.place_target_station = -1;
-    intent.place_target_ring = -1;
-    intent.place_target_slot = -1;
-    intent.plan_station = -1;
-    intent.plan_ring = -1;
-    intent.plan_slot = -1;
-    intent.cancel_planned_station = -1;
-    intent.service_sell_only = COMMODITY_COUNT; /* default: deliver all */
+/* ================================================================== */
+/* sample_input_intent — per-concern samplers, each takes the running  */
+/* input_intent_t by pointer and mutates the relevant fields. The      */
+/* outer function is now an init + ordered call list; CCN drops to a   */
+/* short straight-line shape.                                          */
+/* ================================================================== */
 
-    if (is_key_down(SAPP_KEYCODE_A) || is_key_down(SAPP_KEYCODE_LEFT)) {
-        intent.turn += 1.0f;
-    }
-    if (is_key_down(SAPP_KEYCODE_D) || is_key_down(SAPP_KEYCODE_RIGHT)) {
-        intent.turn -= 1.0f;
-    }
-    if (is_key_down(SAPP_KEYCODE_W) || is_key_down(SAPP_KEYCODE_UP)) {
-        intent.thrust += 1.0f;
-    }
-    if (is_key_down(SAPP_KEYCODE_S) || is_key_down(SAPP_KEYCODE_DOWN)) {
-        intent.thrust -= 1.0f;
-    }
+static void sample_movement(input_intent_t *intent) {
+    if (is_key_down(SAPP_KEYCODE_A) || is_key_down(SAPP_KEYCODE_LEFT))  intent->turn   += 1.0f;
+    if (is_key_down(SAPP_KEYCODE_D) || is_key_down(SAPP_KEYCODE_RIGHT)) intent->turn   -= 1.0f;
+    if (is_key_down(SAPP_KEYCODE_W) || is_key_down(SAPP_KEYCODE_UP))    intent->thrust += 1.0f;
+    if (is_key_down(SAPP_KEYCODE_S) || is_key_down(SAPP_KEYCODE_DOWN))  intent->thrust -= 1.0f;
+    if (intent->thrust != 0.0f || intent->turn != 0.0f) onboarding_mark_moved();
+    intent->mine = is_key_down(SAPP_KEYCODE_M);
+}
 
-    if (intent.thrust != 0.0f || intent.turn != 0.0f)
-        onboarding_mark_moved();
-
-    intent.mine = is_key_down(SAPP_KEYCODE_M);
-
-    /* Tractor: hold Space = grab, tap Space = release.
-     * Track press time; on release, if held < 200ms = tap (release). */
+/* Tractor: hold Space = grab, tap Space (< 200ms) = release. */
+static void sample_tractor(input_intent_t *intent) {
     if (is_key_down(SAPP_KEYCODE_SPACE) && !g.plan_mode_active) {
         if (g.input.tractor_press_time == 0.0f)
             g.input.tractor_press_time = g.world.time;
-        intent.tractor_hold = true;
-    } else {
-        if (g.input.tractor_press_time > 0.0f) {
-            float held = g.world.time - g.input.tractor_press_time;
-            if (held < 0.2f)
-                intent.release_tow = true;  /* tap = release */
-            g.input.tractor_press_time = 0.0f;
-        }
+        intent->tractor_hold = true;
+        return;
     }
-    intent.boost = (is_key_down(SAPP_KEYCODE_LEFT_SHIFT) || is_key_down(SAPP_KEYCODE_RIGHT_SHIFT))
-                   && !LOCAL_PLAYER.docked;
-    if (intent.boost) onboarding_mark_boosted();
-    /* Self-destruct is destructive, so single-press was too easy a
-     * fat-finger. Require X to be held for 1 second continuously while
-     * undocked; release resets. A brief glance at the self-destruct HUD
-     * badge (driven by self_destruct_hold_time in world_draw) gives the
-     * player a visible confirm window before the reset fires. */
-    intent.reset = false;
+    if (g.input.tractor_press_time > 0.0f) {
+        float held = g.world.time - g.input.tractor_press_time;
+        if (held < 0.2f) intent->release_tow = true;
+        g.input.tractor_press_time = 0.0f;
+    }
+}
+
+static void sample_boost(input_intent_t *intent) {
+    intent->boost = (is_key_down(SAPP_KEYCODE_LEFT_SHIFT) ||
+                     is_key_down(SAPP_KEYCODE_RIGHT_SHIFT))
+                    && !LOCAL_PLAYER.docked;
+    if (intent->boost) onboarding_mark_boosted();
+}
+
+/* Self-destruct: hold X for 1 s while undocked. The HUD badge driven
+ * by self_destruct_hold_time in world_draw is the player's confirm
+ * window before the reset fires. */
+static void sample_self_destruct(input_intent_t *intent) {
+    intent->reset = false;
     if (is_key_down(SAPP_KEYCODE_X) && !LOCAL_PLAYER.docked) {
         if (g.input.self_destruct_hold_time == 0.0f)
             g.input.self_destruct_hold_time = g.world.time;
         if (g.world.time - g.input.self_destruct_hold_time >= 1.0f) {
-            intent.reset = true;
+            intent->reset = true;
             g.input.self_destruct_hold_time = 0.0f;
         }
     } else {
         g.input.self_destruct_hold_time = 0.0f;
     }
-    /* Safety: clear placement reticle if no longer towing or now docked */
+}
+
+static void sample_ui_safety(void) {
+    /* Clear placement reticle if no longer towing or now docked. */
     if (g.placement_reticle_active &&
         (LOCAL_PLAYER.docked || LOCAL_PLAYER.ship.towed_scaffold < 0)) {
         g.placement_reticle_active = false;
     }
-    /* Close inspect pane when docked or thrusting */
+    /* Close inspect pane when docked. */
     if (LOCAL_PLAYER.docked) { g.inspect_station = -1; g.inspect_module = -1; }
-    /* SPACE (laser) auto-targets nearest module in beam cone */
-    if (intent.mine && !LOCAL_PLAYER.docked &&
+}
+
+/* SPACE (laser) auto-targets the nearest module in the beam cone.
+ * Targets clear if the laser releases or the player drifts out of range. */
+static void sample_targeting(const input_intent_t *intent) {
+    if (intent->mine && !LOCAL_PLAYER.docked &&
         LOCAL_PLAYER.in_dock_range && LOCAL_PLAYER.nearby_station >= 0) {
         const station_t *st = &g.world.stations[LOCAL_PLAYER.nearby_station];
         vec2 fwd = v2_from_angle(LOCAL_PLAYER.ship.angle);
@@ -248,10 +241,7 @@ input_intent_t sample_input_intent(void) {
             float len = v2_len(to_mod);
             if (len < 1.0f) continue;
             float d = v2_dot(fwd, v2_scale(to_mod, 1.0f / len));
-            if (d > 0.7f && d > best_dot) {
-                best_dot = d;
-                best_mod = idx;
-            }
+            if (d > 0.7f && d > best_dot) { best_dot = d; best_mod = idx; }
         }
         if (best_mod >= 0) {
             g.target_station = LOCAL_PLAYER.nearby_station;
@@ -260,539 +250,555 @@ input_intent_t sample_input_intent(void) {
             g.target_station = -1;
             g.target_module = -1;
         }
+        return;
     }
-    /* Clear target if laser released or out of range */
-    if (!intent.mine) {
-        /* Keep target briefly so E can fire it, but clear if moved away */
-        if (g.target_station >= 0 && g.target_module >= 0) {
-            const station_t *tst = &g.world.stations[g.target_station];
-            if (g.target_module < tst->module_count) {
-                vec2 mp = module_world_pos_ring(tst, tst->modules[g.target_module].ring,
-                                                 tst->modules[g.target_module].slot);
-                float tr = ship_tractor_range(&LOCAL_PLAYER.ship);
-                if (v2_dist_sq(LOCAL_PLAYER.ship.pos, mp) > tr * tr * 1.5f) {
-                    g.target_station = -1;
-                    g.target_module = -1;
-                }
+    /* Laser released: keep target briefly so E can fire it, but clear
+     * if the player drifted out of 1.5× tractor range. */
+    if (!intent->mine && g.target_station >= 0 && g.target_module >= 0) {
+        const station_t *tst = &g.world.stations[g.target_station];
+        if (g.target_module < tst->module_count) {
+            vec2 mp = module_world_pos_ring(tst, tst->modules[g.target_module].ring,
+                                             tst->modules[g.target_module].slot);
+            float tr = ship_tractor_range(&LOCAL_PLAYER.ship);
+            if (v2_dist_sq(LOCAL_PLAYER.ship.pos, mp) > tr * tr * 1.5f) {
+                g.target_station = -1;
+                g.target_module = -1;
             }
         }
     }
-    /* E key: docked → LAUNCH (always). Undocked → activate targeted module
-     * (dock a DOCK module, or toggle the inspect pane for others), or dock
-     * when near a station with no target selected. */
-    if (is_key_pressed(SAPP_KEYCODE_E)) {
-        if (LOCAL_PLAYER.docked) {
-            /* Launch */
-            intent.interact = true;
-        } else if (g.target_station >= 0 && g.target_module >= 0) {
-            /* E on targeted module: dock if it's a dock, otherwise inspect */
-            const station_t *tst = &g.world.stations[g.target_station];
-            if (g.target_module < tst->module_count) {
-                if (tst->modules[g.target_module].type == MODULE_DOCK) {
-                    intent.interact = true;
-                } else {
-                    /* Toggle module info pane */
-                    if (g.inspect_station == g.target_station && g.inspect_module == g.target_module) {
-                        g.inspect_station = -1;
-                        g.inspect_module = -1;
-                    } else {
-                        g.inspect_station = g.target_station;
-                        g.inspect_module = g.target_module;
-                    }
-                }
+}
+
+/* E key: docked = LAUNCH; undocked = activate the targeted module
+ * (dock if it's a DOCK module, otherwise toggle the inspect pane), or
+ * fall back to "dock" when in dock range with no target. */
+static void sample_e_interact(input_intent_t *intent) {
+    if (!is_key_pressed(SAPP_KEYCODE_E)) return;
+    if (LOCAL_PLAYER.docked) { intent->interact = true; return; }
+    if (g.target_station >= 0 && g.target_module >= 0) {
+        const station_t *tst = &g.world.stations[g.target_station];
+        if (g.target_module < tst->module_count) {
+            if (tst->modules[g.target_module].type == MODULE_DOCK) {
+                intent->interact = true;
+            } else if (g.inspect_station == g.target_station &&
+                       g.inspect_module == g.target_module) {
+                g.inspect_station = -1;
+                g.inspect_module = -1;
+            } else {
+                g.inspect_station = g.target_station;
+                g.inspect_module = g.target_module;
             }
-            g.target_station = -1;
-            g.target_module = -1;
-        } else if (LOCAL_PLAYER.in_dock_range) {
-            /* No target but near station — dock */
-            intent.interact = true;
         }
+        g.target_station = -1;
+        g.target_module = -1;
+        return;
+    }
+    if (LOCAL_PLAYER.in_dock_range) intent->interact = true;
+}
+
+/* [Tab] cycle docked tabs (DOCK ↔ CONTRACTS ↔ ...). Shift+Tab reverses. */
+static void sample_station_tab(void) {
+    if (!LOCAL_PLAYER.docked || !is_key_pressed(SAPP_KEYCODE_TAB)) return;
+    bool shift = is_key_down(SAPP_KEYCODE_LEFT_SHIFT) ||
+                 is_key_down(SAPP_KEYCODE_RIGHT_SHIFT);
+    int n = (int)STATION_VIEW_COUNT;
+    g.station_view = (station_view_t)(((int)g.station_view +
+                                       (shift ? n - 1 : 1)) % n);
+    g.selected_contract = -1;
+}
+
+/* YARD tab keys: [1-9] order a scaffold kit. Surface every unlocked
+ * module type this yard can fabricate. (Plans are still useful for
+ * slot reservation, but no longer required to *order* a kit — the
+ * chicken-and-egg for the very first SIGNAL_RELAY would be unsolvable.) */
+static void sample_yard_keys(input_intent_t *intent) {
+    if (!LOCAL_PLAYER.docked || g.station_view != STATION_VIEW_YARD) return;
+    const station_t *st = current_station_ptr();
+    int shown = 0;
+    for (int t = 0; t < MODULE_COUNT && shown < 9; t++) {
+        module_type_t kit = (module_type_t)t;
+        if (module_kind(kit) == MODULE_KIND_NONE) continue;
+        if (!station_has_module(st, kit)) continue;
+        if (!module_unlocked_for_player(LOCAL_PLAYER.ship.unlocked_modules, kit)) continue;
+        if (is_key_pressed(SAPP_KEYCODE_1 + shown)) {
+            if (st->pending_scaffold_count >= 4) {
+                set_notice("Shipyard queue full.");
+            } else if ((int)lroundf(player_current_balance()) < scaffold_order_fee(kit)) {
+                set_notice("Need %d cr to order.", scaffold_order_fee(kit));
+            } else {
+                intent->buy_scaffold_kit = true;
+                intent->scaffold_kit_module = kit;
+                set_notice("Ordered %s scaffold.", module_type_name(kit));
+            }
+            return;
+        }
+        shown++;
+    }
+}
+
+/* WORK (JOBS) tab keys:
+ *   [1/2/3] select a contract slot for selective delivery
+ *   [S]     deliver — selective if a slot is selected, else all
+ * The display in station_ui.c sorts deliverable contracts first so [1]
+ * usually picks "the contract you can fulfill right now". */
+static void sample_work_keys(input_intent_t *intent) {
+    if (!LOCAL_PLAYER.docked || g.station_view != STATION_VIEW_WORK) return;
+
+    const station_t *here_st = current_station_ptr();
+    int here_idx = LOCAL_PLAYER.current_station;
+    vec2 here_pos = here_st ? here_st->pos : v2(0.0f, 0.0f);
+    int slot_contract[3] = {-1, -1, -1};
+    bool slot_full[3] = {false, false, false};
+    int slot_held_in[3] = {0, 0, 0};
+    (void)build_work_slots(here_idx, here_pos, slot_contract, slot_full, slot_held_in);
+    (void)slot_full;
+    (void)slot_held_in;
+
+    /* [1/2/3] select a contract slot. */
+    for (int k = 0; k < 3; k++) {
+        if (!is_key_pressed(SAPP_KEYCODE_1 + k)) continue;
+        if (slot_contract[k] < 0) break;
+        g.selected_contract = slot_contract[k];
+        g.tracked_contract = slot_contract[k];
+        const contract_t *ct = &g.world.contracts[slot_contract[k]];
+        set_notice("Selected: %s. [S] deliver.",
+                   commodity_short_name(ct->commodity));
+        break;
     }
 
-    /* [Tab] cycle docked tabs (DOCK ↔ CONTRACTS). Shift+Tab reverses. */
-    if (LOCAL_PLAYER.docked && is_key_pressed(SAPP_KEYCODE_TAB)) {
-        bool shift = is_key_down(SAPP_KEYCODE_LEFT_SHIFT) ||
-                     is_key_down(SAPP_KEYCODE_RIGHT_SHIFT);
-        int n = (int)STATION_VIEW_COUNT;
-        g.station_view = (station_view_t)(((int)g.station_view +
-                                           (shift ? n - 1 : 1)) % n);
+    if (!is_key_pressed(SAPP_KEYCODE_S)) return;
+
+    /* [S] deliver. Selective if a slot is selected, else everything. */
+    if (g.selected_contract >= 0 && g.selected_contract < MAX_CONTRACTS) {
+        const contract_t *ct = &g.world.contracts[g.selected_contract];
+        if (ct->active) {
+            intent->service_sell = true;
+            intent->service_sell_only = ct->commodity;
+            set_notice("Delivering %s...", commodity_short_name(ct->commodity));
+        } else {
+            /* Selected contract was completed/cancelled; fall back. */
+            intent->service_sell = true;
+            intent->service_sell_only = COMMODITY_COUNT;
+            set_notice("Delivering all matching cargo...");
+        }
         g.selected_contract = -1;
+        return;
     }
+    intent->service_sell = true;
+    intent->service_sell_only = COMMODITY_COUNT;
+    set_notice("Delivering all matching cargo...");
+}
 
-    /* Number keys: context-dependent.
-     * YARD at a shipyard → [1-9] order a scaffold kit. */
-    if (LOCAL_PLAYER.docked && g.station_view == STATION_VIEW_YARD) {
+/* DOCK (ship bay) tab keys:
+ *   [R] REPAIR
+ *   [M] upgrade mining laser
+ *   [H] upgrade hold capacity
+ *   [T] upgrade tractor */
+static void sample_dock_keys(input_intent_t *intent) {
+    if (!LOCAL_PLAYER.docked || g.station_view != STATION_VIEW_DOCK) return;
+    if (is_key_pressed(SAPP_KEYCODE_R)) {
         const station_t *st = current_station_ptr();
-        /* Yard: 1-9 order a scaffold.
-         * Surface every unlocked module type this yard can fabricate.
-         * (Plans are still useful for slot reservation in plan mode, but
-         * are no longer required to *order* a kit — the chicken-and-egg
-         * for the very first SIGNAL_RELAY would be unsolvable otherwise.) */
-        int shown = 0;
-        for (int t = 0; t < MODULE_COUNT && shown < 9; t++) {
-            module_type_t kit = (module_type_t)t;
-            if (module_kind(kit) == MODULE_KIND_NONE) continue;
-            if (!station_has_module(st, kit)) continue;
-            if (!module_unlocked_for_player(LOCAL_PLAYER.ship.unlocked_modules, kit)) continue;
-            if (is_key_pressed(SAPP_KEYCODE_1 + shown)) {
-                if (st->pending_scaffold_count >= 4) {
-                    set_notice("Shipyard queue full.");
-                } else if ((int)lroundf(player_current_balance()) < scaffold_order_fee(kit)) {
-                    set_notice("Need %d cr to order.", scaffold_order_fee(kit));
-                } else {
-                    intent.buy_scaffold_kit = true;
-                    intent.scaffold_kit_module = kit;
-                    set_notice("Ordered %s scaffold.", module_type_name(kit));
-                }
+        int kits_avail =
+            (int)floorf(LOCAL_PLAYER.ship.cargo[COMMODITY_REPAIR_KIT] + 0.0001f) +
+            (st ? (int)floorf(st->inventory[COMMODITY_REPAIR_KIT] + 0.0001f) : 0);
+        float max_hull = ship_max_hull(&LOCAL_PLAYER.ship);
+        bool needs_repair = LOCAL_PLAYER.ship.hull < max_hull;
+        if (needs_repair && kits_avail <= 0) set_notice("No repair kits available.");
+        else intent->service_repair = true;
+    }
+    intent->upgrade_mining  = is_key_pressed(SAPP_KEYCODE_M);
+    intent->upgrade_hold    = is_key_pressed(SAPP_KEYCODE_H);
+    intent->upgrade_tractor = is_key_pressed(SAPP_KEYCODE_T);
+}
+
+/* TRADE tab [S] — sell every commodity this station accepts. */
+static void sample_trade_sell_all(input_intent_t *intent) {
+    if (!LOCAL_PLAYER.docked || g.station_view != STATION_VIEW_TRADE) return;
+    if (!is_key_pressed(SAPP_KEYCODE_S)) return;
+    intent->service_sell = true;
+    intent->service_sell_only = COMMODITY_COUNT;
+    set_notice("Selling...");
+}
+
+/* TRADE picker row resolution + apply.
+ *
+ * The picker is a single page-flipping list of BUY rows (station sells)
+ * followed by SELL rows (station buys). [F] advances the page (wraps
+ * past the last). Digit keys [1]..[5] pick the Nth row on the current
+ * page and fire the matching intent. Row construction must match
+ * draw_trade_view in station_ui.c — divergence silently misroutes
+ * keys for non-dominant commodities. */
+typedef struct {
+    int kind;            /* 0 = BUY, 1 = SELL, -1 = no row */
+    commodity_t commodity;
+    mining_grade_t grade;
+} trade_row_t;
+
+/* Walk station BUY rows (one per commodity/grade with stock>0). */
+static bool trade_resolve_buy_row(const station_t *st, int station_idx,
+                                   int target, int *global_idx,
+                                   trade_row_t *out) {
+    for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++) {
+        if (!station_produces(st, (commodity_t)c)) continue;
+        if (st->base_price[c] <= FLOAT_EPSILON) continue;
+        for (int gi = 0; gi < MINING_GRADE_COUNT; gi++) {
+            int stock = (int)g.station_manifest_summary[station_idx][c][gi];
+            if (stock <= 0) continue;
+            if (*global_idx == target) {
+                out->kind = 0;
+                out->commodity = (commodity_t)c;
+                out->grade = (mining_grade_t)gi;
+                return true;
+            }
+            (*global_idx)++;
+        }
+    }
+    return false;
+}
+
+/* Walk SELL rows (one per commodity/grade the player carries that the
+ * station consumes). */
+static bool trade_resolve_sell_row(const ship_t *ship, const station_t *st,
+                                    int target, int *global_idx,
+                                    trade_row_t *out) {
+    if (!ship->manifest.units) return false;
+    for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++) {
+        if (!station_consumes(st, (commodity_t)c)) continue;
+        for (int gi = 0; gi < MINING_GRADE_COUNT; gi++) {
+            int cnt = 0;
+            for (uint16_t u = 0; u < ship->manifest.count; u++) {
+                const cargo_unit_t *cu = &ship->manifest.units[u];
+                if (cu->commodity == (uint8_t)c && cu->grade == (uint8_t)gi) cnt++;
+            }
+            if (cnt <= 0) continue;
+            if (*global_idx == target) {
+                out->kind = 1;
+                out->commodity = (commodity_t)c;
+                out->grade = (mining_grade_t)gi;
+                return true;
+            }
+            (*global_idx)++;
+        }
+    }
+    return false;
+}
+
+static void trade_apply_buy_row(input_intent_t *intent, const station_t *st,
+                                 const ship_t *ship, trade_row_t row) {
+    float price = station_sell_price(st, row.commodity) *
+                  mining_payout_multiplier(row.grade);
+    float free_volume = ship_cargo_capacity(ship) - ship_total_cargo(ship);
+    float vol = commodity_volume(row.commodity);
+    /* Match server: dense goods buy multi-per-press so a single keystroke
+     * fills one cargo unit. */
+    int per_press = (vol > FLOAT_EPSILON) ? (int)lroundf(1.0f / vol) : 1;
+    if (per_press < 1) per_press = 1;
+    if (free_volume + FLOAT_EPSILON < vol) { set_notice("Hold full."); return; }
+    if (player_current_balance() < price) { set_notice("Need $%d.", (int)lroundf(price)); return; }
+
+    intent->buy_product = true;
+    intent->buy_commodity = row.commodity;
+    intent->buy_grade = row.grade;
+    LOCAL_PLAYER.ship.cargo[row.commodity] += (float)per_press;
+    if (!g.multiplayer_enabled) {
+        station_t *mst = &g.world.stations[LOCAL_PLAYER.current_station];
+        float total = price * (float)per_press;
+        for (int li = 0; li < mst->ledger_count; li++) {
+            if (mst->ledger[li].balance >= total) {
+                mst->ledger[li].balance -= total;
                 break;
             }
-            shown++;
-        }
-    } else if (LOCAL_PLAYER.docked && g.station_view == STATION_VIEW_WORK) {
-        /* JOBS tab keys:
-         *   [1/2/3] select a contract slot for selective delivery
-         *   [S]     deliver — selective if a slot is selected, else all
-         *   [Tab]   next tab (global docked binding)
-         *
-         * The display in station_ui.c sorts deliverable contracts first
-         * so [1] usually picks "the contract you can fulfill right now".
-         * Selecting via [1/2/3] also tracks that contract for the HUD.
-         *
-         * S is shared with VERBS (same semantic) so the player doesn't
-         * learn a new deliver key per tab. [E] is LAUNCH, period. */
-        const station_t *here_st = current_station_ptr();
-        int here_idx = LOCAL_PLAYER.current_station;
-        vec2 here_pos = here_st ? here_st->pos : v2(0.0f, 0.0f);
-
-        /* Slot listing comes from build_work_slots() — the same helper
-         * draw_jobs_view uses, so [1]/[2]/[3] always selects the row
-         * the player sees. */
-        int slot_contract[3] = {-1, -1, -1};
-        bool slot_full[3] = {false, false, false};
-        int slot_held_in[3] = {0, 0, 0};
-        (void)build_work_slots(here_idx, here_pos,
-                               slot_contract, slot_full, slot_held_in);
-        (void)slot_full;
-        (void)slot_held_in;
-
-        /* [1/2/3] select a contract slot. */
-        for (int k = 0; k < 3; k++) {
-            if (!is_key_pressed(SAPP_KEYCODE_1 + k)) continue;
-            if (slot_contract[k] < 0) break;
-            g.selected_contract = slot_contract[k];
-            g.tracked_contract = slot_contract[k];
-            const contract_t *ct = &g.world.contracts[slot_contract[k]];
-            set_notice("Selected: %s. [S] deliver.",
-                       commodity_short_name(ct->commodity));
-            break;
-        }
-
-        /* [S] deliver. Selective if a slot is selected, else everything. */
-        if (is_key_pressed(SAPP_KEYCODE_S)) {
-            if (g.selected_contract >= 0 && g.selected_contract < MAX_CONTRACTS) {
-                const contract_t *ct = &g.world.contracts[g.selected_contract];
-                if (ct->active) {
-                    intent.service_sell = true;
-                    intent.service_sell_only = ct->commodity;
-                    set_notice("Delivering %s...",
-                               commodity_short_name(ct->commodity));
-                } else {
-                    /* Selected contract was completed/cancelled; fall back. */
-                    intent.service_sell = true;
-                    intent.service_sell_only = COMMODITY_COUNT;
-                    set_notice("Delivering all matching cargo...");
-                }
-                g.selected_contract = -1;
-            } else {
-                intent.service_sell = true;
-                intent.service_sell_only = COMMODITY_COUNT;
-                set_notice("Delivering all matching cargo...");
-            }
-        }
-    } else if (LOCAL_PLAYER.docked && g.station_view == STATION_VIEW_DOCK) {
-        /* DOCK tab keys (ship bay: repair + refit).
-         *   [R] REPAIR
-         *   [M] upgrade mining laser
-         *   [H] upgrade hold capacity
-         *   [T] upgrade tractor */
-        if (is_key_pressed(SAPP_KEYCODE_R)) {
-            const station_t *st = current_station_ptr();
-            int kits_avail =
-                (int)floorf(LOCAL_PLAYER.ship.cargo[COMMODITY_REPAIR_KIT] + 0.0001f) +
-                (st ? (int)floorf(st->inventory[COMMODITY_REPAIR_KIT] + 0.0001f) : 0);
-            float max_hull = ship_max_hull(&LOCAL_PLAYER.ship);
-            bool needs_repair = LOCAL_PLAYER.ship.hull < max_hull;
-            if (needs_repair && kits_avail <= 0) {
-                set_notice("No repair kits available.");
-            } else {
-                intent.service_repair = true;
-            }
-        }
-        intent.upgrade_mining = is_key_pressed(SAPP_KEYCODE_M);
-        intent.upgrade_hold   = is_key_pressed(SAPP_KEYCODE_H);
-        intent.upgrade_tractor= is_key_pressed(SAPP_KEYCODE_T);
-    } else if (LOCAL_PLAYER.docked && g.station_view == STATION_VIEW_TRADE) {
-        /* TRADE tab keys:
-         *   [F] BUY primary product (see the dedicated handler below)
-         *   [S] SELL all matching cargo this station accepts */
-        if (is_key_pressed(SAPP_KEYCODE_S)) {
-            intent.service_sell = true;
-            intent.service_sell_only = COMMODITY_COUNT;
-            set_notice("Selling...");
         }
     }
+    set_notice("-$%d  %s %s x%d",
+               (int)lroundf(price * (float)per_press),
+               mining_grade_label(row.grade),
+               commodity_short_name(row.commodity), per_press);
+}
 
-    /* TRADE picker: unified list of BUY rows (station sells) followed by
-     * SELL rows (station buys). [F] advances the current page (wraps at
-     * the last). Digit keys [1]..[5] pick the Nth row on the current
-     * page and fire the matching intent. See draw_trade_view in
-     * station_ui.c for the row layout. */
-    if (LOCAL_PLAYER.docked && g.station_view == STATION_VIEW_TRADE) {
-        const station_t *st = current_station_ptr();
-        if (is_key_pressed(SAPP_KEYCODE_F)) {
-            g.trade_page++;  /* render wraps back to 0 when > available pages */
+static void sample_trade_picker(input_intent_t *intent) {
+    if (!LOCAL_PLAYER.docked || g.station_view != STATION_VIEW_TRADE) return;
+    const station_t *st = current_station_ptr();
+    if (is_key_pressed(SAPP_KEYCODE_F)) g.trade_page++;
+    int digit_pick = -1;
+    for (int i = 0; i < 5 && digit_pick < 0; i++)
+        if (is_key_pressed(SAPP_KEYCODE_1 + i)) digit_pick = i;
+    if (digit_pick < 0 || !st) return;
+
+    const ship_t *ship = &LOCAL_PLAYER.ship;
+    int global_idx = 0;
+    int target = (int)g.trade_page * 5 + digit_pick;
+    int station_idx = (int)(st - g.world.stations);
+    trade_row_t row = { .kind = -1 };
+
+    if (station_idx >= 0 && station_idx < MAX_STATIONS)
+        trade_resolve_buy_row(st, station_idx, target, &global_idx, &row);
+    if (row.kind < 0)
+        trade_resolve_sell_row(ship, st, target, &global_idx, &row);
+
+    if (row.kind == 0) {
+        trade_apply_buy_row(intent, st, ship, row);
+    } else if (row.kind == 1) {
+        intent->service_sell = true;
+        intent->service_sell_only = row.commodity;
+        set_notice("Selling %s %s...",
+                   mining_grade_label(row.grade),
+                   commodity_short_name(row.commodity));
+    } else {
+        /* Past the end — wrap the page pointer so [F] feels natural. */
+        g.trade_page = 0;
+    }
+}
+
+/* Tow mode: server snaps to the closest slot on E. */
+static void sample_placement_tow(input_intent_t *intent) {
+    g.placement_reticle_active = false;
+    if (!is_key_pressed(SAPP_KEYCODE_E)) return;
+    reticle_target_t targets[RETICLE_MAX_TARGETS];
+    int n = collect_reticle_targets(LOCAL_PLAYER.ship.pos, targets, RETICLE_MAX_TARGETS);
+    intent->place_outpost = true;
+    if (n > 0) {
+        intent->place_target_station = (int8_t)targets[0].station;
+        intent->place_target_ring = (int8_t)targets[0].ring;
+        intent->place_target_slot = (int8_t)targets[0].slot;
+    }
+    /* No outpost in range falls through with all -1 sentinels — server
+     * decides whether to materialize a nearby planned station or found
+     * a new outpost from scratch. */
+    set_notice("Placing scaffold...");
+}
+
+/* Plan mode (real station target): pull reticle target every frame so
+ * the rings track the player's nearest slot. If nothing in range for
+ * grace_until expiry, exit plan mode. */
+static void plan_mode_real_track(void) {
+    reticle_target_t targets[RETICLE_MAX_TARGETS];
+    int n = collect_reticle_targets(LOCAL_PLAYER.ship.pos, targets, RETICLE_MAX_TARGETS);
+    if (n == 0) {
+        if (g.world.time >= g.plan_mode_grace_until) g.plan_mode_active = false;
+        return;
+    }
+    g.placement_target_station = targets[0].station;
+    g.placement_target_ring = targets[0].ring;
+    g.placement_target_slot = targets[0].slot;
+    g.plan_mode_grace_until = 0.0f;
+}
+
+/* Plan mode (ghost preview): pick the slot closest to the ship's
+ * forward direction. Ghost preview rings draw around the player's
+ * ship, no server message until E. */
+static void plan_mode_ghost_track(void) {
+    vec2 fwd = v2_from_angle(LOCAL_PLAYER.ship.angle);
+    float best_dot = -2.0f;
+    int best_ring = 1, best_slot = 0;
+    for (int ring = 1; ring <= 1; ring++) { /* ghost starts with ring 1 only */
+        int slots_n = STATION_RING_SLOTS[ring];
+        for (int slot = 0; slot < slots_n; slot++) {
+            float angle = TWO_PI_F * (float)slot / (float)slots_n;
+            vec2 dir = v2(cosf(angle), sinf(angle));
+            float d = v2_dot(fwd, dir);
+            if (d > best_dot) { best_dot = d; best_ring = ring; best_slot = slot; }
         }
+    }
+    g.placement_target_station = -1;
+    g.placement_target_ring = best_ring;
+    g.placement_target_slot = best_slot;
+}
 
-        int digit_pick = -1;
-        for (int i = 0; i < 5 && digit_pick < 0; i++) {
-            if (is_key_pressed(SAPP_KEYCODE_1 + i)) digit_pick = i;
+/* Plan mode B/Esc exit. Returns true if exit fired. Cancel a real
+ * planned outpost too if it was empty (no plans yet). */
+static bool plan_mode_handle_exit(input_intent_t *intent, bool ghost_mode) {
+    if (!is_key_pressed(SAPP_KEYCODE_ESCAPE) && !is_key_pressed(SAPP_KEYCODE_B))
+        return false;
+    if (!ghost_mode) {
+        int s = g.placement_target_station;
+        if (s >= 3 && s < MAX_STATIONS &&
+            g.world.stations[s].planned &&
+            g.world.stations[s].placement_plan_count == 0) {
+            intent->cancel_planned_outpost = true;
+            intent->cancel_planned_station = (int8_t)s;
+            set_notice("Outpost design cancelled.");
         }
+    }
+    g.plan_mode_active = false;
+    return true;
+}
 
-        if (digit_pick >= 0 && st) {
-            /* Walk the same row construction as draw_trade_view: BUY rows
-             * first (station sells sell_c, one per non-zero grade; legacy
-             * float → one COMMON row), then SELL rows (ship holds buy_c,
-             * one per non-zero grade; legacy float → one COMMON row).
-             * Skip (page * 5) rows, pick the digit_pick-th on this page. */
-            const ship_t *ship = &LOCAL_PLAYER.ship;
-            int global_idx = 0;
-            int target = (int)g.trade_page * 5 + digit_pick;
+/* Plan mode R: cycle through unlocked, available module types. */
+static void plan_mode_handle_cycle_type(input_intent_t *intent) {
+    if (!is_key_pressed(SAPP_KEYCODE_R)) return;
+    static const module_type_t plannable[] = {
+        MODULE_FURNACE, MODULE_FURNACE_CU, MODULE_FURNACE_CR,
+        MODULE_FRAME_PRESS, MODULE_LASER_FAB, MODULE_TRACTOR_FAB,
+        MODULE_ORE_SILO, MODULE_CARGO_BAY,
+        MODULE_REPAIR_BAY, MODULE_SIGNAL_RELAY, MODULE_DOCK,
+        MODULE_SHIPYARD,
+    };
+    int count = (int)(sizeof(plannable)/sizeof(plannable[0]));
+    module_type_t planned[PLAYER_PLAN_TYPE_LIMIT];
+    int planned_n = player_planned_types(planned, PLAYER_PLAN_TYPE_LIMIT);
+    uint32_t mask = LOCAL_PLAYER.ship.unlocked_modules;
+    int cur = 0;
+    for (int i = 0; i < count; i++)
+        if ((int)plannable[i] == g.plan_type) { cur = i; break; }
+    int next = -1;
+    for (int step = 1; step <= count; step++) {
+        int idx = (cur + step) % count;
+        module_type_t t = plannable[idx];
+        if (!module_unlocked_for_player(mask, t)) continue;
+        if (planned_n >= PLAYER_PLAN_TYPE_LIMIT) {
+            bool match = false;
+            for (int k = 0; k < planned_n; k++)
+                if (planned[k] == t) { match = true; break; }
+            if (!match) continue;
+        }
+        next = (int)t;
+        break;
+    }
+    if (next >= 0) g.plan_type = next;
+    intent->release_tow = false;
+}
 
-            /* Row type resolution. Walks every produced/consumed
-             * commodity in the same order as the picker (station_ui.c).
-             * Previously this only iterated station_primary_sell()'s
-             * dominant-module output, so multi-furnace stations like
-             * Helios (FE + CU + CR) silently misrouted hotkey presses
-             * for non-dominant commodities. */
-            int row_kind = -1;        /* 0 = BUY, 1 = SELL */
-            commodity_t row_c = 0;
-            mining_grade_t row_g = MINING_GRADE_COMMON;
+/* Plan mode E in ghost preview mode: lock the outpost. */
+static void plan_mode_handle_ghost_lock(input_intent_t *intent) {
+    vec2 pos = LOCAL_PLAYER.ship.pos;
+    bool too_close = false;
+    for (int s = 0; s < MAX_STATIONS; s++) {
+        const station_t *st = &g.world.stations[s];
+        if (!station_exists(st)) continue;
+        if (v2_dist_sq(st->pos, pos) < OUTPOST_MIN_DISTANCE * OUTPOST_MIN_DISTANCE) {
+            too_close = true; break;
+        }
+    }
+    float here_sig = signal_strength_at(&g.world, pos);
+    if (too_close) { set_notice("Too close to an existing station."); return; }
+    if (here_sig <= 0.0f) { set_notice("No signal here."); return; }
+    if (here_sig >= OUTPOST_MAX_SIGNAL) {
+        set_notice("Too deep in station coverage. Move to the fringe.");
+        return;
+    }
+    /* Atomic create + first plan */
+    intent->create_planned_outpost = true;
+    intent->planned_outpost_pos = pos;
+    intent->add_plan = true;
+    intent->plan_station = -2; /* sentinel: just-created */
+    intent->plan_ring = (int8_t)g.placement_target_ring;
+    intent->plan_slot = (int8_t)g.placement_target_slot;
+    intent->plan_type = (module_type_t)g.plan_type;
+    g.outpost_lock_timer = 1.5f;
+    g.outpost_lock_pos = pos;
+    /* Wait for the server to send back the created station, then switch
+     * to real plan mode targeting it. */
+    g.plan_mode_grace_until = g.world.time + 1.5f;
+    set_notice("Station locked! [R] type [E] place [B] exit");
+}
 
-            /* BUY rows — one per (commodity, grade) with > 0 stock at a
-             * station that produces that commodity. */
-            int station_idx = (int)(st - g.world.stations);
-            if (station_idx >= 0 && station_idx < MAX_STATIONS) {
-                for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++) {
-                    if (!station_produces(st, (commodity_t)c)) continue;
-                    if (st->base_price[c] <= FLOAT_EPSILON) continue;
-                    for (int gi = 0; gi < MINING_GRADE_COUNT; gi++) {
-                        int stock = (int)g.station_manifest_summary[station_idx][c][gi];
-                        if (stock <= 0) continue;
-                        if (global_idx == target) {
-                            row_kind = 0; row_c = (commodity_t)c; row_g = (mining_grade_t)gi;
-                            goto row_resolved;
-                        }
-                        global_idx++;
-                    }
-                }
-            }
-            /* SELL rows — every commodity the station consumes that the
-             * player carries. */
-            if (ship->manifest.units) {
-                for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++) {
-                    if (!station_consumes(st, (commodity_t)c)) continue;
-                    for (int gi = 0; gi < MINING_GRADE_COUNT; gi++) {
-                        int cnt = 0;
-                        for (uint16_t u = 0; u < ship->manifest.count; u++) {
-                            const cargo_unit_t *cu = &ship->manifest.units[u];
-                            if (cu->commodity == (uint8_t)c && cu->grade == (uint8_t)gi) cnt++;
-                        }
-                        if (cnt <= 0) continue;
-                        if (global_idx == target) {
-                            row_kind = 1; row_c = (commodity_t)c; row_g = (mining_grade_t)gi;
-                            goto row_resolved;
-                        }
-                        global_idx++;
-                    }
-                }
-            }
-
-            /* Past the end — wrap the page pointer so [F] feels natural. */
-            g.trade_page = 0;
-
-        row_resolved:
-            if (row_kind == 0) {
-                /* BUY action */
-                float price = station_sell_price(st, row_c) * mining_payout_multiplier(row_g);
-                float free_volume = ship_cargo_capacity(ship) - ship_total_cargo(ship);
-                float vol = commodity_volume(row_c);
-                /* Match server: dense goods buy multi-per-press so a
-                 * single keystroke fills one cargo unit. */
-                int per_press = (vol > FLOAT_EPSILON) ? (int)lroundf(1.0f / vol) : 1;
-                if (per_press < 1) per_press = 1;
-                if (free_volume + FLOAT_EPSILON < vol) {
-                    set_notice("Hold full.");
-                } else if (player_current_balance() < price) {
-                    set_notice("Need $%d.", (int)lroundf(price));
-                } else {
-                    intent.buy_product = true;
-                    intent.buy_commodity = row_c;
-                    intent.buy_grade = row_g;
-                    LOCAL_PLAYER.ship.cargo[row_c] += (float)per_press;
-                    if (!g.multiplayer_enabled) {
-                        station_t *mst = &g.world.stations[LOCAL_PLAYER.current_station];
-                        float total = price * (float)per_press;
-                        for (int li = 0; li < mst->ledger_count; li++)
-                            if (mst->ledger[li].balance >= total) {
-                                mst->ledger[li].balance -= total;
-                                break;
-                            }
-                    }
-                    set_notice("-$%d  %s %s x%d",
-                               (int)lroundf(price * (float)per_press),
-                               mining_grade_label(row_g),
-                               commodity_short_name(row_c), per_press);
-                }
-            } else if (row_kind == 1) {
-                /* SELL action — routes through the existing per-commodity
-                 * sell path. Grade-precise server-side sell is a follow-up. */
-                intent.service_sell = true;
-                intent.service_sell_only = row_c;
-                set_notice("Selling %s %s...",
-                           mining_grade_label(row_g), commodity_short_name(row_c));
+/* Plan mode E on a real station: toggle the slot's plan. */
+static void plan_mode_handle_real_place(input_intent_t *intent) {
+    int ps = g.placement_target_station;
+    int pr = g.placement_target_ring;
+    int psl = g.placement_target_slot;
+    bool has_existing = false;
+    if (ps >= 0 && ps < MAX_STATIONS) {
+        const station_t *pst = &g.world.stations[ps];
+        for (int p = 0; p < pst->placement_plan_count; p++) {
+            if (pst->placement_plans[p].ring == pr &&
+                pst->placement_plans[p].slot == psl) {
+                has_existing = true; break;
             }
         }
     }
+    if (has_existing) {
+        intent->cancel_plan_slot = true;
+        intent->cancel_plan_st = (int8_t)ps;
+        intent->cancel_plan_ring = (int8_t)pr;
+        intent->cancel_plan_sl = (int8_t)psl;
+        set_notice("Plan cleared. [R] type [E] place [B] exit");
+        return;
+    }
+    intent->add_plan = true;
+    intent->plan_station = (int8_t)ps;
+    intent->plan_ring = (int8_t)pr;
+    intent->plan_slot = (int8_t)psl;
+    intent->plan_type = (module_type_t)g.plan_type;
+    set_notice("Planned %s. [R] type [E] place [B] exit",
+               module_type_name((module_type_t)g.plan_type));
+}
 
-    /* B / R / E: placement (tow mode) and planning (plan mode).
-     * Tow mode: position auto-picks slot, E commits, no reticle.
-     * Plan mode: position auto-picks slot, R cycles type, E reserves slot.
-     * B enters/exits plan mode. Plans are server-side. */
+/* Plan mode E dispatch: lock, type-cycle, or place. */
+static void plan_mode_handle_e(input_intent_t *intent, bool ghost_mode) {
+    if (!is_key_pressed(SAPP_KEYCODE_E)) return;
+    module_type_t planned[PLAYER_PLAN_TYPE_LIMIT];
+    int planned_n = player_planned_types(planned, PLAYER_PLAN_TYPE_LIMIT);
+    bool already = false;
+    for (int k = 0; k < planned_n; k++)
+        if (planned[k] == (module_type_t)g.plan_type) { already = true; break; }
+    if (!module_unlocked_for_player(LOCAL_PLAYER.ship.unlocked_modules,
+                                    (module_type_t)g.plan_type)) {
+        set_notice("%s is locked.", module_type_name((module_type_t)g.plan_type));
+        return;
+    }
+    if (!already && planned_n >= PLAYER_PLAN_TYPE_LIMIT) {
+        set_notice("Plan limit %d types. Cancel one first.", PLAYER_PLAN_TYPE_LIMIT);
+        return;
+    }
+    if (ghost_mode) plan_mode_handle_ghost_lock(intent);
+    else            plan_mode_handle_real_place(intent);
+}
+
+/* Plan mode top-level: track target, then dispatch B/Esc/R/E. */
+static void sample_plan_mode(input_intent_t *intent) {
+    bool ghost_mode = (g.plan_target_station == -1);
+    if (!ghost_mode) plan_mode_real_track();
+    else             plan_mode_ghost_track();
+    if (plan_mode_handle_exit(intent, ghost_mode)) return;
+    if (!g.plan_mode_active) return;
+    plan_mode_handle_cycle_type(intent);
+    plan_mode_handle_e(intent, ghost_mode);
+}
+
+/* B undocked, not towing: enter plan mode targeting nearest outpost
+ * (real) or kick off ghost preview (none in range). */
+static void sample_b_enter_plan(void) {
+    if (!is_key_pressed(SAPP_KEYCODE_B) || LOCAL_PLAYER.docked) return;
+    reticle_target_t targets[RETICLE_MAX_TARGETS];
+    int n = collect_reticle_targets(LOCAL_PLAYER.ship.pos, targets, RETICLE_MAX_TARGETS);
+    uint32_t mask = LOCAL_PLAYER.ship.unlocked_modules;
+    if (g.plan_type == 0 || g.plan_type == MODULE_DOCK ||
+        !module_unlocked_for_player(mask, (module_type_t)g.plan_type)) {
+        g.plan_type = MODULE_SIGNAL_RELAY;
+    }
+    if (n > 0) {
+        g.plan_mode_active = true;
+        g.placement_target_station = targets[0].station;
+        g.placement_target_ring = targets[0].ring;
+        g.placement_target_slot = targets[0].slot;
+        g.plan_target_station = targets[0].station;
+        set_notice("Plan: [R] type [E] place [B] exit");
+    } else {
+        g.plan_mode_active = true;
+        g.plan_target_station = -1; /* sentinel: ghost */
+        g.placement_target_station = -1;
+        g.placement_target_ring = 1;
+        g.placement_target_slot = 0;
+        set_notice("Plan: [R] type [E] lock [B] exit");
+    }
+}
+
+/* B / R / E: placement (tow mode), planning (plan mode), or enter-plan. */
+static void sample_placement(input_intent_t *intent) {
     if (!LOCAL_PLAYER.docked && LOCAL_PLAYER.ship.towed_scaffold >= 0) {
-        /* TOW MODE: server snaps to closest slot on E. */
-        g.placement_reticle_active = false;
-        if (is_key_pressed(SAPP_KEYCODE_E)) {
-            reticle_target_t targets[RETICLE_MAX_TARGETS];
-            int n = collect_reticle_targets(LOCAL_PLAYER.ship.pos, targets, RETICLE_MAX_TARGETS);
-            if (n > 0) {
-                intent.place_outpost = true;
-                intent.place_target_station = (int8_t)targets[0].station;
-                intent.place_target_ring = (int8_t)targets[0].ring;
-                intent.place_target_slot = (int8_t)targets[0].slot;
-                set_notice("Placing scaffold...");
-            } else {
-                /* No outpost in range — let server decide:
-                 * - materialize a nearby planned station, or
-                 * - found a new outpost from scratch */
-                intent.place_outpost = true;
-                set_notice("Placing scaffold...");
-            }
-        }
-    } else if (g.plan_mode_active) {
-        /* PLAN MODE: cycle types with R, place with E, exit with B/Esc.
-         *
-         * Two sub-modes:
-         *   plan_target_station == -1  →  GHOST PREVIEW: rings draw
-         *     around the player's ship; nothing committed server-side yet.
-         *   plan_target_station >= 3   →  REAL: targeting a server-side
-         *     planned station (created by E in ghost mode or by legacy path).
-         */
-        bool ghost_mode = (g.plan_target_station == -1);
-
-        if (!ghost_mode) {
-            /* Real station: find reticle targets normally. */
-            reticle_target_t targets[RETICLE_MAX_TARGETS];
-            int n = collect_reticle_targets(LOCAL_PLAYER.ship.pos, targets, RETICLE_MAX_TARGETS);
-            if (n == 0) {
-                if (g.world.time >= g.plan_mode_grace_until) {
-                    g.plan_mode_active = false;
-                }
-            } else {
-                g.placement_target_station = targets[0].station;
-                g.placement_target_ring = targets[0].ring;
-                g.placement_target_slot = targets[0].slot;
-                g.plan_mode_grace_until = 0.0f;
-            }
-        } else {
-            /* Ghost mode: pick the slot closest to the ship's forward. */
-            vec2 fwd = v2_from_angle(LOCAL_PLAYER.ship.angle);
-            float best_dot = -2.0f;
-            int best_ring = 1, best_slot = 0;
-            for (int ring = 1; ring <= 1; ring++) { /* ghost starts with ring 1 only */
-                int slots_n = STATION_RING_SLOTS[ring];
-                for (int slot = 0; slot < slots_n; slot++) {
-                    float angle = TWO_PI_F * (float)slot / (float)slots_n;
-                    vec2 dir = v2(cosf(angle), sinf(angle));
-                    float d = v2_dot(fwd, dir);
-                    if (d > best_dot) { best_dot = d; best_ring = ring; best_slot = slot; }
-                }
-            }
-            g.placement_target_station = -1;
-            g.placement_target_ring = best_ring;
-            g.placement_target_slot = best_slot;
-        }
-
-        if (is_key_pressed(SAPP_KEYCODE_ESCAPE) || is_key_pressed(SAPP_KEYCODE_B)) {
-            if (!ghost_mode) {
-                int s = g.placement_target_station;
-                if (s >= 3 && s < MAX_STATIONS &&
-                    g.world.stations[s].planned &&
-                    g.world.stations[s].placement_plan_count == 0) {
-                    intent.cancel_planned_outpost = true;
-                    intent.cancel_planned_station = (int8_t)s;
-                    set_notice("Outpost design cancelled.");
-                }
-            }
-            g.plan_mode_active = false;
-        } else if (g.plan_mode_active) {
-            if (is_key_pressed(SAPP_KEYCODE_R)) {
-                static const module_type_t plannable[] = {
-                    MODULE_FURNACE, MODULE_FURNACE_CU, MODULE_FURNACE_CR,
-                    MODULE_FRAME_PRESS, MODULE_LASER_FAB, MODULE_TRACTOR_FAB,
-                    MODULE_ORE_SILO, MODULE_CARGO_BAY,
-                    MODULE_REPAIR_BAY, MODULE_SIGNAL_RELAY, MODULE_DOCK,
-                    MODULE_SHIPYARD,
-                };
-                int count = (int)(sizeof(plannable)/sizeof(plannable[0]));
-                module_type_t planned[PLAYER_PLAN_TYPE_LIMIT];
-                int planned_n = player_planned_types(planned, PLAYER_PLAN_TYPE_LIMIT);
-                uint32_t mask = LOCAL_PLAYER.ship.unlocked_modules;
-                int cur = 0;
-                for (int i = 0; i < count; i++)
-                    if ((int)plannable[i] == g.plan_type) { cur = i; break; }
-                int next = -1;
-                for (int step = 1; step <= count; step++) {
-                    int idx = (cur + step) % count;
-                    module_type_t t = plannable[idx];
-                    if (!module_unlocked_for_player(mask, t)) continue;
-                    if (planned_n >= PLAYER_PLAN_TYPE_LIMIT) {
-                        bool match = false;
-                        for (int k = 0; k < planned_n; k++)
-                            if (planned[k] == t) { match = true; break; }
-                        if (!match) continue;
-                    }
-                    next = (int)t;
-                    break;
-                }
-                if (next >= 0) g.plan_type = next;
-                intent.release_tow = false;
-            } else if (is_key_pressed(SAPP_KEYCODE_E)) {
-                module_type_t planned[PLAYER_PLAN_TYPE_LIMIT];
-                int planned_n = player_planned_types(planned, PLAYER_PLAN_TYPE_LIMIT);
-                bool already = false;
-                for (int k = 0; k < planned_n; k++)
-                    if (planned[k] == (module_type_t)g.plan_type) { already = true; break; }
-                if (!module_unlocked_for_player(LOCAL_PLAYER.ship.unlocked_modules,
-                                                (module_type_t)g.plan_type)) {
-                    set_notice("%s is locked.", module_type_name((module_type_t)g.plan_type));
-                } else if (!already && planned_n >= PLAYER_PLAN_TYPE_LIMIT) {
-                    set_notice("Plan limit %d types. Cancel one first.",
-                        PLAYER_PLAN_TYPE_LIMIT);
-                } else if (ghost_mode) {
-                    /* Ghost → lock: create planned outpost + first plan
-                     * in one atomic message. The station materializes at
-                     * the player's current ship position. */
-                    vec2 pos = LOCAL_PLAYER.ship.pos;
-                    bool too_close = false;
-                    for (int s = 0; s < MAX_STATIONS; s++) {
-                        const station_t *st = &g.world.stations[s];
-                        if (!station_exists(st)) continue;
-                        if (v2_dist_sq(st->pos, pos) < OUTPOST_MIN_DISTANCE * OUTPOST_MIN_DISTANCE) {
-                            too_close = true; break;
-                        }
-                    }
-                    float here_sig = signal_strength_at(&g.world, pos);
-                    if (too_close) {
-                        set_notice("Too close to an existing station.");
-                    } else if (here_sig <= 0.0f) {
-                        set_notice("No signal here.");
-                    } else if (here_sig >= OUTPOST_MAX_SIGNAL) {
-                        set_notice("Too deep in station coverage. Move to the fringe.");
-                    } else {
-                        /* Atomic create + first plan */
-                        intent.create_planned_outpost = true;
-                        intent.planned_outpost_pos = pos;
-                        intent.add_plan = true;
-                        intent.plan_station = -2; /* sentinel: just-created */
-                        intent.plan_ring = (int8_t)g.placement_target_ring;
-                        intent.plan_slot = (int8_t)g.placement_target_slot;
-                        intent.plan_type = (module_type_t)g.plan_type;
-                        /* Lock effect */
-                        g.outpost_lock_timer = 1.5f;
-                        g.outpost_lock_pos = pos;
-                        /* Transition to grace mode — wait for server to
-                         * send back the created station, then switch to
-                         * real plan mode targeting it. */
-                        g.plan_mode_grace_until = g.world.time + 1.5f;
-                        set_notice("Station locked! [R] type [E] place [B] exit");
-                    }
-                } else {
-                    /* Real station: check if this slot already has a plan.
-                     * If so, E clears it (cancel). Otherwise E adds. */
-                    int ps = g.placement_target_station;
-                    int pr = g.placement_target_ring;
-                    int psl = g.placement_target_slot;
-                    bool has_existing = false;
-                    if (ps >= 0 && ps < MAX_STATIONS) {
-                        const station_t *pst = &g.world.stations[ps];
-                        for (int p = 0; p < pst->placement_plan_count; p++) {
-                            if (pst->placement_plans[p].ring == pr &&
-                                pst->placement_plans[p].slot == psl) {
-                                has_existing = true; break;
-                            }
-                        }
-                    }
-                    if (has_existing) {
-                        intent.cancel_plan_slot = true;
-                        intent.cancel_plan_st = (int8_t)ps;
-                        intent.cancel_plan_ring = (int8_t)pr;
-                        intent.cancel_plan_sl = (int8_t)psl;
-                        set_notice("Plan cleared. [R] type [E] place [B] exit");
-                    } else {
-                        intent.add_plan = true;
-                        intent.plan_station = (int8_t)ps;
-                        intent.plan_ring = (int8_t)pr;
-                        intent.plan_slot = (int8_t)psl;
-                        intent.plan_type = (module_type_t)g.plan_type;
-                        set_notice("Planned %s. [R] type [E] place [B] exit",
-                            module_type_name((module_type_t)g.plan_type));
-                    }
-                }
-            }
-        }
-    } else if (is_key_pressed(SAPP_KEYCODE_B) && !LOCAL_PLAYER.docked) {
-        {
-            /* Undocked, not towing.
-             * Near an existing outpost or planned station → enter plan
-             * mode targeting it. Otherwise → enter ghost preview mode
-             * (rings follow ship, nothing committed until E). */
-            reticle_target_t targets[RETICLE_MAX_TARGETS];
-            int n = collect_reticle_targets(LOCAL_PLAYER.ship.pos, targets, RETICLE_MAX_TARGETS);
-            uint32_t mask = LOCAL_PLAYER.ship.unlocked_modules;
-            if (g.plan_type == 0 || g.plan_type == MODULE_DOCK ||
-                !module_unlocked_for_player(mask, (module_type_t)g.plan_type)) {
-                g.plan_type = MODULE_SIGNAL_RELAY;
-            }
-            if (n > 0) {
-                g.plan_mode_active = true;
-                g.placement_target_station = targets[0].station;
-                g.placement_target_ring = targets[0].ring;
-                g.placement_target_slot = targets[0].slot;
-                g.plan_target_station = targets[0].station;
-                set_notice("Plan: [R] type [E] place [B] exit");
-            } else {
-                /* Ghost preview: rings follow the ship, no server message. */
-                g.plan_mode_active = true;
-                g.plan_target_station = -1; /* sentinel: ghost */
-                g.placement_target_station = -1;
-                g.placement_target_ring = 1;
-                g.placement_target_slot = 0;
-                set_notice("Plan: [R] type [E] lock [B] exit");
-            }
-        }
+        sample_placement_tow(intent);
+        return;
     }
+    if (g.plan_mode_active) {
+        sample_plan_mode(intent);
+        return;
+    }
+    sample_b_enter_plan();
+}
 
-    /* [ ] keys: prev/next track */
+/* [ ] keys cycle music tracks. */
+static void sample_music(void) {
     if (is_key_pressed(SAPP_KEYCODE_LEFT_BRACKET)) {
         music_prev_track(&g.music);
         const music_track_info_t *info = music_get_info(g.music.current_track);
@@ -803,31 +809,69 @@ input_intent_t sample_input_intent(void) {
         const music_track_info_t *info = music_get_info(g.music.current_track);
         if (info) set_notice("%s", info->title);
     }
-    /* H key: hail ping. Visual expanding ring fires locally so the
-     * press feels instant; server decides which (if any) station to
-     * respond with based on ship.comm_range. */
-    if (is_key_pressed(SAPP_KEYCODE_H) && !LOCAL_PLAYER.docked) {
-        intent.hail = true;
-        g.hail_ping_timer  = 0.001f; /* any nonzero = active */
-        g.hail_ping_origin = LOCAL_PLAYER.ship.pos;
-        g.hail_ping_range  = (LOCAL_PLAYER.ship.comm_range > 0.0f)
-                             ? LOCAL_PLAYER.ship.comm_range : 1500.0f;
+}
+
+/* H: hail ping. Visual ring fires locally so the press feels instant;
+ * server decides which (if any) station to respond with based on
+ * ship.comm_range. */
+static void sample_hail(input_intent_t *intent) {
+    if (!is_key_pressed(SAPP_KEYCODE_H) || LOCAL_PLAYER.docked) return;
+    intent->hail = true;
+    g.hail_ping_timer  = 0.001f; /* any nonzero = active */
+    g.hail_ping_origin = LOCAL_PLAYER.ship.pos;
+    g.hail_ping_range  = (LOCAL_PLAYER.ship.comm_range > 0.0f)
+                         ? LOCAL_PLAYER.ship.comm_range : 1500.0f;
+}
+
+/* O: toggle mining autopilot. Server-side AI runs the mining loop on
+ * the player's ship. Manual movement / mine input cancels it. Works
+ * docked or undocked. */
+static void sample_autopilot(input_intent_t *intent) {
+    if (!is_key_pressed(SAPP_KEYCODE_O)) return;
+    if (LOCAL_PLAYER.autopilot_mode) {
+        intent->toggle_autopilot = true; /* always allow turning off */
+        return;
     }
-    /* O key: toggle mining autopilot — server-side AI runs the mining
-     * loop on the player's ship. Any manual movement or mine input
-     * cancels it. Works docked or undocked. */
-    if (is_key_pressed(SAPP_KEYCODE_O)) {
-        if (!LOCAL_PLAYER.autopilot_mode) {
-            float sig = signal_strength_at(&g.world, LOCAL_PLAYER.ship.pos);
-            if (sig < SIGNAL_BAND_OPERATIONAL) {
-                set_notice("Signal too weak for autopilot.");
-            } else {
-                intent.toggle_autopilot = true;
-            }
-        } else {
-            intent.toggle_autopilot = true; /* always allow turning off */
-        }
+    float sig = signal_strength_at(&g.world, LOCAL_PLAYER.ship.pos);
+    if (sig < SIGNAL_BAND_OPERATIONAL) {
+        set_notice("Signal too weak for autopilot.");
+        return;
     }
+    intent->toggle_autopilot = true;
+}
+
+input_intent_t sample_input_intent(void) {
+    input_intent_t intent = { 0 };
+    /* Default buy_grade to "any" (sentinel = MINING_GRADE_COUNT) so
+     * manifest-first transfers don't accidentally prefer COMMON just
+     * because the zero-init lands there. */
+    intent.buy_grade = MINING_GRADE_COUNT;
+    intent.place_target_station = -1;
+    intent.place_target_ring = -1;
+    intent.place_target_slot = -1;
+    intent.plan_station = -1;
+    intent.plan_ring = -1;
+    intent.plan_slot = -1;
+    intent.cancel_planned_station = -1;
+    intent.service_sell_only = COMMODITY_COUNT; /* default: deliver all */
+
+    sample_movement(&intent);
+    sample_tractor(&intent);
+    sample_boost(&intent);
+    sample_self_destruct(&intent);
+    sample_ui_safety();
+    sample_targeting(&intent);
+    sample_e_interact(&intent);
+    sample_station_tab();
+    sample_yard_keys(&intent);
+    sample_work_keys(&intent);
+    sample_dock_keys(&intent);
+    sample_trade_sell_all(&intent);
+    sample_trade_picker(&intent);
+    sample_placement(&intent);
+    sample_music();
+    sample_hail(&intent);
+    sample_autopilot(&intent);
     return intent;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -329,282 +329,306 @@ const char *contextual_hail_message(int station_index) {
     return NULL;
 }
 
+/* ================================================================== */
+/* sim_event handlers — one per event type, dispatched via the table   */
+/* below. process_sim_events drops to a thin loop: bounds-check the    */
+/* event type, look up a handler, call it. Adding a new event = add    */
+/* enum value (in shared/types.h, before SIM_EVENT_COUNT), write a     */
+/* sim_on_<event> handler, fill its slot in k_sim_event_handlers.      */
+/* ================================================================== */
+typedef void (*sim_event_handler_fn)(const sim_event_t *ev);
+
+static bool ev_is_local(const sim_event_t *ev) {
+    return ev->player_id == g.local_player_slot;
+}
+
+static void sim_on_fracture(const sim_event_t *ev) {
+    audio_play_fracture(&g.audio, ev->fracture.tier);
+    if (ev_is_local(ev)) onboarding_mark_fractured();
+}
+
+static void sim_on_mining_tick(const sim_event_t *ev) {
+    if (!ev_is_local(ev)) return;
+    audio_play_mining_tick(&g.audio);
+    onboarding_mark_fractured(); /* "mine" milestone = fired laser */
+}
+
+static void sim_on_dock(const sim_event_t *ev) {
+    if (!ev_is_local(ev)) return;
+    audio_play_dock(&g.audio);
+    g.screen_shake = fmaxf(g.screen_shake, 3.0f); /* dock clunk */
+    g.dock_settle_timer = 1.0f; /* show ship settling before panel */
+    int ds = LOCAL_PLAYER.current_station;
+    if (ds < 3) {
+        g.episode.stations_visited |= (1 << ds);
+        if (g.episode.stations_visited == 7) /* all 3 */
+            episode_trigger(&g.episode, 1); /* Ep 1: Kepler's Law */
+    }
+}
+
+static void sim_on_launch(const sim_event_t *ev) {
+    if (!ev_is_local(ev)) return;
+    audio_play_launch(&g.audio);
+    g.screen_shake = fmaxf(g.screen_shake, 5.0f); /* launch kick */
+    episode_trigger(&g.episode, 0); /* Ep 0: First Light */
+    if (!g.music.playing && !g.music.loading) music_next_track(&g.music);
+}
+
+/* Roll the per-frame sale-fx + hint-bar batch state for one SELL event. */
+static void sell_batch_accumulate(const sim_event_t *ev, int total) {
+    if (ev->sell.station < 0 || ev->sell.station >= MAX_STATIONS) return;
+    if (!station_exists(&g.world.stations[ev->sell.station])) return;
+    spawn_sell_fx(&g.world.stations[ev->sell.station].pos, total,
+                  (mining_grade_t)ev->sell.grade, ev->sell.by_contract != 0);
+    /* If a previous summary is still on-screen (display timer > 0) and
+     * we're not already accumulating, this event starts a fresh run —
+     * zero the leftover counts first so the new batch isn't contaminated. */
+    if (!g.sell_batch.active && g.sell_batch.display_timer > 0.0f) {
+        for (int gi = 0; gi < MINING_GRADE_COUNT; gi++) g.sell_batch.grade_counts[gi] = 0;
+        g.sell_batch.total_cr = 0;
+        g.sell_batch.any_by_contract = false;
+        g.sell_batch.display_timer = 0.0f;
+    }
+    int grade_idx = (int)ev->sell.grade;
+    if (grade_idx >= 0 && grade_idx < MINING_GRADE_COUNT)
+        g.sell_batch.grade_counts[grade_idx]++;
+    g.sell_batch.total_cr += total;
+    if (ev->sell.by_contract) g.sell_batch.any_by_contract = true;
+    g.sell_batch.active = true;
+    g.sell_batch.settle_timer = 0.6f;
+}
+
+static void sim_on_sell(const sim_event_t *ev) {
+    if (!ev_is_local(ev)) return;
+    audio_play_sale(&g.audio);
+    episode_trigger(&g.episode, 2); /* Ep 2: Furnace — first smelt */
+    mining_client_record_strike((mining_grade_t)ev->sell.grade, ev->sell.bonus_cr);
+    int total = ev->sell.base_cr + ev->sell.bonus_cr;
+    if (total > 0) sell_batch_accumulate(ev, total);
+}
+
+static void sim_on_repair(const sim_event_t *ev) {
+    if (ev_is_local(ev)) audio_play_repair(&g.audio);
+}
+
+static void sim_on_upgrade(const sim_event_t *ev) {
+    if (ev_is_local(ev)) audio_play_upgrade(&g.audio, ev->upgrade.upgrade);
+}
+
+static void sim_on_damage(const sim_event_t *ev) {
+    if (!ev_is_local(ev)) return;
+    audio_play_damage(&g.audio, ev->damage.amount);
+    /* Screen shake scales with damage. Tunables chosen so a minor scrape
+     * (~2 hp) wiggles a few pixels and a full ramming hit (~30 hp)
+     * noticeably jolts. */
+    float kick = sqrtf(ev->damage.amount) * 4.0f;
+    if (kick > 40.0f) kick = 40.0f;
+    if (kick > g.screen_shake) g.screen_shake = kick;
+}
+
+static void sim_on_contract_complete(const sim_event_t *ev) {
+    if (ev->contract_complete.action == CONTRACT_TRACTOR) {
+        set_notice("Tractor contract fulfilled.");
+        episode_trigger(&g.episode, 6); /* Ep 6: Hauler */
+    } else if (ev->contract_complete.action == CONTRACT_FRACTURE) {
+        set_notice("Fracture contract complete.");
+    }
+}
+
+static void sim_on_scaffold_ready(const sim_event_t *ev) {
+    int sidx = ev->scaffold_ready.station;
+    int mtype = ev->scaffold_ready.module_type;
+    if (sidx < 0 || sidx >= MAX_STATIONS) return;
+    set_notice("%s scaffold ready at %s.",
+               module_type_name((module_type_t)mtype),
+               g.world.stations[sidx].name);
+}
+
+static void sim_on_outpost_placed(const sim_event_t *ev) {
+    /* Transition from ghost preview to real plan mode: the server just
+     * created the planned station at the position where the player
+     * locked it. */
+    if (!ev_is_local(ev)) return;
+    g.plan_target_station = ev->outpost_placed.slot;
+    g.placement_target_station = ev->outpost_placed.slot;
+}
+
+/* Spawn the 8 shards + cinematic state for a death event. */
+static void death_cinematic_spawn(const sim_event_t *ev) {
+    g.death_cinematic.active = true;
+    g.death_cinematic.phase = 0;
+    g.death_cinematic.pos = v2(ev->death.pos_x, ev->death.pos_y);
+    g.death_cinematic.vel = v2(ev->death.vel_x, ev->death.vel_y);
+    g.death_cinematic.angle = ev->death.angle;
+    g.death_cinematic.spin = (((float)rand() / (float)RAND_MAX) - 0.5f) * 3.0f;
+    g.death_cinematic.age = 0.0f;
+    g.death_cinematic.menu_alpha = 0.0f;
+    for (int s = 0; s < 8; s++) {
+        float ang = ((float)s / 8.0f) * 2.0f * PI_F + (float)(s * 13 % 7) * 0.15f;
+        float speed = 30.0f + (float)((s * 7 + 3) % 5) * 12.0f;
+        g.death_cinematic.fragments[s][0] = 0.0f;
+        g.death_cinematic.fragments[s][1] = 0.0f;
+        g.death_cinematic.fragments[s][2] = cosf(ang) * speed + ev->death.vel_x * 0.6f;
+        g.death_cinematic.fragments[s][3] = sinf(ang) * speed + ev->death.vel_y * 0.6f;
+        g.death_cinematic.fragments[s][4] = ang;
+        g.death_cinematic.fragments[s][5] = ((float)((s * 19 + 7) % 11) - 5.0f) * 0.6f;
+    }
+}
+
+static void sim_on_death(const sim_event_t *ev) {
+    if (!ev_is_local(ev)) return;
+    g.death_ore_mined = ev->death.ore_mined;
+    g.death_credits_earned = ev->death.credits_earned;
+    g.death_credits_spent = ev->death.credits_spent;
+    g.death_asteroids_fractured = ev->death.asteroids_fractured;
+    /* Snapshot the wreckage at the death position. The server has
+     * already respawned the ship at a station, so we use the position
+     * from the death event payload (captured before the move). */
+    death_cinematic_spawn(ev);
+    /* Legacy timer kept for the auto-fade fallback path. */
+    g.death_screen_timer = 0.0f;
+    g.death_screen_max = 0.0f;
+    /* Force-stop any playing episode, reset state, then trigger death
+     * episode so it plays during the cinematic. */
+    if (episode_is_active(&g.episode)) episode_skip(&g.episode);
+    memset(g.episode.watched, 0, sizeof(g.episode.watched));
+    g.episode.stations_visited = 0;
+    episode_trigger(&g.episode, 9); /* Ep 9: Death */
+    episode_save(&g.episode);
+    music_enter_death(&g.music);
+}
+
+/* Pick the hail message: contextual > avatar MOTD > station hardcoded. */
+static const char *hail_choose_message(int station_idx) {
+    const char *ctx = contextual_hail_message(station_idx);
+    if (ctx) return ctx;
+    const avatar_cache_t *av = avatar_get(station_idx);
+    if (av && av->motd_fetched && av->motd[0]) return av->motd;
+    return g.world.stations[station_idx].hail_message;
+}
+
+static void sim_on_hail_response(const sim_event_t *ev) {
+    if (!ev_is_local(ev)) return;
+    int hs = ev->hail_response.station;
+    if (hs < 0 || hs >= MAX_STATIONS) return;
+
+    snprintf(g.hail_station, sizeof(g.hail_station), "%s",
+             g.world.stations[hs].name);
+    snprintf(g.hail_message, sizeof(g.hail_message), "%s",
+             hail_choose_message(hs));
+    g.hail_credits = ev->hail_response.credits;
+    g.hail_station_index = hs;
+    g.hail_timer = 6.0f;
+    if (g.hail_credits > 0.5f) audio_play_sale(&g.audio);
+    if (g.world.stations[hs].station_slug[0])
+        avatar_fetch(hs, g.world.stations[hs].station_slug);
+    /* Surface the hail through the bottom-right hint bar. Includes
+     * the station balance so all the info the old center-screen
+     * overlay carried lands there. */
+    const char *unit = g.world.stations[hs].currency_name;
+    if (!unit[0]) unit = "credits";
+    set_notice("%s: %s  (balance %d %s)",
+               g.hail_station, g.hail_message,
+               (int)lroundf(ev->hail_response.credits), unit);
+    onboarding_mark_hailed();
+}
+
+static void sim_on_module_activated(const sim_event_t *ev) {
+    int si = ev->module_activated.station;
+    int mi = ev->module_activated.module_idx;
+    station_t *act_st = &g.world.stations[si];
+    vec2 mpos = module_world_pos_ring(act_st, act_st->modules[mi].ring,
+                                       act_st->modules[mi].slot);
+    g.commission_timer = 1.5f;
+    g.commission_pos = mpos;
+    module_color_fn((module_type_t)ev->module_activated.module_type,
+                    &g.commission_cr, &g.commission_cg, &g.commission_cb);
+    audio_play_commission(&g.audio);
+    set_notice("%s online.",
+               module_type_name((module_type_t)ev->module_activated.module_type));
+}
+
+static void sim_on_outpost_activated(const sim_event_t *ev) {
+    (void)ev;
+    if (!g.episode.watched[4]) episode_trigger(&g.episode, 4); /* Ep 4: Naming */
+    audio_play_commission(&g.audio);
+}
+
+static void sim_on_npc_spawned(const sim_event_t *ev) {
+    /* Ep 5: Drones — first miner at a player outpost */
+    if (!g.episode.watched[5] &&
+        ev->npc_spawned.role == NPC_ROLE_MINER &&
+        ev->npc_spawned.home_station >= 3)
+        episode_trigger(&g.episode, 5);
+}
+
+static void sim_on_signal_lost(const sim_event_t *ev) {
+    if (ev_is_local(ev) && !g.episode.watched[7])
+        episode_trigger(&g.episode, 7); /* Ep 7: Dark Sector */
+}
+
+static void sim_on_station_connected(const sim_event_t *ev) {
+    if (!g.episode.watched[8] && ev->station_connected.connected_count >= 5)
+        episode_trigger(&g.episode, 8); /* Ep 8: Every AI Dreams */
+}
+
+/* Map order-rejection reason codes to user-visible notices. Reason
+ * codes are defined in shared/types.h next to sim_event_t. */
+static const char *order_reject_message(uint8_t reason) {
+    switch (reason) {
+    case ORDER_REJECT_SCAFFOLD_PLACEMENT_NO_SIGNAL:
+        return "No signal here — tow the scaffold back into station coverage.";
+    case ORDER_REJECT_SCAFFOLD_PLACEMENT_TOO_CLOSE:
+        return "Too close to an existing station — drop further out toward the fringe.";
+    case ORDER_REJECT_SCAFFOLD_PLACEMENT_NEEDS_RELAY:
+        return "Only signal-relay scaffolds can found new outposts. Tow this one to an existing station.";
+    case ORDER_REJECT_SCAFFOLD_PLACEMENT_NO_SLOT:
+        return "No outpost slots available — every station catalog entry is taken.";
+    case ORDER_REJECT_SHIPYARD_NOT_SOLD:    return "This shipyard doesn't sell that scaffold.";
+    case ORDER_REJECT_SHIPYARD_QUEUE_FULL:  return "Shipyard queue full — wait for the next batch to ship.";
+    case ORDER_REJECT_SHIPYARD_LOCKED:      return "Tech tree locked — order the prerequisite module first.";
+    case ORDER_REJECT_SHIPYARD_NO_FUNDS:    return "Not enough credits at this station for the order fee.";
+    case ORDER_REJECT_SELL_NOT_ACCEPTED:    return "This station has no consumer for that commodity — try another dock.";
+    default:                                return "Order rejected.";
+    }
+}
+
+static void sim_on_order_rejected(const sim_event_t *ev) {
+    set_notice("%s", order_reject_message(ev->order_rejected.reason));
+}
+
+/* Dispatch table — designated initializers tie each handler to its
+ * enum slot, so reordering enum values doesn't silently misroute. */
+static const sim_event_handler_fn k_sim_event_handlers[SIM_EVENT_COUNT] = {
+    [SIM_EVENT_FRACTURE]           = sim_on_fracture,
+    [SIM_EVENT_MINING_TICK]        = sim_on_mining_tick,
+    [SIM_EVENT_DOCK]               = sim_on_dock,
+    [SIM_EVENT_LAUNCH]             = sim_on_launch,
+    [SIM_EVENT_SELL]               = sim_on_sell,
+    [SIM_EVENT_REPAIR]             = sim_on_repair,
+    [SIM_EVENT_UPGRADE]            = sim_on_upgrade,
+    [SIM_EVENT_DAMAGE]             = sim_on_damage,
+    [SIM_EVENT_CONTRACT_COMPLETE]  = sim_on_contract_complete,
+    [SIM_EVENT_SCAFFOLD_READY]     = sim_on_scaffold_ready,
+    [SIM_EVENT_OUTPOST_PLACED]     = sim_on_outpost_placed,
+    [SIM_EVENT_DEATH]              = sim_on_death,
+    [SIM_EVENT_HAIL_RESPONSE]      = sim_on_hail_response,
+    [SIM_EVENT_MODULE_ACTIVATED]   = sim_on_module_activated,
+    [SIM_EVENT_OUTPOST_ACTIVATED]  = sim_on_outpost_activated,
+    [SIM_EVENT_NPC_SPAWNED]        = sim_on_npc_spawned,
+    [SIM_EVENT_SIGNAL_LOST]        = sim_on_signal_lost,
+    [SIM_EVENT_STATION_CONNECTED]  = sim_on_station_connected,
+    [SIM_EVENT_ORDER_REJECTED]     = sim_on_order_rejected,
+    /* SIM_EVENT_NPC_KILL: no client handler yet (kill-feed is server-
+     * routed broadcast text; no per-event hook needed here). */
+};
+
 void process_sim_events(const sim_events_t *events) {
     for (int i = 0; i < events->count; i++) {
-        const sim_event_t* ev = &events->events[i];
-        switch (ev->type) {
-            case SIM_EVENT_FRACTURE:
-                audio_play_fracture(&g.audio, ev->fracture.tier);
-                if (ev->player_id == g.local_player_slot)
-                    onboarding_mark_fractured();
-                break;
-            case SIM_EVENT_MINING_TICK:
-                if (ev->player_id == g.local_player_slot) {
-                    audio_play_mining_tick(&g.audio);
-                    onboarding_mark_fractured();  /* "mine" milestone = fired laser */
-                }
-                break;
-            case SIM_EVENT_DOCK:
-                if (ev->player_id == g.local_player_slot) {
-                    audio_play_dock(&g.audio);
-                    g.screen_shake = fmaxf(g.screen_shake, 3.0f); /* dock clunk */
-                    g.dock_settle_timer = 1.0f; /* show ship settling before panel */
-                    /* Track visited original stations for Ep 1 */
-                    int ds = LOCAL_PLAYER.current_station;
-                    if (ds < 3) {
-                        g.episode.stations_visited |= (1 << ds);
-                        if (g.episode.stations_visited == 7) /* all 3 */
-                            episode_trigger(&g.episode, 1); /* Ep 1: Kepler's Law */
-                    }
-                }
-                break;
-            case SIM_EVENT_LAUNCH:
-                if (ev->player_id == g.local_player_slot) {
-                    audio_play_launch(&g.audio);
-                    g.screen_shake = fmaxf(g.screen_shake, 5.0f); /* launch kick */
-                    episode_trigger(&g.episode, 0); /* Ep 0: First Light */
-                    /* Start music on first launch — shuffled */
-                    if (!g.music.playing && !g.music.loading) {
-                        music_next_track(&g.music);
-                    }
-                }
-                break;
-            case SIM_EVENT_SELL:
-                if (ev->player_id == g.local_player_slot) {
-                    audio_play_sale(&g.audio);
-                    episode_trigger(&g.episode, 2); /* Ep 2: Furnace — first smelt */
-                    mining_client_record_strike((mining_grade_t)ev->sell.grade,
-                                                ev->sell.bonus_cr);
-                    int total = ev->sell.base_cr + ev->sell.bonus_cr;
-                    if (total > 0
-                        && ev->sell.station >= 0
-                        && ev->sell.station < MAX_STATIONS
-                        && station_exists(&g.world.stations[ev->sell.station])) {
-                        spawn_sell_fx(&g.world.stations[ev->sell.station].pos,
-                                      total,
-                                      (mining_grade_t)ev->sell.grade,
-                                      ev->sell.by_contract != 0);
-                        /* Accumulate into the hint-bar batch so haulers get
-                         * a summary even when the station is off-camera. If
-                         * a previous summary is still on-screen (display
-                         * timer > 0) and we're not already accumulating, the
-                         * incoming event starts a fresh run — zero the leftover
-                         * counts first so the new batch isn't contaminated. */
-                        if (!g.sell_batch.active && g.sell_batch.display_timer > 0.0f) {
-                            for (int gi2 = 0; gi2 < MINING_GRADE_COUNT; gi2++)
-                                g.sell_batch.grade_counts[gi2] = 0;
-                            g.sell_batch.total_cr = 0;
-                            g.sell_batch.any_by_contract = false;
-                            g.sell_batch.display_timer = 0.0f;
-                        }
-                        int grade_idx = (int)ev->sell.grade;
-                        if (grade_idx >= 0 && grade_idx < MINING_GRADE_COUNT) {
-                            g.sell_batch.grade_counts[grade_idx]++;
-                        }
-                        g.sell_batch.total_cr += total;
-                        if (ev->sell.by_contract) g.sell_batch.any_by_contract = true;
-                        g.sell_batch.active = true;
-                        g.sell_batch.settle_timer = 0.6f;
-                    }
-                }
-                break;
-            case SIM_EVENT_REPAIR:
-                if (ev->player_id == g.local_player_slot) audio_play_repair(&g.audio);
-                break;
-            case SIM_EVENT_UPGRADE:
-                if (ev->player_id == g.local_player_slot) {
-                    audio_play_upgrade(&g.audio, ev->upgrade.upgrade);
-                }
-                break;
-            case SIM_EVENT_DAMAGE:
-                if (ev->player_id == g.local_player_slot) {
-                    audio_play_damage(&g.audio, ev->damage.amount);
-                    /* Screen shake scales with damage. Tunables chosen so a
-                     * minor scrape (~2 hp) wiggles a few pixels and a
-                     * full ramming hit (~30 hp) noticeably jolts. */
-                    float kick = sqrtf(ev->damage.amount) * 4.0f;
-                    if (kick > 40.0f) kick = 40.0f;
-                    if (kick > g.screen_shake) g.screen_shake = kick;
-                }
-                break;
-            case SIM_EVENT_CONTRACT_COMPLETE:
-                if (ev->contract_complete.action == CONTRACT_TRACTOR) {
-                    set_notice("Tractor contract fulfilled.");
-                    episode_trigger(&g.episode, 6); /* Ep 6: Hauler */
-                } else if (ev->contract_complete.action == CONTRACT_FRACTURE) {
-                    set_notice("Fracture contract complete.");
-                }
-                break;
-            case SIM_EVENT_SCAFFOLD_READY: {
-                int sidx = ev->scaffold_ready.station;
-                int mtype = ev->scaffold_ready.module_type;
-                if (sidx >= 0 && sidx < MAX_STATIONS) {
-                    set_notice("%s scaffold ready at %s.",
-                        module_type_name((module_type_t)mtype),
-                        g.world.stations[sidx].name);
-                }
-                break;
-            }
-            case SIM_EVENT_OUTPOST_PLACED: {
-                /* Transition from ghost preview to real plan mode:
-                 * the server just created the planned station at the
-                 * position where the player locked it. */
-                if (ev->player_id == g.local_player_slot) {
-                    g.plan_target_station = ev->outpost_placed.slot;
-                    g.placement_target_station = ev->outpost_placed.slot;
-                }
-                break;
-            }
-            case SIM_EVENT_DEATH:
-                if (ev->player_id == g.local_player_slot) {
-                    g.death_ore_mined = ev->death.ore_mined;
-                    g.death_credits_earned = ev->death.credits_earned;
-                    g.death_credits_spent = ev->death.credits_spent;
-                    g.death_asteroids_fractured = ev->death.asteroids_fractured;
-                    /* Snapshot the wreckage at the death position. The
-                     * server has already respawned the ship at a station,
-                     * so we use the position from the death event payload
-                     * (captured before the server moved the hull). */
-                    g.death_cinematic.active = true;
-                    g.death_cinematic.phase = 0;
-                    g.death_cinematic.pos = v2(ev->death.pos_x, ev->death.pos_y);
-                    g.death_cinematic.vel = v2(ev->death.vel_x, ev->death.vel_y);
-                    g.death_cinematic.angle = ev->death.angle;
-                    g.death_cinematic.spin = (((float)rand() / (float)RAND_MAX) - 0.5f) * 3.0f;
-                    g.death_cinematic.age = 0.0f;
-                    g.death_cinematic.menu_alpha = 0.0f;
-                    /* 8 shards radiating outward from the wreck. Each shard
-                     * starts at the ship origin with a randomized velocity
-                     * and spin. Components: [dx, dy, vx, vy, ang, spin]. */
-                    for (int s = 0; s < 8; s++) {
-                        float ang = ((float)s / 8.0f) * 2.0f * PI_F + (float)(s * 13 % 7) * 0.15f;
-                        float speed = 30.0f + (float)((s * 7 + 3) % 5) * 12.0f;
-                        g.death_cinematic.fragments[s][0] = 0.0f;
-                        g.death_cinematic.fragments[s][1] = 0.0f;
-                        g.death_cinematic.fragments[s][2] = cosf(ang) * speed + ev->death.vel_x * 0.6f;
-                        g.death_cinematic.fragments[s][3] = sinf(ang) * speed + ev->death.vel_y * 0.6f;
-                        g.death_cinematic.fragments[s][4] = ang;
-                        g.death_cinematic.fragments[s][5] = ((float)((s * 19 + 7) % 11) - 5.0f) * 0.6f;
-                    }
-                    /* Legacy timer kept for the auto-fade fallback path
-                     * but cinematic logic ignores it. */
-                    g.death_screen_timer = 0.0f;
-                    g.death_screen_max = 0.0f;
-                    /* Force-stop any playing episode, reset state, then
-                     * trigger death episode so it plays during the cinematic. */
-                    if (episode_is_active(&g.episode))
-                        episode_skip(&g.episode);
-                    memset(g.episode.watched, 0, sizeof(g.episode.watched));
-                    g.episode.stations_visited = 0;
-                    episode_trigger(&g.episode, 9); /* Ep 9: Death */
-                    episode_save(&g.episode);
-                    music_enter_death(&g.music);
-                }
-                break;
-            case SIM_EVENT_HAIL_RESPONSE:
-                if (ev->player_id == g.local_player_slot) {
-                    int hs = ev->hail_response.station;
-                    if (hs >= 0 && hs < MAX_STATIONS) {
-                        snprintf(g.hail_station, sizeof(g.hail_station), "%s", g.world.stations[hs].name);
-                        /* Priority: contextual response > CDN MOTD > hardcoded */
-                        const char *ctx = contextual_hail_message(hs);
-                        if (ctx)
-                            snprintf(g.hail_message, sizeof(g.hail_message), "%s", ctx);
-                        else {
-                            const avatar_cache_t *av = avatar_get(hs);
-                            if (av && av->motd_fetched && av->motd[0])
-                                snprintf(g.hail_message, sizeof(g.hail_message), "%s", av->motd);
-                            else
-                                snprintf(g.hail_message, sizeof(g.hail_message), "%s", g.world.stations[hs].hail_message);
-                        }
-                        g.hail_credits = ev->hail_response.credits;
-                        g.hail_station_index = hs;
-                        g.hail_timer = 6.0f;
-                        if (g.hail_credits > 0.5f)
-                            audio_play_sale(&g.audio);
-                        if (g.world.stations[hs].station_slug[0])
-                            avatar_fetch(hs, g.world.stations[hs].station_slug);
-                        /* Surface the hail through the bottom-right hint bar.
-                         * Includes the station balance so all the info the
-                         * old center-screen overlay carried lands there.
-                         * hail_response.credits is authoritative — computed
-                         * server-side when the hail was issued. */
-                        {
-                            const char *unit = g.world.stations[hs].currency_name;
-                            if (!unit[0]) unit = "credits";
-                            set_notice("%s: %s  (balance %d %s)",
-                                g.hail_station, g.hail_message,
-                                (int)lroundf(ev->hail_response.credits), unit);
-                        }
-                        onboarding_mark_hailed();
-                    }
-                }
-                break;
-            case SIM_EVENT_MODULE_ACTIVATED: {
-                int si = ev->module_activated.station;
-                int mi = ev->module_activated.module_idx;
-                station_t *act_st = &g.world.stations[si];
-                vec2 mpos = module_world_pos_ring(act_st,
-                    act_st->modules[mi].ring, act_st->modules[mi].slot);
-                g.commission_timer = 1.5f;
-                g.commission_pos = mpos;
-                module_color_fn((module_type_t)ev->module_activated.module_type,
-                    &g.commission_cr, &g.commission_cg, &g.commission_cb);
-                audio_play_commission(&g.audio);
-                set_notice("%s online.", module_type_name((module_type_t)ev->module_activated.module_type));
-                break;
-            }
-            case SIM_EVENT_OUTPOST_ACTIVATED:
-                if (!g.episode.watched[4])
-                    episode_trigger(&g.episode, 4); /* Ep 4: Naming */
-                audio_play_commission(&g.audio);
-                break;
-            case SIM_EVENT_NPC_SPAWNED:
-                /* Ep 5: Drones — first miner at a player outpost */
-                if (!g.episode.watched[5] &&
-                    ev->npc_spawned.role == NPC_ROLE_MINER &&
-                    ev->npc_spawned.home_station >= 3)
-                    episode_trigger(&g.episode, 5);
-                break;
-            case SIM_EVENT_SIGNAL_LOST:
-                if (ev->player_id == g.local_player_slot && !g.episode.watched[7])
-                    episode_trigger(&g.episode, 7); /* Ep 7: Dark Sector */
-                break;
-            case SIM_EVENT_STATION_CONNECTED:
-                if (!g.episode.watched[8] && ev->station_connected.connected_count >= 5)
-                    episode_trigger(&g.episode, 8); /* Ep 8: Every AI Dreams */
-                break;
-            case SIM_EVENT_ORDER_REJECTED:
-                /* Surface a precise reason instead of silently fizzling
-                 * the [E] press / shipyard buy. Reason codes are defined
-                 * in shared/types.h next to sim_event_t. */
-                switch (ev->order_rejected.reason) {
-                case ORDER_REJECT_SCAFFOLD_PLACEMENT_NO_SIGNAL:
-                    set_notice("No signal here — tow the scaffold back into station coverage."); break;
-                case ORDER_REJECT_SCAFFOLD_PLACEMENT_TOO_CLOSE:
-                    set_notice("Too close to an existing station — drop further out toward the fringe."); break;
-                case ORDER_REJECT_SCAFFOLD_PLACEMENT_NEEDS_RELAY:
-                    set_notice("Only signal-relay scaffolds can found new outposts. Tow this one to an existing station."); break;
-                case ORDER_REJECT_SCAFFOLD_PLACEMENT_NO_SLOT:
-                    set_notice("No outpost slots available — every station catalog entry is taken."); break;
-                case ORDER_REJECT_SHIPYARD_NOT_SOLD:
-                    set_notice("This shipyard doesn't sell that scaffold."); break;
-                case ORDER_REJECT_SHIPYARD_QUEUE_FULL:
-                    set_notice("Shipyard queue full — wait for the next batch to ship."); break;
-                case ORDER_REJECT_SHIPYARD_LOCKED:
-                    set_notice("Tech tree locked — order the prerequisite module first."); break;
-                case ORDER_REJECT_SHIPYARD_NO_FUNDS:
-                    set_notice("Not enough credits at this station for the order fee."); break;
-                case ORDER_REJECT_SELL_NOT_ACCEPTED:
-                    set_notice("This station has no consumer for that commodity — try another dock."); break;
-                default:
-                    set_notice("Order rejected.");
-                    break;
-                }
-                break;
-            default:
-                break;
-        }
+        const sim_event_t *ev = &events->events[i];
+        if ((unsigned)ev->type >= SIM_EVENT_COUNT) continue;
+        sim_event_handler_fn h = k_sim_event_handlers[ev->type];
+        if (h) h(ev);
     }
 }
 


### PR DESCRIPTION
Closes #407 (manual successor to closed PR #349). Hits the four functions called out by the CRAP report.

## Summary

| Function | Before | After | Approach |
|---|---:|---:|---|
| `src/main.c:process_sim_events` | ~30+ | ~4 | per-event handlers + designated-init dispatch table indexed by `SIM_EVENT_COUNT` |
| `src/input.c:sample_input_intent` | ~219 | ~1 | 17 per-concern samplers + plan-mode sub-dispatch + trade-row resolver split |
| `server/main.c:main` | ~101 | ~6 | bootstrap split (`read_env_config`, `ensure_persistence_dirs`, `load_world_state`); per-event broadcasts via `srv_dispatch_sim_event` + named `srv_on_*` handlers; loop body split into `run_sim_ticks`, `tick_session_timers`, `broadcast_dirty_station_data` |
| `src/hud.c:draw_hud` | ~172 | (lower; partial) | `draw_death_overlay` extracted (135 lines, gated on death cinematic — pure additive) |

## What's not done

`draw_hud` is only partially reduced. The remaining sections (low-HP warning, MP indicator, signal-lost warning, full per-panel flight HUD layout) are still inline. They're still over CCN 25 but extracting them risks visual regression that `signal_test` can't catch since it doesn't link the renderer. Worth a follow-up pass with browser smoke-testing.

## Caveats

- `signal_test` doesn't cover client UI (renderer / input). Behavior parity for `sample_input_intent` and `draw_hud` is verified by inspection + same-shape extraction. Smoke-test the HUD compact/wide modes, trade picker page wrap, plan mode (ghost preview → lock → real plan → exit) in a browser before merging if you want maximum confidence.

## Test plan
- [x] `make test` — 336 / 336 (no regressions)
- [x] Pre-commit hook (native + WASM) green
- [ ] CI green
- [ ] Manual: HUD compact + wide layouts
- [ ] Manual: trade picker on each station type
- [ ] Manual: plan mode flow