### PR TITLE
voice(web): wire real STT/TTS/OAuth from voicebox prototype

### DIFF
--- a/web/play.html
+++ b/web/play.html
@@ -71,7 +71,7 @@
 
     <canvas id="canvas" oncontextmenu="event.preventDefault()" tabindex="-1"></canvas>
 
-    <script src="voicebox.js"></script>
+    <script type="module" src="voicebox.js"></script>
     <script>
       var canvas = document.getElementById('canvas');
 

--- a/web/shell.html
+++ b/web/shell.html
@@ -91,7 +91,7 @@
         <canvas id="canvas" oncontextmenu="event.preventDefault()" tabindex="-1"></canvas>
       </div>
     </div>
-    <script src="voicebox.js"></script>
+    <script type="module" src="voicebox.js"></script>
     <script>
       var Module = {
         canvas: document.getElementById("canvas"),

--- a/web/voice/auth.js
+++ b/web/voice/auth.js
@@ -1,0 +1,75 @@
+// auth.js — OpenRouter OAuth (PKCE S256) for browser apps.
+//
+// Flow:
+//   1. generate code_verifier + code_challenge, redirect to /auth
+//   2. on return, exchange ?code= for a long-lived user API key via /api/v1/auth/keys
+//   3. cache key in localStorage; subsequent visits go straight to chat.
+
+const KEY_STORAGE   = "voicebox.openrouter.key";
+const VERIFIER_KEY  = "voicebox.openrouter.code_verifier";
+
+function b64url(bytes) {
+  let s = btoa(String.fromCharCode(...bytes));
+  return s.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function makePkcePair() {
+  const buf = new Uint8Array(32);
+  crypto.getRandomValues(buf);
+  const verifier  = b64url(buf);
+  const digest    = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  const challenge = b64url(new Uint8Array(digest));
+  return { verifier, challenge };
+}
+
+export function getStoredKey() {
+  return localStorage.getItem(KEY_STORAGE);
+}
+
+export function clearStoredKey() {
+  localStorage.removeItem(KEY_STORAGE);
+}
+
+export async function startLogin() {
+  const { verifier, challenge } = await makePkcePair();
+  sessionStorage.setItem(VERIFIER_KEY, verifier);
+  // callback_url must be an exact match to the URL OpenRouter will redirect to.
+  // For dev we just use the page itself; the ?code=… arrives at the same path.
+  const cb = location.origin + location.pathname;
+  const url = new URL("https://openrouter.ai/auth");
+  url.searchParams.set("callback_url",         cb);
+  url.searchParams.set("code_challenge",       challenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  location.href = url.toString();
+}
+
+// Run on page load: if the URL contains ?code=…, exchange it for a key,
+// strip the param from the URL, and return the key.
+export async function maybeCompleteLogin() {
+  const params = new URLSearchParams(location.search);
+  const code   = params.get("code");
+  if (!code) return null;
+
+  const verifier = sessionStorage.getItem(VERIFIER_KEY);
+  sessionStorage.removeItem(VERIFIER_KEY);
+
+  // Strip ?code= from URL so refreshes don't re-run the exchange.
+  history.replaceState({}, "", location.pathname);
+
+  const r = await fetch("https://openrouter.ai/api/v1/auth/keys", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      code,
+      code_verifier: verifier,
+      code_challenge_method: "S256",
+    }),
+  });
+  if (!r.ok) {
+    throw new Error(`OAuth exchange failed: ${r.status} ${await r.text()}`);
+  }
+  const { key } = await r.json();
+  if (!key) throw new Error("OAuth exchange: no key in response");
+  localStorage.setItem(KEY_STORAGE, key);
+  return key;
+}

