### PR TITLE
Economy: hauler maintenance drain + manifest desync fix

### DIFF
--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -1112,6 +1112,23 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                     }
                 }
             }
+            /* Wear-and-tear maintenance: each home-dock visit consumes
+             * one repair kit regardless of damage. This is the baseline
+             * demand that keeps kits flowing through the economy --
+             * without it, Prospect's kit shelf never drains (haulers
+             * rarely take real damage), kit-import contracts never
+             * trip, and the inter-station chain stalls. Force-debit so
+             * the hauler is on the hook for upkeep just like a repair. */
+            if (station_has_module(home, MODULE_DOCK)
+                && home->inventory[COMMODITY_REPAIR_KIT] >= 1.0f) {
+                float kit_price = home->base_price[COMMODITY_REPAIR_KIT];
+                if (kit_price < 0.01f) kit_price = 6.0f;
+                ledger_force_debit(home, npc->session_token, kit_price, ship);
+                home->inventory[COMMODITY_REPAIR_KIT] -= 1.0f;
+                if (manifest_consume_by_commodity(&home->manifest,
+                                                  COMMODITY_REPAIR_KIT, 1) > 0)
+                    home->named_ingots_dirty = true;
+            }
         }
         break;
     }

--- a/src/net_sync.c
+++ b/src/net_sync.c
@@ -198,10 +198,12 @@ void apply_remote_player_manifest(const NetStationManifestEntry *entries,
                                   int count) {
     if (g.local_player_slot < 0 || g.local_player_slot >= MAX_PLAYERS) return;
     ship_t *ship = &g.world.players[g.local_player_slot].ship;
-    /* Skip overwriting while a local action is being predicted to
-     * avoid flicker between predicted state and a slightly older
-     * server snapshot. */
-    if (g.action_predict_timer > 0.0f) return;
+    /* Always apply -- WORLD_STATE overwrites cargo[] every tick, so
+     * gating manifest on action_predict_timer leaves cargo and
+     * manifest in inconsistent states (cargo refreshed, manifest
+     * frozen at pre-action). The trade UI then shows phantom rows
+     * (manifest > cargo). The brief predict/snapshot flicker is the
+     * lesser evil compared to ghost SELL rows the player can't act on. */
     if (!ship->manifest.units && !ship_manifest_bootstrap(ship)) return;
     manifest_clear(&ship->manifest);
     if (count <= 0) return;


### PR DESCRIPTION
## Summary

1. **Hauler maintenance drain**: each home-dock visit force-debits 1 repair kit so Prospect's kit shelf actually drains, the kit-import threshold trips, and the cross-station chain stays alive. Previously haulers rarely took real damage so kit demand was effectively zero.

2. **Manifest/cargo desync**: `apply_remote_player_manifest` gated on `action_predict_timer` to avoid flicker, but `apply_remote_world_state` overwrites `ship.cargo[]` unconditionally. Result: during prediction the client ended up with cargo refreshed but manifest frozen at the pre-action state. After the predict window expired the manifest update never re-arrived -- the trade UI then surfaced phantom SELL rows like "(7 held)" for items the player no longer carried (root cause behind the held-count cap in #431). Drop the predict gate.

## Test plan
- [x] make test (337/337)
- [ ] Localhost: trade panel never shows held > cargo
- [ ] Localhost: kits drain at Prospect within minutes of seeded haulers cycling

🤖 Generated with [Claude Code](https://claude.com/claude-code)