### PR TITLE
PvP rocks: directional hit indicator + kill-feed line

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -655,7 +655,8 @@ static void emergency_recover_ship(world_t *w, server_player_t *sp) {
  * fires with the correct killer/cause even if the lethal blow lands
  * several ticks after the ramp-down begins. */
 static void apply_ship_damage_attributed(world_t *w, server_player_t *sp, float damage,
-                                          const uint8_t killer_token[8], uint8_t cause) {
+                                          const uint8_t killer_token[8], uint8_t cause,
+                                          vec2 source) {
     if (damage <= 0.0f) return;
     sp->ship.hull = fmaxf(0.0f, sp->ship.hull - damage);
     /* Record attribution if this hit is non-environmental, OR if no
@@ -670,12 +671,18 @@ static void apply_ship_damage_attributed(world_t *w, server_player_t *sp, float 
     } else if (sp->last_damage_cause == DEATH_CAUSE_UNKNOWN) {
         sp->last_damage_cause = cause;
     }
-    emit_event(w, (sim_event_t){.type = SIM_EVENT_DAMAGE, .player_id = sp->id, .damage.amount = damage});
+    emit_event(w, (sim_event_t){
+        .type = SIM_EVENT_DAMAGE, .player_id = sp->id,
+        .damage = { .amount = damage, .source_x = source.x, .source_y = source.y },
+    });
     if (sp->ship.hull <= 0.01f) emergency_recover_ship(w, sp);
 }
 
 static void apply_ship_damage(world_t *w, server_player_t *sp, float damage) {
-    apply_ship_damage_attributed(w, sp, damage, NULL, DEATH_CAUSE_ASTEROID);
+    /* Environmental, unsourced — caller doesn't know where the hit
+     * came from. Client treats source = (0,0) as "unknown" and skips
+     * the directional indicator. */
+    apply_ship_damage_attributed(w, sp, damage, NULL, DEATH_CAUSE_ASTEROID, v2(0.0f, 0.0f));
 }
 
 /* ================================================================== */
@@ -704,7 +711,9 @@ static void resolve_ship_circle(world_t *w, server_player_t *sp, vec2 center, fl
         float impact = -vel_toward;
         float dmg = sp->docked ? 0.0f : collision_damage_for(impact, 1.0f);
         if (dmg > 0.0f) {
-            apply_ship_damage_attributed(w, sp, dmg, NULL, DEATH_CAUSE_STATION);
+            /* Source = the offending station-module circle. Player's
+             * directional indicator points at the wall they hit. */
+            apply_ship_damage_attributed(w, sp, dmg, NULL, DEATH_CAUSE_STATION, center);
         }
         /* Clamp inward velocity component to zero — slide along the surface
          * tangent on the next tick instead of bouncing back through it. */
@@ -762,8 +771,10 @@ static void resolve_ship_asteroid_collision(world_t *w, server_player_t *sp, ast
             float dmg = sp->docked ? 0.0f : collision_damage_for(impact, size_mult);
             if (dmg > 0.0f) {
                 uint8_t cause = attributed ? DEATH_CAUSE_THROWN_ROCK : DEATH_CAUSE_ASTEROID;
+                /* Source = rock position so the indicator points at
+                 * the actual incoming projectile, not the thrower. */
                 apply_ship_damage_attributed(w, sp, dmg,
-                    attributed ? a->last_towed_token : NULL, cause);
+                    attributed ? a->last_towed_token : NULL, cause, a->pos);
             }
         }
 
@@ -4255,10 +4266,14 @@ void world_sim_step(world_t *w, float dt) {
                  * that wouldn't bruise a static collision. */
                 float dmg = collision_damage_for(impact, 0.7f);
                 if (dmg > 0.0f) {
+                    /* Each player's directional indicator points at
+                     * the OTHER ship — the rammer they collided with. */
                     apply_ship_damage_attributed(w, &w->players[i], dmg,
-                        w->players[j].session_token, DEATH_CAUSE_RAM);
+                        w->players[j].session_token, DEATH_CAUSE_RAM,
+                        w->players[j].ship.pos);
                     apply_ship_damage_attributed(w, &w->players[j], dmg,
-                        w->players[i].session_token, DEATH_CAUSE_RAM);
+                        w->players[i].session_token, DEATH_CAUSE_RAM,
+                        w->players[i].ship.pos);
                 }
             }
         }