--- a/web/voice/personas.js
+++ b/web/voice/personas.js
@@ -1,0 +1,57 @@
+// personas.js — voice + system-prompt registry, mirrors native voicebox/personas/.
+//
+// Each persona has:
+//   voice    — Kokoro v1.0 voice ID (string)
+//   speed    — playback speed (1.0 native)
+//   system   — system-prompt text used for ASK-type events (LLM elaboration)
+// (DSP fx is a native-side concern; in browser we rely on Kokoro voice differences alone for now.)
+
+export const PERSONAS = {
+  nav7: {
+    voice: "am_michael",
+    speed: 1.05,
+    system:
+`You are NAV-7, the onboard signal-relay AI of an independent miner working out of Sector One. You are calm, terse, mildly sardonic, loyal to your captain. You speak in plain prose, 1 short sentence by default, never more than 2. You speak as if over the intercom. Never narrate actions, never describe yourself, never use markdown or asterisks. If [SHIP TELEMETRY] is provided, ground answers in it; if a value is missing, say so plainly.
+
+When given a [STAGE DIRECTION], you must rephrase it as NAV-7 speaking to the captain. Never quote the directive back. Examples:
+  Directive: 'Tell the captain we are docking at Hephaestus.'
+  GOOD:  Docking with Hephaestus now, Captain.
+  WRONG: Tell the captain we are docking at Hephaestus.`,
+  },
+
+  prospect: {
+    voice: "af_sarah",
+    speed: 1.0,
+    system:
+`You are Prospect Refinery — the operations voice of an iron-tier mining station in Sector One. Pragmatic, tired, notices everything, says little. Plain prose, 1 short sentence by default. Never narrate actions, never use markdown. Ground answers in [SHIP TELEMETRY] if present.`,
+  },
+
+  kepler: {
+    voice: "am_eric",
+    speed: 1.0,
+    system:
+`You are Kepler Yard — the foreman voice of a frame-and-shipyard hub. Engineer first, polite second; sentences sometimes trail off into mechanical thought. 1 short sentence default, 2 max. Never quote any [STAGE DIRECTION] back; speak in your own voice.`,
+  },
+
+  helios: {
+    voice: "bm_lewis",
+    speed: 1.05,
+    system:
+`You are Helios Works — the dispatch voice of a copper-and-crystal processing hub. Ambitious, enthusiastic, uses "we" when "I" would do. You see opportunity in every report. 1 short sentence default, 2 max.`,
+  },
+
+  // Anonymous NPC voices for ambient sprite chatter — random pick per session.
+  miner: {
+    voice: "am_fenrir",
+    speed: 1.0,
+    system: `You are an unnamed asteroid miner working in Sector One. Terse, focused. One fragment of a sentence at a time.`,
+  },
+
+  hauler: {
+    voice: "bm_george",
+    speed: 1.0,
+    system: `You are an unnamed hauler running ingot routes in Sector One. Workmanlike, brief. One fragment at a time.`,
+  },
+};
+
+export const DEFAULT_PERSONA = "nav7";

