### PR TITLE
fix(ci): scope deploy concurrency group per-ref so PRs don't kill each other

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,10 @@ permissions:
   id-token: write
 
 concurrency:
-  group: deploy
+  # Per-ref so PR runs don't cancel each other. Multiple PRs were colliding
+  # on a shared "deploy" group, killing tests mid-flight. The deploy job
+  # further down still only fires on main, so deploys remain serialized.
+  group: deploy-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Workflow-level `concurrency: deploy` shared a single group across all refs. With multiple PRs in flight (e.g. the voice queue), every new push fired `pull_request` events that cancelled the in-progress workflow on every other PR.

PR #450 only managed to land green by getting lucky with timing. PR #451 got cancelled three times in a row.

## Fix

```yaml
concurrency:
  group: deploy-${{ github.ref }}   # was: deploy
  cancel-in-progress: true
```

PR runs are now per-ref (one slot per branch — re-pushing a PR still cancels its own previous run, which is the intent). The downstream `deploy` job is still gated on `branches: [main]`, so production deploys remain single-flight.

## Verification

- Test: this PR's own CI should run green to completion (no other PR's pull_request will cancel it).
- Then merging it should let PRs #449/#451 (and future voice work) finish CI normally.

Refs: voice MVP queue at #423, #433, #434, #435, #436, #437, #441.