### PR TITLE
Fix: kit sell at broke station consumed cargo without paying

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -1009,6 +1009,12 @@ static void try_sell_station_cargo(world_t *w, server_player_t *sp) {
      * Only the selective-filter path needs this notice; the bulk
      * SELL_CARGO already drops what fits and ignores the rest. */
     float pre_cargo = (selective ? sp->ship.cargo[filter] : 0.0f);
+    /* Cap each accept by what the station can still pay for, so a broke
+     * station can't silently consume cargo it can't afford. Grade bonuses
+     * are excluded from the budget check (they're a topup, not the price)
+     * and are still subject to the final credit_pool cap. */
+    float budget = st->credit_pool;
+    bool out_of_credit = false;
 
     /* Deliver any cargo matching active supply contracts at this station.
      *
@@ -1032,6 +1038,12 @@ static void try_sell_station_cargo(world_t *w, server_player_t *sp) {
         if (space < 0.01f) continue;
         float deliver = fminf(fminf(sp->ship.cargo[c], ct->quantity_needed), space);
         float price_per = contract_price(ct);
+        if (price_per > 0.0f && deliver * price_per > budget) {
+            deliver = budget / price_per;
+            out_of_credit = true;
+        }
+        if (deliver < 0.01f) { if (price_per > 0.0f) out_of_credit = true; continue; }
+        budget -= deliver * price_per;
         payout += deliver * price_per;
         if (deliver > 0.01f) sold_against_contract = true;
         sp->ship.cargo[c] -= deliver;
@@ -1089,6 +1101,12 @@ static void try_sell_station_cargo(world_t *w, server_player_t *sp) {
             if (space > 0.01f) {
                 float accepted = fminf(sp->ship.cargo[buy], space);
                 float price = station_buy_price(st, buy);
+                if (price > 0.0f && accepted * price > budget) {
+                    accepted = budget / price;
+                    out_of_credit = true;
+                }
+                if (accepted < 0.01f) { if (price > 0.0f) out_of_credit = true; continue; }
+                budget -= accepted * price;
                 payout += accepted * price;
                 sp->ship.cargo[buy] -= accepted;
                 st->inventory[buy] += accepted;
@@ -1144,6 +1162,12 @@ static void try_sell_station_cargo(world_t *w, server_player_t *sp) {
             .type = SIM_EVENT_ORDER_REJECTED,
             .player_id = sp->id,
             .order_rejected = { .reason = ORDER_REJECT_SELL_NOT_ACCEPTED },
+        });
+    } else if (out_of_credit) {
+        emit_event(w, (sim_event_t){
+            .type = SIM_EVENT_ORDER_REJECTED,
+            .player_id = sp->id,
+            .order_rejected = { .reason = ORDER_REJECT_SELL_STATION_BROKE },
         });
     }
     /* Clear the one-shot filter so the next plain SELL_CARGO press

--- a/shared/types.h
+++ b/shared/types.h
@@ -754,6 +754,7 @@ enum {
     ORDER_REJECT_SHIPYARD_LOCKED = 7,               /* tech tree gate */
     ORDER_REJECT_SHIPYARD_NO_FUNDS = 8,             /* ledger spend failed */
     ORDER_REJECT_SELL_NOT_ACCEPTED = 9,             /* this station has no consumer for the picked commodity */
+    ORDER_REJECT_SELL_STATION_BROKE = 10,           /* station ran out of credit pool mid-sale */
 };
 
 typedef struct {

--- a/src/main.c
+++ b/src/main.c
@@ -633,6 +633,7 @@ static const char *order_reject_message(uint8_t reason) {
     case ORDER_REJECT_SHIPYARD_LOCKED:      return "Tech tree locked — order the prerequisite module first.";
     case ORDER_REJECT_SHIPYARD_NO_FUNDS:    return "Not enough credits at this station for the order fee.";
     case ORDER_REJECT_SELL_NOT_ACCEPTED:    return "This station has no consumer for that commodity — try another dock.";
+    case ORDER_REJECT_SELL_STATION_BROKE:   return "This station ran out of credit — sale partial or refused. Try again later.";
     default:                                return "Order rejected.";
     }
 }


### PR DESCRIPTION
## Summary
- Selling kits at Prospect glitched: cargo moved into station inventory first, then payout was capped at credit_pool — if the station was broke (drained by kit-import contracts), kits were silently consumed for partial or zero credit.
- Fix: track a running credit budget across both contract and fab-fallback paths. Scale each accept to what the station can pay for; refuse the rest.
- New reject reason \`ORDER_REJECT_SELL_STATION_BROKE\` so the player gets a notice instead of wondering where their kits went.

## Test plan
- [x] make test (337/337)
- [ ] Sell kits at Prospect when its credit_pool is low — verify no cargo loss + warning shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)