### PR TITLE
PvP rocks: hit feedback — damage popup + red vignette pulse (#386)

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -141,6 +141,19 @@ typedef struct {
         uint8_t r, g, b;
         char text[16];
     } sell_fx[16];
+    /* Floating "-N" damage popups spawned on SIM_EVENT_DAMAGE. World-space
+     * red text that rises and fades over ~1.0s. Smaller pool than sell_fx
+     * because hits are less frequent than sales but burst-y during
+     * combat. */
+    struct {
+        vec2 pos;
+        float age;
+        float life;
+        char text[8];
+    } damage_fx[8];
+    /* Hit vignette: red border pulse on the local player's HUD when they
+     * take damage. Set on SIM_EVENT_DAMAGE, decays each frame. */
+    float damage_flash_timer;
     /* Per-station manifest summary — [commodity][grade] unit counts.
      * Unified read path for the TRADE UI whether we're in singleplayer
      * (populated every frame from g.world.stations[s].manifest) or

--- a/src/hud.c
+++ b/src/hud.c
@@ -479,6 +479,10 @@ static void hud_draw_shared_panels(float screen_w, float screen_h, float sig_qua
     hud_draw_hail_sigil(screen_w, screen_h);
     hud_draw_module_inspect_pane(screen_w);
     hud_draw_signal_lost_warning(screen_w, screen_h, sig_quality);
+    /* Hit feedback vignette — drawn last so it sits above the HUD
+     * readouts, but the inset rectangle in the middle leaves the
+     * action row + flight readouts unobscured. */
+    draw_damage_flash(screen_w, screen_h);
 }
 
 /* Pending credits across all stations — sum of every ledger entry the

--- a/src/main.c
+++ b/src/main.c
@@ -424,6 +424,11 @@ static void sim_on_damage(const sim_event_t *ev) {
     float kick = sqrtf(ev->damage.amount) * 4.0f;
     if (kick > 40.0f) kick = 40.0f;
     if (kick > g.screen_shake) g.screen_shake = kick;
+    /* Hit feedback: floating "-N" popup near the receiver's ship + red
+     * vignette pulse on the HUD. Both decay independently of the audio. */
+    int amount = (int)lroundf(ev->damage.amount);
+    if (amount > 0) spawn_damage_fx(&LOCAL_PLAYER.ship.pos, amount);
+    g.damage_flash_timer = 0.4f;
 }
 
 static void sim_on_contract_complete(const sim_event_t *ev) {
@@ -893,6 +898,7 @@ static void sim_step(float dt) {
 
     step_notice_timer(dt);
     update_sell_fx(dt);
+    update_damage_fx(dt);
     if (g.action_predict_timer > 0.0f)
         g.action_predict_timer = fmaxf(0.0f, g.action_predict_timer - dt);
     if (g.dock_settle_timer > 0.0f)
@@ -1358,6 +1364,7 @@ static void render_world(void) {
     draw_callsigns();      /* Readable sdtx labels above local + remote ships */
     draw_npc_chatter();    /* Short radio one-liners near NPC sprites (#291) */
     draw_sell_fx();        /* +$N payout popups floating above stations */
+    draw_damage_fx();      /* -N hit popups floating above the receiver's ship */
     draw_autopilot_path(); /* Dotted line showing A* path ahead */
     draw_tracked_contract_highlight();  /* Pulsing ring on the current contract's next objective */
     draw_compass_ring();   /* Navigation compass around player ship */

--- a/src/world_draw.c
+++ b/src/world_draw.c
@@ -2165,6 +2165,104 @@ void draw_sell_fx(void) {
 }
 
 /* ================================================================== */
+/* Damage FX — floating "-N" + red vignette on SIM_EVENT_DAMAGE       */
+/* ================================================================== */
+
+void spawn_damage_fx(const vec2 *origin, int amount) {
+    if (amount <= 0 || !origin) return;
+    int slot = -1;
+    float oldest_age = -1.0f;
+    int pool = (int)(sizeof(g.damage_fx) / sizeof(g.damage_fx[0]));
+    for (int i = 0; i < pool; i++) {
+        if (g.damage_fx[i].life <= 0.0f) { slot = i; break; }
+        if (g.damage_fx[i].age > oldest_age) { oldest_age = g.damage_fx[i].age; slot = i; }
+    }
+    if (slot < 0) return;
+    /* Small jitter so back-to-back hits don't render on top of each other. */
+    static uint32_t seed = 0x600DBADu;
+    seed = seed * 1664525u + 1013904223u;
+    float jitter_x = ((int)((seed >> 8) & 0x1F) - 16) * 1.5f;
+    seed = seed * 1664525u + 1013904223u;
+    float jitter_y = ((int)((seed >> 8) & 0x1F) - 16) * 1.0f;
+    g.damage_fx[slot].pos = v2(origin->x + jitter_x, origin->y + 24.0f + jitter_y);
+    g.damage_fx[slot].age = 0.0f;
+    g.damage_fx[slot].life = 1.0f;
+    snprintf(g.damage_fx[slot].text, sizeof(g.damage_fx[slot].text), "-%d", amount);
+}
+
+void update_damage_fx(float dt) {
+    int pool = (int)(sizeof(g.damage_fx) / sizeof(g.damage_fx[0]));
+    for (int i = 0; i < pool; i++) {
+        if (g.damage_fx[i].life <= 0.0f) continue;
+        g.damage_fx[i].age += dt;
+        if (g.damage_fx[i].age >= g.damage_fx[i].life) g.damage_fx[i].life = 0.0f;
+    }
+    if (g.damage_flash_timer > 0.0f) {
+        g.damage_flash_timer -= dt;
+        if (g.damage_flash_timer < 0.0f) g.damage_flash_timer = 0.0f;
+    }
+}
+
+void draw_damage_fx(void) {
+    float view_w = cam_right() - cam_left();
+    float view_h = cam_bottom() - cam_top();
+    const float cell = 8.0f;
+    sdtx_canvas(view_w, view_h);
+    sdtx_origin(cam_left() / cell, cam_top() / cell);
+    int pool = (int)(sizeof(g.damage_fx) / sizeof(g.damage_fx[0]));
+    for (int i = 0; i < pool; i++) {
+        if (g.damage_fx[i].life <= 0.0f) continue;
+        float t = g.damage_fx[i].age / g.damage_fx[i].life;
+        if (t > 1.0f) continue;
+        /* Rise ~22 px and fade in the last quarter. */
+        float rise_y = -22.0f * t;
+        float alpha = (t < 0.75f) ? 1.0f : (1.0f - (t - 0.75f) / 0.25f);
+        if (alpha < 0.0f) alpha = 0.0f;
+        uint8_t a8 = (uint8_t)(alpha * 255.0f);
+        float x = g.damage_fx[i].pos.x;
+        float y = g.damage_fx[i].pos.y + rise_y;
+        if (!on_screen(x, y, 32.0f)) continue;
+        int len = (int)strlen(g.damage_fx[i].text);
+        sdtx_color4b(255, 70, 70, a8);
+        sdtx_pos((x - len * cell * 0.5f) / cell, y / cell);
+        sdtx_puts(g.damage_fx[i].text);
+    }
+}
+
+/* Red border vignette pulsed when the local player takes damage. Inner
+ * 60 % of the screen stays clear; only the outer ring tints, so the
+ * HUD readouts in the corners aren't washed out. */
+void draw_damage_flash(float screen_w, float screen_h) {
+    if (g.damage_flash_timer <= 0.0f) return;
+    /* Linear fade — timer was set to 0.4s on damage. Square the alpha
+     * so the early frames hit hard then ease out. */
+    float t = g.damage_flash_timer / 0.4f;
+    if (t > 1.0f) t = 1.0f;
+    float alpha = t * t * 0.55f;
+
+    /* Border ring: four trapezoids around an inset rect. */
+    float ix = screen_w * 0.20f;
+    float iy = screen_h * 0.20f;
+    float ix2 = screen_w - ix;
+    float iy2 = screen_h - iy;
+    sgl_begin_quads();
+    sgl_c4f(0.95f, 0.18f, 0.18f, alpha);
+    /* top */
+    sgl_v2f(0.0f, 0.0f);     sgl_v2f(screen_w, 0.0f);
+    sgl_v2f(ix2,  iy);       sgl_v2f(ix,   iy);
+    /* bottom */
+    sgl_v2f(ix,   iy2);      sgl_v2f(ix2,  iy2);
+    sgl_v2f(screen_w, screen_h); sgl_v2f(0.0f, screen_h);
+    /* left */
+    sgl_v2f(0.0f, 0.0f);     sgl_v2f(ix,   iy);
+    sgl_v2f(ix,   iy2);      sgl_v2f(0.0f, screen_h);
+    /* right */
+    sgl_v2f(ix2,  iy);       sgl_v2f(screen_w, 0.0f);
+    sgl_v2f(screen_w, screen_h); sgl_v2f(ix2,  iy2);
+    sgl_end();
+}
+
+/* ================================================================== */
 /* Scaffold world objects                                             */
 /* ================================================================== */
 

--- a/src/world_draw.h
+++ b/src/world_draw.h
@@ -86,4 +86,15 @@ void spawn_sell_fx(const vec2 *origin, int amount, mining_grade_t grade, bool by
 void update_sell_fx(float dt);
 void draw_sell_fx(void);
 
+/* --- Damage FX: floating "-N" popups + red vignette on SIM_EVENT_DAMAGE
+ * for the local player. Mirrors sell_fx but tighter lifetime and a
+ * single hot color. spawn_damage_fx is a no-op when amount <= 0. */
+void spawn_damage_fx(const vec2 *origin, int amount);
+void update_damage_fx(float dt);
+void draw_damage_fx(void);
+/* Red border vignette pulsed on the receiver's HUD for ~0.4s after a
+ * damage event. Driven by g.damage_flash_timer, decremented in
+ * update_damage_fx. */
+void draw_damage_flash(float screen_w, float screen_h);
+
 #endif /* WORLD_DRAW_H */


### PR DESCRIPTION
Closes #386 (Rock-throw E: hit feedback).

Builds on the SIM_EVENT_DAMAGE wiring added in #406. When a damage event fires for the local player, three things now happen on top of the existing audio + screen shake:

1. **Floating "-N" red text** at the receiver's ship position. Mirrors `spawn_sell_fx` — same world-space rise + fade, smaller pool (8), tighter lifetime (1.0 s).
2. **Red border vignette** on the HUD — outer ring pulses ~0.4 s on hit. Inner 60% stays clear so the action row + flight readouts aren't washed out. Linear-then-squared alpha decay so the first frames hit hard, the tail eases out.
3. (Audio + screen shake unchanged — already in place from prior work.)

## Implementation
- `src/client.h` — `g.damage_fx[8]` pool + `g.damage_flash_timer`.
- `src/world_draw.{h,c}` — `spawn_damage_fx` / `update_damage_fx` / `draw_damage_fx` (mirrors of the sell_fx trio) + `draw_damage_flash` (4-quad red border).
- `src/main.c` — `sim_on_damage` spawns the popup + sets the flash timer for the local player.
- `src/hud.c` — `hud_draw_shared_panels` calls `draw_damage_flash` last so the vignette sits above HUD readouts.

Ramming damage and any other `SIM_EVENT_DAMAGE` source gets the same treatment automatically — no per-cause branching.

## Test plan
- [x] `make test` — 336 / 336
- [x] Pre-commit hook (native + WASM) green
- [ ] CI green
- [ ] Manual: ram a station at speed (or take a thrown rock in MP) and verify red "-N" rises near the ship + outer-ring red flash for ~0.4s