### PR TITLE
chore: sweep dead SIGNAL_VOICE blocks + voice PCM ring buffer

### DIFF
--- a/shared/types.h
+++ b/shared/types.h
@@ -35,7 +35,6 @@ enum {
     MAX_SCAFFOLDS = 16,  /* uint8 index — see banner above (#285 to lift) */
     AUDIO_VOICE_COUNT = 24,
     AUDIO_MIX_FRAMES = 512,
-    AUDIO_VOICE_RING_FRAMES = 11025, /* ~250ms at 44.1kHz: PCM ring buffer for voice input */
 };
 
 enum {
@@ -577,14 +576,6 @@ typedef struct {
  * Should ADD samples (not overwrite). frames = sample frames, channels = 1 or 2. */
 typedef void (*audio_mix_callback_t)(float *buffer, int frames, int channels, void *user);
 
-/* Voice PCM input ring buffer: captures PCM from voicebox subprocess */
-typedef struct {
-    float samples[AUDIO_VOICE_RING_FRAMES * 2]; /* stereo (2-channel) ring buffer */
-    int write_pos;  /* write head: where mic input writes next */
-    int read_pos;   /* read head: where mixer reads next */
-    int sample_rate; /* 24kHz from voicebox; mixer resamples to output rate */
-} audio_voice_pcm_t;
-
 typedef struct {
     bool valid;
     uint32_t rng;
@@ -596,8 +587,6 @@ typedef struct {
     /* External audio sources mixed after SFX voices */
     audio_mix_callback_t mix_callback;
     void *mix_callback_user;
-    /* Voice PCM from voicebox subprocess */
-    audio_voice_pcm_t voice_pcm;
     float music_duck_target; /* 0.0 = full duck, 1.0 = no duck; smoothly interpolated */
     float music_duck_current;
 } audio_state_t;

--- a/src/audio.c
+++ b/src/audio.c
@@ -11,10 +11,6 @@
 #include <unistd.h>
 #endif
 
-#ifdef SIGNAL_VOICE
-#include "voice.h"
-#endif
-
 static uint32_t audio_rng_next(audio_state_t* a) {
     a->rng = (a->rng * 1664525u) + 1013904223u;
     return a->rng;
@@ -79,7 +75,6 @@ void audio_init(audio_state_t* a) {
     a->rng = 0xA11D0F5Du;
     a->music_duck_current = 1.0f;
     a->music_duck_target = 1.0f;
-    a->voice_pcm.sample_rate = 24000; /* kokoro default */
     saudio_setup(&(saudio_desc){
         .sample_rate = 44100,
         .num_channels = 2,
@@ -92,95 +87,12 @@ void audio_init(audio_state_t* a) {
         a->channels = saudio_channels();
         a->sample_rate = saudio_sample_rate();
     }
-#ifdef SIGNAL_VOICE
-    voice_pcm_init();
-#endif
 }
 
 void audio_step(audio_state_t* a, float dt) {
     if (a->mining_tick_cooldown > 0.0f) {
         a->mining_tick_cooldown = fmaxf(0.0f, a->mining_tick_cooldown - dt);
     }
-}
-
-/* Ring buffer utilities for voice PCM. Always defined — the ring is
-   always zero-init, so on OFF builds these return 0 and no I/O happens. */
-static int audio_voice_ring_available(audio_state_t* a) {
-    audio_voice_pcm_t* v = &a->voice_pcm;
-    if (v->write_pos >= v->read_pos) {
-        return v->write_pos - v->read_pos;
-    } else {
-        return AUDIO_VOICE_RING_FRAMES - v->read_pos + v->write_pos;
-    }
-}
-
-#ifdef SIGNAL_VOICE
-static int audio_voice_ring_space(audio_state_t* a) {
-    return AUDIO_VOICE_RING_FRAMES - audio_voice_ring_available(a) - 1;
-}
-#endif
-
-/* Resample a single voice PCM frame from voice_rate to output_rate.
- * Uses linear interpolation. */
-static float audio_resample_voice(audio_state_t* a, float* resample_phase) {
-    audio_voice_pcm_t* v = &a->voice_pcm;
-    if (audio_voice_ring_available(a) == 0) return 0.0f;
-
-    float ratio = (float)v->sample_rate / (float)a->sample_rate;
-
-    int src_idx = (int)(*resample_phase);
-    float frac = *resample_phase - (float)src_idx;
-    *resample_phase += ratio;
-
-    int read_idx = (v->read_pos + src_idx * 2) % (AUDIO_VOICE_RING_FRAMES * 2);
-    int read_idx_next = (read_idx + 2) % (AUDIO_VOICE_RING_FRAMES * 2);
-
-    float s0 = v->samples[read_idx];
-    float s1 = v->samples[read_idx_next];
-
-    return lerpf(s0, s1, frac);
-}
-
-/* Read pending PCM frames from voicebox pipe. Non-blocking, drops data if no space. */
-static void audio_voice_pcm_pull(audio_state_t* a) {
-#ifndef SIGNAL_VOICE
-    (void)a;
-#else
-    audio_voice_pcm_t* v = &a->voice_pcm;
-    int space = audio_voice_ring_space(a);
-    if (space < 1024) return; /* not enough buffered space */
-
-    /* Try to read PCM header + frames from voicebox fd 3 */
-    uint8_t header[4];
-    ssize_t nread = read(3, header, sizeof(header));
-    if (nread != 4) return;
-
-    uint32_t sr = (uint32_t)header[0] | ((uint32_t)header[1] << 8) |
-                  ((uint32_t)header[2] << 16) | ((uint32_t)header[3] << 24);
-    if (sr > 0 && sr < 96000) {
-        v->sample_rate = (int)sr;
-    }
-
-    /* Read interleaved float32 stereo samples */
-    float samples[512 * 2]; /* up to 512 frames */
-    int frames_to_read = (space / 2 - 4) / 2; /* leave headroom */
-    if (frames_to_read > 512) frames_to_read = 512;
-    if (frames_to_read <= 0) return;
-
-    nread = read(3, samples, frames_to_read * 2 * sizeof(float));
-    if (nread <= 0) return;
-
-    int frames_read = (int)(nread / (2 * sizeof(float)));
-    for (int i = 0; i < frames_read * 2; i++) {
-        int write_idx = (v->write_pos * 2 + i) % (AUDIO_VOICE_RING_FRAMES * 2);
-        v->samples[write_idx] = samples[i];
-    }
-    v->write_pos = (v->write_pos + frames_read) % AUDIO_VOICE_RING_FRAMES;
-
-    /* Update music duck target based on queue depth */
-    int queue = audio_voice_ring_available(a);
-    a->music_duck_target = (queue > 1000) ? 0.25f : 1.0f; /* ~6dB = 0.25x power */
-#endif
 }
 
 void audio_generate_stream(audio_state_t* a) {
@@ -194,10 +106,7 @@ void audio_generate_stream(audio_state_t* a) {
     a->sample_rate = sample_rate;
     const float sample_dt = 1.0f / (float)sample_rate;
 
-    audio_voice_pcm_pull(a);
-
     int frames_requested = saudio_expect();
-    float voice_resample_phase = 0.0f;
     while (frames_requested > 0) {
         int frames_to_mix = frames_requested > AUDIO_MIX_FRAMES ? AUDIO_MIX_FRAMES : frames_requested;
         memset(a->mix_buffer, 0, sizeof(float) * (size_t)(frames_to_mix * channels));
@@ -253,20 +162,6 @@ void audio_generate_stream(audio_state_t* a) {
             /* Apply music ducking: scale music channel by duck_current */
             for (int fi = 0; fi < frames_to_mix * channels; fi++) {
                 a->mix_buffer[fi] *= a->music_duck_current;
-            }
-        }
-
-        /* Mix in voice PCM (with resampling from 24kHz to output rate) */
-        if (audio_voice_ring_available(a) > 0) {
-            for (int fi = 0; fi < frames_to_mix; fi++) {
-                float voice_sample = audio_resample_voice(a, &voice_resample_phase);
-                if (channels == 1) {
-                    a->mix_buffer[fi] += voice_sample * 0.5f; /* scale down to avoid clipping */
-                } else {
-                    int base = fi * channels;
-                    a->mix_buffer[base + 0] += voice_sample * 0.5f;
-                    a->mix_buffer[base + 1] += voice_sample * 0.5f;
-                }
             }
         }
 

--- a/src/client.h
+++ b/src/client.h
@@ -330,8 +330,6 @@ typedef struct {
     float hail_ping_timer;       /* seconds since last ping, 0 = inactive */
     vec2  hail_ping_origin;      /* world-space origin (ship pos at press) */
     float hail_ping_range;       /* ship comm_range at press time */
-    /* Voice state emission throttle (≤1 Hz) */
-    float voice_state_emit_time;  /* last time STATE line was sent to voicebox */
     /* --- Camera --- */
     vec2 camera_pos;         /* smoothed camera position */
     bool camera_initialized;

--- a/src/main.c
+++ b/src/main.c
@@ -17,9 +17,6 @@
 #include "avatar.h"
 #include "mining_client.h"
 
-#ifdef SIGNAL_VOICE
-#include "voice.h"
-#endif
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
@@ -370,10 +367,6 @@ static void sim_on_dock(const sim_event_t *ev) {
         g.episode.stations_visited |= (1 << ds);
         if (g.episode.stations_visited == 7) /* all 3 */
             episode_trigger(&g.episode, 1); /* Ep 1: Kepler's Law */
-#ifdef SIGNAL_VOICE
-        const char *station_persona[] = {"prospect", "kepler", "helios"};
-        voice_event(station_persona[ds], "Docking clamps engaged.");
-#endif
     }
 }
 
@@ -383,13 +376,6 @@ static void sim_on_launch(const sim_event_t *ev) {
     g.screen_shake = fmaxf(g.screen_shake, 5.0f); /* launch kick */
     episode_trigger(&g.episode, 0); /* Ep 0: First Light */
     if (!g.music.playing && !g.music.loading) music_next_track(&g.music);
-#ifdef SIGNAL_VOICE
-    int ds = LOCAL_PLAYER.current_station;
-    if (ds >= 0 && ds < 3) {
-        const char *station_persona[] = {"prospect", "kepler", "helios"};
-        voice_event(station_persona[ds], "Departure clearance granted.");
-    }
-#endif
 }
 
 /* Roll the per-frame sale-fx + hint-bar batch state for one SELL event. */
@@ -423,28 +409,14 @@ static void sim_on_sell(const sim_event_t *ev) {
     mining_client_record_strike((mining_grade_t)ev->sell.grade, ev->sell.bonus_cr);
     int total = ev->sell.base_cr + ev->sell.bonus_cr;
     if (total > 0) sell_batch_accumulate(ev, total);
-#ifdef SIGNAL_VOICE
-    int station = ev->sell.station;
-    if (station >= 0 && station < 3) {
-        const char *station_persona[] = {"prospect", "kepler", "helios"};
-        char msg[64];
-        snprintf(msg, sizeof(msg), "Credits received: +%d.", total);
-        voice_event(station_persona[station], msg);
-    }
-#endif
 }
 
 static void sim_on_repair(const sim_event_t *ev) {
     if (ev_is_local(ev)) audio_play_repair(&g.audio);
-    /* TODO: SIGNAL_VOICE — sim_event_t has no `repair` member; need
-       a station id added to the repair event before this can fire.
-       Tracked as follow-up to Voice D. */
 }
 
 static void sim_on_upgrade(const sim_event_t *ev) {
     if (ev_is_local(ev)) audio_play_upgrade(&g.audio, ev->upgrade.upgrade);
-    /* TODO: SIGNAL_VOICE — sim_event_t.upgrade has only `upgrade`, no
-       station id; needs the upgrade event extended before voice can fire. */
 }
 
 static void sim_on_damage(const sim_event_t *ev) {
@@ -474,13 +446,6 @@ static void sim_on_damage(const sim_event_t *ev) {
             g.damage_dir_timer = 1.5f;
         }
     }
-#ifdef SIGNAL_VOICE
-    if (amount > 0) {
-        char msg[64];
-        snprintf(msg, sizeof(msg), "Hull breach detected. Damage: -%d.", amount);
-        voice_event("nav7", msg);
-    }
-#endif
 }
 
 static void sim_on_npc_kill(const sim_event_t *ev) {
@@ -507,13 +472,6 @@ static void sim_on_npc_kill(const sim_event_t *ev) {
                  "%s killed by %s", role, weapon);
     }
     g.kill_feed_timer = 3.0f;
-#ifdef SIGNAL_VOICE
-    if (you_killed) {
-        char msg[96];
-        snprintf(msg, sizeof(msg), "Hostile %s eliminated.", role);
-        voice_event("nav7", msg);
-    }
-#endif
 }
 
 static void sim_on_contract_complete(const sim_event_t *ev) {
@@ -523,8 +481,6 @@ static void sim_on_contract_complete(const sim_event_t *ev) {
     } else if (ev->contract_complete.action == CONTRACT_FRACTURE) {
         set_notice("Fracture contract complete.");
     }
-    /* TODO: SIGNAL_VOICE — sim_event_t.contract_complete has only
-       `action`, no destination-station id; needs the event extended. */
 }
 
 static void sim_on_scaffold_ready(const sim_event_t *ev) {
@@ -534,9 +490,6 @@ static void sim_on_scaffold_ready(const sim_event_t *ev) {
     set_notice("%s scaffold ready at %s.",
                module_type_name((module_type_t)mtype),
                g.world.stations[sidx].name);
-#ifdef SIGNAL_VOICE
-    voice_event("kepler", "Scaffold assembly complete. Ready for deployment.");
-#endif
 }
 
 static void sim_on_outpost_placed(const sim_event_t *ev) {
@@ -546,9 +499,6 @@ static void sim_on_outpost_placed(const sim_event_t *ev) {
     if (!ev_is_local(ev)) return;
     g.plan_target_station = ev->outpost_placed.slot;
     g.placement_target_station = ev->outpost_placed.slot;
-#ifdef SIGNAL_VOICE
-    voice_event("nav7", "Outpost foundation established.");
-#endif
 }
 
 /* Spawn the 8 shards + cinematic state for a death event. */
@@ -594,9 +544,6 @@ static void sim_on_death(const sim_event_t *ev) {
     episode_trigger(&g.episode, 9); /* Ep 9: Death */
     episode_save(&g.episode);
     music_enter_death(&g.music);
-#ifdef SIGNAL_VOICE
-    voice_event("nav7", "Signal lost. Wreckage detected. Initiating respawn protocol.");
-#endif
 }
 
 /* Pick the hail message: contextual > avatar MOTD > station hardcoded. */
@@ -633,17 +580,6 @@ static void sim_on_hail_response(const sim_event_t *ev) {
                (int)lroundf(ev->hail_response.credits), unit);
     onboarding_mark_hailed();
 
-#ifdef SIGNAL_VOICE
-    const char *station_persona[] = {"prospect", "kepler", "helios"};
-    if (hs >= 0 && hs < 3 && g.hail_message[0]) {
-        voice_event(station_persona[hs], g.hail_message);
-        /* Emit elaboration trigger with context */
-        const ship_t *ship = &LOCAL_PLAYER.ship;
-        const char *directive = "status_update";
-        if (ship->towed_count > 0) directive = "cargo_hold_full";
-        voice_ask(station_persona[hs], directive);
-    }
-#endif
 }
 
 static void sim_on_module_activated(const sim_event_t *ev) {
@@ -659,24 +595,12 @@ static void sim_on_module_activated(const sim_event_t *ev) {
     audio_play_commission(&g.audio);
     const char *module_name = module_type_name((module_type_t)ev->module_activated.module_type);
     set_notice("%s online.", module_name);
-#ifdef SIGNAL_VOICE
-    if (si >= 0 && si < 3) {
-        const char *station_persona[] = {"prospect", "kepler", "helios"};
-        char msg[96];
-        snprintf(msg, sizeof(msg), "%s commissioned and online.", module_name);
-        voice_event(station_persona[si], msg);
-    }
-#endif
 }
 
 static void sim_on_outpost_activated(const sim_event_t *ev) {
     (void)ev;
     if (!g.episode.watched[4]) episode_trigger(&g.episode, 4); /* Ep 4: Naming */
     audio_play_commission(&g.audio);
-    /* TODO: SIGNAL_VOICE — sim_event_t.outpost_activated has only
-       `slot`, not a station id mapped to a persona. Outposts (slot>=3)
-       have no persona configured today; needs persona registration
-       per outpost. */
 }
 
 static void sim_on_npc_spawned(const sim_event_t *ev) {
@@ -776,32 +700,6 @@ static void episode_per_frame(void) {
 }
 
 /* Emit ship state to voicebox for context-aware elaboration (≤1 Hz throttle) */
-#ifdef SIGNAL_VOICE
-static void voice_emit_state_throttled(float dt) {
-    g.voice_state_emit_time -= dt;
-    if (g.voice_state_emit_time > 0.0f) return;
-
-    g.voice_state_emit_time = 1.0f; /* throttle to 1 Hz */
-
-    /* Build STATE line with ship telemetry */
-    char state_buf[256];
-    const ship_t *ship = &LOCAL_PLAYER.ship;
-    const station_t *nearby = (LOCAL_PLAYER.nearby_station >= 0 && LOCAL_PLAYER.nearby_station < MAX_STATIONS)
-                              ? &g.world.stations[LOCAL_PLAYER.nearby_station] : NULL;
-
-    snprintf(state_buf, sizeof(state_buf),
-             "callsign=%s;sector=%d;hold=%.0f/%.0f;credits=%.0f;towing=%d%s",
-             LOCAL_PLAYER.callsign,
-             (int)(g.world.time / 60.0f) % 9,
-             ship_total_cargo(ship),
-             ship_cargo_capacity(ship),
-             player_current_balance(),
-             ship->towed_count,
-             nearby ? "" : "");
-
-    voice_state(state_buf);
-}
-#endif
 
 static void sim_step(float dt) {
     reset_step_feedback();
@@ -1097,9 +995,6 @@ static void init(void) {
     avatar_init();
     hull_fog_init();
 
-#ifdef SIGNAL_VOICE
-    voice_init();
-#endif
 
     g.pass_action.colors[0].load_action = SG_LOADACTION_CLEAR;
     g.pass_action.colors[0].clear_value = (sg_color){ 0.018f, 0.024f, 0.045f, 1.0f };
@@ -1800,9 +1695,6 @@ static void frame(void) {
      * path which fills the summary directly (see TODO in src/net.c). */
     if (!g.multiplayer_enabled) refresh_station_manifest_summaries();
 
-#ifdef SIGNAL_VOICE
-    voice_emit_state_throttled(frame_dt);
-#endif
 
     audio_generate_stream(&g.audio);
 
@@ -1815,9 +1707,6 @@ static void frame(void) {
 }
 
 static void cleanup(void) {
-#ifdef SIGNAL_VOICE
-    voice_quit();
-#endif
     avatar_shutdown();
     episode_shutdown(&g.episode);
     music_shutdown(&g.music);

--- a/src/onboarding.c
+++ b/src/onboarding.c
@@ -9,10 +9,6 @@
 #include "station_voice.h"
 #include "world_draw.h"
 #include "signal_model.h"  /* SIGNAL_BAND_OPERATIONAL threshold */
-#ifdef SIGNAL_VOICE
-/* voice_event removed with the voice subsystem; onboarding milestones
- * still surface as HUD/HINT text via the rest of the onboarding flow. */
-#endif
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif


### PR DESCRIPTION
## Summary
Follow-up to #471. The voice subsystem was deleted but `#ifdef SIGNAL_VOICE`-gated callsites and the audio voice-PCM ring buffer were left behind. Finishing the cleanup.

- `src/main.c`: 19 `#ifdef SIGNAL_VOICE` blocks gone (station hails, state-emit throttle, voice_init, the four stale TODO stubs).
- `src/audio.c`: voice PCM ring buffer gone — `audio_voice_ring_*`, `audio_resample_voice`, `audio_voice_pcm_pull`, and the empty mix branch.
- `shared/types.h`: `audio_voice_pcm_t`, `AUDIO_VOICE_RING_FRAMES`, `voice_pcm` field removed from `audio_state_t`.
- `src/client.h`: drop `voice_state_emit_time`.
- `src/onboarding.c`: drop orphaned SIGNAL_VOICE comment.

233 lines deleted, no behavior change.

## Test plan
- [x] `make test` — 340/340 passing
- [ ] Native + web build with audio still working

🤖 Generated with [Claude Code](https://claude.com/claude-code)