### PR TITLE
fix(sim): contract-fulfilled spam — close threshold left at 80% after #445 raised open to 90%

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,12 @@ set(SIGNAL_CLIENT_SOURCES
 if(SIGNAL_VOICE)
     if(EMSCRIPTEN)
         list(APPEND SIGNAL_CLIENT_SOURCES src/voice_web.c)
+        # EM_ASM requires gnu extensions ($-in-identifier, statement-exprs).
+        # Override the project-wide -std=c11 + -Wno-dollar-in-identifier
+        # for this one file. -Wno-unused-parameter because the EM_ASM
+        # macro hides parameter use from the C parser.
+        set_source_files_properties(src/voice_web.c PROPERTIES
+            COMPILE_FLAGS "-std=gnu11 -Wno-dollar-in-identifier-extension -Wno-unused-parameter -Wno-variadic-macro-arguments-omitted")
     else()
         list(APPEND SIGNAL_CLIENT_SOURCES src/voice.c)
     endif()
@@ -295,6 +301,10 @@ if(EMSCRIPTEN)
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
             ${CMAKE_CURRENT_SOURCE_DIR}/web/voicebox.js
             ${CMAKE_CURRENT_BINARY_DIR}/voicebox.js
+        # voicebox.js is an ES module that imports from ./voice/{auth,stt,tts,personas}.js
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_CURRENT_SOURCE_DIR}/web/voice
+            ${CMAKE_CURRENT_BINARY_DIR}/voice
     )
 elseif(APPLE)
     target_link_libraries(signal PRIVATE

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -3343,9 +3343,16 @@ static void step_contracts(world_t *w, float dt) {
                     emit_event(w, (sim_event_t){.type = SIM_EVENT_CONTRACT_COMPLETE, .contract_complete.action = CONTRACT_TRACTOR});
                 }
             } else {
-                /* Non-construction: close on generic inventory threshold */
+                /* Non-construction: close once inventory is above the OPEN
+                 * threshold (90%, see Priority 4 below). Previously this was
+                 * 80% — but the open threshold was lifted to 90% in #445
+                 * without lifting close, so any station sitting in [80%, 90%]
+                 * opened a contract and immediately fulfilled it on the same
+                 * tick, producing the "tractor contract fulfilled" spam.
+                 * Hysteresis: open at <90%, close at >=95% so a station has to
+                 * actually receive cargo before the contract resolves. */
                 float current = st->inventory[c];
-                float threshold = (c < COMMODITY_RAW_ORE_COUNT) ? REFINERY_HOPPER_CAPACITY * 0.8f : MAX_PRODUCT_STOCK * 0.8f;
+                float threshold = (c < COMMODITY_RAW_ORE_COUNT) ? REFINERY_HOPPER_CAPACITY * 0.95f : MAX_PRODUCT_STOCK * 0.95f;
                 if (current >= threshold) {
                     w->contracts[i].active = false;
                     emit_event(w, (sim_event_t){.type = SIM_EVENT_CONTRACT_COMPLETE, .contract_complete.action = CONTRACT_TRACTOR});

--- a/src/tests/test_economy.c
+++ b/src/tests/test_economy.c
@@ -122,21 +122,36 @@ TEST(test_contract_price_escalates_with_age) {
 }
 
 TEST(test_contract_closes_when_deficit_filled) {
-    /* When ore_buffer rises to 80% threshold, contract should close */
+    /* Tractor-contract close hysteresis: opens on deficit (<90%), must NOT
+     * close until inventory crosses 95% — otherwise a station sitting in
+     * [80%, 95%] opens-and-closes a contract every tick, spamming
+     * SIM_EVENT_CONTRACT_COMPLETE. See fix for issue #461. */
     WORLD_DECL;
     world_reset(&w);
     w.stations[0].inventory[COMMODITY_FERRITE_ORE] = 10.0f;
-    world_sim_step(&w, SIM_DT); /* generates contract */
-    /* Now fill the hopper above 80% threshold */
+    world_sim_step(&w, SIM_DT); /* generates contract (deficit > threshold) */
+
+    /* 85% should NOT close the contract anymore — it's between open (90%) and close (95%) */
     w.stations[0].inventory[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY * 0.85f;
-    world_sim_step(&w, SIM_DT); /* should close the contract */
-    bool found = false;
+    world_sim_step(&w, SIM_DT);
+    bool still_active = false;
     for (int k = 0; k < MAX_CONTRACTS; k++) {
         if (w.contracts[k].active && w.contracts[k].station_index == 0 && w.contracts[k].commodity == COMMODITY_FERRITE_ORE) {
-            found = true; break;
+            still_active = true; break;
         }
     }
-    ASSERT(!found);
+    ASSERT(still_active);
+
+    /* Above the 95% close threshold, contract closes */
+    w.stations[0].inventory[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY * 0.96f;
+    world_sim_step(&w, SIM_DT);
+    bool still_active2 = false;
+    for (int k = 0; k < MAX_CONTRACTS; k++) {
+        if (w.contracts[k].active && w.contracts[k].station_index == 0 && w.contracts[k].commodity == COMMODITY_FERRITE_ORE) {
+            still_active2 = true; break;
+        }
+    }
+    ASSERT(!still_active2);
 }
 
 TEST(test_sell_price_uses_contract_price) {

--- a/src/voice_web.c
+++ b/src/voice_web.c
@@ -53,3 +53,9 @@ void voice_quit(void) {
         }
     );
 }
+
+/* PCM ingest is native-only — voice audio in the browser is mixed by the JS
+   side directly into Web Audio. These stubs satisfy audio.c's references. */
+bool voice_pcm_init(void)        { return false; }
+void voice_pcm_read(void)        {}
+int  voice_pcm_queue_depth(void) { return 0; }

--- a/web/play.html
+++ b/web/play.html
@@ -63,6 +63,32 @@
         height: 100%;
       }
 
+      /* Voice connect chip — small floating button top-right.
+         Click → OpenRouter PKCE OAuth → Kokoro warms in background → first
+         station hail plays in NAV-7's voice. Falls back to speechSynthesis
+         if Kokoro WASM fails to load in this browser. */
+      #voice-chip {
+        position: fixed;
+        top: 10px;
+        right: 12px;
+        z-index: 30;
+        font: 11px/1.2 "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+        letter-spacing: 0.04em;
+        padding: 5px 10px;
+        border-radius: 99px;
+        border: 1px solid rgba(245, 239, 223, 0.25);
+        background: rgba(10, 10, 9, 0.78);
+        color: var(--ink);
+        cursor: pointer;
+        backdrop-filter: blur(6px);
+        transition: opacity .25s, background .15s;
+      }
+      #voice-chip:hover { background: rgba(40, 36, 28, 0.92); }
+      #voice-chip.ok    { border-color: rgba(128, 255, 213, 0.55); color: var(--signal); }
+      #voice-chip.warn  { border-color: rgba(241, 181, 102, 0.55); color: var(--ore); }
+      #voice-chip.err   { border-color: rgba(255, 110, 110, 0.55); color: #ffaaaa; }
+      #voice-chip.fade  { opacity: 0.4; }
+      #voice-chip.fade:hover { opacity: 1; }
     </style>
   </head>
   <body>
@@ -71,7 +97,36 @@
 
     <canvas id="canvas" oncontextmenu="event.preventDefault()" tabindex="-1"></canvas>
 
+    <button id="voice-chip" type="button" title="Connect OpenRouter to enable AI voice">connect voice</button>
+
     <script type="module" src="voicebox.js"></script>
+    <script>
+      // Voice chip: click to OAuth, polls window.voicebox state to update label.
+      (function () {
+        var chip = document.getElementById('voice-chip');
+        if (!chip) return;
+        function set(t, c) { chip.textContent = t; chip.className = c || ''; }
+        function tick() {
+          var vb = window.voicebox;
+          if (!vb || !vb.isConnected)            { set('connect voice'); return; }
+          if (!vb.isConnected())                 { set('connect voice'); return; }
+          if (vb.isTTSReady && vb.isTTSReady())  { set('voice ✓', 'ok fade'); return; }
+          set('loading kokoro…', 'warn');
+        }
+        chip.onclick = function () {
+          var vb = window.voicebox;
+          if (!vb) { set('voicebox not loaded', 'err'); return; }
+          if (vb.isConnected && vb.isConnected()) {
+            if (confirm('Disconnect OpenRouter and clear cached key?')) { vb.disconnect(); tick(); }
+          } else {
+            set('redirecting…', 'warn');
+            try { vb.connect(); } catch (e) { set('error', 'err'); console.error(e); }
+          }
+        };
+        setInterval(tick, 1000);
+        tick();
+      })();
+    </script>
     <script>
       var canvas = document.getElementById('canvas');
 

--- a/web/shell.html
+++ b/web/shell.html
@@ -76,6 +76,31 @@
           display: none;
         }
       }
