### PR TITLE
fix(sim): suppress contract-fulfilled spam from inventory-driven auto-close

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,3 +26,12 @@ logs/
 
 # Third-party archives we don't need at build time.
 *.dSYM/
+
+# Voice assets — Kokoro/Whisper model dirs (~400 MB) and the voicebox
+# binary (platform-specific) don't belong in the server image. The server
+# never speaks; voice is client-side. Persona files DO ship since they're
+# tiny and useful for any host that runs the native client locally.
+assets/voice/kokoro/
+assets/voice/whisper/
+assets/voice/voicebox
+assets/voice/voicebox.exe

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -3339,23 +3339,26 @@ static void step_contracts(world_t *w, float dt) {
                 if (st->scaffold && c == COMMODITY_FRAME && st->scaffold_progress < 1.0f)
                     all_supplied = false;
                 if (all_supplied) {
+                    bool was_claimed = (w->contracts[i].claimed_by >= 0);
                     w->contracts[i].active = false;
-                    emit_event(w, (sim_event_t){.type = SIM_EVENT_CONTRACT_COMPLETE, .contract_complete.action = CONTRACT_TRACTOR});
+                    if (was_claimed)
+                        emit_event(w, (sim_event_t){.type = SIM_EVENT_CONTRACT_COMPLETE, .contract_complete.action = CONTRACT_TRACTOR});
                 }
             } else {
                 /* Non-construction: close once inventory is above the OPEN
-                 * threshold (90%, see Priority 4 below). Previously this was
-                 * 80% — but the open threshold was lifted to 90% in #445
-                 * without lifting close, so any station sitting in [80%, 90%]
-                 * opened a contract and immediately fulfilled it on the same
-                 * tick, producing the "tractor contract fulfilled" spam.
-                 * Hysteresis: open at <90%, close at >=95% so a station has to
-                 * actually receive cargo before the contract resolves. */
+                 * threshold. Hysteresis (open <90%, close >=95%) keeps a
+                 * single station from oscillating, but production-chain
+                 * stations consume ingots fast enough to re-cross 90%
+                 * within seconds — so we only fire CONTRACT_COMPLETE when
+                 * a player/NPC actually claimed and delivered. Otherwise
+                 * the contract just retires silently. */
                 float current = st->inventory[c];
                 float threshold = (c < COMMODITY_RAW_ORE_COUNT) ? REFINERY_HOPPER_CAPACITY * 0.95f : MAX_PRODUCT_STOCK * 0.95f;
                 if (current >= threshold) {
+                    bool was_claimed = (w->contracts[i].claimed_by >= 0);
                     w->contracts[i].active = false;
-                    emit_event(w, (sim_event_t){.type = SIM_EVENT_CONTRACT_COMPLETE, .contract_complete.action = CONTRACT_TRACTOR});
+                    if (was_claimed)
+                        emit_event(w, (sim_event_t){.type = SIM_EVENT_CONTRACT_COMPLETE, .contract_complete.action = CONTRACT_TRACTOR});
                 }
             }
             break;


### PR DESCRIPTION
## Summary
- Production-chain stations consume ingots fast enough to oscillate across the 90%/95% open/close hysteresis every few seconds, firing \`SIM_EVENT_CONTRACT_COMPLETE\` on every close — \"Tractor contract fulfilled\" spam in the HUD even though nothing was delivered.
- Only emit the completion event when the contract was actually claimed (\`claimed_by >= 0\`). Inventory-driven auto-close retires the contract silently.

Closes #461 follow-up — #462 raised the close threshold to add hysteresis but in production-heavy stations 5% isn't enough to prevent oscillation.

## Test plan
- [x] \`make test\` — 337/337 pass; existing \`test_contract_closes_when_deficit_filled\` still asserts the contract closes at 96% (no event-emission assertion to break)
- [ ] Run docker compose locally and watch HUD for several minutes — expect no \"fulfilled\" notice unless a player/NPC actually delivers

🤖 Generated with [Claude Code](https://claude.com/claude-code)