### PR TITLE
fix: unblock main CI — BUF_APPEND, format-truncation, MSVC shadow

### DIFF
--- a/server/main.c
+++ b/server/main.c
@@ -472,11 +472,13 @@ static void json_escape_append(char *buf, int *pos, int bufsz, const char *s) {
     *pos = p;
 }
 
-/* Safe snprintf append: clamp pos so it never exceeds bufsz */
+/* Safe snprintf append: clamp pos to bufsz before snprintf to avoid undefined behavior */
 #define BUF_APPEND(pos, buf, bufsz, ...) do { \
-    int _n = snprintf((buf) + (pos), (size_t)((bufsz) - (pos)), __VA_ARGS__); \
-    if (_n > 0) (pos) += _n; \
-    if ((pos) > (bufsz)) (pos) = (bufsz); \
+    if ((pos) < (bufsz)) { \
+        int _n = snprintf((buf) + (pos), (size_t)((bufsz) - (pos)), __VA_ARGS__); \
+        if (_n > 0) (pos) += _n; \
+        if ((pos) > (bufsz)) (pos) = (bufsz); \
+    } \
 } while (0)
 
 /* Cap visible_asteroids in the agent-facing JSON. Populated stations

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -1483,9 +1483,9 @@ void step_npc_ships(world_t *w, float dt) {
                      * keyed off last_towed_token) credits the NPC's
                      * ledger at the home station. Same hook the player
                      * pickup uses — symmetrical economic identity. */
-                    asteroid_t *a = &w->asteroids[best_frag];
-                    memcpy(a->last_towed_token, npc->session_token,
-                           sizeof(a->last_towed_token));
+                    asteroid_t *frag = &w->asteroids[best_frag];
+                    memcpy(frag->last_towed_token, npc->session_token,
+                           sizeof(frag->last_towed_token));
                 }
             }
             break;

--- a/src/client.h
+++ b/src/client.h
@@ -166,7 +166,7 @@ typedef struct {
         vec2 pos;
         float age;
         float life;
-        char text[8];
+        char text[16];   /* "-2147483648" worst case + null + slack */
     } damage_fx[8];
     /* Hit vignette: red border pulse on the local player's HUD when they
      * take damage. Set on SIM_EVENT_DAMAGE, decays each frame. */


### PR DESCRIPTION
Three small fixes that together turn all three native CI targets (linux/macos/windows) green again, unblocking the agent dispatcher.

## Fixes

1. **server/main.c BUF_APPEND macro** — guard the snprintf with `if (pos < bufsz)` so the size cast can never go negative. Resolves `-Werror=aggressive-loop-optimizations` on Linux GCC. (Cherry-picked from the github-agent's earlier attempt on PR #429 which got stranded behind main.)
2. **src/client.h damage_fx.text** — widened from 8 to 16 bytes. `-%d` of a 32-bit int needs up to 12 chars. Resolves `-Werror=format-truncation` on Linux GCC.
3. **server/sim_ai.c:1486** — renamed inner `asteroid_t *a` (post-fracture fragment pickup) to `frag` so it no longer shadows the outer `a` from line 1428. Resolves MSVC C4456 (treated as error C2220) on Windows.

## Why this is a fresh PR

PR #429 was based on commit cb7a521 and main has since moved past it (#428 landed an NPC-type refactor). Merging main into the old branch caused a wave of unrelated incompatible-pointer-type errors. Cleaner to start fresh from main.

Closes #427.

## Verification

- `cmake --build build` clean locally on macOS clang (release).
- Server build, full client build, and the three test suites all compile.
- No behavior change — all three are pure compile-time hygiene fixes.