### PR TITLE
Economy: chain seed + auto-respawn; HUD: drop directional hit indicator

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -4500,14 +4500,27 @@ void world_reset(world_t *w) {
         }
     }
 
-    /* --- NPC ships: 2 miners at refinery, 2 haulers for logistics,
-     *     1 tow drone at each shipyard for autonomous scaffold delivery --- */
+    /* --- NPC ships: seed haulers at every station so the inter-station
+     * trade chain has a carrier on every hop. Without a Kepler-homed
+     * hauler, frames pile up at Kepler with nobody to deliver them to
+     * Helios; without a Helios-homed hauler, repair kits can't reach
+     * Prospect's dock. The contract dispatcher in step_hauler picks
+     * the best fillable contract from the home station's inventory,
+     * so spawning the right home is the only seeding step needed.
+     *
+     * Miners also spread: Helios's CU/CR furnaces need their own
+     * feed (Prospect-homed miners only deliver to Prospect's hopper).
+     *
+     * Tow drones stay at the two shipyards (Kepler, Helios). --- */
+    spawn_npc(w, 0, NPC_ROLE_MINER);    /* Prospect: ferrite hopper feed */
     spawn_npc(w, 0, NPC_ROLE_MINER);
-    spawn_npc(w, 0, NPC_ROLE_MINER);
+    spawn_npc(w, 2, NPC_ROLE_MINER);    /* Helios: CU/CR hopper feed */
+    spawn_npc(w, 0, NPC_ROLE_HAULER);   /* Prospect -> Kepler ferrite ingots */
     spawn_npc(w, 0, NPC_ROLE_HAULER);
-    spawn_npc(w, 0, NPC_ROLE_HAULER);
-    spawn_npc(w, 1, NPC_ROLE_TOW); /* Kepler shipyard */
-    spawn_npc(w, 2, NPC_ROLE_TOW); /* Helios shipyard */
+    spawn_npc(w, 1, NPC_ROLE_HAULER);   /* Kepler -> Helios frames */
+    spawn_npc(w, 2, NPC_ROLE_HAULER);   /* Helios -> Prospect repair kits */
+    spawn_npc(w, 1, NPC_ROLE_TOW);      /* Kepler shipyard */
+    spawn_npc(w, 2, NPC_ROLE_TOW);      /* Helios shipyard */
 
     /* Precompute station nav meshes now that geometry is finalized. */
     station_rebuild_all_nav(w);

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -319,6 +319,13 @@ typedef struct {
     float time;
     float field_spawn_timer;
     float gravity_accumulator;  /* runs gravity at reduced rate */
+    /* Replenish dead haulers / miners. Decremented in step_npc_ships;
+     * when it hits zero, replenish_npc_roster spawns AT MOST one NPC
+     * (the most-understaffed station/role pair) and resets the timer.
+     * Drip-feed is intentional: a full chain wipe takes time to
+     * recover so PvP harassment has weight, but the chain isn't a
+     * permanent loss. */
+    float npc_respawn_timer;
     sim_events_t events;
     contract_t contracts[MAX_CONTRACTS];
     bool player_only_mode;

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -300,6 +300,71 @@ static void mirror_npc_to_character(world_t *w, int npc_slot) {
     }
 }
 
