### PR TITLE
chore: emit compile_commands.json + symlink for clangd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
 
+# Always emit compile_commands.json so clangd / editor LSPs can resolve
+# include paths without per-developer config. The Makefile's `build`
+# target symlinks this into the repo root after configure.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Build-mode toggles. Exactly one of these may be ON at a time; with none
 # set, every target (server, test, client) is built.
 option(BUILD_TESTS_ONLY  "Only build the test executable"       OFF)

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ GENERATOR := $(shell command -v ninja >/dev/null 2>&1 && echo "-G Ninja")
 # --- Native desktop client ---
 build:
 	cmake $(GENERATOR) -S . -B build
+	@ln -sf build/compile_commands.json compile_commands.json
 	cmake --build build --target signal --parallel
 
 # --- Emscripten web client ---
@@ -19,6 +20,7 @@ build-web:
 # --- Headless game server ---
 build-server:
 	cmake $(GENERATOR) -S . -B build
+	@ln -sf build/compile_commands.json compile_commands.json
 	cmake --build build --target signal_server --parallel
 
 # --- Tests ---
@@ -33,6 +35,7 @@ TEST_QUIET := $(if $(TEST_VERBOSE),,--quiet)
 # introduced this. Keep -g for usable stack traces on failure.
 build-test:
 	cmake $(GENERATOR) -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS_DEBUG="-O2 -g"
+	@ln -sf build/compile_commands.json compile_commands.json
 	cmake --build build --target signal_test --parallel
 
 # Default `test` is serial — the suite has shared `/tmp/test_*.sav`


### PR DESCRIPTION
## Summary
- `set(CMAKE_EXPORT_COMPILE_COMMANDS ON)` in the top-level CMakeLists so every configure emits the database.
- `make build` / `build-server` / `build-test` symlink `build/compile_commands.json` into the repo root after configure.
- `compile_commands.json` is already in `.gitignore`, so the symlink is per-developer and doesn't get committed.

## Why
Editor LSPs (clangd, VSCode C/C++) had no way to discover the project's `-Ishared`, `-Iserver`, `-Isrc` flags without per-dev config. Every header touch produced a flood of "math_util.h not found" / "unknown type ship_t" / cascading-typename diagnostics that were entirely tooling noise — actual builds via cmake worked fine.

## Test plan
- [x] `make build` produces `compile_commands.json` symlink.
- [x] clangd resolves types in `game_sim.h` / `manifest.h` / `types.h`.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)