### PR TITLE
HUD: unify trade-row construction + header-band currency fallbacks

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -76,6 +76,33 @@ typedef struct {
     int kits_short_by;
 } station_ui_state_t;
 
+/* TRADE picker row — single source of truth shared by the picker
+ * renderer (station_ui.c) and the input handler (input.c). Both walk
+ * the SAME row list so a [1] keypress can never hit a different row
+ * than the one drawn on screen. See build_trade_rows() below. */
+typedef struct {
+    uint8_t        kind;       /* 0 = BUY (station sells), 1 = SELL (station buys) */
+    commodity_t    commodity;
+    mining_grade_t grade;
+    int            stock;      /* units available on the active side */
+    int            unit_price; /* per-unit, already grade-multiplied */
+    bool           actionable; /* player can do this transaction right now */
+    bool           is_float_fallback; /* legacy float row (no manifest unit) */
+} trade_row_t;
+
+/* Pagination constants — input.c walks `g.trade_page * TRADE_ROWS_PER_PAGE`
+ * to find the first row on the current page; the renderer wraps when
+ * total_pages * TRADE_ROWS_PER_PAGE >= row_count. */
+#define TRADE_ROWS_PER_PAGE 5
+#define TRADE_MAX_ROWS      20
+
+/* Build the unified row list for `st` against the player's `ship`.
+ * Output is zero-or-more rows in `out[0..count-1]`, capped at `max`
+ * (caller passes a TRADE_MAX_ROWS-sized buffer). Returns the count.
+ * BUY rows come first, then SELL rows — matches the picker layout. */
+int build_trade_rows(const station_t *st, const ship_t *ship,
+                     trade_row_t out[], int max);
+
 /* ------------------------------------------------------------------ */
 /* Client game state                                                  */
 /* ------------------------------------------------------------------ */

--- a/src/input.c
+++ b/src/input.c
@@ -419,75 +419,15 @@ static void sample_trade_sell_all(input_intent_t *intent) {
     set_notice("Selling...");
 }
 
