### PR TITLE
fix(sim): autopilot smelt drop point + NPC↔NPC collision

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -4339,6 +4339,44 @@ void world_sim_step(world_t *w, float dt) {
         }
     }
 
+    /* NPC-NPC collision: same mass-symmetric resolution as player-player.
+     * Without this, AI ships happily phase through each other — most
+     * visibly when haulers stack on the same berth approach lane. Damage
+     * is attributed both ways so a careless rammer eats hull too. */
+    for (int i = 0; i < MAX_NPC_SHIPS; i++) {
+        npc_ship_t *a = &w->npc_ships[i];
+        if (!a->active || a->state == NPC_STATE_DOCKED) continue;
+        const hull_def_t *adef = npc_hull_def(a);
+        for (int j = i + 1; j < MAX_NPC_SHIPS; j++) {
+            npc_ship_t *b = &w->npc_ships[j];
+            if (!b->active || b->state == NPC_STATE_DOCKED) continue;
+            const hull_def_t *bdef = npc_hull_def(b);
+            float minimum = adef->ship_radius + bdef->ship_radius;
+            vec2 delta = v2_sub(a->pos, b->pos);
+            float d_sq = v2_len_sq(delta);
+            if (d_sq >= minimum * minimum) continue;
+            float d = sqrtf(d_sq);
+            vec2 normal = d > 0.00001f ? v2_scale(delta, 1.0f / d) : v2(1.0f, 0.0f);
+            float overlap = minimum - d;
+            a->pos = v2_add(a->pos, v2_scale(normal, overlap * 0.5f));
+            b->pos = v2_sub(b->pos, v2_scale(normal, overlap * 0.5f));
+            float rel_vel = v2_dot(v2_sub(a->vel, b->vel), normal);
+            if (rel_vel < 0.0f) {
+                float impact = -rel_vel;
+                vec2 impulse = v2_scale(normal, rel_vel * 0.6f);
+                a->vel = v2_sub(a->vel, impulse);
+                b->vel = v2_add(b->vel, impulse);
+                float dmg = collision_damage_for(impact, 0.7f);
+                if (dmg > 0.0f) {
+                    apply_npc_ship_damage_attributed(w, i, dmg,
+                        b->session_token, DEATH_CAUSE_RAM);
+                    apply_npc_ship_damage_attributed(w, j, dmg,
+                        a->session_token, DEATH_CAUSE_RAM);
+                }
+            }
+        }
+    }
+
     /* Player-NPC collision: same shape as player-player. Players push
      * NPCs around at full force (mass-symmetric), and ramming a hauler
      * costs both sides hull. NPC physics writes land on npc_ship_t for

--- a/server/sim_autopilot.c
+++ b/server/sim_autopilot.c
@@ -14,21 +14,111 @@
 /* Player autopilot — server-side AI driving the player's own ship    */
 /* ================================================================== */
 
