### PR TITLE
feat(economy): unify named_ingot into cargo_unit — single identity store

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -980,15 +980,15 @@ static int manifest_transfer_by_commodity(manifest_t *src, manifest_t *dst,
                                               MINING_GRADE_COUNT, n);
 }
 
-/* Flip station.named_ingots_dirty when a given manifest transfer affected
- * a station manifest. `named_ingots_dirty` doubles as the manifest-summary
+/* Flip station.manifest_dirty when a given manifest transfer affected
+ * a station manifest. `manifest_dirty` doubles as the manifest-summary
  * dirty flag for Phase 2 broadcasts; setting it here means every
  * transaction that moves provenance also pokes the MP summary. */
 static void manifest_mark_station_dirty(world_t *w, manifest_t *touched) {
     if (!w || !touched) return;
     for (int s = 0; s < MAX_STATIONS; s++) {
         if (&w->stations[s].manifest == touched) {
-            w->stations[s].named_ingots_dirty = true;
+            w->stations[s].manifest_dirty = true;
             return;
         }
     }
@@ -1311,7 +1311,7 @@ static void try_repair_ship(world_t *w, server_player_t *sp) {
             st->inventory[COMMODITY_REPAIR_KIT] = 0.0f;
         manifest_consume_by_commodity(&st->manifest,
                                       COMMODITY_REPAIR_KIT, from_station);
-        st->named_ingots_dirty = true;
+        st->manifest_dirty = true;
     }
 
     /* Cost = station retail on station-sourced kits + labor at non-shipyard. */
@@ -1365,7 +1365,7 @@ static void try_apply_ship_upgrade(world_t *w, server_player_t *sp, ship_upgrade
         st->inventory[comm] -= (float)from_station;
         if (st->inventory[comm] < 0.0f) st->inventory[comm] = 0.0f;
         manifest_consume_by_commodity(&st->manifest, comm, from_station);
-        st->named_ingots_dirty = true;
+        st->manifest_dirty = true;
     }
 
     switch (upgrade) {
@@ -4557,7 +4557,7 @@ void world_seed_station_manifests(world_t *w) {
         manifest_migrate_legacy_inventory(&w->stations[i].manifest,
                                           w->stations[i].inventory,
                                           COMMODITY_COUNT, origin);
-        w->stations[i].named_ingots_dirty = true;
+        w->stations[i].manifest_dirty = true;
     }
 }
 

--- a/server/main.c
+++ b/server/main.c
@@ -263,76 +263,82 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
         break;
     case NET_MSG_BUY_INGOT:
         /* RATi v2: purchase a specific named ingot from the docked
-         * station's stockpile. Payload: [type:1][pubkey:32]. */
+         * station's manifest. Payload: [type:1][pubkey:32]. The unit
+         * is transferred from station.manifest to ship.manifest with
+         * its full provenance (prefix_class, origin_station,
+         * mined_block, parent_merkle) preserved. */
         if (len >= 33 && world.players[pid].docked) {
             int sidx = world.players[pid].current_station;
             if (sidx < 0 || sidx >= MAX_STATIONS) break;
             station_t *st = &world.stations[sidx];
             ship_t *ship = &world.players[pid].ship;
             const uint8_t *pk = &data[1];
-            int slot = -1;
-            for (int i = 0; i < st->named_ingots_count; i++) {
-                if (memcmp(st->named_ingots[i].pubkey, pk, 32) == 0) { slot = i; break; }
-            }
+            int slot = manifest_find(&st->manifest, pk);
             if (slot < 0) break;
-            named_ingot_t *src = &st->named_ingots[slot];
+            cargo_unit_t *src = &st->manifest.units[slot];
+            if ((cargo_kind_t)src->kind != CARGO_KIND_INGOT) break;
             int price;
-            switch (src->prefix_class) {
+            switch ((ingot_prefix_t)src->prefix_class) {
             case INGOT_PREFIX_RATI:         price = INGOT_PRICE_RATI; break;
             case INGOT_PREFIX_COMMISSIONED: price = INGOT_PRICE_COMMISSIONED; break;
             case INGOT_PREFIX_ANONYMOUS:    price = 0; break;
             default:                        price = INGOT_PRICE_M; break;
             }
             if (price <= 0) break;
-            if (ship->hold_ingots_count >= SHIP_HOLD_INGOTS_MAX) break;
             /* Use ledger_spend so the credit pool stays conserved. */
             if (!ledger_spend(st, world.players[pid].session_token, (float)price, ship)) break;
-            /* Move ingot: append to hold, compact stockpile. */
-            ship->hold_ingots[ship->hold_ingots_count++] = *src;
-            *src = st->named_ingots[--st->named_ingots_count];
-            memset(&st->named_ingots[st->named_ingots_count], 0, sizeof(named_ingot_t));
-            st->named_ingots_dirty = true;
-            char cs[12]; mining_render_callsign(ship->hold_ingots[ship->hold_ingots_count - 1].pubkey, cs);
+            cargo_unit_t copy = *src;
+            if (!ship->manifest.units && !ship_manifest_bootstrap(ship)) break;
+            if (!manifest_push(&ship->manifest, &copy)) break;
+            (void)manifest_remove(&st->manifest, (uint16_t)slot, NULL);
+            st->manifest_dirty = true;
+            char cs[12]; mining_render_callsign(copy.pub, cs);
             char msg[96];
             snprintf(msg, sizeof(msg), "%s purchased %s for %d", world.players[pid].callsign, cs, price);
             signal_channel_post(&world, sidx, msg, "");
         }
         break;
     case NET_MSG_DELIVER_INGOT:
-        /* RATi v2: deposit a specific hold-ingot into the docked
-         * station's stockpile. Payload: [type:1][hold_index:1]. */
+        /* RATi v2: deposit a specific hold ingot into the docked
+         * station's manifest. Payload: [type:1][hold_index:1]. The
+         * index is into ship.manifest filtered by named ingots
+         * (kind == INGOT && prefix != ANONYMOUS). */
         if (len >= 2 && world.players[pid].docked) {
             int sidx = world.players[pid].current_station;
             if (sidx < 0 || sidx >= MAX_STATIONS) break;
             station_t *st = &world.stations[sidx];
             ship_t *ship = &world.players[pid].ship;
-            int hidx = data[1];
-            if (hidx < 0 || hidx >= ship->hold_ingots_count) break;
-            /* LRU evict on full stockpile, same path as smelt. */
-            if (st->named_ingots_count >= STATION_NAMED_INGOTS_MAX) {
-                int worst = 0;
-                uint64_t oldest = st->named_ingots[0].mined_block;
-                for (int k = 1; k < STATION_NAMED_INGOTS_MAX; k++) {
-                    if (st->named_ingots[k].mined_block < oldest) {
-                        oldest = st->named_ingots[k].mined_block;
-                        worst = k;
-                    }
-                }
-                char ev_cs[12]; mining_render_callsign(st->named_ingots[worst].pubkey, ev_cs);
-                char ev_msg[96];
-                snprintf(ev_msg, sizeof(ev_msg), "stockpile full — voided %s", ev_cs);
-                signal_channel_post(&world, sidx, ev_msg, "");
-                st->named_ingots[worst] = st->named_ingots[STATION_NAMED_INGOTS_MAX - 1];
-                st->named_ingots_count = STATION_NAMED_INGOTS_MAX - 1;
+            int target = data[1];
+            int hidx = -1;
+            int seen = 0;
+            for (uint16_t u = 0; u < ship->manifest.count; u++) {
+                const cargo_unit_t *cu = &ship->manifest.units[u];
+                if ((cargo_kind_t)cu->kind != CARGO_KIND_INGOT) continue;
+                if ((ingot_prefix_t)cu->prefix_class == INGOT_PREFIX_ANONYMOUS) continue;
+                if (seen == target) { hidx = (int)u; break; }
+                seen++;
             }
-            st->named_ingots[st->named_ingots_count++] = ship->hold_ingots[hidx];
-            ship->hold_ingots[hidx] = ship->hold_ingots[--ship->hold_ingots_count];
-            memset(&ship->hold_ingots[ship->hold_ingots_count], 0, sizeof(named_ingot_t));
+            if (hidx < 0) break;
+            cargo_unit_t copy = ship->manifest.units[hidx];
+            /* FIFO-evict the oldest manifest entry on full station, mirroring
+             * the smelt rotation path. The evicted unit's pubkey is voided
+             * so it can never be re-deposited. */
+            if (st->manifest.count >= st->manifest.cap) {
+                cargo_unit_t evicted = {0};
+                if (manifest_remove(&st->manifest, 0, &evicted) &&
+                    (ingot_prefix_t)evicted.prefix_class != INGOT_PREFIX_ANONYMOUS) {
+                    char ev_cs[12]; mining_render_callsign(evicted.pub, ev_cs);
+                    char ev_msg[96];
+                    snprintf(ev_msg, sizeof(ev_msg), "stockpile full — voided %s", ev_cs);
+                    signal_channel_post(&world, sidx, ev_msg, "");
+                }
+            }
+            if (!manifest_push(&st->manifest, &copy)) break;
+            (void)manifest_remove(&ship->manifest, (uint16_t)hidx, NULL);
             /* Pay delivery credit through the ledger so supply stays balanced. */
             ledger_credit_supply(st, world.players[pid].session_token, (float)INGOT_DELIVERY_CREDIT);
-            st->named_ingots_dirty = true;
-            const named_ingot_t *deposited = &st->named_ingots[st->named_ingots_count - 1];
-            char cs[12]; mining_render_callsign(deposited->pubkey, cs);
+            st->manifest_dirty = true;
+            char cs[12]; mining_render_callsign(copy.pub, cs);
             char msg[96];
             snprintf(msg, sizeof(msg), "%s delivered %s", world.players[pid].callsign, cs);
             signal_channel_post(&world, sidx, msg, "");
@@ -933,13 +939,15 @@ static void ev_handler(struct mg_connection *c, int ev, void *ev_data) {
             }
         }
 
-        /* RATi v2: per-station named-ingot stockpile snapshot. New
-         * client sees what's currently on offer at every station so
-         * the MARKET stockpile UI is populated immediately. */
+        /* RATi v2: per-station named-ingot snapshot, derived from the
+         * unified manifest. New client sees what's currently on offer
+         * at every station so the MARKET stockpile UI is populated
+         * immediately. Wire shape unchanged. */
         for (int sidx = 0; sidx < MAX_STATIONS; sidx++) {
-            if (world.stations[sidx].named_ingots_count <= 0) continue;
-            uint8_t buf[STATION_INGOTS_HEADER + STATION_NAMED_INGOTS_MAX * NAMED_INGOT_RECORD_SIZE];
+            if (!station_exists(&world.stations[sidx])) continue;
+            uint8_t buf[STATION_INGOTS_HEADER + 255 * NAMED_INGOT_RECORD_SIZE];
             int len = serialize_station_ingots(buf, sidx, &world.stations[sidx]);
+            if (len <= STATION_INGOTS_HEADER) continue;
             ws_send(c, buf, (size_t)len);
         }
 
@@ -1112,9 +1120,10 @@ static void broadcast_ship_states(void) {
         /* Full ship state sent only to the owning player. */
         ws_send(world.players[i].conn, buf, (size_t)len);
 
-        /* RATi v2: also push hold-ingot snapshot. Cheap (max 8 × 52B
-         * = 416B + header). Ride along with the per-player ship tick. */
-        uint8_t hbuf[HOLD_INGOTS_HEADER + SHIP_HOLD_INGOTS_MAX * NAMED_INGOT_RECORD_SIZE];
+        /* RATi v2: also push hold-ingot snapshot, derived from the
+         * ship manifest. Wire shape unchanged. Sized for the wire cap
+         * (u8 count) so an unusually full hold can't truncate. */
+        uint8_t hbuf[HOLD_INGOTS_HEADER + 255 * NAMED_INGOT_RECORD_SIZE];
         int hlen = serialize_hold_ingots(hbuf, &world.players[i].ship);
         ws_send(world.players[i].conn, hbuf, (size_t)hlen);
 
@@ -1471,13 +1480,14 @@ static void broadcast_dirty_station_data(uint64_t now, uint64_t *last_station_id
         }
         station_identity_dirty[s] = false;
     }
-    /* RATi v2: named-ingot stockpile + per-(commodity, grade) manifest
-     * summary. Smaller payload than identity (~3KB worst case) so we
-     * send to everyone regardless of signal range — MARKET is global. */
+    /* RATi v2: per-station named-ingot snapshot (derived from the
+     * unified manifest) + per-(commodity, grade) manifest summary.
+     * Smaller payload than identity (~3KB worst case) so we send to
+     * everyone regardless of signal range — MARKET is global. */
     for (int s = 0; s < MAX_STATIONS; s++) {
-        if (!world.stations[s].named_ingots_dirty) continue;
+        if (!world.stations[s].manifest_dirty) continue;
         if (!station_exists(&world.stations[s])) continue;
-        uint8_t buf[STATION_INGOTS_HEADER + STATION_NAMED_INGOTS_MAX * NAMED_INGOT_RECORD_SIZE];
+        uint8_t buf[STATION_INGOTS_HEADER + 255 * NAMED_INGOT_RECORD_SIZE];
         int len = serialize_station_ingots(buf, s, &world.stations[s]);
         for (int p = 0; p < MAX_PLAYERS; p++) {
             if (!world.players[p].connected || !world.players[p].conn) continue;
@@ -1490,7 +1500,7 @@ static void broadcast_dirty_station_data(uint64_t now, uint64_t *last_station_id
             if (!world.players[p].connected || !world.players[p].conn) continue;
             ws_send(world.players[p].conn, mbuf, (size_t)mlen);
         }
-        world.stations[s].named_ingots_dirty = false;
+        world.stations[s].manifest_dirty = false;
     }
 }
 

--- a/server/net_protocol.h
+++ b/server/net_protocol.h
@@ -248,34 +248,42 @@ static inline int serialize_asteroids_full(uint8_t *buf, const asteroid_t *aster
     return ASTEROID_MSG_HEADER + count * ASTEROID_RECORD_SIZE;
 }
 
-/* RATi v2 — write a single named ingot record into the buffer.
- * Layout matches the on-wire NAMED_INGOT_RECORD_SIZE definition. */
-static inline void write_named_ingot(uint8_t *p, const named_ingot_t *m) {
+/* RATi v2 — write a single named-ingot wire record from a cargo_unit_t.
+ * Layout matches the on-wire NAMED_INGOT_RECORD_SIZE definition.
+ * The wire shape is unchanged after the named_ingot_t -> cargo_unit_t
+ * unification — we just project the cargo_unit's named-ingot fields
+ * onto the same byte layout. */
+static inline void write_named_ingot_unit(uint8_t *p, const cargo_unit_t *u) {
     memset(p, 0, NAMED_INGOT_RECORD_SIZE);
-    memcpy(&p[0], m->pubkey, 32);
-    p[32] = m->prefix_class;
-    p[33] = m->metal;
+    memcpy(&p[0], u->pub, 32);
+    p[32] = u->prefix_class;
+    p[33] = u->commodity;
     /* p[34..35] pad */
-    for (int k = 0; k < 8; k++) p[36 + k] = (uint8_t)(m->mined_block >> (8 * k));
-    p[44] = m->origin_station;
+    for (int k = 0; k < 8; k++) p[36 + k] = (uint8_t)(u->mined_block >> (8 * k));
+    p[44] = u->origin_station;
     /* p[45..51] pad */
 }
 
-/* Per-station named-ingot stockpile snapshot. Sent on dock + on
- * stockpile change. */
+/* Per-station named-ingot snapshot. Walks the station manifest and
+ * surfaces every CARGO_KIND_INGOT unit whose prefix is non-anonymous
+ * (the rest are bulk fungibles already covered by the manifest summary).
+ * Cap at 255 (wire count is u8). */
 static inline int serialize_station_ingots(uint8_t *buf, int station_idx,
                                            const station_t *st) {
-    int n = st->named_ingots_count;
-    if (n < 0) n = 0;
-    if (n > STATION_NAMED_INGOTS_MAX) n = STATION_NAMED_INGOTS_MAX;
-    if (n > 255) n = 255; /* count fits in u8 */
+    int n = 0;
     buf[0] = NET_MSG_STATION_INGOTS;
     buf[1] = (uint8_t)station_idx;
-    buf[2] = (uint8_t)n;
-    for (int i = 0; i < n; i++) {
-        uint8_t *p = &buf[STATION_INGOTS_HEADER + i * NAMED_INGOT_RECORD_SIZE];
-        write_named_ingot(p, &st->named_ingots[i]);
+    if (st->manifest.units) {
+        for (uint16_t i = 0; i < st->manifest.count && n < 255; i++) {
+            const cargo_unit_t *u = &st->manifest.units[i];
+            if ((cargo_kind_t)u->kind != CARGO_KIND_INGOT) continue;
+            if ((ingot_prefix_t)u->prefix_class == INGOT_PREFIX_ANONYMOUS) continue;
+            uint8_t *p = &buf[STATION_INGOTS_HEADER + n * NAMED_INGOT_RECORD_SIZE];
+            write_named_ingot_unit(p, u);
+            n++;
+        }
     }
+    buf[2] = (uint8_t)n;
     return STATION_INGOTS_HEADER + n * NAMED_INGOT_RECORD_SIZE;
 }
 
@@ -352,17 +360,23 @@ static inline int serialize_player_manifest(uint8_t *buf, const ship_t *ship) {
     return PLAYER_MANIFEST_HEADER + n * PLAYER_MANIFEST_ENTRY;
 }
 
-/* Local player's hold-ingot snapshot. Sent on contents change. */
+/* Local player's hold-ingot snapshot, derived from the ship manifest.
+ * Walks ship.manifest for non-anonymous CARGO_KIND_INGOT units. Cap at
+ * 255 (wire count is u8). */
 static inline int serialize_hold_ingots(uint8_t *buf, const ship_t *ship) {
-    int n = ship->hold_ingots_count;
-    if (n < 0) n = 0;
-    if (n > SHIP_HOLD_INGOTS_MAX) n = SHIP_HOLD_INGOTS_MAX;
+    int n = 0;
     buf[0] = NET_MSG_HOLD_INGOTS;
-    buf[1] = (uint8_t)n;
-    for (int i = 0; i < n; i++) {
-        uint8_t *p = &buf[HOLD_INGOTS_HEADER + i * NAMED_INGOT_RECORD_SIZE];
-        write_named_ingot(p, &ship->hold_ingots[i]);
+    if (ship && ship->manifest.units) {
+        for (uint16_t i = 0; i < ship->manifest.count && n < 255; i++) {
+            const cargo_unit_t *u = &ship->manifest.units[i];
+            if ((cargo_kind_t)u->kind != CARGO_KIND_INGOT) continue;
+            if ((ingot_prefix_t)u->prefix_class == INGOT_PREFIX_ANONYMOUS) continue;
+            uint8_t *p = &buf[HOLD_INGOTS_HEADER + n * NAMED_INGOT_RECORD_SIZE];
+            write_named_ingot_unit(p, u);
+            n++;
+        }
     }
+    buf[1] = (uint8_t)n;
     return HOLD_INGOTS_HEADER + n * NAMED_INGOT_RECORD_SIZE;
 }
 

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -877,7 +877,7 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                     int whole = (int)floorf(take + 0.0001f);
                     if (whole > 0) {
                         if (station_manifest_drain_commodity(home, ingot, whole) > 0)
-                            home->named_ingots_dirty = true;
+                            home->manifest_dirty = true;
                     }
                 }
             } else {
@@ -928,7 +928,7 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                         int whole = (int)floorf(take + 0.0001f);
                         if (whole > 0) {
                             if (station_manifest_drain_commodity(home, best_ingot, whole) > 0)
-                                home->named_ingots_dirty = true;
+                                home->manifest_dirty = true;
                         }
                     }
                 }
@@ -998,7 +998,7 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                 if (int_delta > 0) {
                     if (station_manifest_seed_from_npc(dest, (commodity_t)i,
                                                        int_delta, n) > 0)
-                        dest->named_ingots_dirty = true;
+                        dest->manifest_dirty = true;
                 }
                 /* Pay the NPC for fulfilling a contract. Walk active
                  * TRACTOR contracts at this destination for the same
@@ -1054,7 +1054,7 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                         if (whole > 0) {
                             manifest_consume_by_commodity(&dest->manifest,
                                                           (commodity_t)c, whole);
-                            dest->named_ingots_dirty = true;
+                            dest->manifest_dirty = true;
                         }
                     }
                 }
@@ -1109,7 +1109,7 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                         home->inventory[COMMODITY_REPAIR_KIT] = 0.0f;
                     if (manifest_consume_by_commodity(&home->manifest,
                                                      COMMODITY_REPAIR_KIT, apply) > 0)
-                        home->named_ingots_dirty = true;
+                        home->manifest_dirty = true;
                     /* Write through ship layer; reverse-mirror at
                      * end of the NPC tick pushes the value back to
                      * npc->hull. */
@@ -1137,7 +1137,7 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                 home->inventory[COMMODITY_REPAIR_KIT] -= 1.0f;
                 if (manifest_consume_by_commodity(&home->manifest,
                                                   COMMODITY_REPAIR_KIT, 1) > 0)
-                    home->named_ingots_dirty = true;
+                    home->manifest_dirty = true;
             }
         }
         break;

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -58,7 +58,7 @@ static bool station_manifest_push_ingot(station_t *st, const cargo_unit_t *unit)
     /* Phase 2: flag dirty on every successful push so the manifest-
      * summary broadcast runs after smelts too (not just rotations). */
     if (manifest_push(&st->manifest, unit)) {
-        st->named_ingots_dirty = true;
+        st->manifest_dirty = true;
         return true;
     }
     return false;
@@ -526,9 +526,6 @@ void step_furnace_smelting(world_t *w, float dt) {
         if (a->smelt_progress >= 1.0f && smelt_station >= 0) {
             station_t *st = &w->stations[smelt_station];
             fracture_claim_state_t *claim_state = &w->fracture_claims[i];
-            cargo_unit_t named_unit = {0};
-            bool have_named_unit = false;
-            int prefix = MINING_CLASS_ANONYMOUS;
             /* L11: fill legacy fragment_pub up-front so the compat shim is
              * visible at the top of the block regardless of code flow. */
             if (fragment_pub_is_zero(a))
@@ -669,11 +666,10 @@ void step_furnace_smelting(world_t *w, float dt) {
             if (st->inventory[output] > MAX_PRODUCT_STOCK)
                 st->inventory[output] = MAX_PRODUCT_STOCK;
 
-            /* Dual-write discrete units for the floored stock delta so
-             * manifest counts stay aligned with the legacy float path.
-             * Compute the leading-unit hash only when we actually cross
-             * an integer boundary — skips a sha256 per tick on partial
-             * smelts. */
+            /* Push one manifest unit per integer of finished ingot
+             * smelted. Each unit carries its own prefix_class derived
+             * from base58(pub); this is the single identity store now —
+             * the legacy named_ingots[] dual store was removed. */
             {
                 /* The furnace beam-engagement check (above) guarantees
                  * stock_before + a->ore <= MAX_PRODUCT_STOCK, so the
@@ -682,75 +678,44 @@ void step_furnace_smelting(world_t *w, float dt) {
                 int units_before = (int)floorf(stock_before + 0.0001f);
                 int units_after = (int)floorf(st->inventory[output] + 0.0001f);
                 int manifest_units = units_after - units_before;
-                if (manifest_units > 0) {
-                    have_named_unit = hash_ingot(output, grade, a->fragment_pub,
-                                                 0, &named_unit);
-                    if (have_named_unit)
-                        prefix = mining_pubkey_class(named_unit.pub);
-                }
                 int pushed = 0;
+                int first_named_idx = -1;
                 for (int idx = 0; idx < manifest_units; idx++) {
                     cargo_unit_t unit = {0};
                     if (!hash_ingot(output, grade, a->fragment_pub, (uint16_t)idx, &unit))
                         continue;
+                    /* Stamp origin so the unit can be traced back to this
+                     * refinery without a side table. mined_block is filled
+                     * after-the-fact for the first non-anonymous unit (so
+                     * the signal_channel post is the chain anchor). */
+                    unit.origin_station = (uint8_t)smelt_station;
                     if (!station_manifest_push_ingot(st, &unit))
                         break;
                     pushed++;
+                    if (first_named_idx < 0 &&
+                        (ingot_prefix_t)unit.prefix_class != INGOT_PREFIX_ANONYMOUS) {
+                        first_named_idx = (int)st->manifest.count - 1;
+                    }
                 }
-                /* Mark dirty so the MP broadcast loop forwards the new
-                 * STATION_MANIFEST. Without this, smelts that didn't
-                 * mint a RATi-class named_unit (the common case) never
-                 * triggered a broadcast — clients kept reading stale
-                 * counts and the supply strip / TRADE picker never
-                 * reflected the new ingot stock. */
-                if (pushed > 0) st->named_ingots_dirty = true;
+                if (pushed > 0) st->manifest_dirty = true;
                 SIM_LOG("[smelt] station %d %s grade=%d ore=%.2f units=%d pushed=%d\n",
                         smelt_station, commodity_short_name(output),
                         (int)grade, a->ore, manifest_units, pushed);
-            }
 
-            /* RATi v2 compatibility: mirror the first hashed ingot into
-             * the legacy named-ingot stockpile when it carries a class
-             * prefix. This keeps the transition path aligned with the
-             * manifest unit identity instead of inventing a second pub. */
-            if (have_named_unit && prefix != MINING_CLASS_ANONYMOUS) {
-                /* If the stockpile is full, LRU-evict the entry with
-                 * the smallest mined_block (oldest first). The evicted
-                 * pubkey is voided to the chain so it can never be
-                 * re-deposited, keeping namespace honest. */
-                if (st->named_ingots_count >= STATION_NAMED_INGOTS_MAX) {
-                    int worst = 0;
-                    uint64_t oldest = st->named_ingots[0].mined_block;
-                    for (int k = 1; k < STATION_NAMED_INGOTS_MAX; k++) {
-                        if (st->named_ingots[k].mined_block < oldest) {
-                            oldest = st->named_ingots[k].mined_block;
-                            worst = k;
-                        }
-                    }
-                    char ev_cs[12];
-                    mining_render_callsign(st->named_ingots[worst].pubkey, ev_cs);
-                    char ev_msg[96];
-                    snprintf(ev_msg, sizeof(ev_msg),
-                             "stockpile full — voided %s", ev_cs);
-                    signal_channel_post(w, smelt_station, ev_msg, "");
-                    /* Compact: move last into evicted slot. */
-                    st->named_ingots[worst] = st->named_ingots[STATION_NAMED_INGOTS_MAX - 1];
-                    st->named_ingots_count = STATION_NAMED_INGOTS_MAX - 1;
+                /* Announce the first named ingot on the station signal
+                 * channel and stamp the resulting block id back onto the
+                 * manifest unit. This replaces the old named_ingot_t
+                 * stockpile mirror — the unit IS the named-ingot record. */
+                if (first_named_idx >= 0 &&
+                    first_named_idx < (int)st->manifest.count) {
+                    cargo_unit_t *u = &st->manifest.units[first_named_idx];
+                    char cs[12];
+                    mining_render_callsign(u->pub, cs);
+                    char text[96];
+                    snprintf(text, sizeof(text), "smelted %s", cs);
+                    u->mined_block = signal_channel_post(w, smelt_station, text, "");
                 }
-
-                named_ingot_t *ing = &st->named_ingots[st->named_ingots_count++];
-                memset(ing, 0, sizeof(*ing));
-                memcpy(ing->pubkey, named_unit.pub, 32);
-                ing->prefix_class   = (uint8_t)prefix;
-                ing->metal          = (uint8_t)ingot;
-                ing->origin_station = (uint8_t)smelt_station;
-
-                char cs[12];
-                mining_render_callsign(named_unit.pub, cs);
-                char text[96];
-                snprintf(text, sizeof(text), "smelted %s", cs);
-                ing->mined_block = signal_channel_post(w, smelt_station, text, "");
-                st->named_ingots_dirty = true;
+                (void)ingot; /* unused now — kept above for the inventory write */
             }
 
             clear_asteroid(a);
@@ -964,7 +929,7 @@ void step_module_delivery(world_t *w, station_t *st, int station_idx,
             int whole = (int)floorf(deliver + 0.0001f);
             if (whole > 0) {
                 int drained = manifest_consume_by_commodity(&st->manifest, mat, whole);
-                if (drained > 0) st->named_ingots_dirty = true;
+                if (drained > 0) st->manifest_dirty = true;
             }
         }
 
@@ -1037,7 +1002,7 @@ void step_dock_repair_kit_fab(world_t *w, float dt) {
                 unit.recipe_id = (uint16_t)RECIPE_REPAIR_KIT_FAB;
                 if (!manifest_push(&st->manifest, &unit)) break;
             }
-            st->named_ingots_dirty = true;
+            st->manifest_dirty = true;
         }
         st->repair_kit_fab_timer = 0.0f;
         SIM_LOG("[shipyard-fab] station %d minted %d kits (1 frame + 1 laser + 1 tractor consumed)\n",

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -62,12 +62,38 @@ static uint32_t crc32_file(FILE *f) {
 }
 
 #define SAVE_MAGIC 0x5349474E  /* "SIGN" */
-#define SAVE_VERSION 34  /* MODULE_FURNACE_CU/_CR collapsed into MODULE_FURNACE */
+#define SAVE_VERSION 35  /* named_ingot_t collapsed into cargo_unit_t */
 /* v31 widened inventory[] / base_price[] by one slot (REPAIR_KIT). v32
  * appends npc_ship_t.hull (a single float, version-gated read so v31
  * saves still load with default hull). MIN stays at 31 so we don't
- * wipe v31 worlds on this bump. */
+ * wipe v31 worlds on this bump.
+ *
+ * v35: dropped station.named_ingots[64] + named_ingots_count + the
+ * named_ingot_t struct. Old saves are migrated by reading the legacy
+ * named-ingot block (52B per slot, fixed layout) and converting each
+ * non-empty entry into a manifest unit. */
 #define MIN_SAVE_VERSION 31
+
+/* Legacy named-ingot block layout — preserved here only so v25..v34
+ * saves can be migrated forward. The original named_ingot_t was
+ * field-by-field WRITE_FIELD'd, so the on-disk record matches the
+ * struct's natural layout with 8-byte alignment for mined_block. That
+ * came out to 56 bytes per record (the 52-byte WIRE record packs
+ * tighter; only the disk used the natural padding). */
+typedef struct {
+    uint8_t  pubkey[32];      /* 0..31 */
+    uint8_t  prefix_class;    /* 32 */
+    uint8_t  metal;           /* 33 */
+    uint8_t  _pad[2];         /* 34..35 */
+    /* compiler inserts 4 bytes here to 8-align mined_block */
+    uint64_t mined_block;     /* 40..47 */
+    uint8_t  origin_station;  /* 48 */
+    uint8_t  _pad2[7];        /* 49..55 */
+} legacy_named_ingot_t;
+_Static_assert(sizeof(legacy_named_ingot_t) == 56,
+               "legacy_named_ingot_t must match the on-disk v34 layout");
+#define LEGACY_STATION_NAMED_INGOTS_MAX 64
+#define LEGACY_SHIP_HOLD_INGOTS_MAX     8
 
 /* Set by world_load() before read_station() so per-station readers know
  * which version they're parsing and can handle field additions. */
@@ -201,10 +227,9 @@ static bool write_station_session(FILE *f, const station_t *s) {
         WRITE_FIELD(f, s->arm_rotation[a]);
         WRITE_FIELD(f, s->arm_speed[a]);
     }
-    /* RATi v2: named ingot stockpile (v26+). */
-    WRITE_FIELD(f, s->named_ingots_count);
-    for (int i = 0; i < STATION_NAMED_INGOTS_MAX; i++)
-        WRITE_FIELD(f, s->named_ingots[i]);
+    /* v35: named-ingot stockpile collapsed into manifest. The
+     * v25..v34 dual-store fields (count + 64 × named_ingot_t) are no
+     * longer written. Migration on load converts old saves forward. */
     /* Manifest (v29+, #339 slice A). Previously guarded to require
      * empty — now serialized as count + packed cargo_unit_t entries.
      * cap is NOT persisted; on load the manifest bootstraps at the
@@ -262,15 +287,49 @@ static bool read_station_session(FILE *f, station_t *s) {
         READ_FIELD(f, s->arm_rotation[a]);
         READ_FIELD(f, s->arm_speed[a]);
     }
-    /* RATi v2: named ingot stockpile (v26+). Older saves leave the
-     * stockpile zero-initialized, which is the empty state. */
-    if (g_loaded_save_version >= 26) {
-        READ_FIELD(f, s->named_ingots_count);
-        if (s->named_ingots_count < 0) s->named_ingots_count = 0;
-        if (s->named_ingots_count > STATION_NAMED_INGOTS_MAX)
-            s->named_ingots_count = STATION_NAMED_INGOTS_MAX;
-        for (int i = 0; i < STATION_NAMED_INGOTS_MAX; i++)
-            READ_FIELD(f, s->named_ingots[i]);
+    /* v26..v34 wrote a named-ingot stockpile block (count + 64
+     * fixed-size records). v35 dropped the dual store; the manifest
+     * is now the single source of truth. We still read the legacy
+     * block off disk so subsequent fields stay byte-aligned, but its
+     * contents are migrated into the manifest only when the file
+     * predates the manifest (v26..v28); for v29..v34 the manifest
+     * already contains the same units (dual-write at smelt time) and
+     * the legacy block is discarded to avoid double-counting. */
+    if (g_loaded_save_version >= 26 && g_loaded_save_version <= 34) {
+        int legacy_count = 0;
+        legacy_named_ingot_t legacy[LEGACY_STATION_NAMED_INGOTS_MAX];
+        READ_FIELD(f, legacy_count);
+        for (int i = 0; i < LEGACY_STATION_NAMED_INGOTS_MAX; i++)
+            READ_FIELD(f, legacy[i]);
+        if (g_loaded_save_version < 29) {
+            /* No manifest in the file; lift the named records into the
+             * manifest as smelt-recipe units so the trade picker sees
+             * them after the world reset. parent_merkle is unknown for
+             * legacy entries — leave it zero. */
+            if (!station_manifest_bootstrap(s)) return false;
+            if (legacy_count < 0) legacy_count = 0;
+            if (legacy_count > LEGACY_STATION_NAMED_INGOTS_MAX)
+                legacy_count = LEGACY_STATION_NAMED_INGOTS_MAX;
+            for (int i = 0; i < legacy_count; i++) {
+                const legacy_named_ingot_t *src = &legacy[i];
+                /* Empty slots in the legacy array were zero-initialized
+                 * (pubkey all zero); skip those. */
+                static const uint8_t zero_pk[32] = {0};
+                if (memcmp(src->pubkey, zero_pk, 32) == 0) continue;
+                if (s->manifest.count >= s->manifest.cap) break;
+                cargo_unit_t u = {0};
+                u.kind = (uint8_t)CARGO_KIND_INGOT;
+                u.commodity = src->metal;
+                u.grade = (uint8_t)MINING_GRADE_COMMON;
+                u.prefix_class = src->prefix_class;
+                u.recipe_id = (uint16_t)RECIPE_SMELT;
+                u.origin_station = src->origin_station;
+                u.mined_block = src->mined_block;
+                memcpy(u.pub, src->pubkey, 32);
+                (void)manifest_push(&s->manifest, &u);
+            }
+        }
+        (void)legacy; /* silence unused warning when nothing is migrated */
     }
     /* Manifest (v29+). For v29+, allocate via bootstrap + reserve, then
      * read entries. Pre-v29 saves get Slice D migration: their float
@@ -977,8 +1036,9 @@ typedef struct {
 } player_save_v3_t;
 
 static void migrate_v3_ship(ship_t *dst, const ship_v3_t *src) {
-    /* ship_t gained hold_ingots[] after PLY3 and now also carries a
-     * runtime-only manifest that is never loaded from disk here. */
+    /* ship_t had hold_ingots[] from PLY3 forward; v35 collapsed that
+     * dual store into the ship manifest. The runtime-only manifest is
+     * not loaded here. */
     ship_cleanup(dst);
     memset(dst, 0, sizeof(*dst));
     (void)ship_manifest_bootstrap(dst);
@@ -1001,13 +1061,13 @@ static void migrate_v3_ship(ship_t *dst, const ship_v3_t *src) {
     dst->stat_credits_earned = src->stat_credits_earned;
     dst->stat_credits_spent = src->stat_credits_spent;
     dst->stat_asteroids_fractured = src->stat_asteroids_fractured;
-    /* New fields — zero-init. */
-    memset(dst->hold_ingots, 0, sizeof(dst->hold_ingots));
-    dst->hold_ingots_count = 0;
 }
 
 /* PLY4 ship layout — the pre-manifest ship_t payload kept explicit so
- * adding runtime-only fields to ship_t doesn't change the on-disk bytes. */
+ * adding runtime-only fields to ship_t doesn't change the on-disk bytes.
+ * v35 dropped hold_ingots from ship_t but the on-disk PLY4/PLY5 ship
+ * blob still embeds the legacy hold-ingot array, so the bytes stay
+ * stable for old saves. */
 typedef struct {
     vec2 pos; vec2 vel; float angle; float hull;
     float cargo[COMMODITY_COUNT];
@@ -1019,7 +1079,7 @@ typedef struct {
     uint32_t unlocked_modules;
     float stat_ore_mined, stat_credits_earned, stat_credits_spent;
     int stat_asteroids_fractured;
-    named_ingot_t hold_ingots[SHIP_HOLD_INGOTS_MAX];
+    legacy_named_ingot_t hold_ingots[LEGACY_SHIP_HOLD_INGOTS_MAX];
     int hold_ingots_count;
 } ship_v4_t;
 
@@ -1053,8 +1113,9 @@ static void encode_v4_ship(ship_v4_t *dst, const ship_t *src) {
     dst->stat_credits_earned = src->stat_credits_earned;
     dst->stat_credits_spent = src->stat_credits_spent;
     dst->stat_asteroids_fractured = src->stat_asteroids_fractured;
-    memcpy(dst->hold_ingots, src->hold_ingots, sizeof(dst->hold_ingots));
-    dst->hold_ingots_count = src->hold_ingots_count;
+    /* Legacy hold-ingot array stays zero on save: the ship manifest
+     * is the single source of truth post-v35. The bytes still occupy
+     * the on-disk slot so PLY4/PLY5 readers stay byte-aligned. */
 }
 
 static void migrate_v4_ship(ship_t *dst, const ship_v4_t *src) {
@@ -1081,8 +1142,29 @@ static void migrate_v4_ship(ship_t *dst, const ship_v4_t *src) {
     dst->stat_credits_earned = src->stat_credits_earned;
     dst->stat_credits_spent = src->stat_credits_spent;
     dst->stat_asteroids_fractured = src->stat_asteroids_fractured;
-    memcpy(dst->hold_ingots, src->hold_ingots, sizeof(dst->hold_ingots));
-    dst->hold_ingots_count = src->hold_ingots_count;
+    /* v35 migration: lift legacy hold-ingot rows into the ship manifest
+     * as smelt-recipe units so the player keeps custody. Empty slots
+     * (zero pubkey) skip. PLY5 saves wrote zeros here under the new
+     * encode_v4_ship; this only matters for older PLY3/PLY4 saves
+     * captured before the unification. */
+    int n = src->hold_ingots_count;
+    if (n < 0) n = 0;
+    if (n > LEGACY_SHIP_HOLD_INGOTS_MAX) n = LEGACY_SHIP_HOLD_INGOTS_MAX;
+    static const uint8_t zero_pk[32] = {0};
+    for (int i = 0; i < n; i++) {
+        const legacy_named_ingot_t *lg = &src->hold_ingots[i];
+        if (memcmp(lg->pubkey, zero_pk, 32) == 0) continue;
+        cargo_unit_t u = {0};
+        u.kind = (uint8_t)CARGO_KIND_INGOT;
+        u.commodity = lg->metal;
+        u.grade = (uint8_t)MINING_GRADE_COMMON;
+        u.prefix_class = lg->prefix_class;
+        u.recipe_id = (uint16_t)RECIPE_SMELT;
+        u.origin_station = lg->origin_station;
+        u.mined_block = lg->mined_block;
+        memcpy(u.pub, lg->pubkey, 32);
+        (void)manifest_push(&dst->manifest, &u);
+    }
 }
 
 /* Old ship layout with global credits field — for PLY2 migration */
@@ -1189,8 +1271,6 @@ static void migrate_v2_ship(ship_t *dst, const ship_v2_t *src) {
     dst->stat_asteroids_fractured = src->stat_asteroids_fractured;
     /* RATi v2 fields not present in PLY2 — zero-init. */
     dst->comm_range = 0.0f;
-    memset(dst->hold_ingots, 0, sizeof(dst->hold_ingots));
-    dst->hold_ingots_count = 0;
 }
 
 static bool player_load_from_path(server_player_t *sp, world_t *w, const char *path, int slot) {

--- a/shared/manifest.h
+++ b/shared/manifest.h
@@ -5,9 +5,11 @@
 
 #include "types.h"
 
-_Static_assert(sizeof(cargo_unit_t) == 72, "cargo_unit_t must stay 72 bytes");
-_Static_assert(offsetof(cargo_unit_t, pub) == 8, "cargo_unit_t pub offset changed");
-_Static_assert(offsetof(cargo_unit_t, parent_merkle) == 40,
+_Static_assert(sizeof(cargo_unit_t) == 80, "cargo_unit_t must stay 80 bytes");
+_Static_assert(offsetof(cargo_unit_t, mined_block) == 8,
+               "cargo_unit_t mined_block offset changed");
+_Static_assert(offsetof(cargo_unit_t, pub) == 16, "cargo_unit_t pub offset changed");
+_Static_assert(offsetof(cargo_unit_t, parent_merkle) == 48,
                "cargo_unit_t parent_merkle offset changed");
 
 const char *cargo_kind_name(cargo_kind_t kind);

--- a/shared/protocol.h
+++ b/shared/protocol.h
@@ -104,8 +104,9 @@ enum {
 #define INGOT_DELIVERY_CREDIT     100
 
 /* Named ingot wire record: [pubkey:32][prefix:1][metal:1][_pad:2][mined_block:8][origin:1][_pad2:7] = 52 bytes
- * Mirrors named_ingot_t exactly so the server can write the struct
- * directly. Class authorization is in the leading char(s) of base58(pubkey). */
+ * The wire shape predates the named_ingot_t -> cargo_unit_t unification;
+ * the server now projects the same fields off cargo_unit_t. Class
+ * authorization is in the leading char(s) of base58(pubkey). */
 #define NAMED_INGOT_RECORD_SIZE 52
 
 /* NET_MSG_STATION_INGOTS layout:

--- a/shared/types.h
+++ b/shared/types.h
@@ -113,22 +113,6 @@ typedef enum {
     INGOT_PREFIX_COUNT
 } ingot_prefix_t;
 
-/* A named ingot is a uniquely-identified unit of refined ore. The
- * pubkey IS the future hull's name; the prefix decides which hull
- * class can be minted from it. Provenance fields let any client trace
- * the ingot's history through the chain log. */
-typedef struct {
-    uint8_t  pubkey[32];      /* identity, set at smelt */
-    uint8_t  prefix_class;    /* ingot_prefix_t */
-    uint8_t  metal;           /* commodity_t — FERRITE/CUPRITE/CRYSTAL_INGOT */
-    uint8_t  _pad[2];
-    uint64_t mined_block;     /* chain block id at mint */
-    uint8_t  origin_station;  /* refinery that smelted it */
-    uint8_t  _pad2[7];
-} named_ingot_t;
-
-#define STATION_NAMED_INGOTS_MAX 64
-#define SHIP_HOLD_INGOTS_MAX     8
 #define SHIP_MANIFEST_DEFAULT_CAP    32
 #define STATION_MANIFEST_DEFAULT_CAP 256
 
@@ -141,16 +125,27 @@ typedef enum {
     CARGO_KIND_COUNT
 } cargo_kind_t;
 
+/* Unified cargo identity. Carries the named-ingot fields (prefix_class,
+ * mined_block, origin_station) so a single store covers raw ingots,
+ * fabricated frames/lasers/tractors, and repair kits. The legacy
+ * named_ingot_t / station.named_ingots[] / ship.hold_ingots[] dual store
+ * was collapsed into the manifest; cargo_unit_t.pub is now the single
+ * identity for both ingots and finished goods.
+ *
+ * For non-ingot kinds prefix_class is INGOT_PREFIX_ANONYMOUS, mined_block
+ * is 0, and origin_station is the station that crafted the unit. */
 typedef struct {
     uint8_t  kind;              /* cargo_kind_t */
     uint8_t  commodity;         /* commodity_t */
     uint8_t  grade;             /* mining_grade_t */
-    uint8_t  _pad;              /* reserved, zero */
+    uint8_t  prefix_class;      /* ingot_prefix_t (anonymous for non-ingot kinds) */
     uint16_t recipe_id;         /* recipe_id_t */
-    uint16_t _pad2;             /* reserved, zero */
+    uint8_t  origin_station;    /* refinery/fabricator that produced it */
+    uint8_t  _pad;              /* reserved, zero */
+    uint64_t mined_block;       /* chain block id at mint (0 for non-ingot) */
     uint8_t  pub[32];           /* content hash */
     uint8_t  parent_merkle[32]; /* sorted-input merkle root */
-} cargo_unit_t;
+} cargo_unit_t;                 /* 80 bytes */
 
 typedef struct {
     uint16_t count;
@@ -207,12 +202,11 @@ typedef struct {
     float stat_credits_earned;
     float stat_credits_spent;
     int stat_asteroids_fractured;
-    /* Named ingots in the player's hold — carried between stations
-     * for sale or hull construction. Bulk anonymous ingots still ride
-     * in cargo[] as fungible counts; this list holds identified ones. */
-    named_ingot_t hold_ingots[SHIP_HOLD_INGOTS_MAX];
-    int           hold_ingots_count;
-    manifest_t    manifest; /* ship cargo manifest; stays empty until transfer migration lands */
+    /* Ship cargo manifest — single source of identity for held units.
+     * Named ingots and bulk finished goods both live here; the legacy
+     * hold_ingots[] / named_ingot_t dual store was collapsed in the
+     * "unify ingot identity" PR. */
+    manifest_t    manifest;
 } ship_t;
 
 typedef enum {
@@ -339,14 +333,14 @@ typedef struct {
     /* Station credit pool: fixed money supply, no inflation.
      * Smelting pays from pool, player spending refills it. */
     float credit_pool;
-    /* Named ingot stockpile (RATi v2). Refinery deposits here on smelt
-     * when the winning pubkey carries a class prefix. Players buy from
-     * this list at the MARKET tab; shipyards consume entries to mint
-     * hulls bound to the ingot's pubkey identity. LRU evict on full. */
-    named_ingot_t named_ingots[STATION_NAMED_INGOTS_MAX];
-    int           named_ingots_count;
-    bool          named_ingots_dirty;  /* server-only: drives wire push */
-    manifest_t    manifest;            /* station cargo manifest; smelt/fab dual-write feeds it */
+    /* Station cargo manifest — single source of identity for stocked
+     * units (named ingots + fabricated goods). Refinery pushes a unit
+     * per smelt; shipyards consume units to mint hulls bound to the
+     * pub identity. The legacy named_ingots[] dual store was collapsed
+     * in the "unify ingot identity" PR. `manifest_dirty` drives the
+     * wire-push (server-only). */
+    manifest_t    manifest;
+    bool          manifest_dirty;
     /* Dock repair-kit fab cadence: server-only countdown. When it
      * reaches zero and the station has 1 frame + 1 laser + 1 tractor
      * in inventory, consume them, mint REPAIR_KIT_PER_BATCH kits, and

--- a/src/main.c
+++ b/src/main.c
@@ -1037,11 +1037,9 @@ static void init(void) {
             cbs.on_world_time = on_remote_world_time;
             cbs.on_events = apply_remote_events;
             cbs.on_signal_channel = apply_remote_signal_channel;
-            cbs.on_station_ingots = apply_remote_station_ingots;
             cbs.on_station_manifest = apply_remote_station_manifest;
             cbs.on_player_manifest = apply_remote_player_manifest;
             cbs.on_highscores = apply_remote_highscores;
-            cbs.on_hold_ingots = apply_remote_hold_ingots;
             g.multiplayer_enabled = net_init(server_url, &cbs);
             if (g.multiplayer_enabled) {
                 /* Deactivate the local server — the remote server is authoritative.

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -409,8 +409,14 @@ bool hash_ingot(commodity_t commodity, mining_grade_t grade,
     out_unit->commodity = (uint8_t)commodity;
     out_unit->grade = (uint8_t)grade;
     out_unit->recipe_id = (uint16_t)RECIPE_SMELT;
+    /* origin_station / mined_block default to 0; smelt-side caller fills
+     * them in from the refinery context. */
     memcpy(out_unit->parent_merkle, fragment_pub, HASH_BYTES);
     hash_recipe_pub(RECIPE_SMELT, fragment_pub, output_index, out_unit->pub);
+    /* prefix_class is derived from the leading char of base58(pub) — set
+     * it once here so callers don't have to recompute. ingot_prefix_t
+     * mirrors mining_pubkey_class() one-to-one. */
+    out_unit->prefix_class = (uint8_t)mining_pubkey_class(out_unit->pub);
     return true;
 }
 
@@ -548,7 +554,7 @@ int station_finished_mint(station_t *st, commodity_t c, int n,
          * residue (production accumulator) below 1.0. */
         float frac = st->inventory[c] - floorf(st->inventory[c]);
         st->inventory[c] = (float)manifest_count_by_commodity(&st->manifest, c) + frac;
-        st->named_ingots_dirty = true;
+        st->manifest_dirty = true;
     }
     return minted;
 }
@@ -562,7 +568,7 @@ int station_finished_drain(station_t *st, commodity_t c, int n) {
         float frac = st->inventory[c] - floorf(st->inventory[c]);
         st->inventory[c] = (float)manifest_count_by_commodity(&st->manifest, c) + frac;
         if (st->inventory[c] < 0.0f) st->inventory[c] = 0.0f;
-        st->named_ingots_dirty = true;
+        st->manifest_dirty = true;
     }
     return drained;
 }

--- a/src/net.c
+++ b/src/net.c
@@ -593,24 +593,17 @@ static void handle_message(const uint8_t* data, int len) {
         break;
 
     case NET_MSG_STATION_INGOTS:
-        if (len >= STATION_INGOTS_HEADER && net_state.callbacks.on_station_ingots) {
-            uint8_t station_id = data[1];
+        /* Wire payload kept for backward compatibility — a server still
+         * sends per-station named-ingot snapshots derived from the
+         * unified manifest. The client no longer maintains a separate
+         * named-ingot store (single-source-of-truth refactor); the
+         * STATION_MANIFEST summary feeds the trade UI counts and the
+         * full provenance lives in the singleplayer mirror's manifest.
+         * We just length-validate and drop the bytes here. */
+        if (len >= STATION_INGOTS_HEADER) {
             int count = data[2];
             int expected = STATION_INGOTS_HEADER + count * NAMED_INGOT_RECORD_SIZE;
-            if (len < expected) break;
-            if (count > STATION_NAMED_INGOTS_MAX) count = STATION_NAMED_INGOTS_MAX;
-            static named_ingot_t scratch[STATION_NAMED_INGOTS_MAX];
-            for (int i = 0; i < count; i++) {
-                const uint8_t *p = &data[STATION_INGOTS_HEADER + i * NAMED_INGOT_RECORD_SIZE];
-                memcpy(scratch[i].pubkey, &p[0], 32);
-                scratch[i].prefix_class = p[32];
-                scratch[i].metal        = p[33];
-                uint64_t mb = 0;
-                for (int k = 0; k < 8; k++) mb |= ((uint64_t)p[36 + k]) << (8 * k);
-                scratch[i].mined_block = mb;
-                scratch[i].origin_station = p[44];
-            }
-            net_state.callbacks.on_station_ingots(station_id, scratch, count);
+            (void)expected;
         }
         break;
 
@@ -668,23 +661,15 @@ static void handle_message(const uint8_t* data, int len) {
         break;
 
     case NET_MSG_HOLD_INGOTS:
-        if (len >= HOLD_INGOTS_HEADER && net_state.callbacks.on_hold_ingots) {
+        /* Wire payload kept for backward compatibility (see
+         * NET_MSG_STATION_INGOTS above for the rationale). The named-
+         * ingot identity now lives in the ship manifest, populated by
+         * PLAYER_MANIFEST + the singleplayer mirror; the dedicated
+         * hold-ingot wire snapshot is informational only. */
+        if (len >= HOLD_INGOTS_HEADER) {
             int count = data[1];
             int expected = HOLD_INGOTS_HEADER + count * NAMED_INGOT_RECORD_SIZE;
-            if (len < expected) break;
-            if (count > SHIP_HOLD_INGOTS_MAX) count = SHIP_HOLD_INGOTS_MAX;
-            static named_ingot_t scratch[SHIP_HOLD_INGOTS_MAX];
-            for (int i = 0; i < count; i++) {
-                const uint8_t *p = &data[HOLD_INGOTS_HEADER + i * NAMED_INGOT_RECORD_SIZE];
-                memcpy(scratch[i].pubkey, &p[0], 32);
-                scratch[i].prefix_class = p[32];
-                scratch[i].metal        = p[33];
-                uint64_t mb = 0;
-                for (int k = 0; k < 8; k++) mb |= ((uint64_t)p[36 + k]) << (8 * k);
-                scratch[i].mined_block = mb;
-                scratch[i].origin_station = p[44];
-            }
-            net_state.callbacks.on_hold_ingots(scratch, count);
+            (void)expected;
         }
         break;
 

--- a/src/net.h
+++ b/src/net.h
@@ -175,12 +175,6 @@ typedef struct {
 
 typedef void (*net_on_signal_channel_fn)(const NetSignalChannelMsg *msgs, int count);
 
-/* RATi v2 — per-station named ingot stockpile snapshot. */
-typedef void (*net_on_station_ingots_fn)(uint8_t station_id,
-                                         const named_ingot_t *ingots, int count);
-/* RATi v2 — local player's hold ingots snapshot. */
-typedef void (*net_on_hold_ingots_fn)(const named_ingot_t *ingots, int count);
-
 /* Phase 2 — per-station manifest summary. Each entry = one
  * {commodity, grade, count} triple with count > 0. */
 typedef struct {
@@ -228,8 +222,6 @@ typedef struct {
     void (*on_world_time)(float server_time);
     void (*on_events)(const sim_event_t *events, int count);
     net_on_signal_channel_fn on_signal_channel;
-    net_on_station_ingots_fn on_station_ingots;
-    net_on_hold_ingots_fn    on_hold_ingots;
     net_on_station_manifest_fn on_station_manifest;
     net_on_player_manifest_fn  on_player_manifest;
     net_on_highscores_fn       on_highscores;

--- a/src/net_sync.c
+++ b/src/net_sync.c
@@ -145,18 +145,6 @@ void apply_remote_stations(uint8_t index, const float* inventory, float credit_p
     st->credit_pool = credit_pool;
 }
 
-void apply_remote_station_ingots(uint8_t station_id,
-                                 const named_ingot_t *ingots, int count) {
-    if (station_id >= MAX_STATIONS) return;
-    if (count < 0) count = 0;
-    if (count > STATION_NAMED_INGOTS_MAX) count = STATION_NAMED_INGOTS_MAX;
-    station_t *st = &g.world.stations[station_id];
-    /* Full replacement — server is the source of truth. */
-    memset(st->named_ingots, 0, sizeof(st->named_ingots));
-    for (int i = 0; i < count; i++) st->named_ingots[i] = ingots[i];
-    st->named_ingots_count = count;
-}
-
 /* Phase 2 wire: server → client station manifest summary. Fully
  * replaces the (commodity, grade) count matrix for this station so a
  * missing entry reads as zero. */
@@ -226,16 +214,6 @@ void apply_remote_player_manifest(const NetStationManifestEntry *entries,
             if (!manifest_push(&ship->manifest, &unit)) break;
         }
     }
-}
-
-void apply_remote_hold_ingots(const named_ingot_t *ingots, int count) {
-    if (g.local_player_slot < 0 || g.local_player_slot >= MAX_PLAYERS) return;
-    if (count < 0) count = 0;
-    if (count > SHIP_HOLD_INGOTS_MAX) count = SHIP_HOLD_INGOTS_MAX;
-    ship_t *ship = &g.world.players[g.local_player_slot].ship;
-    memset(ship->hold_ingots, 0, sizeof(ship->hold_ingots));
-    for (int i = 0; i < count; i++) ship->hold_ingots[i] = ingots[i];
-    ship->hold_ingots_count = count;
 }
 
 void apply_remote_contracts(const contract_t* contracts, int count) {

--- a/src/net_sync.h
+++ b/src/net_sync.h
@@ -22,12 +22,6 @@ void apply_remote_station_identity(const NetStationIdentity* si);
 void apply_remote_scaffolds(const NetScaffoldState* scaffolds, int count);
 void apply_remote_hail_response(uint8_t station, float credits, int contract_index);
 void apply_remote_signal_channel(const NetSignalChannelMsg *msgs, int count);
-/* RATi v2 — copy a station's named-ingot stockpile into world.stations[]
- * so the MARKET tab can render it. */
-void apply_remote_station_ingots(uint8_t station_id,
-                                 const named_ingot_t *ingots, int count);
-/* RATi v2 — copy local pilot's hold-ingot snapshot into LOCAL_PLAYER.ship. */
-void apply_remote_hold_ingots(const named_ingot_t *ingots, int count);
 /* Phase 2 — station manifest summary (per-{commodity, grade} counts). */
 void apply_remote_station_manifest(uint8_t station_id,
                                    const NetStationManifestEntry *entries,

--- a/src/tests/test_save.c
+++ b/src/tests/test_save.c
@@ -538,7 +538,12 @@ TEST(test_world_save_load_preserves_smelted_ingots) {
 /* v29: +2 bytes per station (uint16 manifest count) = +128 bytes for all
  * MAX_STATIONS=64 slots. Empty stations carry only the count; no units. */
 /* v30: +1 byte per contract (required_grade) = +24 for MAX_CONTRACTS=24. */
-#define EXPECTED_SAVE_SIZE 269292 /* v33: npc_ship_t.session_token added (8B × 16 NPC slots = 128B over v32) */
+/* v35: dropped station.named_ingots[] (4B count + 64 × 56B record =
+ * 3588B per station, × MAX_STATIONS=64 = 229,632 bytes saved). The
+ * 56-byte per-slot disk size includes natural alignment padding — the
+ * 52-byte wire record packed tighter, but the field-by-field WRITE
+ * preserved the in-memory layout. */
+#define EXPECTED_SAVE_SIZE (269292 - (4 + 64 * 56) * 64) /* v35 */
 
 TEST(test_save_file_size_stable) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
@@ -575,7 +580,7 @@ TEST(test_save_header_golden_bytes) {
     ASSERT_EQ_INT((int)fread(&spawn_timer, 4, 1, f), 1);
     fclose(f);
     ASSERT_EQ_INT((int)magic, (int)0x5349474E);    /* "SIGN" */
-    ASSERT_EQ_INT((int)version, 34);
+    ASSERT_EQ_INT((int)version, 35);
     ASSERT(rng != 0);  /* seed is set */
     ASSERT_EQ_FLOAT(time_val, 0.0f, 0.001f);
     ASSERT_EQ_FLOAT(spawn_timer, 0.0f, 0.001f);

--- a/src/tests/test_world_sim.c
+++ b/src/tests/test_world_sim.c
@@ -281,25 +281,30 @@ TEST(test_refinery_deposits_named_ingot) {
     w->players[0].ship.vel = v2(0.0f, 0.0f);
 
     /* Run sim until smelt completes (smelt_progress accumulates ~0.5/s). */
-    int initial_named = w->stations[0].named_ingots_count;
     int initial_manifest = w->stations[0].manifest.count;
     float initial_bulk = w->stations[0].inventory[COMMODITY_FERRITE_INGOT];
     for (int i = 0; i < 600 && w->asteroids[slot].active; i++)
         world_sim_step(w, 1.0f / 120.0f);
     /* Asteroid should be consumed. */
     ASSERT(!w->asteroids[slot].active);
-    /* Either an anonymous ingot landed in inventory, or a named ingot
-     * landed in the stockpile — depending on what the universe rolled. */
-    bool got_named = (w->stations[0].named_ingots_count > initial_named);
+    /* Smelt always lands the units in the manifest now (single source
+     * of truth — no separate named-ingot stockpile). The float
+     * inventory bumps in lockstep. */
     bool got_bulk = (w->stations[0].inventory[COMMODITY_FERRITE_INGOT] > initial_bulk);
-    ASSERT(got_named || got_bulk);
+    ASSERT(got_bulk);
     ASSERT_EQ_INT(w->stations[0].manifest.count - initial_manifest, 10);
+    bool any_named = false;
     for (int i = initial_manifest; i < w->stations[0].manifest.count; i++) {
         cargo_unit_t *unit = &w->stations[0].manifest.units[i];
         ASSERT_EQ_INT(unit->kind, CARGO_KIND_INGOT);
         ASSERT_EQ_INT(unit->commodity, COMMODITY_FERRITE_INGOT);
         ASSERT_EQ_INT(unit->grade, MINING_GRADE_RATI);
         ASSERT_EQ_INT(unit->recipe_id, RECIPE_SMELT);
+        /* origin_station is stamped at smelt time. */
+        ASSERT_EQ_INT(unit->origin_station, 0);
+        /* prefix_class always matches mining_pubkey_class(pub). */
+        ASSERT_EQ_INT(unit->prefix_class, mining_pubkey_class(unit->pub));
+        if ((ingot_prefix_t)unit->prefix_class != INGOT_PREFIX_ANONYMOUS) any_named = true;
     }
     ASSERT(memcmp(w->stations[0].manifest.units[initial_manifest].parent_merkle,
                   w->stations[0].manifest.units[w->stations[0].manifest.count - 1].parent_merkle,
@@ -307,11 +312,16 @@ TEST(test_refinery_deposits_named_ingot) {
     ASSERT(memcmp(w->stations[0].manifest.units[initial_manifest].pub,
                   w->stations[0].manifest.units[w->stations[0].manifest.count - 1].pub,
                   32) != 0);
-    /* If named, validate prefix_class matches mining_pubkey_class. */
-    if (got_named) {
-        named_ingot_t *ing = &w->stations[0].named_ingots[w->stations[0].named_ingots_count - 1];
-        ASSERT_EQ_INT(ing->prefix_class, mining_pubkey_class(ing->pubkey));
-        ASSERT(ing->prefix_class != MINING_CLASS_ANONYMOUS);
+    /* The first non-anonymous unit gets a non-zero mined_block stamped
+     * after the signal_channel post; anonymous units stay at 0. */
+    if (any_named) {
+        for (int i = initial_manifest; i < w->stations[0].manifest.count; i++) {
+            cargo_unit_t *unit = &w->stations[0].manifest.units[i];
+            if ((ingot_prefix_t)unit->prefix_class != INGOT_PREFIX_ANONYMOUS) {
+                ASSERT(unit->mined_block != 0);
+                break;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Why

Today the economy maintains **three** identity layers for the same ingot:
- `mining_keypair_t` (derivation, at fracture time)
- `named_ingot_t` (per-station 64-slot fixed array, plus a per-ship 8-slot array)
- `cargo_unit_t` (variable-cap manifest entries with merkle parents)

For raw ingots we kept TWO records — a `named_ingot_t` AND a `cargo_unit_t` — synchronized by the `named_ingots_dirty` flag and the `station_finished_*` accessors. **That's the root cause of the manifest/inventory drift bugs we've been fighting.**

This PR collapses `named_ingot_t` into `cargo_unit_t`, deletes `station_t::named_ingots[64]` and `ship_t::hold_ingots[8]` entirely, and makes the manifest the single source of truth for ingot identity end-to-end.

## What changed

### Data shape
`cargo_unit_t` grows from 72B → 80B and gains the named-ingot fields (`prefix_class`, `origin_station`, `mined_block`). `hash_ingot()` now stamps `prefix_class` from `base58(pub)` at smelt time so callers don't compute it twice. The static asserts in `shared/manifest.h` are updated for the new size/offsets.

### Smelt
`sim_production.c` smelt_complete pushes one manifest entry per integer of finished ingot, stamps `origin_station` on each, and posts the signal-channel announce + back-stamps `mined_block` onto the first non-anonymous unit. The dual-write into `named_ingots[]` is gone.

### BUY_INGOT / DELIVER_INGOT
`server/main.c` now walks `station.manifest` by pubkey for BUY and transfers the `cargo_unit_t` to `ship.manifest`. DELIVER walks `ship.manifest` filtered to non-anonymous `CARGO_KIND_INGOT` units and FIFO-evicts on full station manifest.

### Wire protocol — no version bump
- `NET_MSG_STATION_INGOTS` / `NET_MSG_HOLD_INGOTS` shapes are unchanged (still 52-byte records on the wire).
- Server-side `serialize_station_ingots` / `serialize_hold_ingots` walk the manifest filtered by `class != ANONYMOUS` and project the same fields off `cargo_unit_t`.
- Client-side: dropped `apply_remote_station_ingots` / `apply_remote_hold_ingots` entirely. Nothing on the client UI ever read the named-ingot arrays — the wire callbacks were write-only into a dead store. The receivers in `src/net.c` now length-validate and discard, preserving forward wire compatibility with older servers.

### Save migration (v34 → v35)
- `SAVE_VERSION` bumps to 35; `MIN_SAVE_VERSION` stays at 31.
- Writer drops the per-station `(count + 64 × named_ingot_t)` block (the in-memory size was 56B/record due to natural alignment, so 4 + 64×56 = 3588B saved per station × 64 slots = **229,632B per save**).
- The PLY4/PLY5 ship blob still carries an 8-slot legacy hold-ingot array on disk (kept as `legacy_named_ingot_t` so byte layout stays stable); `encode_v4_ship` zeros it out on save.
- `read_station_session` reads + discards the v26..v34 legacy block so subsequent fields stay byte-aligned. v29..v34 already had the manifest in-file (the dual-write left both consistent), so dropping the legacy block prevents double-counting. v26..v28 (now below MIN, listed for completeness) would lift legacy entries into the manifest as smelt-recipe units.
- `migrate_v4_ship` lifts any non-zero legacy hold-ingot entries into `ship.manifest` so older PLY3/PLY4 saves keep custody.
- `test_save_file_size_stable` and `test_save_header_golden_bytes` updated.

## Verification
- `make test` → **340/340 pass** at -O2.
- Rebuilt at -O1 and reran → **340/340 pass**.

## Coordination notes for concurrent branches
- `harden/inventory-encapsulation-and-ubsan` (`station.inventory` → `_inventory_cache` rename + invariant asserts): no overlap with the named-ingot store; that branch and this one layer cleanly. If harden lands first, expect a small mechanical rebase pass to rename `inventory` → `_inventory_cache` in `server/main.c` BUY/DELIVER and the smelt path.
- `fix/test-isolation-for-sharding`: no shared files.

## Follow-up
Tightening the `mining_keypair_t` → `cargo_unit_t` bridge — fragments could carry their prospective `cargo_unit_t` at fracture time so smelting just transfers ownership — is still worthwhile. Intentionally **not** in this PR; it's already a large change.

## Test plan
- [ ] CI: `make test` passes on the build matrix.
- [ ] Spot-check on a fresh world: smelt, sell, dock pricing reflects RATi prefix on named ingots.
- [ ] Load a v34 save (if any are around) → verify it boots without losing manifest contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)