--- a/web/voice/stt.js
+++ b/web/voice/stt.js
@@ -1,0 +1,132 @@
+// stt.js — local Whisper STT in the browser via transformers.js.
+//
+// Loads on first use (~75 MB whisper-tiny.en cached by the browser after).
+// Records mic audio with AudioWorklet, decodes on speech-end (button release
+// for now; VAD-driven endpointing will come in Stage 1.5).
+//
+// API:
+//   const stt = await STT.init({ model: "Xenova/whisper-tiny.en" });
+//   stt.onTranscript = (text) => { ... };
+//   stt.startCapture();   // open mic
+//   stt.holdToTalk(true); // begin recording into the active buffer
+//   stt.holdToTalk(false);// stop recording, transcribe, fire onTranscript
+
+import { pipeline, env } from "https://cdn.jsdelivr.net/npm/@xenova/transformers@2.17.2";
+
+// transformers.js downloads from HF Hub by default; cache aggressively
+env.allowLocalModels = false;
+env.useBrowserCache = true;
+
+const TARGET_SR = 16000; // whisper expects 16k mono float32
+
+class _STT {
+  constructor() {
+    this.transcriber = null;
+    this.audioCtx    = null;
+    this.workletNode = null;
+    this.micStream   = null;
+    this.recording   = false;
+    this.buf         = []; // accumulated Float32Arrays at AudioContext.sampleRate
+    this.onTranscript = null;
+    this.onStatus     = null;
+  }
+
+  _status(s) { if (this.onStatus) this.onStatus(s); }
+
+  async init({ model = "Xenova/whisper-tiny.en" } = {}) {
+    this._status("loading whisper model…");
+    this.transcriber = await pipeline("automatic-speech-recognition", model);
+    this._status("whisper ready");
+  }
+
+  async startCapture() {
+    if (this.audioCtx) return; // already open
+    this.micStream = await navigator.mediaDevices.getUserMedia({
+      audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true },
+    });
+    this.audioCtx  = new AudioContext({ sampleRate: TARGET_SR });
+    // try setting target rate; browsers usually honor it but some don't —
+    // we resample manually below as a backstop.
+    const src      = this.audioCtx.createMediaStreamSource(this.micStream);
+
+    // Inline AudioWorkletProcessor as a Blob URL so we don't need a separate file.
+    const procSrc = `
+      class CaptureProc extends AudioWorkletProcessor {
+        process(inputs) {
+          const ch = inputs[0][0];
+          if (ch && ch.length) this.port.postMessage(ch.slice());
+          return true;
+        }
+      }
+      registerProcessor("capture-proc", CaptureProc);
+    `;
+    const url = URL.createObjectURL(new Blob([procSrc], { type: "application/javascript" }));
+    await this.audioCtx.audioWorklet.addModule(url);
+    this.workletNode = new AudioWorkletNode(this.audioCtx, "capture-proc");
+    this.workletNode.port.onmessage = (ev) => {
+      if (this.recording) this.buf.push(ev.data);
+    };
+    src.connect(this.workletNode);
+    // Don't connect to destination — we don't want to monitor the mic to speakers.
+    this._status("mic open");
+  }
+
+  holdToTalk(on) {
+    if (!this.audioCtx || !this.transcriber) return;
+    if (on) {
+      this.buf = [];
+      this.recording = true;
+      this._status("recording");
+    } else if (this.recording) {
+      this.recording = false;
+      const merged = this._mergeBuffers(this.buf);
+      this.buf = [];
+      this._status(`captured ${merged.length} samples (${(merged.length/this.audioCtx.sampleRate).toFixed(2)} s)`);
+      // resample to 16k if AudioContext gave us something else
+      const audio = this._resample(merged, this.audioCtx.sampleRate, TARGET_SR);
+      if (audio.length < TARGET_SR * 0.2) {
+        this._status("clip too short — ignored");
+        return;
+      }
+      this._transcribe(audio);
+    }
+  }
+
+  async _transcribe(audio) {
+    this._status("transcribing…");
+    const t0 = performance.now();
+    const out = await this.transcriber(audio, {
+      chunk_length_s: 30,
+      stride_length_s: 5,
+      language: "en",
+    });
+    const dt = (performance.now() - t0).toFixed(0);
+    this._status(`stt ${dt} ms`);
+    if (this.onTranscript) this.onTranscript(out.text.trim());
+  }
+
+  _mergeBuffers(chunks) {
+    let total = 0; for (const c of chunks) total += c.length;
+    const out = new Float32Array(total);
+    let off = 0;
+    for (const c of chunks) { out.set(c, off); off += c.length; }
+    return out;
+  }
+
+  _resample(input, fromSr, toSr) {
+    if (Math.abs(fromSr - toSr) < 1) return input;
+    const ratio = fromSr / toSr;
+    const outLen = Math.floor(input.length / ratio);
+    const out = new Float32Array(outLen);
+    for (let i = 0; i < outLen; i++) {
+      const src = i * ratio;
+      const i0  = Math.floor(src);
+      const i1  = Math.min(i0 + 1, input.length - 1);
+      const f   = src - i0;
+      out[i] = input[i0] * (1 - f) + input[i1] * f;
+    }
+    return out;
+  }
+}
+
+export const STT = new _STT();