--- a/server/net_protocol.h
+++ b/server/net_protocol.h
@@ -906,7 +906,14 @@ static inline int serialize_events(uint8_t *buf, const sim_events_t *events) {
             p[2] = (uint8_t)ev->upgrade.upgrade;
             break;
         case SIM_EVENT_DAMAGE:
-            write_f32_le(&p[2], ev->damage.amount);
+            write_f32_le(&p[2],  ev->damage.amount);
+            write_f32_le(&p[6],  ev->damage.source_x);
+            write_f32_le(&p[10], ev->damage.source_y);
+            break;
+        case SIM_EVENT_NPC_KILL:
+            p[2] = ev->npc_kill.cause;
+            p[3] = ev->npc_kill.npc_role;
+            memcpy(&p[4], ev->npc_kill.killer_token, 8);
             break;
         case SIM_EVENT_OUTPOST_PLACED:
             p[2] = (uint8_t)ev->outpost_placed.slot;

--- a/shared/types.h
+++ b/shared/types.h
@@ -682,7 +682,12 @@ typedef struct {
         struct { asteroid_tier_t tier; int asteroid_id; } fracture;
         struct { float ore; int fragments; } pickup;
         struct { ship_upgrade_t upgrade; } upgrade;
-        struct { float amount; } damage;
+        /* SIM_EVENT_DAMAGE: source_x/source_y let the client pick a
+         * world-space direction for the directional hit indicator
+         * (chevron at the screen edge pointing toward the threat).
+         * Both zero = unknown source (legacy callers, environmental
+         * hits) — client renders a center-screen pulse instead. */
+        struct { float amount; float source_x; float source_y; } damage;
         /* SIM_EVENT_SELL: populated when a fragment is smelted. grade
          * is mining_grade_t; base_cr is ore * station_buy_price;
          * bonus_cr is the extra credits the multiplier added on top.

--- a/src/client.h
+++ b/src/client.h
@@ -154,6 +154,18 @@ typedef struct {
     /* Hit vignette: red border pulse on the local player's HUD when they
      * take damage. Set on SIM_EVENT_DAMAGE, decays each frame. */
     float damage_flash_timer;
+    /* Directional hit indicator. dir_x/dir_y is a unit vector in WORLD
+     * space pointing from the ship toward the source of the most
+     * recent damage event. Renderer projects it onto the screen edge.
+     * timer counts down from ~1.5 s. (0,0) = no source / unknown. */
+    float damage_dir_x;
+    float damage_dir_y;
+    float damage_dir_timer;
+    /* PvP kill-feed: short text shown at top-center for ~3 s when
+     * SIM_EVENT_NPC_KILL fires (eventually also when a remote player
+     * dies). Text + remaining lifetime; 0 = empty. */
+    char  kill_feed_text[64];
+    float kill_feed_timer;
     /* Per-station manifest summary — [commodity][grade] unit counts.
      * Unified read path for the TRADE UI whether we're in singleplayer
      * (populated every frame from g.world.stations[s].manifest) or

--- a/src/hud.c
+++ b/src/hud.c
@@ -473,12 +473,87 @@ static void hud_draw_signal_lost_warning(float screen_w, float screen_h, float s
 
 /* Render the post-classify shared panels common to compact + wide.
  * Called once per frame after each layout's top-status section. */
+/* Directional hit indicator — solid red triangle on the screen edge
+ * pointing in the world-space direction the most recent damage came
+ * from. The vector g.damage_dir_{x,y} is unit; we project onto the
+ * smaller of the screen-edge intercepts so the chevron always sits
+ * just inside the visible boundary. Fades out over the timer's
+ * lifetime. */
+static void hud_draw_hit_indicator(float screen_w, float screen_h) {
+    if (g.damage_dir_timer <= 0.0f) return;
+    /* Squared decay so the spike is visible immediately and the tail
+     * eases out. */
+    float t = g.damage_dir_timer / 1.5f;
+    if (t > 1.0f) t = 1.0f;
+    float alpha = t * t;
+
+    /* Pick a margin from the screen edge proportional to the smaller
+     * dimension so it tracks compact / wide layouts. */
+    float margin = fminf(screen_w, screen_h) * 0.06f;
+    /* Half the available rect — the indicator orbits the screen
+     * center on this radius, scaled to land just inside the edge in
+     * the dominant axis. */
+    float cx = screen_w * 0.5f;
+    float cy = screen_h * 0.5f;
+    float ax = screen_w * 0.5f - margin;
+    float ay = screen_h * 0.5f - margin;
+    /* Clamp the world-space dir to the screen rectangle: scale the
+     * vector so |dx|/ax or |dy|/ay equals 1, whichever hits first. */
+    float dx = g.damage_dir_x;
+    float dy = g.damage_dir_y;
+    float k_x = (fabsf(dx) > 0.001f) ? (ax / fabsf(dx)) : 1e9f;
+    float k_y = (fabsf(dy) > 0.001f) ? (ay / fabsf(dy)) : 1e9f;
+    float k = fminf(k_x, k_y);
+    float px = cx + dx * k;
+    float py = cy + dy * k;
+
+    /* Triangle pointing along (dx, dy). Side perpendicular = (-dy, dx). */
+    float size = margin * 0.9f;
+    float tip_x = px + dx * size * 0.5f;
+    float tip_y = py + dy * size * 0.5f;
+    float bx = px - dx * size * 0.5f;
+    float by = py - dy * size * 0.5f;
+    float perp_x = -dy * size * 0.45f;
+    float perp_y =  dx * size * 0.45f;
+
+    sgl_begin_triangles();
+    sgl_c4f(0.95f, 0.20f, 0.20f, alpha);
+    sgl_v2f(tip_x,           tip_y);
+    sgl_v2f(bx + perp_x,     by + perp_y);
+    sgl_v2f(bx - perp_x,     by - perp_y);
+    sgl_end();
+}
+
+/* PvP kill-feed — single line at top-center, fades on the timer.
+ * Server-emitted SIM_EVENT_NPC_KILL drives the text; eventually
+ * remote-player kills will share the same surface. */
+static void hud_draw_kill_feed(float screen_w, float screen_h) {
+    if (g.kill_feed_timer <= 0.0f) return;
+    if (g.kill_feed_text[0] == '\0') return;
+    float cell = 8.0f;
+    /* Fade-in for the first 0.2 s, fade-out for the last 0.5 s. */
+    float a = 1.0f;
+    if (g.kill_feed_timer > 2.8f) a = (3.0f - g.kill_feed_timer) / 0.2f;
+    else if (g.kill_feed_timer < 0.5f) a = g.kill_feed_timer / 0.5f;
+    if (a < 0.0f) a = 0.0f;
+    if (a > 1.0f) a = 1.0f;
+    uint8_t a8 = (uint8_t)(a * 255.0f);
+    sdtx_canvas(screen_w, screen_h);
+    sdtx_origin(0.0f, 0.0f);
+    sdtx_color4b(255, 220, 100, a8);  /* warm gold reads as scoreboard */
+    sdtx_centered_text(screen_w * 0.5f, (screen_h * 0.08f) / cell, cell,
+                       g.kill_feed_text);
+    (void)screen_h;
+}
+
 static void hud_draw_shared_panels(float screen_w, float screen_h, float sig_quality, bool compact) {
     hud_draw_alpha_banner_and_mp_indicator(screen_w, compact);
     hud_draw_nav_label(screen_w, screen_h);
     hud_draw_hail_sigil(screen_w, screen_h);
     hud_draw_module_inspect_pane(screen_w);
     hud_draw_signal_lost_warning(screen_w, screen_h, sig_quality);
+    hud_draw_hit_indicator(screen_w, screen_h);
+    hud_draw_kill_feed(screen_w, screen_h);
     /* Hit feedback vignette — drawn last so it sits above the HUD
      * readouts, but the inset rectangle in the middle leaves the
      * action row + flight readouts unobscured. */

--- a/src/main.c
+++ b/src/main.c
@@ -429,6 +429,45 @@ static void sim_on_damage(const sim_event_t *ev) {
     int amount = (int)lroundf(ev->damage.amount);
     if (amount > 0) spawn_damage_fx(&LOCAL_PLAYER.ship.pos, amount);
     g.damage_flash_timer = 0.4f;
+    /* Directional indicator — chevron at the screen edge pointing at
+     * the threat. Source = (0,0) means "unknown" (legacy / environmental);
+     * skip the indicator for those so it doesn't flicker at world origin. */
+    if (ev->damage.source_x != 0.0f || ev->damage.source_y != 0.0f) {
+        float dx = ev->damage.source_x - LOCAL_PLAYER.ship.pos.x;
+        float dy = ev->damage.source_y - LOCAL_PLAYER.ship.pos.y;
+        float d = sqrtf(dx * dx + dy * dy);
+        if (d > 1.0f) {
+            g.damage_dir_x = dx / d;
+            g.damage_dir_y = dy / d;
+            g.damage_dir_timer = 1.5f;
+        }
+    }
+}
+
+static void sim_on_npc_kill(const sim_event_t *ev) {
+    /* Kill-feed line. Prefer the local player's perspective: if I'm
+     * the killer, prepend "You killed"; otherwise show the killer's
+     * callsign if we know it (multiplayer player kills NPC). For now
+     * we don't have a token-to-callsign cache, so the bare role +
+     * cause cover the singleplayer case where the local player is
+     * always the killer. */
+    const char *role = (ev->npc_kill.npc_role == NPC_ROLE_MINER) ? "Miner"
+                     : (ev->npc_kill.npc_role == NPC_ROLE_HAULER) ? "Hauler"
+                     : "Tow drone";
+    const char *weapon = (ev->npc_kill.cause == DEATH_CAUSE_THROWN_ROCK) ? "thrown rock"
+                       : (ev->npc_kill.cause == DEATH_CAUSE_RAM) ? "ramming"
+                       : "collision";
+    bool you_killed = !g.multiplayer_enabled ||
+        (memcmp(ev->npc_kill.killer_token,
+                g.world.players[g.local_player_slot].session_token, 8) == 0);
+    if (you_killed) {
+        snprintf(g.kill_feed_text, sizeof(g.kill_feed_text),
+                 "You killed %s with %s", role, weapon);
+    } else {
+        snprintf(g.kill_feed_text, sizeof(g.kill_feed_text),
+                 "%s killed by %s", role, weapon);
+    }
+    g.kill_feed_timer = 3.0f;
 }
 
 static void sim_on_contract_complete(const sim_event_t *ev) {
@@ -624,8 +663,7 @@ static const sim_event_handler_fn k_sim_event_handlers[SIM_EVENT_COUNT] = {
     [SIM_EVENT_SIGNAL_LOST]        = sim_on_signal_lost,
     [SIM_EVENT_STATION_CONNECTED]  = sim_on_station_connected,
     [SIM_EVENT_ORDER_REJECTED]     = sim_on_order_rejected,
-    /* SIM_EVENT_NPC_KILL: no client handler yet (kill-feed is server-
-     * routed broadcast text; no per-event hook needed here). */
+    [SIM_EVENT_NPC_KILL]           = sim_on_npc_kill,
 };
 
 void process_sim_events(const sim_events_t *events) {
@@ -899,6 +937,17 @@ static void sim_step(float dt) {
     step_notice_timer(dt);
     update_sell_fx(dt);
     update_damage_fx(dt);
+    if (g.damage_dir_timer > 0.0f) {
+        g.damage_dir_timer -= dt;
+        if (g.damage_dir_timer < 0.0f) g.damage_dir_timer = 0.0f;
+    }
+    if (g.kill_feed_timer > 0.0f) {
+        g.kill_feed_timer -= dt;
+        if (g.kill_feed_timer < 0.0f) {
+            g.kill_feed_timer = 0.0f;
+            g.kill_feed_text[0] = '\0';
+        }
+    }
     if (g.action_predict_timer > 0.0f)
         g.action_predict_timer = fmaxf(0.0f, g.action_predict_timer - dt);
     if (g.dock_settle_timer > 0.0f)

--- a/src/net.c
+++ b/src/net.c
@@ -549,7 +549,13 @@ static void handle_message(const uint8_t* data, int len) {
                 case SIM_EVENT_UPGRADE:
                     ev->upgrade.upgrade = (ship_upgrade_t)p[2]; break;
                 case SIM_EVENT_DAMAGE:
-                    ev->damage.amount = read_f32_le(&p[2]); break;
+                    ev->damage.amount   = read_f32_le(&p[2]);
+                    ev->damage.source_x = read_f32_le(&p[6]);
+                    ev->damage.source_y = read_f32_le(&p[10]); break;
+                case SIM_EVENT_NPC_KILL:
+                    ev->npc_kill.cause    = p[2];
+                    ev->npc_kill.npc_role = p[3];
+                    memcpy(ev->npc_kill.killer_token, &p[4], 8); break;
                 case SIM_EVENT_OUTPOST_PLACED:
                     ev->outpost_placed.slot = (int)p[2]; break;
                 case SIM_EVENT_OUTPOST_ACTIVATED:


### PR DESCRIPTION
Two follow-ups to the just-shipped PvP combat: tell the player (a) which direction the threat came from and (b) when their thrown rock actually killed an NPC.

Both ride on events that already exist after #406; only the wire payload extension + a couple of HUD draws are new.

## Changes
- `shared/types.h` — `SIM_EVENT_DAMAGE` payload gains `source_x` / `source_y`. 0,0 = unknown / environmental.
- `server/net_protocol.h` + `src/net.c` — serialize/deserialize the new damage source coords. Also wire `SIM_EVENT_NPC_KILL` to the broadcast (it was emitted server-side by #406 but never sent).
- `server/game_sim.c` — `apply_ship_damage_attributed` gains a `vec2 source` param. Station collision = collision center. Asteroid collision = asteroid pos (indicator points at the rock, not the thrower). PvP ramming = the other player's ship pos for each side.
- `src/client.h` — `g.damage_dir_{x,y}` + timer; `g.kill_feed_text` + timer.
- `src/main.c` — `sim_on_damage` extracts source, computes the unit dir from `ship -> source`, sets the indicator timer to 1.5 s. New `sim_on_npc_kill` formats "You killed Hauler with thrown rock" or "Hauler killed by thrown rock". `SIM_EVENT_NPC_KILL` now bound in the dispatch table.
- `src/hud.c` — `hud_draw_hit_indicator` (solid red triangle on the screen edge pointing at the source, squared-alpha decay over 1.5 s) + `hud_draw_kill_feed` (warm gold top-center text, fade in/out). Both fire from `hud_draw_shared_panels` so compact + wide treat them identically.

## Test plan
- [x] `make test` — 336 / 336
- [x] Pre-commit hook (native + WASM) green
- [ ] CI green
- [ ] Manual: take a rock to the side of the ship, confirm a red triangle pops on the corresponding screen edge and decays
- [ ] Manual: throw a rock that kills a hauler, confirm "You killed Hauler with thrown rock" at top of screen