### PR TITLE
chore: drop dead station_voice references

### DIFF
--- a/src/hud.c
+++ b/src/hud.c
@@ -7,7 +7,6 @@
 #include "net.h"
 #include "net_sync.h"
 #include "onboarding.h"
-#include "station_voice.h"
 #include "world_draw.h"
 #include "avatar.h"
 #include "mining_client.h"

--- a/src/main.c
+++ b/src/main.c
@@ -241,7 +241,7 @@ static void step_notice_timer(float dt) {
 /* sync_world_to_globals removed — everything reads from g.world directly */
 
 /* ------------------------------------------------------------------ */
-/* Contextual hail: pick station-voiced message based on player state */
+/* Contextual hail: pick a station-authored message based on player state */
 /* ------------------------------------------------------------------ */
 
 static bool check_hail_condition(hail_cond_t cond) {
@@ -698,8 +698,6 @@ static void episode_per_frame(void) {
 
     /* Ep 4, 5, 7, 8 are now event-driven (see process_events) */
 }
-
-/* Emit ship state to voicebox for context-aware elaboration (≤1 Hz throttle) */
 
 static void sim_step(float dt) {
     reset_step_feedback();

--- a/src/station_voice.h
+++ b/src/station_voice.h
@@ -88,46 +88,6 @@ static STATION_VOICE_UNUSED const char *STATION_ONBOARD[3][VOICE_ONBOARD_COUNT] 
 };
 
 /* ------------------------------------------------------------------ */
-/* Docked context tips -indexed [station][tip_cycle]                 */
-/* ------------------------------------------------------------------ */
-
-enum {
-    DOCK_TIP_SELL,
-    DOCK_TIP_MARKET,
-    DOCK_TIP_SHIPYARD,
-    DOCK_TIP_LAUNCH,
-    DOCK_TIP_DEFAULT,
-    DOCK_TIP_COUNT,
-};
-
-static STATION_VOICE_UNUSED const char *STATION_DOCK_TIPS[3][DOCK_TIP_COUNT] = {
-    /* Prospect */
-    {
-        /* SELL    */ "Smelter's running. Tow fragments to the furnace.",
-        /* MARKET  */ "Want ingots? Check the market. Not cheap.",
-        /* SHIPYARD*/ "No shipyard here. Try Kepler.",
-        /* LAUNCH  */ "Belt's waiting. Launch when ready.",
-        /* DEFAULT */ "Switch tabs to see what's available.",
-    },
-    /* Kepler */
-    {
-        /* SELL    */ "Deliver ingots here. Check the contracts tab.",
-        /* MARKET  */ "Frames and ingots. Browse the market.",
-        /* SHIPYARD*/ "Shipyard's open. Order a kit from there.",
-        /* LAUNCH  */ "Mind the scaffold arm on the way out.",
-        /* DEFAULT */ "Switch tabs to see what's available.",
-    },
-    /* Helios */
-    {
-        /* SELL    */ "Copper and crystal smelting. Tow fragments here.",
-        /* MARKET  */ "We've got specialty alloys. Check the market.",
-        /* SHIPYARD*/ "No shipyard. Kepler handles kits.",
-        /* LAUNCH  */ "More out there than rocks.",
-        /* DEFAULT */ "Switch tabs to see what's available.",
-    },
-};
-
-/* ------------------------------------------------------------------ */
 /* NPC radio chatter -short one-liners near sprites                  */
 /* ------------------------------------------------------------------ */
 


### PR DESCRIPTION
## Summary
Tail end of the voice cleanup — orphaned text-table + comment refs left in `station_voice.h` and a few callsites.

- `STATION_DOCK_TIPS[3][...]` and the `DOCK_TIP_*` enum: defined but unread anywhere → gone.
- `src/hud.c`: dead `#include "station_voice.h"` removed.
- `src/main.c`: stale "voicebox" / "station-voiced" comment fragments updated.

`station_voice.h` itself stays — it still hosts `STATION_ONBOARD`, `NPC_CHATTER_*`, and the hail tables, all live.

(Branch name comes from a local post-commit hook that renamed it; the diff is just the dead-voice cleanup.)

## Test plan
- [x] `make test` — 340/340 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)