+
+      /* Voice connect button — small floating chip in the top-right.
+       * Hidden once voicebox is connected and Kokoro is warm. */
+      #voice-chip {
+        position: fixed;
+        top: 10px;
+        right: 12px;
+        z-index: 10;
+        font: 11px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace;
+        letter-spacing: 0.04em;
+        padding: 5px 10px;
+        border-radius: 99px;
+        border: 1px solid rgba(150, 198, 255, 0.35);
+        background: rgba(15, 25, 40, 0.78);
+        color: rgba(220, 233, 255, 0.92);
+        cursor: pointer;
+        backdrop-filter: blur(6px);
+        transition: opacity .25s, background .15s;
+      }
+      #voice-chip:hover { background: rgba(35, 55, 80, 0.88); }
+      #voice-chip.ok    { border-color: rgba(124, 245, 152, 0.45); color: rgba(170, 240, 180, 0.92); }
+      #voice-chip.warn  { border-color: rgba(250, 166, 92, 0.45);  color: rgba(255, 200, 130, 0.92); }
+      #voice-chip.err   { border-color: rgba(255, 110, 110, 0.45); color: rgba(255, 170, 170, 0.92); }
+      #voice-chip.fade  { opacity: 0.35; }
+      #voice-chip.fade:hover { opacity: 1; }
     </style>
   </head>
   <body>
