### PR TITLE
feat(trade): per-row sell mirrors per-row buy

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -994,8 +994,107 @@ static void manifest_mark_station_dirty(world_t *w, manifest_t *touched) {
     }
 }
 
+/* Sell exactly one (commodity, grade) unit — the trade-tab per-row
+ * counterpart to `trade_apply_buy_row`. Pulls one cargo_unit_t from the
+ * ship manifest matching `grade` (or the FIFO-first matching commodity
+ * when `grade == MINING_GRADE_COUNT`), credits the player at this
+ * station's buy price + the unit's grade bonus, transfers the manifest
+ * entry to the station, and decrements the float cargo by one.
+ *
+ * Returns true when a unit actually sold, so the caller can skip the
+ * bulk path and not also drain the rest of the cargo. */
+static bool try_sell_one_unit(world_t *w, server_player_t *sp,
+                              commodity_t commodity, mining_grade_t grade) {
+    if (commodity >= COMMODITY_COUNT) return false;
+    /* Raw ore lives in towed fragments now (#259), not in ship.cargo,
+     * so it can't be sold by the per-row path. */
+    if (commodity < COMMODITY_RAW_ORE_COUNT) return false;
+    station_t *st = &w->stations[sp->current_station];
+    if (!station_consumes(st, commodity)) return false;
+    if (sp->ship.cargo[commodity] < 0.999f) return false; /* < 1 unit */
+    float capacity = MAX_PRODUCT_STOCK;
+    float space = fmaxf(0.0f, capacity - st->inventory[commodity]);
+    if (space < 0.999f) {
+        emit_event(w, (sim_event_t){
+            .type = SIM_EVENT_ORDER_REJECTED,
+            .player_id = sp->id,
+            .order_rejected = { .reason = ORDER_REJECT_SELL_INVENTORY_FULL },
+        });
+        return false;
+    }
+
+    /* Find the unit in the ship manifest. Specific-grade mode walks
+     * forward to the first match; "any" mode just takes the FIFO-first
+     * matching commodity (mirrors manifest_transfer_by_commodity_ex). */
+    int unit_idx = -1;
+    for (uint16_t u = 0; u < sp->ship.manifest.count; u++) {
+        const cargo_unit_t *cu = &sp->ship.manifest.units[u];
+        if (cu->commodity != commodity) continue;
+        if (grade < MINING_GRADE_COUNT && (mining_grade_t)cu->grade != grade) continue;
+        unit_idx = (int)u;
+        break;
+    }
+    /* Without a manifest unit we'd be selling provenance-less float
+     * cargo, which the player UI shouldn't have offered. Fall through
+     * to refusal (and keep the cargo) so we don't silently mint a
+     * common-grade payout that breaks the chain. */
+    if (unit_idx < 0) return false;
+
+    mining_grade_t actual_grade = (mining_grade_t)sp->ship.manifest.units[unit_idx].grade;
+    float price = station_buy_price(st, commodity);
+    float mult = mining_payout_multiplier(actual_grade);
+    float graded_price = price * mult;
+    int base_cr = (int)lroundf(price);
+    int bonus_cr = (int)lroundf(graded_price - price);
+
+    /* Move the unit + 1.0 float across. The transfer helper finds the
+     * same FIFO unit we did so the index match is fine; we only used
+     * `unit_idx` to confirm presence. */
+    int moved = manifest_transfer_by_commodity_ex(&sp->ship.manifest,
+                                                   &st->manifest,
+                                                   commodity,
+                                                   grade < MINING_GRADE_COUNT ? grade : MINING_GRADE_COUNT,
+                                                   1);
+    if (moved <= 0) return false;
+    sp->ship.cargo[commodity] -= 1.0f;
+    if (sp->ship.cargo[commodity] < 0.0f) sp->ship.cargo[commodity] = 0.0f;
+    st->inventory[commodity] += 1.0f;
+    if (st->inventory[commodity] > MAX_PRODUCT_STOCK)
+        st->inventory[commodity] = MAX_PRODUCT_STOCK;
+    manifest_mark_station_dirty(w, &st->manifest);
+
+    st->credit_pool -= graded_price;
+    ledger_earn(st, sp->session_token, graded_price);
+    sp->ship.stat_credits_earned += graded_price;
+    SIM_LOG("[sim] player %d sold 1× %s (grade %d) for %.0f cr at %s\n",
+            sp->id, commodity_short_name(commodity), (int)actual_grade,
+            graded_price, st->name);
+    emit_event(w, (sim_event_t){
+        .type = SIM_EVENT_SELL, .player_id = sp->id,
+        .sell = { .station = sp->current_station,
+                  .grade = (uint8_t)actual_grade,
+                  .base_cr = base_cr,
+                  .bonus_cr = bonus_cr,
+                  .by_contract = 0 }});
+    return true;
+}
+
 static void try_sell_station_cargo(world_t *w, server_player_t *sp) {
     station_t *st = &w->stations[sp->current_station];
+
+    /* Per-row sell: trade-tab click on a single grade row drops exactly
+     * one unit — same cadence as the buy hotkeys. Bypasses the bulk
+     * path below so the rest of the hold stays put. */
+    if (sp->input.service_sell_one) {
+        commodity_t commodity = sp->input.service_sell_only;
+        mining_grade_t grade  = sp->input.service_sell_grade;
+        try_sell_one_unit(w, sp, commodity, grade);
+        sp->input.service_sell_only = COMMODITY_COUNT;
+        sp->input.service_sell_grade = MINING_GRADE_COUNT;
+        sp->input.service_sell_one = false;
+        return;
+    }
+
     float payout = 0.0f;
     /* M7: track whether any of the accepted deliveries landed against an
      * active contract so the client's sell FX can tint yellow. */
@@ -1166,6 +1265,8 @@ static void try_sell_station_cargo(world_t *w, server_player_t *sp) {
     /* Clear the one-shot filter so the next plain SELL_CARGO press
      * resumes the default "deliver all" behavior. */
     sp->input.service_sell_only = COMMODITY_COUNT;
+    sp->input.service_sell_grade = MINING_GRADE_COUNT;
+    sp->input.service_sell_one = false;
 }
 
 static void try_repair_ship(world_t *w, server_player_t *sp) {
@@ -4687,6 +4788,8 @@ void player_init_ship(server_player_t *sp, world_t *w) {
     /* Default to "deliver everything matching" — selective delivery
      * is opt-in via NET_ACTION_DELIVER_COMMODITY. */
     sp->input.service_sell_only = COMMODITY_COUNT;
+    sp->input.service_sell_grade = MINING_GRADE_COUNT;
+    sp->input.service_sell_one = false;
     sp->autopilot_mode = 0;
     sp->autopilot_state = 0;
     sp->autopilot_target = -1;

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -190,6 +190,15 @@ typedef struct {
      * delivery to that one commodity, so the player can keep e.g. their
      * crystal cargo while still delivering ferrite. */
     commodity_t service_sell_only;
+    /* Per-row sell mirror of the buy path. When `service_sell_one` is
+     * true the server sells exactly one (commodity, grade) unit per
+     * input message — matching the [1]/[2]/… buy hotkeys. Bulk paths
+     * (sell-all hotkey [S], contract delivery from the yard tab) leave
+     * `service_sell_one` false and continue draining everything that
+     * fits. `service_sell_grade` selects which manifest unit is
+     * dequeued; MINING_GRADE_COUNT means "any grade, FIFO". */
+    mining_grade_t service_sell_grade;
+    bool service_sell_one;
     bool service_repair;
     bool upgrade_mining;
     bool upgrade_hold;

--- a/server/net_protocol.h
+++ b/server/net_protocol.h
@@ -793,12 +793,27 @@ static inline void parse_input(const uint8_t *data, int len, input_intent_t *int
                 intent->scaffold_kit_module = (module_type_t)(action - NET_ACTION_BUY_SCAFFOLD_TYPED);
             }
             /* NET_ACTION_DELIVER_COMMODITY + commodity (70..70+COMMODITY_COUNT)
-             * — selective fulfillment from the contracts tab. Sets
-             * service_sell with a one-shot filter so try_sell_station_cargo
-             * only consumes the chosen commodity. */
+             * — selective fulfillment. Two callers share this action:
+             *   (a) Yard contracts tab [S] → sells everything matching
+             *       the contract's commodity. 4-byte message: 5th byte
+             *       defaults to MINING_GRADE_COUNT below ⇒ bulk.
+             *   (b) Trade tab per-row sell click → sells one unit of a
+             *       specific (commodity, grade). 5-byte message with
+             *       the 5th byte holding a grade index < GRADE_COUNT.
+             * The grade slot doubles as the sell-one switch: a real
+             * grade ⇒ single-unit sell, MINING_GRADE_COUNT ⇒ bulk. */
             else if (action >= NET_ACTION_DELIVER_COMMODITY && action < NET_ACTION_DELIVER_COMMODITY + COMMODITY_COUNT) {
                 intent->service_sell = true;
                 intent->service_sell_only = (commodity_t)(action - NET_ACTION_DELIVER_COMMODITY);
+                intent->service_sell_grade = MINING_GRADE_COUNT;
+                intent->service_sell_one = false;
+                if (len >= 5) {
+                    uint8_t g = data[4];
+                    if (g < MINING_GRADE_COUNT) {
+                        intent->service_sell_grade = (mining_grade_t)g;
+                        intent->service_sell_one = true;
+                    }
+                }
             }
             break;
         }

--- a/src/input.c
+++ b/src/input.c
@@ -494,9 +494,42 @@ static void sample_trade_picker(input_intent_t *intent) {
     if (row->kind == 0) {
         trade_apply_buy_row(intent, st, ship, row);
     } else if (row->kind == 1) {
+        /* Per-row sell — mirror of the buy click. One press = one unit
+         * of (commodity, grade). The bulk [S] hotkey still drains the
+         * hold, but clicking a specific row only nibbles the matching
+         * cargo_unit so the rest stays on board. */
+        if (LOCAL_PLAYER.ship.cargo[row->commodity] < 0.999f) {
+            set_notice("Out of %s.", commodity_short_name(row->commodity));
+            return;
+        }
         intent->service_sell = true;
         intent->service_sell_only = row->commodity;
-        set_notice("Selling %s %s...",
+        intent->service_sell_grade = row->grade;
+        intent->service_sell_one = true;
+        float price = (float)row->unit_price;
+        float bonus_mult = mining_payout_multiplier(row->grade);
+        float payout = price * bonus_mult;
+        LOCAL_PLAYER.ship.cargo[row->commodity] -= 1.0f;
+        if (LOCAL_PLAYER.ship.cargo[row->commodity] < 0.0f)
+            LOCAL_PLAYER.ship.cargo[row->commodity] = 0.0f;
+        if (!g.multiplayer_enabled) {
+            station_t *mst = &g.world.stations[LOCAL_PLAYER.current_station];
+            int idx = -1;
+            for (int li = 0; li < mst->ledger_count; li++) {
+                if (memcmp(mst->ledger[li].player_token,
+                           LOCAL_PLAYER.session_token, 8) == 0) { idx = li; break; }
+            }
+            if (idx < 0 && mst->ledger_count < 16) {
+                idx = mst->ledger_count++;
+                memcpy(mst->ledger[idx].player_token,
+                       LOCAL_PLAYER.session_token, 8);
+                mst->ledger[idx].balance = 0.0f;
+                mst->ledger[idx].lifetime_supply = 0.0f;
+            }
+            if (idx >= 0) mst->ledger[idx].balance += payout;
+        }
+        set_notice("+$%d  %s %s",
+                   (int)lroundf(payout),
                    mining_grade_label(row->grade),
                    commodity_short_name(row->commodity));
     }
@@ -809,6 +842,8 @@ input_intent_t sample_input_intent(void) {
     intent.plan_slot = -1;
     intent.cancel_planned_station = -1;
     intent.service_sell_only = COMMODITY_COUNT; /* default: deliver all */
+    intent.service_sell_grade = MINING_GRADE_COUNT; /* default: any grade */
+    intent.service_sell_one = false;
 
     sample_movement(&intent);
     sample_tractor(&intent);
@@ -913,8 +948,15 @@ void submit_input(const input_intent_t *intent, float dt) {
                 LOCAL_PLAYER.docked = false;
                 LOCAL_PLAYER.in_dock_range = false;
             }
-        } else if (intent->service_sell && intent->service_sell_only < COMMODITY_COUNT)
+        } else if (intent->service_sell && intent->service_sell_only < COMMODITY_COUNT) {
             g.pending_net_action = NET_ACTION_DELIVER_COMMODITY + (uint8_t)intent->service_sell_only;
+            /* Per-row sell rides the same 5th-byte slot as buy_grade.
+             * Server treats `grade < MINING_GRADE_COUNT` as the
+             * single-unit signal; bulk-sell branches keep the sentinel
+             * so the existing behavior is unchanged. */
+            if (intent->service_sell_one && intent->service_sell_grade < MINING_GRADE_COUNT)
+                g.pending_net_buy_grade = (uint8_t)intent->service_sell_grade;
+        }
         else if (intent->service_sell)
             g.pending_net_action = 3;
         else if (intent->service_repair)

--- a/src/tests/test_economy.c
+++ b/src/tests/test_economy.c
@@ -679,8 +679,60 @@ TEST(test_ship_total_cargo_kit_density) {
                     100.0f * REPAIR_KIT_CARGO_DENSITY + 5.0f, 0.001f);
 }
 
+/* Per-row sell mirrors per-row buy: one click sells one (commodity, grade)
+ * unit, the rest of the hold stays put. Pre-fix, [S] sold every grade of
+ * the row's commodity in one shot. */
+TEST(test_per_row_sell_drains_one_unit_only) {
+    WORLD_HEAP w = calloc(1, sizeof(world_t));
+    world_reset(w);
+    server_player_t *sp = &w->players[0];
+    player_init_ship(sp, w);
+    sp->connected = true;
+    sp->session_ready = true;
+    memset(sp->session_token, 0xAA, 8);
+
+    /* Dock at Helios — its laser/tractor fabs accept frame ingot input. */
+    int helios = -1;
+    for (int s = 0; s < MAX_STATIONS; s++) {
+        if (!station_is_active(&w->stations[s])) continue;
+        if (station_consumes(&w->stations[s], COMMODITY_FRAME)) { helios = s; break; }
+    }
+    ASSERT(helios >= 0);
+    sp->docked = true;
+    sp->current_station = (uint8_t)helios;
+    sp->ship.pos = w->stations[helios].pos;
+
+    /* Stuff three frame ingots into the hold + manifest, then ask the
+     * server to sell exactly one. */
+    sp->ship.cargo[COMMODITY_FRAME] = 3.0f;
+    cargo_unit_t u = {0};
+    u.commodity = COMMODITY_FRAME;
+    u.grade = (uint8_t)MINING_GRADE_COMMON;
+    for (int i = 0; i < 3; i++) {
+        sp->ship.manifest.units[sp->ship.manifest.count++] = u;
+    }
+
+    sp->input.service_sell = true;
+    sp->input.service_sell_only = COMMODITY_FRAME;
+    sp->input.service_sell_grade = MINING_GRADE_COMMON;
+    sp->input.service_sell_one = true;
+    world_sim_step(w, SIM_DT);
+
+    ASSERT_EQ_FLOAT(sp->ship.cargo[COMMODITY_FRAME], 2.0f, 0.001f);
+    ASSERT_EQ_INT(sp->ship.manifest.count, 2);
+    /* Issuing sell-all next pulls the rest in one go (regression: the
+     * sell-one branch must not stick after consuming). */
+    sp->input.service_sell = true;
+    sp->input.service_sell_only = COMMODITY_FRAME;
+    sp->input.service_sell_one = false;
+    sp->input.service_sell_grade = MINING_GRADE_COUNT;
+    world_sim_step(w, SIM_DT);
+    ASSERT_EQ_FLOAT(sp->ship.cargo[COMMODITY_FRAME], 0.0f, 0.001f);
+}
+
 void register_economy_basic_tests(void) {
     TEST_SECTION("\nEconomy tests:\n");
+    RUN(test_per_row_sell_drains_one_unit_only);
     RUN(test_station_production_yard_makes_frames);
     RUN(test_station_production_beamworks_makes_modules);
     RUN(test_station_repair_cost_no_damage);


### PR DESCRIPTION
## Summary
Trade-tab sell rows now sell one (commodity, grade) unit per click — same cadence as the buy rows. Bulk paths ([S] sell-all, yard contract delivery) are unchanged.

- **Wire**: the existing 5th `buy_grade` byte doubles as the sell grade when action is in `NET_ACTION_DELIVER_COMMODITY` range. A real grade ⇒ single-unit sell; `MINING_GRADE_COUNT` ⇒ bulk (legacy).
- **Server** (`try_sell_station_cargo` / new `try_sell_one_unit`): walks the manifest for the matching (commodity, grade) `cargo_unit_t`, prices it at station buy price × grade bonus, transfers exactly one unit + 1.0 float, emits a real-grade `SIM_EVENT_SELL`.
- **Client** (`sample_trade_picker`): sell-row click optimistically debits one unit + credits the station ledger so SP feels instant.

## Test plan
- [x] `make test` — 339/339 passing (new `test_per_row_sell_drains_one_unit_only`)
- [ ] Click sell row [1] in docked trade tab; only one ingot leaves the hold

🤖 Generated with [Claude Code](https://claude.com/claude-code)