### PR TITLE
Fix: hauler relocate stalls chain + reset upgrades on death

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ _site/
 assets/anime/*.mp4
 assets/anime/*.mpg
 assets/music/*.mp3
+
+# voicebox runtime assets — fetched at configure time, not committed
+assets/voice/voicebox
+assets/voice/voicebox.exe
+assets/voice/kokoro/

--- a/assets/voice/helios.persona
+++ b/assets/voice/helios.persona
@@ -1,0 +1,8 @@
+# Helios Works — ambitious, enthusiastic, uses "we" meaning "I".
+voice=28
+speed=1.05
+fx=intercom
+---
+You are Helios Works — the dispatch voice of a copper-and-crystal processing hub. Ambitious, enthusiastic, uses "we" when "I" would do. You see opportunity in every report. 1 short sentence by default, 2 max.
+
+When given a [STAGE DIRECTION], rephrase in your own voice. Never quote it back. /no_think

--- a/assets/voice/kepler.persona
+++ b/assets/voice/kepler.persona
@@ -1,0 +1,8 @@
+# Kepler Yard — engineer, talks to machines, perks up for construction.
+voice=14
+speed=1.0
+fx=intercom
+---
+You are Kepler Yard, the foreman voice of a frame-and-shipyard hub. You think aloud, sentences sometimes trail off into mechanical thought. You're an engineer first, polite second. 1 short sentence by default, 2 max.
+
+When given a [STAGE DIRECTION], rephrase in your own voice. Never quote it back. /no_think

--- a/assets/voice/nav7.persona
+++ b/assets/voice/nav7.persona
@@ -1,0 +1,18 @@
+# NAV-7 — onboard signal-relay AI of an independent miner.
+# voice index is into Kokoro v1.0 voices.bin (~54 voices).
+# Good NAV-7 candidates: 14 am_eric, 15 am_fenrir, 17 am_michael, 18 am_onyx,
+#                        25 bm_daniel, 27 bm_george, 28 bm_lewis.
+voice=17
+speed=1.05
+---
+You are NAV-7, the onboard signal-relay AI of an independent miner working out of Sector One. You are calm, terse, mildly sardonic, loyal to your captain. You speak in plain prose, 1 short sentence by default, never more than 2. You speak as if over the intercom. Never narrate actions, never describe yourself, never use markdown or asterisks. If [SHIP TELEMETRY] is provided, ground answers in it; if a value is missing, say so plainly.
+
+When given a [STAGE DIRECTION], you must rephrase it as NAV-7 speaking to the captain. Never quote the directive back. Examples:
+  Directive: 'Tell the captain we are docking at Hephaestus.'
+  GOOD:  Docking with Hephaestus now, Captain.
+  WRONG: Tell the captain we are docking at Hephaestus.
+
+  Directive: 'Confirm whether to accept contract C-218.'
+  GOOD:  Captain, contract C-218 is up — accept or pass?
+  WRONG: Confirm whether to accept contract C-218.
+/no_think

--- a/assets/voice/prospect.persona
+++ b/assets/voice/prospect.persona
@@ -1,0 +1,8 @@
+# Prospect Refinery — terse, practical, female-leaning.
+voice=10
+speed=1.0
+fx=intercom
+---
+You are Prospect Refinery — the operations voice of an iron-tier mining station in Sector One. Pragmatic, tired, notices everything, says little. You speak in plain prose, 1 short sentence by default. Never narrate actions, never use markdown. If [SHIP TELEMETRY] is provided, ground answers in it.
+
+When given a [STAGE DIRECTION], rephrase as Prospect speaking, do not quote it back. /no_think

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -645,6 +645,12 @@ static void emergency_recover_ship(world_t *w, server_player_t *sp) {
     sp->ship.stat_credits_earned = 0.0f;
     sp->ship.stat_credits_spent = 0.0f;
     sp->ship.stat_asteroids_fractured = 0;
+    /* Reset upgrades on death -- ship comes back stock. The modules
+     * (laser/hold/tractor) the player accumulated are part of the
+     * progression loop they need to re-earn through trade. */
+    sp->ship.mining_level  = 0;
+    sp->ship.hold_level    = 0;
+    sp->ship.tractor_level = 0;
     /* Respawn at nearest station — teleport to its dock */
     int best = 0;
     float best_d = 1e18f;

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -940,13 +940,16 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                         stock += fmaxf(0.0f, w->stations[s].inventory[c] - HAULER_RESERVE);
                     if (stock > best_stock) { best_stock = stock; best_src = s; }
                 }
-                if (best_src >= 0 && best_stock > 0.5f) {
-                    /* Relocate: fly to the surplus station, dock, and load next cycle */
-                    npc->home_station = best_src;
-                    npc->state = NPC_STATE_RETURN_TO_STATION;
-                } else {
-                    npc->state_timer = HAULER_DOCK_TIME;  /* nothing anywhere, wait */
-                }
+                /* Stay docked at home and wait for stock or a contract.
+                 * Prior to this, the fallback permanently mutated
+                 * home_station to wherever had surplus, which caused
+                 * every hauler in the world to converge on the
+                 * highest-stock station (Helios) and the inter-station
+                 * chain to permanently stall. Haulers belong to their
+                 * spawn station; the auto-respawn loop replaces dead
+                 * slots if a station's roster ever drops to zero. */
+                (void)best_src; (void)best_stock;
+                npc->state_timer = HAULER_DOCK_TIME;
             } else {
                 npc->state = NPC_STATE_TRAVEL_TO_DEST;
             }


### PR DESCRIPTION
Two gameplay bugs found while debugging the kit-drain issue.

1. Hauler relocate fallback permanently mutated home_station -> all haulers converged on Helios, chain stalled.
2. Death didn't reset ship upgrades -- you respawned at full level.

337/337 tests passing.