+/* Target NPC roster per starter station — must match the world_reset
+ * seed (see game_sim.c: spawn_npc calls). Outposts (>=3) are player-
+ * built and don't get auto-replenished here; they can scaffold their
+ * own NPCs via gameplay later. */
+static void station_target_npc_counts(int station_idx, const station_t *st,
+                                      int *miners, int *haulers) {
+    *miners = 0;
+    *haulers = 0;
+    if (!st || !station_is_active(st)) return;
+    switch (station_idx) {
+    case 0: *miners = 2; *haulers = 2; return;  /* Prospect */
+    case 1: *miners = 0; *haulers = 1; return;  /* Kepler   */
+    case 2: *miners = 1; *haulers = 1; return;  /* Helios   */
+    default: return;                            /* outposts: no auto */
+    }
+}
+
+/* Walk the active NPC pool and count active members per home station,
+ * per role. Used by replenish_npc_roster to pick the most-understaffed
+ * (station, role) pair. */
+static void count_npc_roster(const world_t *w,
+                             int miners[MAX_STATIONS],
+                             int haulers[MAX_STATIONS]) {
+    for (int s = 0; s < MAX_STATIONS; s++) { miners[s] = 0; haulers[s] = 0; }
+    for (int n = 0; n < MAX_NPC_SHIPS; n++) {
+        const npc_ship_t *npc = &w->npc_ships[n];
+        if (!npc->active) continue;
+        if (npc->home_station < 0 || npc->home_station >= MAX_STATIONS) continue;
+        if (npc->role == NPC_ROLE_MINER)  miners[npc->home_station]++;
+        if (npc->role == NPC_ROLE_HAULER) haulers[npc->home_station]++;
+    }
+}
+
+/* Spawn at most ONE NPC to fill the largest gap between actual and
+ * target roster. Drip-feed (caller gates with npc_respawn_timer) so a
+ * full wipe recovers gradually. Gated on station credit_pool > 100 so
+ * a broke station can't endlessly mint replacement drones — same bar
+ * as the contract dispatcher uses. Returns true if a spawn fired. */
+static bool replenish_npc_roster(world_t *w) {
+    int miners[MAX_STATIONS], haulers[MAX_STATIONS];
+    count_npc_roster(w, miners, haulers);
+
+    /* Find the largest shortfall across all (station, role) pairs.
+     * Tie-broken by station index (lower wins). */
+    int best_station = -1;
+    npc_role_t best_role = NPC_ROLE_MINER;
+    int best_shortfall = 0;
+    for (int s = 0; s < MAX_STATIONS; s++) {
+        int target_m = 0, target_h = 0;
+        station_target_npc_counts(s, &w->stations[s], &target_m, &target_h);
+        if (w->stations[s].credit_pool < 100.0f) continue;
+        int short_m = target_m - miners[s];
+        int short_h = target_h - haulers[s];
+        if (short_m > best_shortfall) {
+            best_shortfall = short_m; best_station = s; best_role = NPC_ROLE_MINER;
+        }
+        if (short_h > best_shortfall) {
+            best_shortfall = short_h; best_station = s; best_role = NPC_ROLE_HAULER;
+        }
+    }
+    if (best_station < 0) return false;
+    int slot = spawn_npc(w, best_station, best_role);
+    return slot >= 0;
+}
+
 void rebuild_characters_from_npcs(world_t *w) {
     /* Free heap-allocated manifests on all ships[] slots before we
      * deactivate the characters that pinned them. Without this, slots
@@ -1161,7 +1226,21 @@ static void step_tow_drone(world_t *w, npc_ship_t *npc, int n, float dt) {
     }
 }
 
+/* Cooldown between auto-respawn attempts. 15 s feels recoverable
+ * (full chain-wipe of 7 NPCs comes back over ~100 s) without making
+ * the rocks-vs-NPC PvP feature feel toothless. */
+#define NPC_RESPAWN_INTERVAL 15.0f
+
 void step_npc_ships(world_t *w, float dt) {
+    /* Replenish dead haulers/miners on a slow drip. The first call
+     * after world_reset waits the full interval so the seeded roster
+     * isn't immediately doubled. */
+    if (w->npc_respawn_timer <= 0.0f) w->npc_respawn_timer = NPC_RESPAWN_INTERVAL;
+    w->npc_respawn_timer -= dt;
+    if (w->npc_respawn_timer <= 0.0f) {
+        w->npc_respawn_timer = NPC_RESPAWN_INTERVAL;
+        (void)replenish_npc_roster(w);
+    }
     for (int n = 0; n < MAX_NPC_SHIPS; n++) {
         npc_ship_t *npc = &w->npc_ships[n];
         if (!npc->active) continue;

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -7,6 +7,7 @@
 #include "sim_ai.h"
 #include "sim_nav.h"
 #include "sim_flight.h"
+#include "sim_production.h" /* sim_can_smelt_ore for miner asteroid filter */
 #include "signal_model.h"
 #include "manifest.h"
 #include "ship.h"
@@ -411,18 +412,33 @@ static int npc_find_mineable_asteroid(const world_t *w, const npc_ship_t *npc) {
         if (!miner_target_taken(w, idx, self_char)) return idx;
     }
 
-    /* Normal: find nearest mineable asteroid */
-    int best = -1;
-    float best_d = 1e18f;
-    for (int i = 0; i < MAX_ASTEROIDS; i++) {
-        const asteroid_t *a = &w->asteroids[i];
-        if (!a->active || a->tier == ASTEROID_TIER_S) continue;
-        if (signal_npc_confidence(signal_strength_at(w, a->pos)) < 0.1f) continue;
-        if (miner_target_taken(w, i, self_char)) continue;
-        float d = v2_dist_sq(npc->pos, a->pos);
-        if (d < best_d) { best_d = d; best = i; }
+    /* Two-pass nearest search:
+     *   pass 1 — only ores the miner's HOME station can actually smelt.
+     *            Prevents a Prospect miner from filling its hold with
+     *            cuprite (Prospect has no FURNACE_CU); same for a Helios
+     *            miner grabbing ferrite ore.
+     *   pass 2 — any ore. Fallback so a miner is never idle when there's
+     *            ANY rock in range (e.g. early game with sparse spawns).
+     * Two passes preserve the "nearest available" feel while preferring
+     * useful loads. */
+    const station_t *home = (npc->home_station >= 0 && npc->home_station < MAX_STATIONS)
+                          ? &w->stations[npc->home_station]
+                          : NULL;
+    for (int pass = 0; pass < 2; pass++) {
+        int best = -1;
+        float best_d = 1e18f;
+        for (int i = 0; i < MAX_ASTEROIDS; i++) {
+            const asteroid_t *a = &w->asteroids[i];
+            if (!a->active || a->tier == ASTEROID_TIER_S) continue;
+            if (signal_npc_confidence(signal_strength_at(w, a->pos)) < 0.1f) continue;
+            if (miner_target_taken(w, i, self_char)) continue;
+            if (pass == 0 && home && !sim_can_smelt_ore(home, a->commodity)) continue;
+            float d = v2_dist_sq(npc->pos, a->pos);
+            if (d < best_d) { best_d = d; best = i; }
+        }
+        if (best >= 0) return best;
     }
-    return best;
+    return -1;
 }
 
 static void npc_steer_toward(npc_ship_t *npc, vec2 target, float accel, float turn_speed, float dt) {

--- a/src/hud.c
+++ b/src/hud.c
@@ -473,55 +473,15 @@ static void hud_draw_signal_lost_warning(float screen_w, float screen_h, float s
 
 /* Render the post-classify shared panels common to compact + wide.
  * Called once per frame after each layout's top-status section. */
-/* Directional hit indicator — solid red triangle on the screen edge
- * pointing in the world-space direction the most recent damage came
- * from. The vector g.damage_dir_{x,y} is unit; we project onto the
- * smaller of the screen-edge intercepts so the chevron always sits
- * just inside the visible boundary. Fades out over the timer's
- * lifetime. */
+/* Directional hit indicator removed — the rendered triangle didn't
+ * read well in practice. Symbol kept (no-op) so the call site doesn't
+ * need surgery, and damage_dir_{x,y,timer} keep updating in case a
+ * future replacement (audio panning? a 3D-style "incoming" callout?)
+ * wants to consume them. The kill-feed + popup + screen shake + audio
+ * already cover the "you got hit" telemetry. */
 static void hud_draw_hit_indicator(float screen_w, float screen_h) {
-    if (g.damage_dir_timer <= 0.0f) return;
-    /* Squared decay so the spike is visible immediately and the tail
-     * eases out. */
-    float t = g.damage_dir_timer / 1.5f;
-    if (t > 1.0f) t = 1.0f;
-    float alpha = t * t;
-
-    /* Pick a margin from the screen edge proportional to the smaller
-     * dimension so it tracks compact / wide layouts. */
-    float margin = fminf(screen_w, screen_h) * 0.06f;
-    /* Half the available rect — the indicator orbits the screen
-     * center on this radius, scaled to land just inside the edge in
-     * the dominant axis. */
-    float cx = screen_w * 0.5f;
-    float cy = screen_h * 0.5f;
-    float ax = screen_w * 0.5f - margin;
-    float ay = screen_h * 0.5f - margin;
-    /* Clamp the world-space dir to the screen rectangle: scale the
-     * vector so |dx|/ax or |dy|/ay equals 1, whichever hits first. */
-    float dx = g.damage_dir_x;
-    float dy = g.damage_dir_y;
-    float k_x = (fabsf(dx) > 0.001f) ? (ax / fabsf(dx)) : 1e9f;
-    float k_y = (fabsf(dy) > 0.001f) ? (ay / fabsf(dy)) : 1e9f;
-    float k = fminf(k_x, k_y);
-    float px = cx + dx * k;
-    float py = cy + dy * k;
-
-    /* Triangle pointing along (dx, dy). Side perpendicular = (-dy, dx). */
-    float size = margin * 0.9f;
-    float tip_x = px + dx * size * 0.5f;
-    float tip_y = py + dy * size * 0.5f;
-    float bx = px - dx * size * 0.5f;
-    float by = py - dy * size * 0.5f;
-    float perp_x = -dy * size * 0.45f;
-    float perp_y =  dx * size * 0.45f;
-
-    sgl_begin_triangles();
-    sgl_c4f(0.95f, 0.20f, 0.20f, alpha);
-    sgl_v2f(tip_x,           tip_y);
-    sgl_v2f(bx + perp_x,     by + perp_y);
-    sgl_v2f(bx - perp_x,     by - perp_y);
-    sgl_end();
+    (void)screen_w;
+    (void)screen_h;
 }
 
 /* PvP kill-feed — single line at top-center, fades on the timer.

--- a/src/tests/test_world_sim.c
+++ b/src/tests/test_world_sim.c
@@ -36,6 +36,54 @@ TEST(test_world_reset_spawns_npcs) {
     ASSERT_EQ_INT(haulers, 4);
 }
 
+TEST(test_dead_hauler_auto_respawns) {
+    /* Confirm replenish_npc_roster fires from step_npc_ships: kill a
+     * Kepler-homed hauler, run sim past the respawn cooldown, expect
+     * a replacement to appear at the same home with full hull.
+     * Without this loop, hostile players could permanently sabotage
+     * a station's chain by repeatedly sniping its drones. */
+    WORLD_HEAP w = calloc(1, sizeof(world_t));
+    world_reset(w);
+    /* Find the Kepler-homed hauler. */
+    int target_slot = -1;
+    for (int n = 0; n < MAX_NPC_SHIPS; n++) {
+        if (!w->npc_ships[n].active) continue;
+        if (w->npc_ships[n].role != NPC_ROLE_HAULER) continue;
+        if (w->npc_ships[n].home_station != 1) continue;
+        target_slot = n;
+        break;
+    }
+    ASSERT(target_slot >= 0);
+    /* Force-kill via the public damage helper. ship.hull is the
+     * authoritative side post-#294 slice 9-11 so we hit ship.hull
+     * directly to skip the npc-side mirror lag. */
+    ship_t *s = world_npc_ship_for(w, target_slot);
+    ASSERT(s != NULL);
+    s->hull = 0.0f;
+    /* One sim step lets the despawn check at top of step_npc_ships
+     * notice and free the slot. */
+    world_sim_step(w, SIM_DT);
+    int kepler_haulers = 0;
+    for (int n = 0; n < MAX_NPC_SHIPS; n++) {
+        if (!w->npc_ships[n].active) continue;
+        if (w->npc_ships[n].role != NPC_ROLE_HAULER) continue;
+        if (w->npc_ships[n].home_station == 1) kepler_haulers++;
+    }
+    ASSERT_EQ_INT(kepler_haulers, 0);
+
+    /* Run past the 15 s respawn cooldown. SIM_DT = 1/120 s so 1900
+     * ticks ≈ 15.83 s — comfortable margin. */
+    for (int i = 0; i < 1900; i++) world_sim_step(w, SIM_DT);
+
+    int kepler_haulers_after = 0;
+    for (int n = 0; n < MAX_NPC_SHIPS; n++) {
+        if (!w->npc_ships[n].active) continue;
+        if (w->npc_ships[n].role != NPC_ROLE_HAULER) continue;
+        if (w->npc_ships[n].home_station == 1) kepler_haulers_after++;
+    }
+    ASSERT_EQ_INT(kepler_haulers_after, 1);
+}
+
 TEST(test_player_init_ship_docked) {
     WORLD_DECL;
     world_reset(&w);
@@ -1130,6 +1178,7 @@ void register_world_sim_basic_tests(void) {
     RUN(test_world_reset_creates_stations);
     RUN(test_world_reset_spawns_asteroids);
     RUN(test_world_reset_spawns_npcs);
+    RUN(test_dead_hauler_auto_respawns);
     RUN(test_player_init_ship_docked);
     RUN(test_world_sim_step_advances_time);
     RUN(test_world_sim_step_moves_ship_with_thrust);

--- a/src/tests/test_world_sim.c
+++ b/src/tests/test_world_sim.c
@@ -19,6 +19,11 @@ TEST(test_world_reset_spawns_asteroids) {
 }
 
 TEST(test_world_reset_spawns_npcs) {
+    /* Starter NPC roster covers the inter-station chain:
+     *   Prospect: 2 miners (ferrite), 2 haulers (ferrite -> Kepler)
+     *   Helios:   1 miner  (CU/CR),   1 hauler  (kits / modules out)
+     *   Kepler:                       1 hauler  (frames -> Helios)
+     * Plus a tow drone at each shipyard (Kepler, Helios). */
     WORLD_DECL;
     world_reset(&w);
     int miners = 0, haulers = 0;
@@ -27,8 +32,8 @@ TEST(test_world_reset_spawns_npcs) {
         if (w.npc_ships[i].role == NPC_ROLE_MINER) miners++;
         if (w.npc_ships[i].role == NPC_ROLE_HAULER) haulers++;
     }
-    ASSERT_EQ_INT(miners, 2);
-    ASSERT_EQ_INT(haulers, 2);
+    ASSERT_EQ_INT(miners, 3);
+    ASSERT_EQ_INT(haulers, 4);
 }
 
 TEST(test_player_init_ship_docked) {


### PR DESCRIPTION
Three small follow-ups, batched.

## d522fe2 — drop the directional hit indicator
Same fate as the damage flash: looked worse than the existing telemetry. `hud_draw_hit_indicator` is now a no-op. State (`damage_dir_x/y/timer`, `SIM_EVENT_DAMAGE.source_x/y` wire field) still updates so a future replacement (audio panning, 3D-style incoming callout) can consume it.

## 823c4eb — seed haulers + a miner at every station
The contract auto-generator was issuing the right asks (Kepler ↔ ferrite ingots, Helios ↔ frames, Prospect ↔ kits) but **all starter NPCs were homed at Prospect**, so only the first hop had a carrier. Frames piled up at Kepler, kits piled up at Helios, nobody delivered.

- Prospect: 2 miners, 2 haulers (unchanged)
- **+1 miner at Helios** (CU/CR hopper feed)
- **+1 hauler at Kepler** (Kepler → Helios frames)
- **+1 hauler at Helios** (Helios → Prospect kits, modules outbound)
- Tow drones unchanged

`npc_find_mineable_asteroid` now does a two-pass nearest search: pass 1 only considers ores the home station can actually smelt (`sim_can_smelt_ore`), pass 2 falls back to "any ore". Stops a Prospect miner from filling its hold with cuprite.

## c972160 — auto-respawn dead haulers / miners
Without auto-respawn, hostile players (or unlucky asteroid collisions) can permanently sabotage a station's chain. New drip-feed: every 15 s, find the largest gap between actual and target roster across starter stations, spawn ONE replacement (gated on `credit_pool > 100`). Full chain wipe of 7 NPCs recovers over ~100 s — slow enough that PvP harassment has weight, fast enough that the economy doesn't deadlock.

- `world_t.npc_respawn_timer`
- `replenish_npc_roster` + `station_target_npc_counts` (Prospect 2/2, Kepler 0/1, Helios 1/1; outposts not auto-replenished)
- New test `test_dead_hauler_auto_respawns` force-kills the Kepler hauler, runs sim ~16 s, asserts a replacement appears

## Test plan
- [x] `make test` — 337 / 337 (one new)
- [x] Pre-commit hook (native + WASM) green
- [x] 60-second NPC economy scenario test still passes with the new roster
- [ ] CI green
- [ ] Manual: dock at Helios, confirm a hauler is homed there carrying frames out / kits back