### PR TITLE
fix(sim): unblock the inter-station economy (HAULER_RESERVE, distress pre-empt, diagnostics)

### DIFF
--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -1426,6 +1426,26 @@ void step_npc_ships(world_t *w, float dt) {
                 if (target >= 0) npc->target_asteroid = target;
                 else { npc->target_asteroid = -1; npc->state = NPC_STATE_RETURN_TO_STATION; break; }
             }
+            /* Pre-empt for FRACTURE distress: a stuck hauler may have
+             * posted a distress contract since we left dock. Switch
+             * only if the distress target is SIGNIFICANTLY closer than
+             * our current target (≥50% nearer) — keeps the response
+             * fast for genuine shortcut detours but prevents thrashing
+             * mid-approach when the current target is close enough that
+             * any FRACTURE rock looks "closer" each tick. */
+            if (npc->towed_fragment < 0 && npc_target_valid(w, npc)) {
+                vec2 cur_pos = w->asteroids[npc->target_asteroid].pos;
+                float cur_d2 = v2_dist_sq(npc->pos, cur_pos);
+                for (int k = 0; k < MAX_CONTRACTS; k++) {
+                    if (!w->contracts[k].active) continue;
+                    if (w->contracts[k].action != CONTRACT_FRACTURE) continue;
+                    int idx = w->contracts[k].target_index;
+                    if (idx < 0 || idx >= MAX_ASTEROIDS || !w->asteroids[idx].active) continue;
+                    if (idx == npc->target_asteroid) break;
+                    float new_d2 = v2_dist_sq(npc->pos, w->asteroids[idx].pos);
+                    if (new_d2 < cur_d2 * 0.25f) { npc->target_asteroid = idx; break; }
+                }
+            }
             asteroid_t *a = &w->asteroids[npc->target_asteroid];
             npc_steer_with_path(w, n, npc, a->pos, hull->accel, hull->turn_speed, dt);
             npc_apply_physics(npc, hull->drag, dt, w);

--- a/shared/economy_const.h
+++ b/shared/economy_const.h
@@ -23,7 +23,12 @@ static const float STATION_REPAIR_COST_PER_HULL = 5.0f;
 /* Refined-product stockpile cap: needs to be wide enough that a full hold
  * of ingots can be converted without stalling at the cap. */
 static const float MAX_PRODUCT_STOCK = 120.0f;
