### PR TITLE
Slice 13 ship/NPC unify + tractor tangential drag (orbit fix)

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -1648,6 +1648,7 @@ static bool is_already_towed(const ship_t *ship, int asteroid_idx) {
 #define BAND_REST_LEN     80.0f
 #define BAND_SPRING_K      6.0f   /* per unit of stretch */
 #define BAND_DAMPING       2.0f   /* relative-vel along band */
+#define BAND_TANGENT_DRAG  3.0f   /* opposes orbital drift so rocks trail behind, not orbit */
 #define BAND_SHIP_MASS     8.0f   /* ship is heavier than a rock; reaction force scaled by 1/MASS */
 static void apply_band_force(server_player_t *sp, asteroid_t *a, float dt) {
     vec2 to_ship = v2_sub(sp->ship.pos, a->pos);
@@ -1660,13 +1661,22 @@ static void apply_band_force(server_player_t *sp, asteroid_t *a, float dt) {
     float stretch = dist - BAND_REST_LEN;
     float spring_mag = BAND_SPRING_K * stretch;     /* signed: + = pull, - = push */
 
-    /* Damping: oppose component of relative velocity along the band. */
+    /* Damping along the band axis: oppose along-band relative velocity. */
     vec2 rel_vel = v2_sub(sp->ship.vel, a->vel);
     float vel_along = v2_dot(rel_vel, dir);
     float damp_mag = BAND_DAMPING * vel_along;
 
-    float total = spring_mag + damp_mag;
-    vec2 force = v2_scale(dir, total);
+    /* Axial force = spring + axial damping. */
+    vec2 force_axial = v2_scale(dir, spring_mag + damp_mag);
+
+    /* Tangential drag: kill the rock's perpendicular drift relative to
+     * the ship. Without this the band only restores radial distance —
+     * any sideways relative velocity persists and the rock ends up
+     * orbiting rather than trailing behind. */
+    vec2 vel_tangent = v2_sub(rel_vel, v2_scale(dir, vel_along));
+    vec2 force_tangent = v2_scale(vel_tangent, BAND_TANGENT_DRAG);
+
+    vec2 force = v2_add(force_axial, force_tangent);
 
     /* Apply to rock (full force) + reaction on ship (1/MASS). */
     a->vel       = v2_add(a->vel, v2_scale(force, dt));

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -184,26 +184,20 @@ ship_t *world_npc_ship_for(world_t *w, int npc_slot) {
     return npc_ship_for(w, npc_slot);
 }
 
-/* End-of-tick paired-pool sync. Each field flows in the direction of
- * its current authority:
+/* End-of-tick paired-pool sync — npc -> ship for physics fields plus
+ * ship -> npc for hull. Slice 13's pre-mirror (mirror_ship_pos_to_npc,
+ * called at the top of each NPC step) is what makes external ship.pos
+ * /vel/angle writes between ticks survive; after that pull, this
+ * end-of-tick mirror just round-trips them back to the ship.
  *
  *   - hull is ship-authoritative since Slice 9/11 (apply_npc_ship_damage,
  *     hauler dock auto-repair both write ship.hull). Push ship -> npc
  *     so the npc-side despawn check reads a fresh value next tick.
- *   - pos / vel / angle / thrusting are still npc-authoritative — the
- *     dispatch writes them on the npc side. Push npc -> ship so the
- *     ship is a faithful end-of-tick snapshot. Required for the
- *     parity invariant (test_npc_ship_physics_in_sync_each_tick) and
- *     for any external reader that takes ship_t as the canonical
- *     view. Slice 13 flips these to ship-authoritative; this function
- *     becomes ship -> npc only at that point.
- *
- * Caveat for the npc-authoritative direction: external code that
- * mutates ship.pos/vel/angle *between* two ticks will have its
- * change overwritten here at the next end-of-tick. That's the bug
- * Slice 13 fixes. Until then, external physics writes don't survive
- * this transitional sync — only damage does (via the ship-authoritative
- * hull path). */
+ *   - pos / vel / angle / thrusting still get integrated on npc fields
+ *     by the existing dispatch; npc -> ship at end of tick keeps the
+ *     ship faithful for external readers and parity tests. Slice 14
+ *     will collapse this into a single direction once npc_ship_t loses
+ *     its physics fields. */
 static void mirror_ship_to_npc(world_t *w, int npc_slot) {
     ship_t *s = npc_ship_for(w, npc_slot);
     if (!s) return;
@@ -212,6 +206,21 @@ static void mirror_ship_to_npc(world_t *w, int npc_slot) {
     s->pos = npc->pos;
     s->vel = npc->vel;
     s->angle = npc->angle;
+}
+
+/* Slice 13: pre-mirror at the top of each NPC step. Pulls any external
+ * ship.pos/vel/angle writes (PvP rock impulse, future autopilot, etc.)
+ * into the npc fields BEFORE physics integrates this tick. Without
+ * this, the post-mirror at end-of-tick would clobber the external
+ * write with the integrated-from-stale-npc value — that was the bug
+ * the parity tripwire (Slice 13a) was set up to surface. */
+static void mirror_ship_pos_to_npc(world_t *w, int npc_slot) {
+    ship_t *s = npc_ship_for(w, npc_slot);
+    if (!s) return;
+    npc_ship_t *npc = &w->npc_ships[npc_slot];
+    npc->pos = s->pos;
+    npc->vel = s->vel;
+    npc->angle = s->angle;
 }
 
 /* Apply damage to an NPC with optional kill attribution. The reverse
@@ -1349,6 +1358,9 @@ void step_npc_ships(world_t *w, float dt) {
             continue;
         }
         npc->thrusting = false;
+        /* Slice 13: pull external ship.pos/vel/angle writes into the
+         * npc fields before physics integration this tick. */
+        mirror_ship_pos_to_npc(w, n);
         mirror_npc_to_character(w, n);
         npc_validate_stations(w, npc);
 

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -905,6 +905,14 @@ TEST(test_tow_drone_delivers_to_planned_outpost) {
     w.npc_ships[drone_idx].state = NPC_STATE_DOCKED;
     w.npc_ships[drone_idx].state_timer = 0.0f;
     w.npc_ships[drone_idx].pos = w.stations[1].pos;
+    /* Slice 13: also seed the paired ship_t so the pre-mirror at the
+     * top of step_npc_ships doesn't drag the drone back to its
+     * spawn position next tick. */
+    {
+        ship_t *drone_ship = world_npc_ship_for(&w, drone_idx);
+        ASSERT(drone_ship != NULL);
+        drone_ship->pos = w.stations[1].pos;
+    }
 
     /* Run up to 30s — wait for drone to grab the scaffold */
     npc_ship_t *drone = &w.npc_ships[drone_idx];

--- a/src/tests/test_econ_sim.c
+++ b/src/tests/test_econ_sim.c
@@ -597,6 +597,15 @@ TEST(test_e2e_npc_dock_auto_repair_drains_kits) {
      * the dock-arrival condition (dist < dock_radius * 0.7). */
     hauler->pos = w->stations[shipyard].pos;
     hauler->vel = v2(0.0f, 0.0f);
+    /* Slice 13: physics is ship-authoritative going into the tick — write
+     * the paired ship_t too so the pre-mirror doesn't overwrite the npc
+     * fields with a stale ship snapshot. */
+    {
+        ship_t *hauler_ship = world_npc_ship_for(w, hauler_slot);
+        ASSERT(hauler_ship != NULL);
+        hauler_ship->pos = w->stations[shipyard].pos;
+        hauler_ship->vel = v2(0.0f, 0.0f);
+    }
 
     float kits_before = w->stations[shipyard].inventory[COMMODITY_REPAIR_KIT];
     /* A handful of ticks — first one should land it at the berth and

--- a/src/tests/test_pvp_rocks.c
+++ b/src/tests/test_pvp_rocks.c
@@ -294,9 +294,15 @@ TEST(test_thrown_rock_kills_npc_emits_event) {
      * nor any belt physics drifts them out of the contact window. The
      * test only cares about kill attribution, not nav stability. */
     vec2 npc_pin = npc->pos;
+    ship_t *npc_ship = world_npc_ship_for(&w, npc_idx);
+    ASSERT(npc_ship != NULL);
+    npc_ship->pos = npc_pin;
+    npc_ship->vel = v2(0.0f, 0.0f);
     for (int t = 0; t < 120 && !kill; t++) {
         npc->vel = v2(0.0f, 0.0f);
         npc->pos = npc_pin;
+        npc_ship->vel = v2(0.0f, 0.0f);
+        npc_ship->pos = npc_pin;
         world_sim_step(&w, 1.0f / 120.0f);
         kill = find_npc_kill_event(&w);
     }


### PR DESCRIPTION
## Summary
- **Slice 13 of #294**: pre-mirror ship.pos/vel/angle into npc fields at top of each NPC step. External writes to ship_t (PvP rock impulse, autopilot, test setup) now survive into physics integration instead of being clobbered by the post-mirror.
- Tests that wrote npc.pos directly updated to also seed the paired ship_t. Same pattern Slice 9-11 used for hull.
- **Tractor orbit fix**: rocks were orbiting instead of trailing because BAND_DAMPING only opposed velocity along the band axis. Added BAND_TANGENT_DRAG (=3) that kills perpendicular relative velocity, so towed rocks settle into the wake behind the ship.

## Test plan
- [x] make test (337/337)
- [ ] In-game: tow a rock, drive in a circle — rock should trail behind, not orbit

🤖 Generated with [Claude Code](https://claude.com/claude-code)