--- a/web/voice/tts.js
+++ b/web/voice/tts.js
@@ -1,0 +1,114 @@
+// tts.js — local Kokoro v1.0 TTS in the browser via kokoro-js.
+//
+// First call lazily downloads the ONNX weights (~325 MB int8). Cached after.
+// API:
+//   await TTS.init({ voice: "am_michael", device: "wasm" });
+//   TTS.speak("hello captain.");          // queued, returns immediately
+//   await TTS.flush();                    // resolves when all queued audio has played
+//   TTS.cancel();                         // drop pending + stop current playback (barge-in)
+//
+// Voices: af_alloy, af_bella, af_nicole, am_adam, am_eric, am_fenrir, am_michael,
+//         bm_lewis, bf_emma, etc. Same catalog as the native voicebox Kokoro v1.0.
+
+import { KokoroTTS } from "https://cdn.jsdelivr.net/npm/kokoro-js@latest/+esm";
+
+const MODEL = "onnx-community/Kokoro-82M-v1.0-ONNX";
+
+class _TTS {
+  constructor() {
+    this.kokoro    = null;
+    this.audioCtx  = null;
+    this.voice     = "am_michael";
+    this.queue     = [];          // pending {text, persona} jobs
+    this.draining  = false;
+    this.curSrc    = null;        // current AudioBufferSourceNode
+    this.cancelled = false;
+    this.onStatus  = null;
+    this.onSpeakingChange = null; // (bool) — for mic gating / UI
+    this._idleResolvers = [];
+  }
+
+  _status(s) { if (this.onStatus) this.onStatus(s); }
+  _setSpeaking(b) { if (this.onSpeakingChange) this.onSpeakingChange(b); }
+
+  async init({ voice = "am_michael", device = "wasm" } = {}) {
+    if (this.kokoro) return;
+    this.voice = voice;
+    this._status(`loading kokoro (${device})…`);
+    const t0 = performance.now();
+    this.kokoro = await KokoroTTS.from_pretrained(MODEL, {
+      dtype: "q8",
+      device,
+    });
+    this.audioCtx = new AudioContext();
+    this._status(`kokoro ready in ${((performance.now()-t0)/1000).toFixed(1)} s`);
+  }
+
+  setVoice(v)   { this.voice = v; }
+  isIdle()      { return !this.draining && this.queue.length === 0 && !this.curSrc; }
+
+  speak(text, persona = null) {
+    if (!text || !text.trim()) return;
+    if (this.cancelled) this.cancelled = false;
+    this.queue.push({ text: text.trim(), persona });
+    if (!this.draining) this._drain();
+  }
+
+  cancel() {
+    this.cancelled = true;
+    this.queue = [];
+    if (this.curSrc) { try { this.curSrc.stop(); } catch {} this.curSrc = null; }
+    this._setSpeaking(false);
+    this._resolveIdle();
+  }
+
+  flush() {
+    if (this.isIdle()) return Promise.resolve();
+    return new Promise(res => this._idleResolvers.push(res));
+  }
+
+  _resolveIdle() {
+    const r = this._idleResolvers; this._idleResolvers = [];
+    r.forEach(fn => fn());
+  }
+
+  async _drain() {
+    if (!this.kokoro || !this.audioCtx) return;
+    if (this.audioCtx.state === "suspended") await this.audioCtx.resume();
+    this.draining = true;
+    this._setSpeaking(true);
+    while (this.queue.length && !this.cancelled) {
+      const job = this.queue.shift();
+      const voice = job.persona?.voice ?? this.voice;
+      let audio;
+      try {
+        const t0 = performance.now();
+        audio = await this.kokoro.generate(job.text, { voice });
+        this._status(`tts ${(performance.now()-t0).toFixed(0)} ms`);
+      } catch (err) {
+        this._status(`tts error: ${err.message}`);
+        continue;
+      }
+      if (this.cancelled) break;
+      await this._play(audio);
+    }
+    this.draining = false;
+    if (this.queue.length === 0) this._setSpeaking(false);
+    this._resolveIdle();
+  }
+
+  _play({ audio, sampling_rate }) {
+    return new Promise((resolve) => {
+      const buf = this.audioCtx.createBuffer(1, audio.length, sampling_rate);
+      buf.copyToChannel(audio, 0);
+      const src = this.audioCtx.createBufferSource();
+      src.buffer = buf;
+      src.connect(this.audioCtx.destination);
+      src.onended = () => { if (this.curSrc === src) this.curSrc = null; resolve(); };
+      this.curSrc = src;
+      src.start();
+    });
+  }
+}
+
+export const TTS = new _TTS();