-static const float HAULER_RESERVE = 24.0f;  /* keep 20% stock for player purchases */
+/* Reserve a small floor for player purchases without choking the
+ * inter-station chain. Was 24 (20% of MAX_PRODUCT_STOCK) — too high:
+ * in NPC-only steady-state, stations smelt ~24 ingots over 5 minutes,
+ * which never crosses the 24-floor, so no hauler ever picks up cargo.
+ * 6 ingots is enough for one player to top off a hold; surplus flows. */
+static const float HAULER_RESERVE = 6.0f;
 
 /* --- Shipyard repair-kit fab --- */
 /* A station with MODULE_SHIPYARD consumes 1 frame + 1 laser + 1 tractor

--- a/src/tests/test_econ_sim.c
+++ b/src/tests/test_econ_sim.c
@@ -23,6 +23,53 @@ TEST(test_econ_sim_npc_only_5min) {
                 w->stations[2].inventory[COMMODITY_CUPRITE_INGOT],
                 w->stations[2].inventory[COMMODITY_CRYSTAL_INGOT],
                 w->stations[1].inventory[COMMODITY_FRAME]);
+            /* Diagnostic: contracts open per station, by commodity */
+            int active = 0, claimed = 0;
+            for (int k = 0; k < MAX_CONTRACTS; k++) {
+                if (!w->contracts[k].active) continue;
+                active++;
+                if (w->contracts[k].claimed_by >= 0) claimed++;
+            }
+            int npc_idle = 0, npc_busy = 0, npc_docked = 0;
+            for (int n = 0; n < MAX_NPC_SHIPS; n++) {
+                if (!w->npc_ships[n].active) continue;
+                npc_state_t s = w->npc_ships[n].state;
+                if (s == NPC_STATE_IDLE) npc_idle++;
+                else if (s == NPC_STATE_DOCKED) npc_docked++;
+                else npc_busy++;
+            }
+            printf("        contracts: active=%d claimed=%d  npc: idle=%d docked=%d travelling=%d\n",
+                active, claimed, npc_idle, npc_docked, npc_busy);
+            /* Per-station ore inventory (raw input to smelters) */
+            printf("        ore: prospect[FE=%.1f]  helios[CU=%.1f CR=%.1f]\n",
+                w->stations[0].inventory[COMMODITY_FERRITE_ORE],
+                w->stations[2].inventory[COMMODITY_CUPRITE_ORE],
+                w->stations[2].inventory[COMMODITY_CRYSTAL_ORE]);
+            /* Per-NPC: home, role, state, current cargo */
+            for (int n = 0; n < MAX_NPC_SHIPS; n++) {
+                if (!w->npc_ships[n].active) continue;
+                float total_cargo = 0.0f;
+                for (int c = 0; c < COMMODITY_COUNT; c++) total_cargo += w->npc_ships[n].cargo[c];
+                const char *role = w->npc_ships[n].role == NPC_ROLE_MINER ? "miner"
+                                  : w->npc_ships[n].role == NPC_ROLE_HAULER ? "hauler"
+                                  : w->npc_ships[n].role == NPC_ROLE_TOW ? "tow" : "?";
+                printf("        npc[%d] %s home=%d state=%d cargo=%.1f\n",
+                    n, role, w->npc_ships[n].home_station,
+                    (int)w->npc_ships[n].state, total_cargo);
+            }
+            /* Helios CU sourcing: count CU asteroids in signal coverage
+             * around station 2 within mining range. If zero, the issue
+             * is belt seeding, not pathfinding. */
+            int cu_in_range = 0;
+            const station_t *helios = &w->stations[2];
+            for (int a = 0; a < MAX_ASTEROIDS; a++) {
+                if (!w->asteroids[a].active) continue;
+                if (w->asteroids[a].commodity != COMMODITY_CUPRITE_ORE) continue;
+                if (signal_strength_at(w, w->asteroids[a].pos) <= 0.0f) continue;
+                float d = v2_len(v2_sub(w->asteroids[a].pos, helios->pos));
+                if (d < 3000.0f) cu_in_range++;
+            }
+            printf("        helios CU asteroids in signal+3kU: %d\n", cu_in_range);
         }
     }
     printf("    t=300s: pools [%.0f, %.0f, %.0f]\n",


### PR DESCRIPTION
## Summary
NPC-only 5-min sim showed the economy was completely frozen — 0 frames pressed, no inter-station deliveries, station pools static. Three cascading bugs:

1. **\`HAULER_RESERVE 24 → 6\`** (\`shared/economy_const.h\`). The 24-ingot reserve floor exceeded NPC throughput (Prospect smelts ~24 FE ingots in 5 min), so \`take = max(0, inventory - 24) = 0\` for the entire NPC operating range. Lower it to 6 — still enough for a player to top off, no longer choking the chain.

2. **Miner pre-empts to nearer FRACTURE distress contracts** (\`server/sim_ai.c\`). \`generate_npc_distress_contracts\` already posts a \`CONTRACT_FRACTURE\` when a hauler gets stuck behind an asteroid, and \`npc_find_mineable_asteroid\` already prioritizes them — but the priority only applies at dock time. Miners on 2-minute mining cycles couldn't respond fast enough, so distress contracts went unfilled. Add an in-flight pre-emption gated on a 4× distance improvement to avoid mid-approach thrashing.

3. **Diagnostic: \`helios CU asteroids in signal+3kU\`** (\`src/tests/test_econ_sim.c\`). Confirms the remaining Helios-no-CU issue is a pathing/dwell-time problem, not a belt-seeding problem (34–41 CU rocks reachable). Tracked separately.

## Verification
\`test_econ_sim_npc_only_5min\` (5 minutes simulated, 9 NPCs, no players):

| metric                    | before        | after         |
|---------------------------|---------------|---------------|
| station pool total        | 30000 → 29172 | 30000 → 29627 |
| frames pressed @ Kepler   | 0             | 5             |
| Kepler payouts to haulers | 0             | 373 cr        |
| visible hauler cycles     | 0             | 1+            |

Helios CU still 0 — separate issue, not addressed here.

## Test plan
- [x] \`make test\` — 337/337 pass
- [x] \`test_econ_sim_npc_only_5min\` shows real flow (frames pressed, payouts)
- [ ] Run docker compose, watch dock UI for ingot stock turnover
- [ ] Verify player-side: HAULER_RESERVE=6 still leaves enough on shelf for a casual buy

🤖 Generated with [Claude Code](https://claude.com/claude-code)