-/* Find the nearest active station with an ore-buyer module — that's
- * where the autopilot will sell. */
-static int autopilot_find_refinery(const world_t *w, vec2 pos) {
+/* Map a ferrite/cuprite/crystal ore commodity to the matching furnace
+ * module type. Returns MODULE_COUNT when the commodity is not a smeltable
+ * ore (e.g. nothing towed yet). */
+static module_type_t furnace_for_ore(commodity_t ore) {
+    switch (ore) {
+        case COMMODITY_FERRITE_ORE: return MODULE_FURNACE;
+        case COMMODITY_CUPRITE_ORE: return MODULE_FURNACE_CU;
+        case COMMODITY_CRYSTAL_ORE: return MODULE_FURNACE_CR;
+        default: return MODULE_COUNT;
+    }
+}
+
+/* What ore commodity is the player carrying right now? Picks the first
+ * towed fragment's commodity. Returns COMMODITY_COUNT when nothing is
+ * towed. */
+static commodity_t autopilot_towed_commodity(const world_t *w, const server_player_t *sp) {
+    for (int t = 0; t < sp->ship.towed_count; t++) {
+        int idx = sp->ship.towed_fragments[t];
+        if (idx < 0 || idx >= MAX_ASTEROIDS) continue;
+        const asteroid_t *a = &w->asteroids[idx];
+        if (!a->active) continue;
+        return a->commodity;
+    }
+    return COMMODITY_COUNT;
+}
+
+/* True if the station has the furnace required to smelt `ore`. When `ore`
+ * is COMMODITY_COUNT (nothing towed), accept any furnace — we just need a
+ * place to land. */
+static bool station_can_smelt_ore(const station_t *st, commodity_t ore) {
+    module_type_t want = furnace_for_ore(ore);
+    if (want == MODULE_COUNT) {
+        return station_has_module(st, MODULE_FURNACE) ||
+               station_has_module(st, MODULE_FURNACE_CU) ||
+               station_has_module(st, MODULE_FURNACE_CR);
+    }
+    return station_has_module(st, want);
+}
+
+/* Compute the smelt-beam drop point for `ore` at `st`: the midpoint of a
+ * matching furnace and its nearest adjacent-ring module. Mirrors the
+ * pairing logic in step_furnace_smelting so the autopilot parks where
+ * fragments will actually be pulled in. Falls back to the station center
+ * when no furnace+silo pair exists. */
+static vec2 station_smelt_drop_point(const station_t *st, commodity_t ore) {
+    module_type_t want = furnace_for_ore(ore);
+    vec2 best_mid = st->pos;
+    float best_silo_d = 1e18f;
+    bool found = false;
+    for (int m = 0; m < st->module_count; m++) {
+        if (st->modules[m].scaffold) continue;
+        module_type_t mt = st->modules[m].type;
+        bool is_furn = (mt == MODULE_FURNACE) || (mt == MODULE_FURNACE_CU) || (mt == MODULE_FURNACE_CR);
+        if (!is_furn) continue;
+        if (want != MODULE_COUNT && mt != want) continue;
+        int ring = st->modules[m].ring;
+        vec2 furnace_pos = module_world_pos_ring(st, ring, st->modules[m].slot);
+        int adj_rings[2] = { ring + 1, ring - 1 };
+        for (int ri = 0; ri < 2; ri++) {
+            int adj = adj_rings[ri];
+            if (adj < 1 || adj > STATION_NUM_RINGS) continue;
+            for (int m2 = 0; m2 < st->module_count; m2++) {
+                if (st->modules[m2].ring != adj) continue;
+                if (st->modules[m2].scaffold) continue;
+                vec2 mp2 = module_world_pos_ring(st, adj, st->modules[m2].slot);
+                float d = v2_dist_sq(furnace_pos, mp2);
+                if (d < best_silo_d) {
+                    best_silo_d = d;
+                    best_mid = v2_scale(v2_add(furnace_pos, mp2), 0.5f);
+                    found = true;
+                }
+            }
+        }
+    }
+    return found ? best_mid : st->pos;
+}
+
+/* Find the nearest active station with a dock and a furnace that can
+ * smelt the player's currently-towed ore. When nothing is towed, falls
+ * back to any dock+furnace station so the ship still has somewhere to
+ * land for repair / find-target reset. */
+static int autopilot_find_refinery(const world_t *w, const server_player_t *sp) {
+    commodity_t ore = autopilot_towed_commodity(w, sp);
     int best = -1;
     float best_d = 1e18f;
     for (int s = 0; s < MAX_STATIONS; s++) {
         const station_t *st = &w->stations[s];
         if (!station_is_active(st)) continue;
         if (!station_has_module(st, MODULE_DOCK)) continue;
-        if (!station_has_module(st, MODULE_HOPPER) &&
-            !station_has_module(st, MODULE_FURNACE) &&
-            !station_has_module(st, MODULE_FURNACE_CU) &&
-            !station_has_module(st, MODULE_FURNACE_CR)) continue;
-        float d = v2_dist_sq(pos, st->pos);
+        if (!station_can_smelt_ore(st, ore)) continue;
+        float d = v2_dist_sq(sp->ship.pos, st->pos);
         if (d < best_d) { best_d = d; best = s; }
+    }
+    /* Last-resort fallback: any dock+any-furnace station. Keeps damaged
+     * ships with empty tow able to limp home even if no station matches
+     * the commodity filter. */
+    if (best < 0) {
+        for (int s = 0; s < MAX_STATIONS; s++) {
+            const station_t *st = &w->stations[s];
+            if (!station_is_active(st)) continue;
+            if (!station_has_module(st, MODULE_DOCK)) continue;
+            if (!station_can_smelt_ore(st, COMMODITY_COUNT)) continue;
+            float d = v2_dist_sq(sp->ship.pos, st->pos);
+            if (d < best_d) { best_d = d; best = s; }
+        }
     }
     return best;
 }
@@ -420,7 +510,7 @@ void step_autopilot(world_t *w, server_player_t *sp, float dt) {
             sp->autopilot_timer = 0.0f;
             break;
         }
-        int s = autopilot_find_refinery(w, sp->ship.pos);
+        int s = autopilot_find_refinery(w, sp);
         if (s < 0) {
             sp->autopilot_state = AUTOPILOT_STEP_FIND_TARGET;
             break;
@@ -430,29 +520,31 @@ void step_autopilot(world_t *w, server_player_t *sp, float dt) {
         /* Damage routing: if hull is below the repair threshold, this
          * is a "dock for repair" run; we approach the dock berth and
          * trigger interact when close. Otherwise it's a "drop fragments
-         * at the hopper" run; we just need to get within hopper-pull
-         * range, release the tractor, and head out again. */
+         * at the hopper" run; we park at the smelt drop point — the
+         * midpoint of the matching furnace + adjacent-ring silo — so
+         * fragments actually fall inside both pull radii. Targeting
+         * st->pos is wrong: with a station whose furnace+silo are off
+         * to one side, the spring tow keeps fragments at center and
+         * the silo never reaches them. */
         bool need_repair = autopilot_needs_repair(&sp->ship);
+        commodity_t towed_ore = autopilot_towed_commodity(w, sp);
+        vec2 smelt_pt = station_smelt_drop_point(st, towed_ore);
 
-        /* Fragments stay towed — furnace smelting claims them directly.
-         * Just fly close enough for furnace range. Standoff 200u
-         * puts the ship inside furnace pull range from ring 1 modules. */
         vec2 fly_target = need_repair
             ? station_approach_target(st, sp->ship.pos)
-            : st->pos;
+            : smelt_pt;
         nav_path_t *path = nav_player_path(sp->id);
         flight_cmd_t cmd = flight_steer_to(w, &sp->ship, path, fly_target,
-                                            need_repair ? 0.0f : 200.0f, 120.0f, dt);
+                                            need_repair ? 0.0f : 80.0f, 120.0f, dt);
         sp->input.turn = cmd.turn;
         sp->input.thrust = cmd.thrust;
         sp->input.mine = false;
-        float dist = sqrtf(v2_dist_sq(sp->ship.pos, st->pos));
+        float dist = sqrtf(v2_dist_sq(sp->ship.pos, smelt_pt));
 
-        /* Drop-and-leave path (no damage): once we've released the
-         * tractor and are inside the hopper area, we don't need to
-         * dock — the furnace beam smelts our fragments asynchronously
-         * and credits us directly. Just turn around and find the next
-         * mining target. */
+        /* Drop-and-leave path (no damage): once the smelter has consumed
+         * everything we towed in, head back out for another load. The
+         * furnace pulls fragments in while we hold position at the
+         * smelt point above. */
         if (!need_repair && sp->ship.towed_count == 0 && dist < 500.0f) {
             sp->autopilot_state = AUTOPILOT_STEP_FIND_TARGET;
             sp->autopilot_target = -1;

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -602,8 +602,10 @@ void step_furnace_smelting(world_t *w, float dt) {
             if (ore_value > 0.0f) {
                 uint8_t bc = by_contract ? 1 : 0;
                 if (tower >= 0) {
+                    float credited = 0.0f;
                     if (w->players[tower].session_ready)
-                        ledger_credit_supply(st, w->players[tower].session_token, graded_value);
+                        credited = ledger_credit_supply_amount(st, w->players[tower].session_token, graded_value);
+                    w->players[tower].ship.stat_credits_earned += credited;
                     emit_event(w, (sim_event_t){
                         .type = SIM_EVENT_SELL, .player_id = tower,
                         .sell = { .station = smelt_station, .grade = (uint8_t)grade,
@@ -611,8 +613,10 @@ void step_furnace_smelting(world_t *w, float dt) {
                                   .by_contract = bc }});
                     if (fracturer >= 0 && fracturer != tower) {
                         float finders = graded_value * 0.25f;
+                        float fcredited = 0.0f;
                         if (w->players[fracturer].session_ready)
-                            ledger_credit_supply(st, w->players[fracturer].session_token, finders);
+                            fcredited = ledger_credit_supply_amount(st, w->players[fracturer].session_token, finders);
+                        w->players[fracturer].ship.stat_credits_earned += fcredited;
                         emit_event(w, (sim_event_t){
                             .type = SIM_EVENT_SELL, .player_id = fracturer,
                             .sell = { .station = smelt_station, .grade = (uint8_t)grade,
@@ -622,8 +626,10 @@ void step_furnace_smelting(world_t *w, float dt) {
                     }
                 } else if (fracturer >= 0) {
                     float half = graded_value * 0.5f;
+                    float credited = 0.0f;
                     if (w->players[fracturer].session_ready)
-                        ledger_credit_supply(st, w->players[fracturer].session_token, half);
+                        credited = ledger_credit_supply_amount(st, w->players[fracturer].session_token, half);
+                    w->players[fracturer].ship.stat_credits_earned += credited;
                     emit_event(w, (sim_event_t){
                         .type = SIM_EVENT_SELL, .player_id = fracturer,
                         .sell = { .station = smelt_station, .grade = (uint8_t)grade,

--- a/src/tests/test_navigation.c
+++ b/src/tests/test_navigation.c
@@ -221,13 +221,11 @@ TEST(test_autopilot_completes_mining_cycle) {
 
     run_autopilot_ticks(w, &w->players[0], 90.0f);
 
-    /* Should have earned credits in 90s of autopilot. Currently flaky
-     * (known autopilot hover/overshoot bug, separate from this slice),
-     * so logged as [WARN] rather than asserted. Promote to ASSERT once
-     * autopilot is fixed — the suite previously hid real regressions
-     * here. */
-    if (w->players[0].ship.stat_credits_earned <= earned_before)
-        TEST_WARN("no credits earned in 90s (autopilot flake, track separately)");
+    /* A full mining cycle (find → mine → return → smelt) should pay out
+     * within 90 sim-seconds. Asserted; promoted from [WARN] once #345
+     * landed (autopilot was parking at station center where the silo
+     * couldn't reach the towed fragments). */
+    ASSERT(w->players[0].ship.stat_credits_earned > earned_before);
     /* w auto-freed by WORLD_HEAP cleanup */
 }
 
@@ -296,19 +294,16 @@ TEST(test_autopilot_multiple_players) {
         earned_start[p] = w->players[p].ship.stat_credits_earned;
     }
 
-    for (int i = 0; i < 90 * 120; i++) {
+    for (int i = 0; i < 180 * 120; i++) {
         world_sim_step(w, 1.0f / 120.0f);
     }
 
-    /* At least 2 of 3 should have earned credits in 180s. Same flaky
-     * autopilot bug as test_autopilot_completes_mining_cycle — logged
-     * rather than asserted until the root cause lands. */
+    /* At least 2 of 3 should have earned credits in 180s. */
     int earned = 0;
     for (int p = 0; p < 3; p++) {
         if (w->players[p].ship.stat_credits_earned > earned_start[p]) earned++;
     }
-    if (earned < 2)
-        TEST_WARNF("only %d/3 autopilot players earned credits in 180s (autopilot flake)", earned);
+    ASSERT(earned >= 2);
 
     /* All should still be alive (hull > 0 or docked). */
     for (int p = 0; p < 3; p++) {
@@ -356,13 +351,14 @@ TEST(test_autopilot_follows_path_waypoints) {
             }
         }
 
-        /* Ship should have passed within 150u of each waypoint
-         * (80u is the advancement threshold, 150u gives margin).
-         * Logged rather than asserted — autopilot flake as above. */
-        for (int j = 0; j < wp_count; j++) {
+        /* Ship should have passed within 150u of each intermediate
+         * waypoint (80u is the advancement threshold, 150u gives margin).
+         * The final waypoint IS the mining target — the ship parks at
+         * the asteroid's mining standoff (radius + 120u) and never
+         * approaches within 150u, so exclude it from the check. */
+        for (int j = 0; j < wp_count - 1; j++) {
             float min_dist = sqrtf(closest[j]);
-            if (min_dist > 150.0f)
-                TEST_WARNF("waypoint %d: closest approach %.0fu (expected <150u, autopilot flake)", j, min_dist);
+            ASSERT(min_dist <= 150.0f);
         }
     }
     /* w auto-freed by WORLD_HEAP cleanup */


### PR DESCRIPTION
## Summary
- **#345 autopilot reliability**: RETURN_TO_REFINERY now parks at the matching furnace+silo midpoint instead of station center (silo was 343u from fragments parked at center on Prospect's layout, so smelt never engaged). Refinery picker filters by towed-ore commodity.
- **stat_credits_earned**: smelt-time supplier credits now bump the lifetime-earnings stat to mirror the dock-sell path. Without this, every credit earned via tractor delivery was invisible to highscores.
- **NPC↔NPC collision**: added the missing pass. Player↔player and player↔NPC existed; NPCs phased through each other.
- **Tests**: three `[WARN]`-only autopilot tests promoted to hard `ASSERT` (closes #345's acceptance criteria). Multi-player loop matched to its 180s comment. Waypoint test excludes the final (target) waypoint since the ship parks at mining standoff.

## Test plan
- [x] `make test` — 337/337 passing, 0 warnings
- [ ] Local docker compose: confirm autopilot players earn credits and NPCs bounce off each other
- [ ] Verify HUD highscores reflect smelt income in singleplayer

🤖 Generated with [Claude Code](https://claude.com/claude-code)