--- a/web/voicebox.js
+++ b/web/voicebox.js
@@ -1,179 +1,243 @@
 /*
- * voicebox.js -- WASM browser voice integration
- * Provides a JavaScript bridge for Signal's voice system.
- * Handles STT (Whisper), TTS (Kokoro), and LLM elaboration (OpenRouter).
+ * voicebox.js — WASM browser voice integration for Signal.
+ *
+ * Delegates to ES-module helpers in web/voice/:
+ *   auth.js      OAuth-PKCE flow against openrouter.ai
+ *   stt.js       Whisper-tiny.en via transformers.js (AudioWorklet mic capture)
+ *   tts.js       Kokoro v1.0 via kokoro-js (per-persona voice + speed)
+ *   personas.js  static catalog of voice/system-prompt config
+ *
+ * The C side (src/voice_web.c, EM_JS) calls window.voicebox.{init,event,ask,
+ * setState,setMicEnabled,quit}. Those are exposed below.
+ *
+ * Voice never leaves the device — STT + TTS are local WASM. Only the
+ * transcribed text + a [SHIP TELEMETRY] blob round-trip to OpenRouter for
+ * ASK elaborations, paid for by the player's own key.
  */
 
-window.voicebox = (function() {
-  const state = {
-    initialized: false,
+import { getStoredKey, clearStoredKey, startLogin, maybeCompleteLogin }
+    from "./voice/auth.js";
+import { STT } from "./voice/stt.js";
+import { TTS } from "./voice/tts.js";
+import { PERSONAS, DEFAULT_PERSONA } from "./voice/personas.js";
+
+const state = {
+    apiKey:     null,
+    sttReady:   false,
+    ttsReady:   false,
     micEnabled: false,
-    openRouterKey: null,
-    selectedModel: 'openrouter/auto', // Default or user-selected model
-    personas: {},
-    shipState: {},
-  };
+    selectedModel: "openai/gpt-oss-20b:free",
+    shipState:  "",
+};
 
-  async function init() {
-    console.log('[voicebox] Initializing...');
-    state.initialized = true;
-    // Load persisted OpenRouter key if available
-    const savedKey = localStorage.getItem('voicebox_openrouter_key');
-    if (savedKey) {
-      state.openRouterKey = savedKey;
-      console.log('[voicebox] Loaded persisted OpenRouter key');
-    }
-    // Load persisted model selection
-    const savedModel = localStorage.getItem('voicebox_selected_model');
-    if (savedModel) {
-      state.selectedModel = savedModel;
-      console.log(`[voicebox] Loaded persisted model: ${savedModel}`);
-    }
-  }
+function log(...args) { console.log("[voicebox]", ...args); }
 
-  function event(persona, line) {
-    console.log(`[voicebox] event: ${persona} says "${line}"`);
-    // Line will be spoken via TTS (Kokoro)
-    if (state.micEnabled && state.openRouterKey) {
-      // Process elaboration if needed, then play TTS
-      playTTS(persona, line);
-    } else {
-      playTTS(persona, line);
-    }
-  }
+// ---------- TTS pipeline ----------
 
-  function setState(fields) {
-    console.log(`[voicebox] setState: ${fields}`);
-    // Parse semicolon-separated fields: key1=value1;key2=value2
-    const pairs = fields.split(';');
-    pairs.forEach(pair => {
-      const [key, value] = pair.split('=');
-      if (key && value) {
-        state.shipState[key.trim()] = value.trim();
-      }
-    });
-  }
+async function ensureTTS() {
+    if (state.ttsReady) return;
+    log("loading Kokoro v1.0 (~325 MB; cached after first load)…");
+    await TTS.init({ voice: PERSONAS[DEFAULT_PERSONA].voice, device: "wasm" });
+    state.ttsReady = true;
+}
 
-  async function ask(persona, directive) {
-    console.log(`[voicebox] ask: ${persona} elaborates on "${directive}"`);
-    if (!state.openRouterKey) {
-      console.log('[voicebox] No OpenRouter key available; skipping elaboration');
-      return;
+function speakWithPersona(personaName, text) {
+    if (!text || !text.trim()) return;
+    const persona = PERSONAS[personaName] || PERSONAS[DEFAULT_PERSONA];
+    if (!state.ttsReady) {
+        ensureTTS().then(() => TTS.speak(text, persona))
+                   .catch(err => log("TTS load failed:", err.message));
+        return;
     }
-    // Query LLM for elaboration
+    TTS.speak(text, persona);
+}
+
+// ---------- LLM (OpenRouter) ----------
+
+async function askLLM(personaName, directive) {
+    if (!state.apiKey) {
+        log("ASK skipped — not connected to OpenRouter");
+        return;
+    }
+    const persona = PERSONAS[personaName] || PERSONAS[DEFAULT_PERSONA];
+    const messages = [
+        { role: "system", content: persona.system },
+        { role: "user",   content:
+            `[SHIP TELEMETRY] ${state.shipState}\n` +
+            `[STAGE DIRECTION — speak in your own voice. Paraphrase in 1 short ` +
+            `sentence; do not quote this directive verbatim.] ${directive}` },
+    ];
+
+    let r;
     try {
-      const contextStr = Object.entries(state.shipState)
-        .map(([k, v]) => `${k}: ${v}`)
-        .join(', ');
-      const prompt = `As ${persona}, briefly elaborate on: ${directive}. Context: ${contextStr}`;
-      const response = await queryLLM(prompt);
-      if (response) {
-        playTTS(persona, response);
-      }
-    } catch (err) {
-      console.error(`[voicebox] LLM elaboration failed: ${err}`);
+        r = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+            method: "POST",
+            headers: {
+                "Content-Type":  "application/json",
+                "Authorization": `Bearer ${state.apiKey}`,
+                "HTTP-Referer":  location.origin,
+                "X-Title":       "signal-web-voice",
+            },
+            body: JSON.stringify({
+                model: state.selectedModel,
+                stream: true,
+                messages,
+            }),
+        });
+    } catch (err) { log("ASK fetch error:", err.message); return; }
+    if (!r.ok) { log(`ASK HTTP ${r.status}`); return; }
+
+    // Stream SSE; emit each complete sentence to TTS as it arrives.
+    const reader   = r.body.getReader();
+    const dec      = new TextDecoder();
+    let leftover   = "";
+    let sentBuf    = "";
+    let inThink    = false;
+
+    function drainSentences(force = false) {
+        while (true) {
+            // skip <think>…</think> qwen reasoning blocks
+            if (!inThink && sentBuf.includes("<think>") &&
+                            !sentBuf.includes("</think>")) {
+                sentBuf = sentBuf.split("<think>")[0];
+                inThink = true;
+            }
+            if (inThink) {
+                const close = sentBuf.indexOf("</think>");
+                if (close < 0) return;
+                sentBuf = sentBuf.slice(close + "</think>".length);
+                inThink = false;
+            }
+            const m = sentBuf.match(force ? /^.+/s : /^.*?[.!?\n]/s);
+            if (!m) return;
+            const candidate = m[0];
+            const remainder = sentBuf.slice(candidate.length);
+            const letters = (candidate.match(/[a-zA-Z]/g) || []).length;
+            if (!force && letters < 4) return;
+            const sentence = candidate.trim();
+            if (sentence) speakWithPersona(personaName, sentence);
+            sentBuf = remainder;
+            if (!force) continue;
+            return;
+        }
     }
-  }
 
-  async function queryLLM(prompt) {
-    // Call OpenRouter API with user's key
-    try {
-      const response = await fetch('https://openrouter.io/api/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${state.openRouterKey}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          model: state.selectedModel,
-          messages: [{
-            role: 'user',
-            content: prompt,
-          }],
-          max_tokens: 50,
-        }),
-      });
-      if (!response.ok) {
-        const err = await response.text();
-        throw new Error(`OpenRouter request failed: ${err}`);
-      }
-      const data = await response.json();
-      return data.choices?.[0]?.message?.content || null;
-    } catch (err) {
-      console.error(`[voicebox] LLM query error: ${err}`);
-      return null;
+    while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        leftover += dec.decode(value, { stream: true });
+        let idx;
+        while ((idx = leftover.indexOf("\n\n")) >= 0) {
+            const event = leftover.slice(0, idx);
+            leftover    = leftover.slice(idx + 2);
+            for (const line of event.split("\n")) {
+                if (!line.startsWith("data: ")) continue;
+                const payload = line.slice(6);
+                if (payload === "[DONE]") continue;
+                try {
+                    const j = JSON.parse(payload);
+                    const delta = j.choices?.[0]?.delta?.content ?? "";
+                    if (delta) { sentBuf += delta; drainSentences(false); }
+                } catch { /* keepalives */ }
+            }
+        }
     }