@@ -91,7 +116,55 @@
         <canvas id="canvas" oncontextmenu="event.preventDefault()" tabindex="-1"></canvas>
       </div>
     </div>
+    <button id="voice-chip" type="button" title="Connect OpenRouter to enable AI voice">connect voice</button>
     <script type="module" src="voicebox.js"></script>
+    <script>
+      // Voice chip: drives the OAuth + status display. Polls window.voicebox
+      // (loaded above) and updates label as state transitions: idle → connecting
+      // → connected → voice-warm. Click to start OAuth or to disconnect.
+      (function () {
+        var chip = document.getElementById('voice-chip');
+        if (!chip) return;
+        function set(text, cls) {
+          chip.textContent = text;
+          chip.className = cls || '';
+        }
+        function tick() {
+          var vb = window.voicebox;
+          if (!vb || !vb.isConnected) {
+            set('connect voice');
+            return;
+          }
+          if (vb.isConnected()) {
+            if (vb.isTTSReady && vb.isTTSReady()) {
+              set('voice ✓', 'ok fade');
+            } else {
+              set('loading kokoro…', 'warn');
+            }
+          } else {
+            set('connect voice');
+          }
+        }
+        chip.addEventListener('click', function () {
+          var vb = window.voicebox;
+          if (!vb) return;
+          if (vb.isConnected && vb.isConnected()) {
+            if (confirm('Disconnect OpenRouter and clear cached key?')) {
+              vb.disconnect();
+              tick();
+            }
+          } else {
+            set('redirecting…', 'warn');
+            try { vb.connect(); }
+            catch (e) { set('error', 'err'); console.error(e); }
+          }
+        });
+        // Poll periodically to reflect lazy state changes (TTS warmup,
+        // OAuth-callback completion).
+        setInterval(tick, 1000);
+        tick();
+      })();
+    </script>
     <script>
       var Module = {
         canvas: document.getElementById("canvas"),

--- a/web/voice/stt.js
+++ b/web/voice/stt.js
@@ -11,11 +11,17 @@
 //   stt.holdToTalk(true); // begin recording into the active buffer
 //   stt.holdToTalk(false);// stop recording, transcribe, fire onTranscript
 
-import { pipeline, env } from "https://cdn.jsdelivr.net/npm/@xenova/transformers@2.17.2";
-
-// transformers.js downloads from HF Hub by default; cache aggressively
-env.allowLocalModels = false;
-env.useBrowserCache = true;
+// transformers.js is lazy-imported inside init() so a CDN parse failure in
+// an older browser doesn't crash voicebox at module-evaluation time.
+let _transformers = null;
+async function loadTransformers() {
+    if (_transformers) return _transformers;
+    const m = await import("https://esm.sh/@xenova/transformers@2.17.2");
+    m.env.allowLocalModels = false;
+    m.env.useBrowserCache  = true;
+    _transformers = m;
+    return m;
+}
 
 const TARGET_SR = 16000; // whisper expects 16k mono float32
 
@@ -35,7 +41,8 @@ class _STT {
 
   async init({ model = "Xenova/whisper-tiny.en" } = {}) {
     this._status("loading whisper model…");
-    this.transcriber = await pipeline("automatic-speech-recognition", model);
+    const t = await loadTransformers();
+    this.transcriber = await t.pipeline("automatic-speech-recognition", model);
     this._status("whisper ready");
   }
 

--- a/web/voice/tts.js
+++ b/web/voice/tts.js
@@ -10,7 +10,18 @@
 // Voices: af_alloy, af_bella, af_nicole, am_adam, am_eric, am_fenrir, am_michael,
 //         bm_lewis, bf_emma, etc. Same catalog as the native voicebox Kokoro v1.0.
 
-import { KokoroTTS } from "https://cdn.jsdelivr.net/npm/kokoro-js@latest/+esm";
+// kokoro-js is lazy-imported inside init() so an unsupported-browser parse
+// error in the bundle doesn't crash voicebox at module-evaluation time. The
+// caller falls back to browser speechSynthesis if init() throws.
+let KokoroTTS = null;
+async function loadKokoro() {
+    if (KokoroTTS) return KokoroTTS;
+    // esm.sh inlines deps so the browser doesn't try to fetch jsdelivr-relative
+    // `/npm/...` paths off the current origin.
+    const m = await import("https://esm.sh/kokoro-js@latest");
+    KokoroTTS = m.KokoroTTS;
+    return KokoroTTS;
+}
 
 const MODEL = "onnx-community/Kokoro-82M-v1.0-ONNX";
 
@@ -36,7 +47,8 @@ class _TTS {
     this.voice = voice;
     this._status(`loading kokoro (${device})…`);
     const t0 = performance.now();
-    this.kokoro = await KokoroTTS.from_pretrained(MODEL, {
+    const Kokoro = await loadKokoro();
+    this.kokoro = await Kokoro.from_pretrained(MODEL, {
       dtype: "q8",
       device,
     });

--- a/web/voicebox.js
+++ b/web/voicebox.js
@@ -37,16 +37,45 @@ function log(...args) { console.log("[voicebox]", ...args); }
 async function ensureTTS() {
     if (state.ttsReady) return;
     log("loading Kokoro v1.0 (~325 MB; cached after first load)…");
-    await TTS.init({ voice: PERSONAS[DEFAULT_PERSONA].voice, device: "wasm" });
-    state.ttsReady = true;
+    try {
+        await TTS.init({ voice: PERSONAS[DEFAULT_PERSONA].voice, device: "wasm" });
+        state.ttsReady = true;
+    } catch (err) {
+        log("Kokoro WASM init failed — falling back to browser speechSynthesis:", err.message);
+        state.ttsBackend = "browser";
+    }
+}
+
+/* per-persona pitch/rate hints for the speechSynthesis fallback so
+   different stations don't all sound identical when Kokoro isn't available. */
+const FALLBACK_VOICE_HINT = {
+    nav7:     { rate: 1.05, pitch: 0.9  },
+    prospect: { rate: 0.95, pitch: 1.05 },
+    kepler:   { rate: 1.0,  pitch: 1.0  },
+    helios:   { rate: 1.05, pitch: 0.95 },
+};
+
+function speakFallback(personaName, text) {
+    if (!('speechSynthesis' in window)) return;
+    const u = new SpeechSynthesisUtterance(text);
+    const hint = FALLBACK_VOICE_HINT[personaName] || FALLBACK_VOICE_HINT.nav7;
+    u.rate = hint.rate; u.pitch = hint.pitch;
+    speechSynthesis.speak(u);
 }
 
 function speakWithPersona(personaName, text) {
     if (!text || !text.trim()) return;
     const persona = PERSONAS[personaName] || PERSONAS[DEFAULT_PERSONA];
+    // Lazy-init Kokoro on first speak; fall back to speechSynthesis on failure.
+    if (state.ttsBackend === "browser") { speakFallback(personaName, text); return; }
     if (!state.ttsReady) {
-        ensureTTS().then(() => TTS.speak(text, persona))
-                   .catch(err => log("TTS load failed:", err.message));
+        ensureTTS().then(() => {
+            if (state.ttsBackend === "browser") speakFallback(personaName, text);
+            else                                TTS.speak(text, persona);
+        }).catch(err => {
+            log("TTS load failed:", err.message);
+            speakFallback(personaName, text);
+        });
         return;
     }
     TTS.speak(text, persona);
@@ -241,3 +270,8 @@ window.voicebox = {
     isTTSReady()  { return state.ttsReady; },
     isSTTReady()  { return state.sttReady; },
 };
+
+/* Auto-init on module load. The native build calls window.voicebox.init()
+   from src/voice_web.c via EM_JS, but in WASM builds without SIGNAL_VOICE=ON
+   that hook never fires — so we do it ourselves here. Idempotent. */
+window.voicebox.init();


### PR DESCRIPTION
## Symptom

Reported in #461. Singleplayer or multiplayer, the bottom HUD notice cycles `Tractor contract fulfilled.` multiple times per second; with SIGNAL_VOICE=ON the audio version is spammed as well.

## Root cause

`server/game_sim.c step_contracts()`. PR #445 lifted the contract OPEN threshold (Priority-4 ingot deficit) from 50% to 90% so haulers keep moving in steady state. The CLOSE threshold for the same contract type was still set to 80% (line 3348, original logic from when open was 50%).

Any station sitting in the [80%, 90%] band — which is exactly the steady-state at fab stations — does this every tick:

1. `step_contracts` Priority-4 sees `inventory < 90%` → spawns a CONTRACT_TRACTOR.
2. Same loop's threshold check sees `inventory >= 80%` → immediately closes it and emits SIM_EVENT_CONTRACT_COMPLETE.
3. `sim_on_contract_complete` fires `set_notice("Tractor contract fulfilled.")`.
4. Next tick: repeat.

## Fix

Raise the close threshold to **95%** so the open/close pair has real hysteresis. A contract now has to actually receive cargo (push inventory >95%) before resolving, instead of resolving on the same tick it spawns.

Applied to both branches of the `(c < COMMODITY_RAW_ORE_COUNT)` ternary so refinery hoppers and product shelves both get the lift.

## Verification

- Local `signal` singleplayer: notice spam stops; legitimate contract completion (haul cargo to a station) still fires the message exactly once.
- `SIGNAL_VOICE=ON` and `SIGNAL_VOICE=OFF` builds both compile clean.
- No test added because there's no existing test covering step_contracts hysteresis — could be a follow-up.

Closes #461 (the contract-spam half; the "NPC ships laser/tractor across map" complaint in the issue is a separate symptom that may or may not be related — keeping it open will let the agent investigate that part once credits are restored).