### PR TITLE
fix(docker): exclude voice model dirs from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,3 +26,12 @@ logs/
 
 # Third-party archives we don't need at build time.
 *.dSYM/
+
+# Voice assets — Kokoro/Whisper model dirs (~400 MB) and the voicebox
+# binary (platform-specific) don't belong in the server image. The server
+# never speaks; voice is client-side. Persona files DO ship since they're
+# tiny and useful for any host that runs the native client locally.
+assets/voice/kokoro/
+assets/voice/whisper/
+assets/voice/voicebox
+assets/voice/voicebox.exe


### PR DESCRIPTION
After voice integration landed, building the server docker image transferred ~1 GB of context (Kokoro 333 MB + Whisper 75 MB + voicebox binary) and OOM'd podman on macOS. The server image never speaks — voice is client-side — so these don't belong in the server build context.

Excludes:
- `assets/voice/kokoro/`
- `assets/voice/whisper/`
- `assets/voice/voicebox` (and `.exe`)

Persona files (`*.persona`) are tiny text and remain — useful for any host running the native client.

Verified: `docker compose up -d --build` succeeds locally with this in place; without it, build fails with `no space left on device` even on a fresh podman VM.