-  }
+    drainSentences(true);
+}
 
-  function playTTS(persona, text) {
-    console.log(`[voicebox] playTTS: "${text}"`);
-    // Placeholder: in a real implementation, use Kokoro WASM
-    // For now, use browser's Web Speech API as fallback
-    if ('speechSynthesis' in window) {
-      const utterance = new SpeechSynthesisUtterance(text);
-      utterance.rate = 0.9;
-      speechSynthesis.speak(utterance);
-    }
-  }
+// ---------- STT pipeline (push-to-talk) ----------
 
-  function setMicEnabled(enabled) {
-    console.log(`[voicebox] setMicEnabled: ${enabled}`);
-    state.micEnabled = enabled;
-    // In a real implementation, initialize STT capture here
-  }
+STT.onTranscript = (text) => {
+    if (!text || !state.apiKey) return;
+    log("captain said:", text);
+    // Pilot speech routes through nav7 as a free-form ASK with state.
+    askLLM(DEFAULT_PERSONA,
+        `The captain just said: "${text}". Respond as NAV-7 directly to them.`);
+};
 
-  function quit() {
-    console.log('[voicebox] Quitting...');
-    state.initialized = false;
-  }
+async function ensureSTT() {
+    if (state.sttReady) return;
+    log("loading Whisper tiny.en (~75 MB; cached after first load)…");
+    await STT.init();
+    await STT.startCapture();
+    state.sttReady = true;
+}
 