-/* TRADE picker row resolution + apply.
- *
- * The picker is a single page-flipping list of BUY rows (station sells)
- * followed by SELL rows (station buys). [F] advances the page (wraps
- * past the last). Digit keys [1]..[5] pick the Nth row on the current
- * page and fire the matching intent. Row construction must match
- * draw_trade_view in station_ui.c — divergence silently misroutes
- * keys for non-dominant commodities. */
-typedef struct {
-    int kind;            /* 0 = BUY, 1 = SELL, -1 = no row */
-    commodity_t commodity;
-    mining_grade_t grade;
-} trade_row_t;
-
-/* Walk station BUY rows (one per commodity/grade with stock>0). */
-static bool trade_resolve_buy_row(const station_t *st, int station_idx,
-                                   int target, int *global_idx,
-                                   trade_row_t *out) {
-    for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++) {
-        if (!station_produces(st, (commodity_t)c)) continue;
-        if (st->base_price[c] <= FLOAT_EPSILON) continue;
-        for (int gi = 0; gi < MINING_GRADE_COUNT; gi++) {
-            int stock = (int)g.station_manifest_summary[station_idx][c][gi];
-            if (stock <= 0) continue;
-            if (*global_idx == target) {
-                out->kind = 0;
-                out->commodity = (commodity_t)c;
-                out->grade = (mining_grade_t)gi;
-                return true;
-            }
-            (*global_idx)++;
-        }
-    }
-    return false;
-}
-
-/* Walk SELL rows (one per commodity/grade the player carries that the
- * station consumes). */
-static bool trade_resolve_sell_row(const ship_t *ship, const station_t *st,
-                                    int target, int *global_idx,
-                                    trade_row_t *out) {
-    if (!ship->manifest.units) return false;
-    for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++) {
-        if (!station_consumes(st, (commodity_t)c)) continue;
-        for (int gi = 0; gi < MINING_GRADE_COUNT; gi++) {
-            int cnt = 0;
-            for (uint16_t u = 0; u < ship->manifest.count; u++) {
-                const cargo_unit_t *cu = &ship->manifest.units[u];
-                if (cu->commodity == (uint8_t)c && cu->grade == (uint8_t)gi) cnt++;
-            }
-            if (cnt <= 0) continue;
-            if (*global_idx == target) {
-                out->kind = 1;
-                out->commodity = (commodity_t)c;
-                out->grade = (mining_grade_t)gi;
-                return true;
-            }
-            (*global_idx)++;
-        }
-    }
-    return false;
-}
-
+/* TRADE picker — page through the unified row list and dispatch on the
+ * digit pick. Row construction lives in station_ui.c:build_trade_rows
+ * so the renderer and the input handler share a single source of
+ * truth. Mismatched [1] hotkeys aren't possible by construction. */
 static void trade_apply_buy_row(input_intent_t *intent, const station_t *st,
-                                 const ship_t *ship, trade_row_t row) {
-    float price = station_sell_price(st, row.commodity) *
-                  mining_payout_multiplier(row.grade);
+                                 const ship_t *ship, const trade_row_t *row) {
+    float price = (float)row->unit_price;
     float free_volume = ship_cargo_capacity(ship) - ship_total_cargo(ship);
-    float vol = commodity_volume(row.commodity);
+    float vol = commodity_volume(row->commodity);
     /* Match server: dense goods buy multi-per-press so a single keystroke
      * fills one cargo unit. */
     int per_press = (vol > FLOAT_EPSILON) ? (int)lroundf(1.0f / vol) : 1;
@@ -496,9 +436,9 @@ static void trade_apply_buy_row(input_intent_t *intent, const station_t *st,
     if (player_current_balance() < price) { set_notice("Need $%d.", (int)lroundf(price)); return; }
 
     intent->buy_product = true;
-    intent->buy_commodity = row.commodity;
-    intent->buy_grade = row.grade;
-    LOCAL_PLAYER.ship.cargo[row.commodity] += (float)per_press;
+    intent->buy_commodity = row->commodity;
+    intent->buy_grade = row->grade;
+    LOCAL_PLAYER.ship.cargo[row->commodity] += (float)per_press;
     if (!g.multiplayer_enabled) {
         station_t *mst = &g.world.stations[LOCAL_PLAYER.current_station];
         float total = price * (float)per_press;
@@ -511,8 +451,9 @@ static void trade_apply_buy_row(input_intent_t *intent, const station_t *st,
     }
     set_notice("-$%d  %s %s x%d",
                (int)lroundf(price * (float)per_press),
-               mining_grade_label(row.grade),
-               commodity_short_name(row.commodity), per_press);
+               mining_grade_label(row->grade),
+               commodity_short_name(row->commodity), per_press);
+    (void)st;
 }
 
 static void sample_trade_picker(input_intent_t *intent) {
@@ -525,27 +466,24 @@ static void sample_trade_picker(input_intent_t *intent) {
     if (digit_pick < 0 || !st) return;
 
     const ship_t *ship = &LOCAL_PLAYER.ship;
-    int global_idx = 0;
-    int target = (int)g.trade_page * 5 + digit_pick;
-    int station_idx = (int)(st - g.world.stations);
-    trade_row_t row = { .kind = -1 };
+    trade_row_t rows[TRADE_MAX_ROWS];
+    int row_count = build_trade_rows(st, ship, rows, TRADE_MAX_ROWS);
+    int target = (int)g.trade_page * TRADE_ROWS_PER_PAGE + digit_pick;
 
-    if (station_idx >= 0 && station_idx < MAX_STATIONS)
-        trade_resolve_buy_row(st, station_idx, target, &global_idx, &row);
-    if (row.kind < 0)
-        trade_resolve_sell_row(ship, st, target, &global_idx, &row);
-
-    if (row.kind == 0) {
-        trade_apply_buy_row(intent, st, ship, row);
-    } else if (row.kind == 1) {
-        intent->service_sell = true;
-        intent->service_sell_only = row.commodity;
-        set_notice("Selling %s %s...",
-                   mining_grade_label(row.grade),
-                   commodity_short_name(row.commodity));
-    } else {
+    if (target >= row_count) {
         /* Past the end — wrap the page pointer so [F] feels natural. */
         g.trade_page = 0;
+        return;
+    }
+    const trade_row_t *row = &rows[target];
+    if (row->kind == 0) {
+        trade_apply_buy_row(intent, st, ship, row);
+    } else if (row->kind == 1) {
+        intent->service_sell = true;
+        intent->service_sell_only = row->commodity;
+        set_notice("Selling %s %s...",
+                   mining_grade_label(row->grade),
+                   commodity_short_name(row->commodity));
     }
 }
 

--- a/src/station_ui.c
+++ b/src/station_ui.c
@@ -590,19 +590,61 @@ static int ship_manifest_count_cg(const ship_t *ship,
  * select a row on the current page. [F] pages forward; pages wrap at
  * the last page so the UI never runs out. At-station trades show the
  * generic "$" symbol — contract payouts in WORK still name the issuing
- * station's currency because that's where the money actually lives. */
-typedef struct {
-    uint8_t     kind;       /* 0 = BUY (station sells), 1 = SELL (station buys) */
-    commodity_t commodity;
-    mining_grade_t grade;
-    int         stock;      /* units available on the active side */
-    int         unit_price; /* per-unit, already grade-multiplied */
-    bool        actionable; /* player can do this transaction right now */
-    bool        is_float_fallback; /* no manifest entry, legacy float */
-} trade_row_t;
+ * station's currency because that's where the money actually lives.
+ *
+ * trade_row_t and the pagination constants live in client.h so input.c
+ * can index into the same row list — see build_trade_rows below. */
 
-#define TRADE_ROWS_PER_PAGE 5
-#define TRADE_MAX_ROWS      20
+int build_trade_rows(const station_t *st, const ship_t *ship,
+                     trade_row_t out[], int max) {
+    if (!st || !ship || !out || max <= 0) return 0;
+    int row_count = 0;
+    float free_volume = ship_cargo_capacity(ship) - ship_total_cargo(ship);
+    float credits = player_current_balance();
+
+    /* BUY rows — one per (commodity, grade) where the station has
+     * stock AND has the producing module for that commodity. Walks
+     * every finished commodity (not just the dominant one) so a
+     * multi-furnace station like Helios surfaces all of its outputs. */
+    for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT && row_count < max; c++) {
+        if (!station_produces(st, (commodity_t)c)) continue;
+        float price_base = station_sell_price(st, (commodity_t)c);
+        if (price_base <= FLOAT_EPSILON) continue;
+        for (int gi = 0; gi < MINING_GRADE_COUNT && row_count < max; gi++) {
+            int stock = station_manifest_count_cg(st, (commodity_t)c, (mining_grade_t)gi);
+            if (stock <= 0) continue;
+            int price = (int)lroundf(price_base
+                    * mining_payout_multiplier((mining_grade_t)gi));
+            float vol = commodity_volume((commodity_t)c);
+            bool can = (free_volume + FLOAT_EPSILON >= vol) && (credits >= (float)price);
+            out[row_count++] = (trade_row_t){
+                .kind = 0, .commodity = (commodity_t)c, .grade = (mining_grade_t)gi,
+                .stock = stock, .unit_price = price,
+                .actionable = can, .is_float_fallback = false,
+            };
+        }
+    }
+
+    /* SELL rows — every commodity the station consumes that the player
+     * is carrying. */
+    for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT && row_count < max; c++) {
+        if (!station_consumes(st, (commodity_t)c)) continue;
+        float price_base = station_buy_price(st, (commodity_t)c);
+        if (price_base <= FLOAT_EPSILON) continue;
+        for (int gi = 0; gi < MINING_GRADE_COUNT && row_count < max; gi++) {
+            int held = ship_manifest_count_cg(ship, (commodity_t)c, (mining_grade_t)gi);
+            if (held <= 0) continue;
+            int price = (int)lroundf(price_base
+                    * mining_payout_multiplier((mining_grade_t)gi));
+            out[row_count++] = (trade_row_t){
+                .kind = 1, .commodity = (commodity_t)c, .grade = (mining_grade_t)gi,
+                .stock = held, .unit_price = price,
+                .actionable = (held > 0), .is_float_fallback = false,
+            };
+        }
+    }
+    return row_count;
+}
 
 static void draw_trade_view(const station_ui_state_t *ui,
                             float cx, float cy, float inner_w,
@@ -718,58 +760,10 @@ static void draw_trade_view(const station_ui_state_t *ui,
         my += row_h;
     }
 
-    /* Build the unified row list. BUY rows first (station's offering),
-     * SELL rows after (what the station buys from the hold). */
+    /* Single source of truth for the row list (shared with input.c so
+     * a [1] keypress always hits the same row drawn here). */
     trade_row_t rows[TRADE_MAX_ROWS];
-    int row_count = 0;
-
-    float free_volume = ship_cargo_capacity(ship) - ship_total_cargo(ship);
-    float credits = player_current_balance();
-
-    /* BUY rows — one per (commodity, grade) where the station has
-     * stock AND has the producing module for that commodity. Walks
-     * every finished commodity (not just the dominant one) so a
-     * multi-furnace station like Helios surfaces all of its outputs
-     * at once: previously the picker only showed the highest-priority
-     * module's output, so ferrite ingots smelted at Helios were
-     * invisible to the player. Manifest is authoritative. */
-    for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT && row_count < TRADE_MAX_ROWS; c++) {
-        if (!station_produces(st, (commodity_t)c)) continue;
-        float price_base = station_sell_price(st, (commodity_t)c);
-        if (price_base <= FLOAT_EPSILON) continue;
-        for (int gi = 0; gi < MINING_GRADE_COUNT && row_count < TRADE_MAX_ROWS; gi++) {
-            int stock = station_manifest_count_cg(st, (commodity_t)c, (mining_grade_t)gi);
-            if (stock <= 0) continue;
-            int price = (int)lroundf(price_base
-                    * mining_payout_multiplier((mining_grade_t)gi));
-            float vol = commodity_volume((commodity_t)c);
-            bool can = (free_volume + FLOAT_EPSILON >= vol) && (credits >= (float)price);
-            rows[row_count++] = (trade_row_t){
-                .kind = 0, .commodity = (commodity_t)c, .grade = (mining_grade_t)gi,
-                .stock = stock, .unit_price = price,
-                .actionable = can, .is_float_fallback = false,
-            };
-        }
-    }
-
-    /* SELL rows — every commodity the station consumes that the player
-     * is carrying. Same widening as the BUY side. */
-    for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT && row_count < TRADE_MAX_ROWS; c++) {
-        if (!station_consumes(st, (commodity_t)c)) continue;
-        float price_base = station_buy_price(st, (commodity_t)c);
-        if (price_base <= FLOAT_EPSILON) continue;
-        for (int gi = 0; gi < MINING_GRADE_COUNT && row_count < TRADE_MAX_ROWS; gi++) {
-            int held = ship_manifest_count_cg(ship, (commodity_t)c, (mining_grade_t)gi);
-            if (held <= 0) continue;
-            int price = (int)lroundf(price_base
-                    * mining_payout_multiplier((mining_grade_t)gi));
-            rows[row_count++] = (trade_row_t){
-                .kind = 1, .commodity = (commodity_t)c, .grade = (mining_grade_t)gi,
-                .stock = held, .unit_price = price,
-                .actionable = (held > 0), .is_float_fallback = false,
-            };
-        }
-    }
+    int row_count = build_trade_rows(st, ship, rows, TRADE_MAX_ROWS);
 
     /* Pagination — wrap the current page so [F] at the last page
      * returns to page 0 cleanly. TRADE_ROWS_PER_PAGE is small so page

--- a/src/station_ui.c
+++ b/src/station_ui.c
@@ -347,6 +347,28 @@ static const char *ui_station_currency(const station_t *st) {
     return (st->currency_name[0]) ? st->currency_name : "cr";
 }
 
+/* Compact form of the currency name — first word, lowercased and
+ * trimmed to <= 4 chars. Used by the header band when the full label
+ * ("prospect vouchers", 17 chars) won't fit. Falls back to "cr".
+ * Caller-owned buffer must be >= 5 bytes. */
+static void ui_station_currency_short(const station_t *st, char *out, size_t cap) {
+    if (cap == 0) return;
+    if (!st || !st->currency_name[0]) {
+        snprintf(out, cap, "cr");
+        return;
+    }
+    /* Take the first whitespace-delimited word. "prospect vouchers" -> "prospect" */
+    size_t i = 0, j = 0;
+    while (st->currency_name[i] != '\0' && st->currency_name[i] != ' ' &&
+           j < cap - 1 && j < 4) {
+        char c = st->currency_name[i];
+        out[j++] = (c >= 'A' && c <= 'Z') ? (char)(c - 'A' + 'a') : c;
+        i++;
+    }
+    out[j] = '\0';
+    if (j == 0) snprintf(out, cap, "cr");
+}
+
 
 
 /* ====================================================================
@@ -417,29 +439,33 @@ static void draw_header_band(const station_ui_state_t *ui,
     sdtx_puts(role_label);
 
     if (panel_w >= 360.0f) {
-        char right2[64];
         int balance = (int)lroundf(player_current_balance());
         float sig = signal_strength_at(&g.world, st->pos);
-        snprintf(right2, sizeof(right2), "ledger %d %s   sig %.2f",
-                 balance, ui_station_currency(st), sig);
-        float right2_w = (float)strlen(right2) * cell_w;
         float gap = 16.0f;
-        bool fits = (left_x + role_w + gap + right2_w)
-                  <= (panel_x + panel_w - right_margin);
-        /* If the full string wouldn't fit, try just "ledger N cur" (drop
-         * sig); if that still doesn't fit, drop the whole right side. */
-        if (!fits) {
-            snprintf(right2, sizeof(right2), "ledger %d %s",
-                     balance, ui_station_currency(st));
-            right2_w = (float)strlen(right2) * cell_w;
-            fits = (left_x + role_w + gap + right2_w)
-                 <= (panel_x + panel_w - right_margin);
-        }
-        if (fits) {
-            sdtx_pos(ui_text_pos(panel_x + panel_w - right_margin - right2_w),
+        float right_limit = panel_x + panel_w - right_margin;
+        float left_used = left_x + role_w + gap;
+
+        /* Try four progressively shorter forms, each guaranteed to
+         * convey at least the balance. Pick the longest that fits. */
+        char short_cur[8];
+        ui_station_currency_short(st, short_cur, sizeof(short_cur));
+        const char *full_cur = ui_station_currency(st);
+        const char *forms[4];
+        char buf0[64], buf1[64], buf2[64], buf3[32];
+        snprintf(buf0, sizeof(buf0), "ledger %d %s   sig %.2f",  balance, full_cur,  sig);
+        snprintf(buf1, sizeof(buf1), "ledger %d %s",             balance, full_cur);
+        snprintf(buf2, sizeof(buf2), "%d %s   sig %.2f",         balance, short_cur, sig);
+        snprintf(buf3, sizeof(buf3), "%d %s",                    balance, short_cur);
+        forms[0] = buf0; forms[1] = buf1; forms[2] = buf2; forms[3] = buf3;
+
+        for (int i = 0; i < 4; i++) {
+            float w = (float)strlen(forms[i]) * cell_w;
+            if (left_used + w > right_limit) continue;
+            sdtx_pos(ui_text_pos(right_limit - w),
                      ui_text_pos(panel_y + HEADER_L2));
             sdtx_color3b(PAL_TEXT_SECONDARY);
-            sdtx_puts(right2);
+            sdtx_puts(forms[i]);
+            break;
         }
     }
 


### PR DESCRIPTION
Two follow-ups from the post-CCN HUD review.

## #2 — unify trade-row construction
`input.c` had its own slim `trade_row_t` and `trade_resolve_buy_row` / `trade_resolve_sell_row` helpers walking the (commodity, grade) matrix to map the [1]..[5] keypress to a row. `station_ui.c:draw_trade_view` walked the same matrix to build the displayed picker. Two sources of truth — one walk-order divergence away from a [1] keypress hitting a row that wasn't on screen.

Fix: hoist `trade_row_t` + pagination constants to `client.h`. Extract `build_trade_rows(station, ship, out[], max) -> count` in `station_ui.c` (single source of truth). Both callers consume it. `sample_trade_picker` now indexes `target = page * TRADE_ROWS_PER_PAGE + digit_pick` directly. Hotkey/picker desync is no longer expressible.

## #6 — header-band currency fallbacks
Narrow panel + long currency_name ("prospect vouchers") → previous fallback chain dropped the entire right side, hiding the docked balance. New chain tries four progressive forms and picks the longest that fits:

1. `ledger 1234 prospect vouchers   sig 0.92`
2. `ledger 1234 prospect vouchers`               (drop sig)
3. `1234 pros   sig 0.92`                        (short currency)
4. `1234 pros`                                   (short currency, no sig)

Form 4 always fits unless the panel is essentially zero-width. Balance is always visible.

`ui_station_currency_short()` takes the first whitespace-delimited word, lowercased, capped at 4 chars.

## Test plan
- [x] `make test` — 336 / 336 throughout
- [x] Pre-commit hook (native + WASM) green
- [ ] CI green
- [ ] Manual: dock at Prospect with the docked panel narrow, confirm balance still shows