-  async function getAvailableModels() {
-    // Fetch available models from OpenRouter
-    // Free models are sufficient for the game
-    if (!state.openRouterKey) {
-      console.log('[voicebox] No OpenRouter key; returning default model');
-      return [{ id: 'openrouter/auto', name: 'Auto (Free)' }];
-    }
-    try {
-      const response = await fetch('https://openrouter.io/api/v1/models', {
-        headers: { 'Authorization': `Bearer ${state.openRouterKey}` }
-      });
-      if (!response.ok) throw new Error(`Failed to fetch models: ${response.status}`);
-      const data = await response.json();
-      return (data.data || []).map(m => ({
-        id: m.id,
-        name: `${m.name || m.id}${m.pricing?.prompt ? ' (paid)' : ' (free)'}`
-      }));
-    } catch (err) {
-      console.error(`[voicebox] Failed to fetch available models: ${err}`);
-      return [{ id: 'openrouter/auto', name: 'Auto (Free)' }];
-    }
-  }
+// ---------- public API surface called from voice_web.c ----------
 
-  function setModel(modelId) {
-    if (!modelId) return;
-    state.selectedModel = modelId;
-    localStorage.setItem('voicebox_selected_model', modelId);
-    console.log(`[voicebox] Model set to ${modelId}`);
-  }
+window.voicebox = {
+    /* called from voice_init() at signal startup */
+    init() {
+        log("init");
+        // Try to complete an in-flight OAuth callback first; otherwise restore
+        // a cached key. Mic + TTS load lazily on first use.
+        maybeCompleteLogin().then(newKey => {
+            if (newKey) { state.apiKey = newKey; log("OAuth complete"); return; }
+            const cached = getStoredKey();
+            if (cached) { state.apiKey = cached; log("using cached OpenRouter key"); }
+            else        { log("no OpenRouter key — ASK disabled until /voice/connect is run"); }
+        }).catch(err => log("auth error:", err.message));
 
-  // Public API
-  return {
-    init,
-    event,
-    setState,
-    ask,
-    setMicEnabled,
-    quit,
-    setOpenRouterKey: function(key) {
-      state.openRouterKey = key;
-      localStorage.setItem('voicebox_openrouter_key', key);
-      console.log('[voicebox] OpenRouter key set');
+        // Pre-warm Kokoro in the background once auth is ready, so the first
+        // station hail doesn't wait on a 30-second model download.
+        setTimeout(() => {
+            if (state.apiKey || true) ensureTTS().catch(() => {});
+        }, 500);
     },
-    setModel,
-    getAvailableModels,
-    getState: function() {
-      return { ...state };
+
+    /* deterministic chatter — speak verbatim */
+    event(persona, line) {
+        log(`event ${persona}: ${line}`);
+        speakWithPersona(persona, line);
     },
-  };
-})();
+
+    /* LLM-mediated, state-aware paraphrase */
+    ask(persona, directive) {
+        log(`ask ${persona}: ${directive}`);
+        askLLM(persona, directive).catch(err => log("ASK error:", err.message));
+    },
+
+    /* C side calls this when ship state changes (≤1 Hz) */
+    setState(fields) {
+        state.shipState = fields;
+    },
+
+    /* push-to-talk gate */
+    async setMicEnabled(enabled) {
+        if (enabled === state.micEnabled) return;
+        state.micEnabled = enabled;
+        if (enabled) {
+            try { await ensureSTT(); STT.holdToTalk(true); }
+            catch (err) { log("mic error:", err.message); state.micEnabled = false; }
+        } else if (state.sttReady) {
+            STT.holdToTalk(false);
+        }
+    },
+
+    /* shutdown */
+    quit() {
+        log("quit");
+        if (state.ttsReady) TTS.cancel();
+    },
+
+    // --- player-facing UX (called from a settings UI in the host page) ---
+
+    /* kicks off the OAuth-PKCE redirect to openrouter.ai */
+    connect: startLogin,
+
+    /* clears cached key + signs out */
+    disconnect() {
+        clearStoredKey();
+        state.apiKey = null;
+        log("disconnected");
+    },
+
+    /* model picker */
+    setModel(modelId) { if (modelId) state.selectedModel = modelId; },
+    getModel() { return state.selectedModel; },
+
+    /* introspection */
+    isConnected() { return !!state.apiKey; },
+    isTTSReady()  { return state.ttsReady; },
+    isSTTReady()  { return state.sttReady; },
+};


### PR DESCRIPTION
PR #456 (Voice E) merged scaffolding without an actual implementation. This patch turns it into a working browser voice stack.

## What was broken in #456

| issue | impact |
|---|---|
| OpenRouter URL was `openrouter.io` | every LLM call 404'd |
| TTS used `speechSynthesis` not Kokoro WASM | voice did leave device (browser→Google/Apple), all 4 personas sounded identical |
| STT was a stub | `setMicEnabled()` only flipped a flag; no Whisper, no AudioWorklet |
| No OAuth flow | players had to inject `localStorage.voicebox_openrouter_key` from devtools |
| Persona voices ignored | `playTTS` didn't look up Kokoro voice ID per persona |
| No model files served | Kokoro/Whisper not fetched into browser cache |

## What this PR adds

The four working modules from `cenetex/voicebox/web/` (the validated demo) are imported as ES modules:

```
web/voice/auth.js       OAuth-PKCE flow → openrouter.ai → long-lived user key in localStorage
web/voice/stt.js        Whisper tiny.en (via transformers.js) + AudioWorklet mic capture
web/voice/tts.js        Kokoro v1.0 (via kokoro-js) with per-persona voice + speed
web/voice/personas.js   nav7 (am_michael) / prospect (af_sarah) / kepler (am_eric) / helios (bm_lewis)
```

`web/voicebox.js` is now an ES module that delegates to those. Highlights:

- **Streaming SSE** from OpenRouter; sentence boundaries detected as deltas arrive, fed straight into Kokoro
- **`<think>...</think>`** Qwen reasoning tokens stripped before TTS (mirrors the native voicebox)
- **Per-persona voice**: each station's hails play in their own Kokoro voice ID
- **Lazy model load**: Kokoro starts downloading in the background after init() so first hail isn't delayed
- **Public API unchanged** — `src/voice_web.c` EM_JS calls (`init/event/ask/setState/setMicEnabled/quit`) keep working

`play.html` and `shell.html` updated to load voicebox.js as `type="module"` so the imports resolve.

## Privacy posture

Voice never leaves the device. Only transcribed text + a `[SHIP TELEMETRY]` blob hits OpenRouter, paid for by the player's own key.

## Verification

- `SIGNAL_VOICE=ON` and `SIGNAL_VOICE=OFF` native builds: both compile clean (no Werror)
- Browser end-to-end was validated standalone in cenetex/voicebox/web/ before being ported here
- Player flow on signal.ratimics.com: load page → click "connect voice" (calls `window.voicebox.connect()`) → OAuth roundtrip → return with key cached → first hail plays in NAV-7's voice

Refs: #436, #423, the `cenetex/voicebox` prototype.