### PR TITLE
harden(sim): encapsulate inventory cache, assert invariants, add UBSan CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,30 @@ jobs:
           ulimit -s 16384
           ./build-san/signal_test
 
+  # UBSan + ASan: post-deploy verification on main only. UBSan catches
+  # undefined behavior (signed overflow, strict-aliasing, null derefs,
+  # OOB, etc.) that ASan alone misses; running them together backstops
+  # the post-deploy check with maximum coverage. Same gating model as
+  # test-asan and test-valgrind — informational on PRs, paging on main.
+  test-ubsan:
+    runs-on: ubuntu-latest
+    needs: deploy
+    if: github.ref == 'refs/heads/main'
+    timeout-minutes: 25
+    env:
+      UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+      ASAN_OPTIONS: halt_on_error=1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and run tests with UBSan + ASan
+        run: |
+          cmake -S . -B build-ubsan -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS_ONLY=ON \
+            -DCMAKE_C_FLAGS="-O1 -g -fsanitize=undefined,address -fno-omit-frame-pointer" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=undefined,address"
+          cmake --build build-ubsan --parallel
+          ulimit -s 16384
+          ./build-ubsan/signal_test --quiet
+
   # Static analysis: parallel with tests.
   test-static:
     runs-on: ubuntu-latest

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -1014,7 +1014,7 @@ static bool try_sell_one_unit(world_t *w, server_player_t *sp,
     if (!station_consumes(st, commodity)) return false;
     if (sp->ship.cargo[commodity] < 0.999f) return false; /* < 1 unit */
     float capacity = MAX_PRODUCT_STOCK;
-    float space = fmaxf(0.0f, capacity - st->inventory[commodity]);
+    float space = fmaxf(0.0f, capacity - st->_inventory_cache[commodity]);
     if (space < 0.999f) {
         emit_event(w, (sim_event_t){
             .type = SIM_EVENT_ORDER_REJECTED,
@@ -1059,9 +1059,9 @@ static bool try_sell_one_unit(world_t *w, server_player_t *sp,
     if (moved <= 0) return false;
     sp->ship.cargo[commodity] -= 1.0f;
     if (sp->ship.cargo[commodity] < 0.0f) sp->ship.cargo[commodity] = 0.0f;
-    st->inventory[commodity] += 1.0f;
-    if (st->inventory[commodity] > MAX_PRODUCT_STOCK)
-        st->inventory[commodity] = MAX_PRODUCT_STOCK;
+    st->_inventory_cache[commodity] += 1.0f;
+    if (st->_inventory_cache[commodity] > MAX_PRODUCT_STOCK)
+        st->_inventory_cache[commodity] = MAX_PRODUCT_STOCK;
     manifest_mark_station_dirty(w, &st->manifest);
 
     st->credit_pool -= graded_price;
@@ -1121,7 +1121,7 @@ static void try_sell_station_cargo(world_t *w, server_player_t *sp) {
      * players no longer carry raw ore in ship.cargo[] — fragments ride
      * in ship.towed_fragments[] and are consumed by furnaces at dock.
      * Ore-contract fulfillment is driven by smelter-throughput bumping
-     * station.inventory[ORE], not by this delivery path. Leaving the
+     * station._inventory_cache[ORE], not by this delivery path. Leaving the
      * ore branch in would be a silent no-op. */
     for (int k = 0; k < MAX_CONTRACTS; k++) {
         contract_t *ct = &w->contracts[k];
@@ -1132,14 +1132,14 @@ static void try_sell_station_cargo(world_t *w, server_player_t *sp) {
         if (selective && filter != c) continue;
         if (sp->ship.cargo[c] < 0.01f) continue;
         float capacity = MAX_PRODUCT_STOCK;
-        float space = fmaxf(0.0f, capacity - st->inventory[c]);
+        float space = fmaxf(0.0f, capacity - st->_inventory_cache[c]);
         if (space < 0.01f) continue;
         float deliver = fminf(fminf(sp->ship.cargo[c], ct->quantity_needed), space);
         float price_per = contract_price(ct);
         payout += deliver * price_per;
         if (deliver > 0.01f) sold_against_contract = true;
         sp->ship.cargo[c] -= deliver;
-        st->inventory[c] += deliver;
+        st->_inventory_cache[c] += deliver;
         /* Phase 1 manifest-first: move whole-unit deliveries across the
          * ship/station manifests so provenance survives the transaction.
          * Fractional deliveries still ride the float dual-write. Grade
@@ -1192,14 +1192,14 @@ static void try_sell_station_cargo(world_t *w, server_player_t *sp) {
         had_sellable_cargo = true;
         {
             float capacity = MAX_PRODUCT_STOCK;
-            float space = fmaxf(0.0f, capacity - st->inventory[buy]);
+            float space = fmaxf(0.0f, capacity - st->_inventory_cache[buy]);
             if (space <= 0.01f) tried_but_full = true;
             if (space > 0.01f) {
                 float accepted = fminf(sp->ship.cargo[buy], space);
                 float price = station_buy_price(st, buy);
                 payout += accepted * price;
                 sp->ship.cargo[buy] -= accepted;
-                st->inventory[buy] += accepted;
+                st->_inventory_cache[buy] += accepted;
                 /* Manifest dual-write + per-unit grade bonus — see contract branch. */
                 int whole = (int)floorf(accepted + 0.0001f);
                 if (whole > 0) {
@@ -1286,7 +1286,7 @@ static void try_repair_ship(world_t *w, server_player_t *sp) {
      * LABOR_FEE_PER_HP for the install. Partial repair is allowed if
      * neither source has enough kits. */
     int kits_in_cargo  = (int)floorf(sp->ship.cargo[COMMODITY_REPAIR_KIT] + 0.0001f);
-    int kits_at_station = (int)floorf(st->inventory[COMMODITY_REPAIR_KIT] + 0.0001f);
+    int kits_at_station = (int)floorf(st->_inventory_cache[COMMODITY_REPAIR_KIT] + 0.0001f);
     int hp_needed       = (int)ceilf(missing);
     int hp_apply        = hp_needed;
     if (hp_apply > kits_in_cargo + kits_at_station)
@@ -1307,9 +1307,9 @@ static void try_repair_ship(world_t *w, server_player_t *sp) {
 
     /* Drain station inventory + station manifest for the fallback. */
     if (from_station > 0) {
-        st->inventory[COMMODITY_REPAIR_KIT] -= (float)from_station;
-        if (st->inventory[COMMODITY_REPAIR_KIT] < 0.0f)
-            st->inventory[COMMODITY_REPAIR_KIT] = 0.0f;
+        st->_inventory_cache[COMMODITY_REPAIR_KIT] -= (float)from_station;
+        if (st->_inventory_cache[COMMODITY_REPAIR_KIT] < 0.0f)
+            st->_inventory_cache[COMMODITY_REPAIR_KIT] = 0.0f;
         manifest_consume_by_commodity(&st->manifest,
                                       COMMODITY_REPAIR_KIT, from_station);
         st->manifest_dirty = true;
@@ -1347,7 +1347,7 @@ static void try_apply_ship_upgrade(world_t *w, server_player_t *sp, ship_upgrade
     commodity_t comm = (commodity_t)(COMMODITY_FRAME + required);
     int units_needed = (int)ceilf(upgrade_product_cost(&sp->ship, upgrade));
     int in_cargo  = (int)floorf(sp->ship.cargo[comm] + 0.0001f);
-    int at_station = (int)floorf(st->inventory[comm] + 0.0001f);
+    int at_station = (int)floorf(st->_inventory_cache[comm] + 0.0001f);
     if (in_cargo + at_station < units_needed) return;
 
     int from_cargo   = (units_needed < in_cargo) ? units_needed : in_cargo;
@@ -1363,8 +1363,8 @@ static void try_apply_ship_upgrade(world_t *w, server_player_t *sp, ship_upgrade
         manifest_consume_by_commodity(&sp->ship.manifest, comm, from_cargo);
     }
     if (from_station > 0) {
-        st->inventory[comm] -= (float)from_station;
-        if (st->inventory[comm] < 0.0f) st->inventory[comm] = 0.0f;
+        st->_inventory_cache[comm] -= (float)from_station;
+        if (st->_inventory_cache[comm] < 0.0f) st->_inventory_cache[comm] = 0.0f;
         manifest_consume_by_commodity(&st->manifest, comm, from_station);
         st->manifest_dirty = true;
     }
@@ -2763,7 +2763,7 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
              * server says avail=0". */
             float available = (c >= COMMODITY_RAW_ORE_COUNT)
                 ? (float)manifest_count_by_commodity(&docked_st->manifest, c)
-                : docked_st->inventory[c];
+                : docked_st->_inventory_cache[c];
             float free_volume = ship_cargo_capacity(&sp->ship) - ship_total_cargo(&sp->ship);
             float vol = commodity_volume(c);
             float space = (vol > FLOAT_EPSILON) ? (free_volume / vol) : free_volume;
@@ -2824,8 +2824,8 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
             }
             if (charge_amount > 0.01f && ledger_spend(docked_st, sp->session_token, charge_cost, &sp->ship)) {
                 sp->ship.cargo[c] += charge_amount;
-                docked_st->inventory[c] -= charge_amount;
-                if (docked_st->inventory[c] < 0.0f) docked_st->inventory[c] = 0.0f;
+                docked_st->_inventory_cache[c] -= charge_amount;
+                if (docked_st->_inventory_cache[c] < 0.0f) docked_st->_inventory_cache[c] = 0.0f;
                 if (!finished && whole > 0) {
                     moved = manifest_transfer_by_commodity_ex(
                         &docked_st->manifest, &sp->ship.manifest,
@@ -3078,7 +3078,7 @@ static void step_player(world_t *w, server_player_t *sp, float dt) {
                             grade_ok = false;
                         }
                     }
-                    float available = grade_ok ? nearby_st->inventory[c] : 0.0f;
+                    float available = grade_ok ? nearby_st->_inventory_cache[c] : 0.0f;
                     float base = station_sell_price(nearby_st, c);
                     float gmult = (sp->input.buy_grade < MINING_GRADE_COUNT)
                         ? mining_payout_multiplier((mining_grade_t)sp->input.buy_grade)
@@ -3091,7 +3091,7 @@ static void step_player(world_t *w, server_player_t *sp, float dt) {
                         float cost = amount * price_per;
                         if (ledger_spend(nearby_st, sp->session_token, cost, &sp->ship)) {
                             sp->ship.cargo[c] += amount;
-                            nearby_st->inventory[c] -= amount;
+                            nearby_st->_inventory_cache[c] -= amount;
                             /* Phase 1/2.5 manifest-first: if the station
                              * has a matching manifest unit, transfer it
                              * to the ship so the ingot's provenance (pub,
@@ -3448,7 +3448,7 @@ static void step_contracts(world_t *w, float dt) {
                  * within seconds — so we only fire CONTRACT_COMPLETE when
                  * a player/NPC actually claimed and delivered. Otherwise
                  * the contract just retires silently. */
-                float current = st->inventory[c];
+                float current = st->_inventory_cache[c];
                 float threshold = (c < COMMODITY_RAW_ORE_COUNT) ? REFINERY_HOPPER_CAPACITY * 0.95f : MAX_PRODUCT_STOCK * 0.95f;
                 if (current >= threshold) {
                     bool was_claimed = (w->contracts[i].claimed_by >= 0);
@@ -3564,7 +3564,7 @@ static void step_contracts(world_t *w, float dt) {
             int worst_ore = -1;
             for (int c = 0; c < COMMODITY_RAW_ORE_COUNT; c++) {
                 if (!sim_can_smelt_ore(st, (commodity_t)c)) continue;
-                float deficit = REFINERY_HOPPER_CAPACITY * 0.5f - st->inventory[c];
+                float deficit = REFINERY_HOPPER_CAPACITY * 0.5f - st->_inventory_cache[c];
                 if (deficit > worst_deficit) { worst_deficit = deficit; worst_ore = c; }
             }
             if (worst_ore >= 0) {
@@ -3608,7 +3608,7 @@ static void step_contracts(world_t *w, float dt) {
                  * filled past cap before Kepler dropped low enough to
                  * trigger a contract. 90% keeps haulers moving while
                  * still gating contracts on actual demand. */
-                float deficit = MAX_PRODUCT_STOCK * 0.9f - st->inventory[checks[j].ingot];
+                float deficit = MAX_PRODUCT_STOCK * 0.9f - st->_inventory_cache[checks[j].ingot];
                 if (deficit > worst_deficit) { worst_deficit = deficit; worst_idx = j; }
             }
             if (worst_idx >= 0) {
@@ -3641,7 +3641,7 @@ static void step_contracts(world_t *w, float dt) {
             const float kit_input_target = 12.0f; /* keep ~3 batches' worth on hand */
             for (int j = 0; j < 3; j++) {
                 if (station_has_module(st, kit_inputs[j].producer)) continue;
-                float deficit = kit_input_target - st->inventory[kit_inputs[j].c];
+                float deficit = kit_input_target - st->_inventory_cache[kit_inputs[j].c];
                 if (deficit > worst_deficit) { worst_deficit = deficit; worst_idx = j; }
             }
             if (worst_idx >= 0) {
@@ -3669,8 +3669,8 @@ static void step_contracts(world_t *w, float dt) {
             && station_has_module(st, MODULE_DOCK)
             && !station_has_module(st, MODULE_SHIPYARD)) {
             const float kit_import_threshold = REPAIR_KIT_STOCK_CAP * 0.25f;
-            if (st->inventory[COMMODITY_REPAIR_KIT] < kit_import_threshold) {
-                float deficit = REPAIR_KIT_STOCK_CAP - st->inventory[COMMODITY_REPAIR_KIT];
+            if (st->_inventory_cache[COMMODITY_REPAIR_KIT] < kit_import_threshold) {
+                float deficit = REPAIR_KIT_STOCK_CAP - st->_inventory_cache[COMMODITY_REPAIR_KIT];
                 float seed = st->base_price[COMMODITY_REPAIR_KIT] > 0.0f
                              ? st->base_price[COMMODITY_REPAIR_KIT]
                              : 6.0f;
@@ -3834,11 +3834,11 @@ static void step_shipyard_manufacture(world_t *w, float dt) {
         if (nascent->build_amount < needed) {
             float rate = shipyard_intake_rate(st, yard_idx, mat);
             float pull = rate * dt;
-            if (pull > st->inventory[mat]) pull = st->inventory[mat];
+            if (pull > st->_inventory_cache[mat]) pull = st->_inventory_cache[mat];
             float room = needed - nascent->build_amount;
             if (pull > room) pull = room;
             if (pull > 0.0f) {
-                st->inventory[mat] -= pull;
+                st->_inventory_cache[mat] -= pull;
                 nascent->build_amount += pull;
             }
         }
@@ -4381,11 +4381,11 @@ void world_sim_step(world_t *w, float dt) {
         for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++) {
             int mc = manifest_count_by_commodity(&st->manifest, (commodity_t)c);
             if (mc <= 0) continue;
-            int fc = (int)floorf(st->inventory[c] + 0.0001f);
+            int fc = (int)floorf(st->_inventory_cache[c] + 0.0001f);
             if (mc <= fc) continue;
-            float frac = st->inventory[c] - (float)fc;
+            float frac = st->_inventory_cache[c] - (float)fc;
             if (frac < 0.0f) frac = 0.0f;
-            st->inventory[c] = (float)mc + frac;
+            st->_inventory_cache[c] = (float)mc + frac;
         }
     }
     step_module_activation(w, dt);
@@ -4559,7 +4559,7 @@ void world_seed_station_manifests(world_t *w) {
         uint8_t origin[8] = { 'S','E','E','D','0','0','0','0' };
         origin[7] = (uint8_t)('0' + (i % 10));
         manifest_migrate_legacy_inventory(&w->stations[i].manifest,
-                                          w->stations[i].inventory,
+                                          w->stations[i]._inventory_cache,
                                           COMMODITY_COUNT, origin);
         w->stations[i].manifest_dirty = true;
     }

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -207,7 +207,8 @@ static void spatial_grid_clear(spatial_grid_t *g) {
 static spatial_cell_t *spatial_grid_get_or_create(spatial_grid_t *g, int cx, int cy) {
     spatial_grid_ensure(g);
     if (!g->entries) return NULL; /* OOM — degrade gracefully */
-    uint32_t h = (uint32_t)((cx * 73856093) ^ (cy * 19349663));
+    /* Mul in unsigned space — signed * 73856093 overflows for |cx| > 29 (UB). */
+    uint32_t h = ((uint32_t)cx * 73856093u) ^ ((uint32_t)cy * 19349663u);
     for (uint32_t i = h & g->mask; ; i = (i + 1) & g->mask) {
         sparse_cell_entry_t *e = &g->entries[i];
         if (e->key_x == INT32_MIN) {

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -109,7 +109,8 @@ static inline void spatial_grid_cell(const spatial_grid_t *g, vec2 pos, int *cx,
 /* Look up a cell by coordinates. Returns NULL if empty. */
 static inline const spatial_cell_t *spatial_grid_lookup(const spatial_grid_t *g, int cx, int cy) {
     if (!g->entries) return NULL;
-    uint32_t h = (uint32_t)((cx * 73856093) ^ (cy * 19349663));
+    /* Mul in unsigned space — signed * 73856093 overflows for |cx| > 29 (UB). */
+    uint32_t h = ((uint32_t)cx * 73856093u) ^ ((uint32_t)cy * 19349663u);
     for (uint32_t i = h & g->mask; ; i = (i + 1) & g->mask) {
         const sparse_cell_entry_t *e = &g->entries[i];
         if (e->key_x == INT32_MIN) return NULL;      /* empty slot */

--- a/server/main.c
+++ b/server/main.c
@@ -529,7 +529,7 @@ static void handle_station_state(struct mg_connection *c, int sid) {
     for (int i = 0; i < COMMODITY_COUNT; i++) {
         if (i > 0) BUF_APPEND(pos, buf, BUFSZ, ",");
         BUF_APPEND(pos, buf, BUFSZ,
-            "\"%s\":%.1f", cnames[i], st->inventory[i]);
+            "\"%s\":%.1f", cnames[i], st->_inventory_cache[i]);
     }
     BUF_APPEND(pos, buf, BUFSZ, "},\"modules\":[");
     for (int m = 0; m < st->module_count; m++) {
@@ -1193,7 +1193,7 @@ static void srv_on_player_state_change(const sim_event_t *ev) {
         uint8_t *p = &sbuf[2];
         p[0] = (uint8_t)st_idx;
         for (int c = 0; c < COMMODITY_COUNT; c++)
-            write_f32_le(&p[1 + c * 4], world.stations[st_idx].inventory[c]);
+            write_f32_le(&p[1 + c * 4], world.stations[st_idx]._inventory_cache[c]);
         ws_send(sp->conn, sbuf, (size_t)(2 + STATION_RECORD_SIZE));
     }
     station_econ_dirty = true;

--- a/server/net_protocol.h
+++ b/server/net_protocol.h
@@ -473,7 +473,7 @@ static inline int serialize_stations(uint8_t *buf, const station_t *stations) {
         uint8_t *p = &buf[2 + count * STATION_RECORD_SIZE];
         p[0] = (uint8_t)i;
         for (int c = 0; c < COMMODITY_COUNT; c++)
-            write_f32_le(&p[1 + c * 4], st->inventory[c]);
+            write_f32_le(&p[1 + c * 4], st->_inventory_cache[c]);
         write_f32_le(&p[1 + COMMODITY_COUNT * 4], st->credit_pool);
         count++;
     }

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -856,7 +856,7 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                 if (w->contracts[k].station_index == npc->home_station) continue;
                 commodity_t c = w->contracts[k].commodity;
                 if (c < COMMODITY_RAW_ORE_COUNT) continue; /* haulers carry ingots only */
-                if (home->inventory[c] < 0.5f) continue; /* no stock to fill */
+                if (home->_inventory_cache[c] < 0.5f) continue; /* no stock to fill */
                 float dist = fmaxf(1.0f, v2_len(v2_sub(w->stations[w->contracts[k].station_index].pos, home->pos)));
                 float score = contract_price(&w->contracts[k]) / dist;
                 if (score > best_score) {
@@ -869,11 +869,11 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                 /* Load the commodity for this contract (leave reserve for players) */
                 commodity_t ingot = w->contracts[best_contract].commodity;
                 npc->dest_station = w->contracts[best_contract].station_index;
-                float avail = fmaxf(0.0f, home->inventory[ingot] - HAULER_RESERVE);
+                float avail = fmaxf(0.0f, home->_inventory_cache[ingot] - HAULER_RESERVE);
                 float take = fminf(avail, space);
                 if (take > 0.5f) {
                     npc->cargo[ingot] += take;
-                    home->inventory[ingot] -= take;
+                    home->_inventory_cache[ingot] -= take;
                     int whole = (int)floorf(take + 0.0001f);
                     if (whole > 0) {
                         if (station_manifest_drain_commodity(home, ingot, whole) > 0)
@@ -903,7 +903,7 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
 
                 for (int wi = 0; wi < want_count; wi++) {
                     commodity_t ingot = wants[wi];
-                    float avail = fmaxf(0.0f, home->inventory[ingot] - HAULER_RESERVE);
+                    float avail = fmaxf(0.0f, home->_inventory_cache[ingot] - HAULER_RESERVE);
                     float need;
                     bool seen = false;
 
@@ -912,7 +912,7 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                     }
                     if (seen || avail <= 0.5f) continue;
 
-                    need = fmaxf(0.0f, MAX_PRODUCT_STOCK * 0.5f - dest->inventory[ingot]);
+                    need = fmaxf(0.0f, MAX_PRODUCT_STOCK * 0.5f - dest->_inventory_cache[ingot]);
                     if (need > best_need) {
                         best_need = need;
                         best_ingot = ingot;
@@ -920,11 +920,11 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                 }
 
                 if (best_ingot < COMMODITY_COUNT) {
-                    float avail = fmaxf(0.0f, home->inventory[best_ingot] - HAULER_RESERVE);
+                    float avail = fmaxf(0.0f, home->_inventory_cache[best_ingot] - HAULER_RESERVE);
                     float take = fminf(avail, space);
                     if (take > 0.5f) {
                         npc->cargo[best_ingot] += take;
-                        home->inventory[best_ingot] -= take;
+                        home->_inventory_cache[best_ingot] -= take;
                         int whole = (int)floorf(take + 0.0001f);
                         if (whole > 0) {
                             if (station_manifest_drain_commodity(home, best_ingot, whole) > 0)
@@ -944,7 +944,7 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                     if (!station_is_active(&w->stations[s])) continue;
                     float stock = 0.0f;
                     for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++)
-                        stock += fmaxf(0.0f, w->stations[s].inventory[c] - HAULER_RESERVE);
+                        stock += fmaxf(0.0f, w->stations[s]._inventory_cache[c] - HAULER_RESERVE);
                     if (stock > best_stock) { best_stock = stock; best_src = s; }
                 }
                 /* Stay docked at home and wait for stock or a contract.
@@ -985,15 +985,15 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
             for (int i = COMMODITY_RAW_ORE_COUNT; i < COMMODITY_COUNT; i++) {
                 if (npc->cargo[i] <= 0.0f) continue;
                 float delivered = npc->cargo[i];
-                float before = dest->inventory[i];
-                dest->inventory[i] += delivered;
-                if (dest->inventory[i] > MAX_PRODUCT_STOCK)
-                    dest->inventory[i] = MAX_PRODUCT_STOCK;
+                float before = dest->_inventory_cache[i];
+                dest->_inventory_cache[i] += delivered;
+                if (dest->_inventory_cache[i] > MAX_PRODUCT_STOCK)
+                    dest->_inventory_cache[i] = MAX_PRODUCT_STOCK;
                 /* Mirror the float bump into the manifest so the trade
                  * picker (manifest-only) sees the new stock. Use the
                  * post-clamp delta so overflow doesn't create phantom
                  * manifest entries. */
-                int int_delta = (int)floorf(dest->inventory[i] + 0.0001f)
+                int int_delta = (int)floorf(dest->_inventory_cache[i] + 0.0001f)
                               - (int)floorf(before + 0.0001f);
                 if (int_delta > 0) {
                     if (station_manifest_seed_from_npc(dest, (commodity_t)i,
@@ -1028,7 +1028,7 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                 /* Feed from station inventory into scaffolds */
                 ship_t hauler_ship = {0};
                 for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++)
-                    hauler_ship.cargo[c] = dest->inventory[c];
+                    hauler_ship.cargo[c] = dest->_inventory_cache[c];
                 if (dest->scaffold) {
                     float needed = SCAFFOLD_MATERIAL_NEEDED * (1.0f - dest->scaffold_progress);
                     float deliver = fminf(hauler_ship.cargo[COMMODITY_FRAME], needed);
@@ -1047,9 +1047,9 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                  * server-side float check (game_sim.c try_buy_product)
                  * sees as 0 and silently rejects. */
                 for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++) {
-                    float consumed = dest->inventory[c] - hauler_ship.cargo[c];
+                    float consumed = dest->_inventory_cache[c] - hauler_ship.cargo[c];
                     if (consumed > 0.01f) {
-                        dest->inventory[c] -= consumed;
+                        dest->_inventory_cache[c] -= consumed;
                         int whole = (int)floorf(consumed + 0.0001f);
                         if (whole > 0) {
                             manifest_consume_by_commodity(&dest->manifest,
@@ -1093,7 +1093,7 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
             float cur_hull = ship ? ship->hull : npc->hull;
             if (cur_hull < max_h - 0.5f
                 && station_has_module(home, MODULE_DOCK)) {
-                int kits = (int)floorf(home->inventory[COMMODITY_REPAIR_KIT] + 0.0001f);
+                int kits = (int)floorf(home->_inventory_cache[COMMODITY_REPAIR_KIT] + 0.0001f);
                 int missing = (int)ceilf(max_h - cur_hull);
                 int apply = kits < missing ? kits : missing;
                 if (apply > 0) {
@@ -1104,9 +1104,9 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                      * still gets credited. Hauler pays it back over
                      * subsequent deliveries. */
                     ledger_force_debit(home, npc->session_token, cost, ship);
-                    home->inventory[COMMODITY_REPAIR_KIT] -= (float)apply;
-                    if (home->inventory[COMMODITY_REPAIR_KIT] < 0.0f)
-                        home->inventory[COMMODITY_REPAIR_KIT] = 0.0f;
+                    home->_inventory_cache[COMMODITY_REPAIR_KIT] -= (float)apply;
+                    if (home->_inventory_cache[COMMODITY_REPAIR_KIT] < 0.0f)
+                        home->_inventory_cache[COMMODITY_REPAIR_KIT] = 0.0f;
                     if (manifest_consume_by_commodity(&home->manifest,
                                                      COMMODITY_REPAIR_KIT, apply) > 0)
                         home->manifest_dirty = true;
@@ -1130,11 +1130,11 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
              * trip, and the inter-station chain stalls. Force-debit so
              * the hauler is on the hook for upkeep just like a repair. */
             if (station_has_module(home, MODULE_DOCK)
-                && home->inventory[COMMODITY_REPAIR_KIT] >= 1.0f) {
+                && home->_inventory_cache[COMMODITY_REPAIR_KIT] >= 1.0f) {
                 float kit_price = home->base_price[COMMODITY_REPAIR_KIT];
                 if (kit_price < 0.01f) kit_price = 6.0f;
                 ledger_force_debit(home, npc->session_token, kit_price, ship);
-                home->inventory[COMMODITY_REPAIR_KIT] -= 1.0f;
+                home->_inventory_cache[COMMODITY_REPAIR_KIT] -= 1.0f;
                 if (manifest_consume_by_commodity(&home->manifest,
                                                   COMMODITY_REPAIR_KIT, 1) > 0)
                     home->manifest_dirty = true;

--- a/server/sim_autopilot.c
+++ b/server/sim_autopilot.c
@@ -579,7 +579,7 @@ void step_autopilot(world_t *w, server_player_t *sp, float dt) {
          * any — better to launch with damage than to idle forever. */
         const station_t *st = &w->stations[sp->current_station];
         float ship_kits = sp->ship.cargo[COMMODITY_REPAIR_KIT];
-        float station_kits = st->inventory[COMMODITY_REPAIR_KIT];
+        float station_kits = st->_inventory_cache[COMMODITY_REPAIR_KIT];
         bool any_kits = (ship_kits + station_kits) > 0.5f;
         if (!autopilot_hull_full(&sp->ship) && any_kits) {
             /* Stay docked; repair will keep ticking from cargo first

--- a/server/sim_construction.c
+++ b/server/sim_construction.c
@@ -165,12 +165,12 @@ void step_module_activation(world_t *w, float dt) {
             station_module_t *m = &st->modules[i];
             if (module_build_state(m) != MODULE_BUILD_AWAITING_SUPPLY) continue;
             commodity_t mat = module_build_material(m->type);
-            if (st->inventory[mat] < 0.01f) continue;
+            if (st->_inventory_cache[mat] < 0.01f) continue;
             float cost = module_build_cost(m->type);
             float needed = cost * (1.0f - module_supply_fraction(m));
             if (needed < 0.01f) continue;
-            float deliver = fminf(st->inventory[mat], needed);
-            st->inventory[mat] -= deliver;
+            float deliver = fminf(st->_inventory_cache[mat], needed);
+            st->_inventory_cache[mat] -= deliver;
             m->build_progress += deliver / cost;
             if (m->build_progress > 1.0f) m->build_progress = 1.0f;
         }

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -232,7 +232,7 @@ void sim_step_refinery_production(world_t *w, float dt) {
         for (int oi = 0; oi < 3; oi++) {
             commodity_t ore = smeltable[oi];
             if (!sim_can_smelt_ore(st, ore)) continue;
-            if (st->inventory[ore] <= 0.01f) continue;
+            if (st->_inventory_cache[ore] <= 0.01f) continue;
             active_ores++;
         }
         if (active_ores == 0) continue;
@@ -256,12 +256,12 @@ void sim_step_refinery_production(world_t *w, float dt) {
         for (int oi = 0; oi < 3; oi++) {
             commodity_t ore = smeltable[oi];
             if (!sim_can_smelt_ore(st, ore)) continue;
-            if (st->inventory[ore] <= 0.01f) continue;
+            if (st->_inventory_cache[ore] <= 0.01f) continue;
             commodity_t ingot = commodity_refined_form(ore);
-            float room = MAX_PRODUCT_STOCK - st->inventory[ingot];
+            float room = MAX_PRODUCT_STOCK - st->_inventory_cache[ingot];
             if (room <= 0.01f) continue;
-            float consume = fminf(fminf(st->inventory[ore], rate * dt), room);
-            st->inventory[ore] -= consume;
+            float consume = fminf(fminf(st->_inventory_cache[ore], rate * dt), room);
+            st->_inventory_cache[ore] -= consume;
             /* Manifest-as-truth: mint ingot manifest entries at integer
              * crossings (legacy-migrate origin so future inspectors can
              * tell this came from the refinery hopper path, not the
@@ -312,10 +312,10 @@ void sim_step_station_production(world_t *w, float dt) {
             commodity_t output_com = recipe.output;
             float stock_before;
             if (input_com >= COMMODITY_COUNT || output_com >= COMMODITY_COUNT) continue;
-            if (st->inventory[output_com] >= MAX_PRODUCT_STOCK) continue;
+            if (st->_inventory_cache[output_com] >= MAX_PRODUCT_STOCK) continue;
 
-            stock_before = st->inventory[output_com];
-            float room = MAX_PRODUCT_STOCK - st->inventory[output_com];
+            stock_before = st->_inventory_cache[output_com];
+            float room = MAX_PRODUCT_STOCK - st->_inventory_cache[output_com];
             float rate = schema->rate > 0.0f ? schema->rate : STATION_PRODUCTION_RATE;
 
             /* Primary: consume from module input buffer (filled by flow graph).
@@ -327,15 +327,15 @@ void sim_step_station_production(world_t *w, float dt) {
                                     st->module_input[m] / recipe.primary_units_per_output);
                 if (recipe.secondary_input < COMMODITY_COUNT) {
                     from_buffer = fminf(from_buffer,
-                                        st->inventory[recipe.secondary_input] /
+                                        st->_inventory_cache[recipe.secondary_input] /
                                         recipe.secondary_units_per_output);
                 }
                 if (from_buffer > 0.0f) {
                     st->module_input[m] -= from_buffer * recipe.primary_units_per_output;
                     if (recipe.secondary_input < COMMODITY_COUNT)
-                        st->inventory[recipe.secondary_input] -=
+                        st->_inventory_cache[recipe.secondary_input] -=
                             from_buffer * recipe.secondary_units_per_output;
-                    st->inventory[output_com] += from_buffer;
+                    st->_inventory_cache[output_com] += from_buffer;
                     room -= from_buffer;
                     produced += from_buffer;
                 }
@@ -344,22 +344,22 @@ void sim_step_station_production(world_t *w, float dt) {
             /* Fallback: slow trickle from station inventory (0.2x rate).
              * Only kicks in when the flow graph delivered nothing this tick.
              * Prevents total stall for poorly-placed fabs. */
-            if (produced < 0.001f && room > 0.01f && st->inventory[input_com] > 0.01f) {
+            if (produced < 0.001f && room > 0.01f && st->_inventory_cache[input_com] > 0.01f) {
                 float fallback_rate = rate * 0.2f;
                 float from_inv = fminf(fallback_rate * dt, room);
                 from_inv = fminf(from_inv,
-                                 st->inventory[input_com] / recipe.primary_units_per_output);
+                                 st->_inventory_cache[input_com] / recipe.primary_units_per_output);
                 if (recipe.secondary_input < COMMODITY_COUNT) {
                     from_inv = fminf(from_inv,
-                                     st->inventory[recipe.secondary_input] /
+                                     st->_inventory_cache[recipe.secondary_input] /
                                      recipe.secondary_units_per_output);
                 }
                 if (from_inv > 0.0f) {
-                    st->inventory[input_com] -= from_inv * recipe.primary_units_per_output;
+                    st->_inventory_cache[input_com] -= from_inv * recipe.primary_units_per_output;
                     if (recipe.secondary_input < COMMODITY_COUNT)
-                        st->inventory[recipe.secondary_input] -=
+                        st->_inventory_cache[recipe.secondary_input] -=
                             from_inv * recipe.secondary_units_per_output;
-                    st->inventory[output_com] += from_inv;
+                    st->_inventory_cache[output_com] += from_inv;
                     produced += from_inv;
                 }
             }
@@ -386,7 +386,7 @@ void sim_step_station_production(world_t *w, float dt) {
                  * the manifest-as-truth refactor is closing out. */
                 {
                     int units_before = (int)floorf(stock_before + 0.0001f);
-                    int units_after = (int)floorf(st->inventory[output_com] + 0.0001f);
+                    int units_after = (int)floorf(st->_inventory_cache[output_com] + 0.0001f);
                     int manifest_units = units_after - units_before;
                     int crafted = 0;
                     for (int idx = 0; idx < manifest_units; idx++) {
@@ -400,9 +400,9 @@ void sim_step_station_production(world_t *w, float dt) {
                          * fractional residue under stock_before stays
                          * because crafted == 0 case still has a
                          * sub-1.0 accumulator, which is fine. */
-                        st->inventory[output_com] -= (float)shortfall;
-                        if (st->inventory[output_com] < (float)units_before)
-                            st->inventory[output_com] = (float)units_before;
+                        st->_inventory_cache[output_com] -= (float)shortfall;
+                        if (st->_inventory_cache[output_com] < (float)units_before)
+                            st->_inventory_cache[output_com] = (float)units_before;
                     }
                 }
             }
@@ -452,7 +452,7 @@ void step_furnace_smelting(world_t *w, float dt) {
                  * accept it (no tractor pull, no smelt) and can route
                  * to a station with room. */
                 commodity_t furnace_ingot = commodity_refined_form(a->commodity);
-                if (st->inventory[furnace_ingot] + a->ore > MAX_PRODUCT_STOCK)
+                if (st->_inventory_cache[furnace_ingot] + a->ore > MAX_PRODUCT_STOCK)
                     continue;  /* hopper full — skip this furnace */
 
                 int ring = st->modules[m].ring;
@@ -661,10 +661,10 @@ void step_furnace_smelting(world_t *w, float dt) {
              * paid for the full ore value via the ledger above. */
             commodity_t ingot = commodity_refined_form(a->commodity);
             commodity_t output = (ingot != a->commodity) ? ingot : a->commodity;
-            float stock_before = st->inventory[output];
-            st->inventory[output] += a->ore;
-            if (st->inventory[output] > MAX_PRODUCT_STOCK)
-                st->inventory[output] = MAX_PRODUCT_STOCK;
+            float stock_before = st->_inventory_cache[output];
+            st->_inventory_cache[output] += a->ore;
+            if (st->_inventory_cache[output] > MAX_PRODUCT_STOCK)
+                st->_inventory_cache[output] = MAX_PRODUCT_STOCK;
 
             /* Push one manifest unit per integer of finished ingot
              * smelted. Each unit carries its own prefix_class derived
@@ -676,7 +676,7 @@ void step_furnace_smelting(world_t *w, float dt) {
                  * post-clamp delta = pre-clamp delta. No more silent
                  * overflow → no more "unknown origin" rows. */
                 int units_before = (int)floorf(stock_before + 0.0001f);
-                int units_after = (int)floorf(st->inventory[output] + 0.0001f);
+                int units_after = (int)floorf(st->_inventory_cache[output] + 0.0001f);
                 int manifest_units = units_after - units_before;
                 int pushed = 0;
                 int first_named_idx = -1;
@@ -815,7 +815,7 @@ void step_module_flow(world_t *w, float dt) {
                     };
                     for (int fi = 0; fi < 6; fi++) {
                         commodity_t com = feedable[fi];
-                        if (st->inventory[com] <= 0.1f) continue;
+                        if (st->_inventory_cache[com] <= 0.1f) continue;
                         /* Check if any module on this station actually wants this */
                         bool wanted = false;
                         for (int c = 0; c < st->module_count; c++) {
@@ -828,7 +828,7 @@ void step_module_flow(world_t *w, float dt) {
                             }
                         }
                         if (!wanted) continue;
-                        float pull = fminf(st->inventory[com], (cap - st->module_output[p]) * 0.5f);
+                        float pull = fminf(st->_inventory_cache[com], (cap - st->module_output[p]) * 0.5f);
                         if (pull > 0.01f) {
                             st->module_output[p] += pull;
                             output = com; /* remember what we're carrying */
@@ -868,13 +868,13 @@ void step_module_flow(world_t *w, float dt) {
                        - st->module_input[best_consumer];
             float pull = best_rate * dt;
             if (pull > st->module_output[p]) pull = st->module_output[p];
-            if (producer_kind == MODULE_KIND_STORAGE && pull > st->inventory[output])
-                pull = st->inventory[output];
+            if (producer_kind == MODULE_KIND_STORAGE && pull > st->_inventory_cache[output])
+                pull = st->_inventory_cache[output];
             if (pull > room) pull = room;
             if (pull > 0.0f) {
                 st->module_output[p] -= pull;
                 if (producer_kind == MODULE_KIND_STORAGE)
-                    st->inventory[output] -= pull;
+                    st->_inventory_cache[output] -= pull;
                 st->module_input[best_consumer] += pull;
             }
         }
@@ -922,9 +922,9 @@ void step_module_delivery(world_t *w, station_t *st, int station_idx,
          * multiplayer broadcaster forwards the new station summary;
          * otherwise clients keep showing materials that construction
          * already consumed until some unrelated event triggers a sync. */
-        if (needed > 0.01f && st->inventory[mat] > 0.01f) {
-            float deliver = fminf(st->inventory[mat], needed);
-            st->inventory[mat] -= deliver;
+        if (needed > 0.01f && st->_inventory_cache[mat] > 0.01f) {
+            float deliver = fminf(st->_inventory_cache[mat], needed);
+            st->_inventory_cache[mat] -= deliver;
             m->build_progress += deliver / cost;
             int whole = (int)floorf(deliver + 0.0001f);
             if (whole > 0) {
@@ -956,7 +956,7 @@ void step_dock_repair_kit_fab(world_t *w, float dt) {
         station_t *st = &w->stations[s];
         if (!station_exists(st)) continue;
         if (!station_has_module(st, MODULE_SHIPYARD)) continue;
-        if (st->inventory[COMMODITY_REPAIR_KIT] >= REPAIR_KIT_STOCK_CAP) continue;
+        if (st->_inventory_cache[COMMODITY_REPAIR_KIT] >= REPAIR_KIT_STOCK_CAP) continue;
 
         st->repair_kit_fab_timer += dt;
         if (st->repair_kit_fab_timer < REPAIR_KIT_FAB_PERIOD) continue;
@@ -964,18 +964,18 @@ void step_dock_repair_kit_fab(world_t *w, float dt) {
         /* All three inputs required. If any are missing, hold the timer
          * at the period (don't keep accumulating) so the next batch
          * fires the moment supply arrives. */
-        if (st->inventory[COMMODITY_FRAME] < 1.0f ||
-            st->inventory[COMMODITY_LASER_MODULE] < 1.0f ||
-            st->inventory[COMMODITY_TRACTOR_MODULE] < 1.0f) {
+        if (st->_inventory_cache[COMMODITY_FRAME] < 1.0f ||
+            st->_inventory_cache[COMMODITY_LASER_MODULE] < 1.0f ||
+            st->_inventory_cache[COMMODITY_TRACTOR_MODULE] < 1.0f) {
             st->repair_kit_fab_timer = REPAIR_KIT_FAB_PERIOD;
             continue;
         }
 
         /* Consume one of each from the float + manifest, in lockstep
          * with the manifest-truth invariant. */
-        st->inventory[COMMODITY_FRAME]          -= 1.0f;
-        st->inventory[COMMODITY_LASER_MODULE]   -= 1.0f;
-        st->inventory[COMMODITY_TRACTOR_MODULE] -= 1.0f;
+        st->_inventory_cache[COMMODITY_FRAME]          -= 1.0f;
+        st->_inventory_cache[COMMODITY_LASER_MODULE]   -= 1.0f;
+        st->_inventory_cache[COMMODITY_TRACTOR_MODULE] -= 1.0f;
         manifest_consume_by_commodity(&st->manifest, COMMODITY_FRAME, 1);
         manifest_consume_by_commodity(&st->manifest, COMMODITY_LASER_MODULE, 1);
         manifest_consume_by_commodity(&st->manifest, COMMODITY_TRACTOR_MODULE, 1);
@@ -983,9 +983,9 @@ void step_dock_repair_kit_fab(world_t *w, float dt) {
         /* Mint kits — clamp at the cap. Each minted unit gets a
          * legacy-migrate manifest entry so the TRADE picker can see
          * them and the per-station origin stays traceable. */
-        float room = REPAIR_KIT_STOCK_CAP - st->inventory[COMMODITY_REPAIR_KIT];
+        float room = REPAIR_KIT_STOCK_CAP - st->_inventory_cache[COMMODITY_REPAIR_KIT];
         float minted = fminf(REPAIR_KIT_PER_BATCH, room);
-        st->inventory[COMMODITY_REPAIR_KIT] += minted;
+        st->_inventory_cache[COMMODITY_REPAIR_KIT] += minted;
         int int_minted = (int)floorf(minted + 0.0001f);
         if (int_minted > 0) {
             uint8_t origin[8] = { 'D','O','C','K','F','A','B','0' };

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -119,7 +119,7 @@ static bool read_station(FILE *f, station_t *s) {
     { uint8_t raw; memcpy(&raw, &s->scaffold, 1); s->scaffold = (raw != 0); }
     READ_FIELD(f, s->scaffold_progress);
     READ_FIELD(f, s->base_price);
-    READ_FIELD(f, s->inventory);
+    READ_FIELD(f, s->_inventory_cache);
     READ_FIELD(f, s->services);
     /* Modules */
     READ_FIELD(f, s->module_count);
@@ -193,7 +193,7 @@ static bool read_station(FILE *f, station_t *s) {
 
 static bool write_station_session(FILE *f, const station_t *s) {
     /* Inventory */
-    WRITE_FIELD(f, s->inventory);
+    WRITE_FIELD(f, s->_inventory_cache);
     /* Per-module production buffers */
     for (int m = 0; m < MAX_MODULES_PER_STATION; m++)
         WRITE_FIELD(f, s->module_input[m]);
@@ -245,7 +245,7 @@ static bool write_station_session(FILE *f, const station_t *s) {
 
 static bool read_station_session(FILE *f, station_t *s) {
     /* Inventory */
-    READ_FIELD(f, s->inventory);
+    READ_FIELD(f, s->_inventory_cache);
     /* Per-module production buffers */
     for (int m = 0; m < MAX_MODULES_PER_STATION; m++)
         READ_FIELD(f, s->module_input[m]);
@@ -351,7 +351,7 @@ static bool read_station_session(FILE *f, station_t *s) {
          * the same save reloads to the same pubs deterministically. */
         uint8_t origin[8] = {0};
         memcpy(origin, s->name, sizeof(origin));
-        (void)manifest_migrate_legacy_inventory(&s->manifest, s->inventory,
+        (void)manifest_migrate_legacy_inventory(&s->manifest, s->_inventory_cache,
                                                 COMMODITY_COUNT, origin);
     }
     return true;

--- a/shared/manifest.h
+++ b/shared/manifest.h
@@ -88,10 +88,10 @@ bool manifest_migrate_legacy_inventory(manifest_t *manifest,
 /* Manifest-as-truth helpers (PR: kill the float<->manifest drift)   */
 /* ---------------------------------------------------------------- */
 /* For finished-good commodities (c >= COMMODITY_RAW_ORE_COUNT) the
- * manifest is the authoritative store. The float `station_t::inventory[c]`
- * is a derived count whose floor() must always equal
- * manifest_count_by_commodity(c). These helpers preserve that
- * invariant by mutating both the manifest and the float in lockstep.
+ * manifest is the authoritative store. The float
+ * `station_t::_inventory_cache[c]` is a derived count whose floor() must
+ * always equal manifest_count_by_commodity(c). These helpers preserve
+ * that invariant by mutating both the manifest and the float in lockstep.
  *
  * Raw-ore commodities (c < COMMODITY_RAW_ORE_COUNT) are NOT covered —
  * raw ore lives only in the float (hopper amounts) and never gains a

--- a/shared/types.h
+++ b/shared/types.h
@@ -285,7 +285,14 @@ typedef struct {
     int8_t planned_owner;    /* player id who created the plan, -1 = system */
     float scaffold_progress; /* 0.0 to 1.0 */
     float base_price[COMMODITY_COUNT];
-    float inventory[COMMODITY_COUNT]; /* unified storage for all commodities */
+    /* Unified storage for all commodities. Treat as the float cache of
+     * the manifest for finished goods (c >= COMMODITY_RAW_ORE_COUNT) —
+     * direct writes to those slots silently break the manifest invariant.
+     * Use station_finished_{mint,drain,accumulate} (see shared/manifest.h)
+     * instead. Raw ore slots (c < COMMODITY_RAW_ORE_COUNT) live only here
+     * and may be read/written directly. The leading underscore signals
+     * "private — go through the accessors". */
+    float _inventory_cache[COMMODITY_COUNT];
     uint32_t services;
     /* Module system */
     station_module_t modules[MAX_MODULES_PER_STATION];

--- a/src/commodity.c
+++ b/src/commodity.c
@@ -169,7 +169,7 @@ float station_buy_price(const station_t* station, commodity_t commodity) {
     if (base < FLOAT_EPSILON) return 0.0f;
     float capacity = (commodity < COMMODITY_RAW_ORE_COUNT)
         ? REFINERY_HOPPER_CAPACITY : MAX_PRODUCT_STOCK;
-    float fill = station->inventory[commodity] / capacity;
+    float fill = station->_inventory_cache[commodity] / capacity;
     if (fill > 1.0f) fill = 1.0f;
     /* Buy cheaper when overstocked: 1.0× at empty, 0.5× at full */
     return base * (1.0f - fill * 0.5f);
@@ -184,7 +184,7 @@ float station_sell_price(const station_t* station, commodity_t commodity) {
     if (base < FLOAT_EPSILON) return 0.0f;
     float capacity = (commodity < COMMODITY_RAW_ORE_COUNT)
         ? REFINERY_HOPPER_CAPACITY : MAX_PRODUCT_STOCK;
-    float fill = station->inventory[commodity] / capacity;
+    float fill = station->_inventory_cache[commodity] / capacity;
     if (fill > 1.0f) fill = 1.0f;
     float deficit = 1.0f - fill;
     /* Sell expensive when scarce: 1× at full, 2× at empty */
@@ -192,5 +192,5 @@ float station_sell_price(const station_t* station, commodity_t commodity) {
 }
 
 float station_inventory_amount(const station_t* station, commodity_t commodity) {
-    return station != NULL ? station->inventory[commodity] : 0.0f;
+    return station != NULL ? station->_inventory_cache[commodity] : 0.0f;
 }

--- a/src/economy.c
+++ b/src/economy.c
@@ -66,28 +66,28 @@ void step_station_production(station_t* stations, int count, float dt) {
             if (!producer_recipe_for_module(mt, &recipe)) continue;
 
             schema = module_schema(mt);
-            room = MAX_PRODUCT_STOCK - station->inventory[recipe.output];
+            room = MAX_PRODUCT_STOCK - station->_inventory_cache[recipe.output];
             if (room <= FLOAT_EPSILON) continue;
 
             rate = schema->rate > 0.0f ? schema->rate : STATION_PRODUCTION_RATE;
             produce = fminf(rate * dt, room);
             produce = fminf(produce,
-                            station->inventory[recipe.primary_input] /
+                            station->_inventory_cache[recipe.primary_input] /
                             recipe.primary_units_per_output);
             if (recipe.secondary_input < COMMODITY_COUNT) {
                 produce = fminf(produce,
-                                station->inventory[recipe.secondary_input] /
+                                station->_inventory_cache[recipe.secondary_input] /
                                 recipe.secondary_units_per_output);
             }
             if (produce <= FLOAT_EPSILON) continue;
 
-            station->inventory[recipe.primary_input] -=
+            station->_inventory_cache[recipe.primary_input] -=
                 produce * recipe.primary_units_per_output;
             if (recipe.secondary_input < COMMODITY_COUNT) {
-                station->inventory[recipe.secondary_input] -=
+                station->_inventory_cache[recipe.secondary_input] -=
                     produce * recipe.secondary_units_per_output;
             }
-            station->inventory[recipe.output] += produce;
+            station->_inventory_cache[recipe.output] += produce;
         }
     }
 }
@@ -119,7 +119,7 @@ bool can_afford_upgrade(const station_t* station, const ship_t* ship, ship_upgra
     commodity_t comm = (commodity_t)(COMMODITY_FRAME + upgrade_required_product(upgrade));
     int units_needed = (int)ceilf(upgrade_product_cost(ship, upgrade));
     int in_cargo  = (int)floorf(ship->cargo[comm] + 0.0001f);
-    int at_station = (int)floorf(station->inventory[comm] + 0.0001f);
+    int at_station = (int)floorf(station->_inventory_cache[comm] + 0.0001f);
     if (in_cargo + at_station < units_needed) return false;
     int from_station = units_needed - (units_needed < in_cargo ? units_needed : in_cargo);
     float credit_cost = (float)from_station * station_sell_price(station, comm);

--- a/src/input.c
+++ b/src/input.c
@@ -400,7 +400,7 @@ static void sample_dock_keys(input_intent_t *intent) {
         const station_t *st = current_station_ptr();
         int kits_avail =
             (int)floorf(LOCAL_PLAYER.ship.cargo[COMMODITY_REPAIR_KIT] + 0.0001f) +
-            (st ? (int)floorf(st->inventory[COMMODITY_REPAIR_KIT] + 0.0001f) : 0);
+            (st ? (int)floorf(st->_inventory_cache[COMMODITY_REPAIR_KIT] + 0.0001f) : 0);
         float max_hull = ship_max_hull(&LOCAL_PLAYER.ship);
         bool needs_repair = LOCAL_PLAYER.ship.hull < max_hull;
         if (needs_repair && kits_avail <= 0) set_notice("No repair kits available.");

--- a/src/main.c
+++ b/src/main.c
@@ -1481,7 +1481,7 @@ static void render_world(void) {
                 default: break;
             }
             if ((int)sell_c >= 0) {
-                int stock = (int)lroundf(tst->inventory[sell_c]);
+                int stock = (int)lroundf(tst->_inventory_cache[sell_c]);
                 int price = (int)lroundf(station_sell_price(tst, sell_c));
                 if (stock > 0)
                     sdtx_printf("[Fire] buy 1 @ %dcr  (stock %d)", price, stock);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1,7 +1,24 @@
 #include "manifest.h"
 
+#include <assert.h>
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* In debug builds, every finished-good accessor exit must leave
+ * floor(inventory[c]) == manifest_count_by_commodity(c). The +0.0001
+ * tolerance matches station_finished_accumulate's rounding. Raw-ore
+ * commodities (< COMMODITY_RAW_ORE_COUNT) are stored only in the float
+ * and have no manifest representation, so we skip them. */
+static void assert_finished_invariant(const station_t *st, commodity_t c) {
+    (void)st; (void)c;
+#ifndef NDEBUG
+    if ((int)c < (int)COMMODITY_RAW_ORE_COUNT) return;
+    if ((int)c >= (int)COMMODITY_COUNT) return;
+    assert((int)floorf(st->inventory[c] + 0.0001f) ==
+           manifest_count_by_commodity(&st->manifest, c));
+#endif
+}
 
 enum {
     HASH_BYTES = 32,
@@ -211,6 +228,7 @@ bool manifest_reserve(manifest_t *manifest, uint16_t cap) {
     manifest->units = resized;
     memset(&manifest->units[old_cap], 0, (cap - old_cap) * sizeof(cargo_unit_t));
     manifest->cap = cap;
+    assert(manifest->count <= manifest->cap);
     return true;
 }
 
@@ -291,6 +309,7 @@ bool manifest_push(manifest_t *manifest, const cargo_unit_t *unit) {
     }
     if (!manifest->units) return false;
     manifest->units[manifest->count++] = *unit;
+    assert(manifest->count <= manifest->cap);
     return true;
 }
 
@@ -551,11 +570,21 @@ int station_finished_mint(station_t *st, commodity_t c, int n,
     }
     if (minted > 0) {
         /* Sync float to the new manifest count, preserving any fractional
-         * residue (production accumulator) below 1.0. */
-        float frac = st->inventory[c] - floorf(st->inventory[c]);
+         * residue (production accumulator) below 1.0. Use the same +0.0001
+         * epsilon as station_finished_accumulate's int_before/int_after
+         * snap — without it, when accumulate rounds 0.9999...→1 to trigger
+         * this mint, frac would be computed as ~0.9999 (not ~0), and the
+         * float would jump to manifest_count + 0.9999, breaking the
+         * invariant by one whole unit. */
+        float v = st->inventory[c];
+        float floor_v = floorf(v + 0.0001f);
+        float frac = v - floor_v;
+        if (frac < 0.0f) frac = 0.0f;     /* clamp tiny negative residue */
+        if (frac >= 1.0f) frac = 0.0f;    /* belt-and-suspenders */
         st->inventory[c] = (float)manifest_count_by_commodity(&st->manifest, c) + frac;
         st->manifest_dirty = true;
     }
+    assert_finished_invariant(st, c);
     return minted;
 }
 
@@ -570,6 +599,7 @@ int station_finished_drain(station_t *st, commodity_t c, int n) {
         if (st->inventory[c] < 0.0f) st->inventory[c] = 0.0f;
         st->manifest_dirty = true;
     }
+    assert_finished_invariant(st, c);
     return drained;
 }
 
@@ -592,9 +622,13 @@ int station_finished_accumulate(station_t *st, commodity_t c, float amount,
      * minting partially fails (manifest cap). */
     st->inventory[c] = after;
 
-    if (delta <= 0) return 0;
+    if (delta <= 0) {
+        assert_finished_invariant(st, c);
+        return 0;
+    }
     int minted = station_finished_mint(st, c, delta, origin);
     /* mint sets inventory[c] = manifest_count + frac; that already
      * captures any cap-induced shortfall. */
+    assert_finished_invariant(st, c);
     return minted;
 }

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -15,7 +15,7 @@ static void assert_finished_invariant(const station_t *st, commodity_t c) {
 #ifndef NDEBUG
     if ((int)c < (int)COMMODITY_RAW_ORE_COUNT) return;
     if ((int)c >= (int)COMMODITY_COUNT) return;
-    assert((int)floorf(st->inventory[c] + 0.0001f) ==
+    assert((int)floorf(st->_inventory_cache[c] + 0.0001f) ==
            manifest_count_by_commodity(&st->manifest, c));
 #endif
 }
@@ -576,12 +576,12 @@ int station_finished_mint(station_t *st, commodity_t c, int n,
          * this mint, frac would be computed as ~0.9999 (not ~0), and the
          * float would jump to manifest_count + 0.9999, breaking the
          * invariant by one whole unit. */
-        float v = st->inventory[c];
+        float v = st->_inventory_cache[c];
         float floor_v = floorf(v + 0.0001f);
         float frac = v - floor_v;
         if (frac < 0.0f) frac = 0.0f;     /* clamp tiny negative residue */
         if (frac >= 1.0f) frac = 0.0f;    /* belt-and-suspenders */
-        st->inventory[c] = (float)manifest_count_by_commodity(&st->manifest, c) + frac;
+        st->_inventory_cache[c] = (float)manifest_count_by_commodity(&st->manifest, c) + frac;
         st->manifest_dirty = true;
     }
     assert_finished_invariant(st, c);
@@ -594,9 +594,9 @@ int station_finished_drain(station_t *st, commodity_t c, int n) {
     if ((int)c >= (int)COMMODITY_COUNT) return 0;
     int drained = manifest_consume_by_commodity(&st->manifest, c, n);
     if (drained > 0) {
-        float frac = st->inventory[c] - floorf(st->inventory[c]);
-        st->inventory[c] = (float)manifest_count_by_commodity(&st->manifest, c) + frac;
-        if (st->inventory[c] < 0.0f) st->inventory[c] = 0.0f;
+        float frac = st->_inventory_cache[c] - floorf(st->_inventory_cache[c]);
+        st->_inventory_cache[c] = (float)manifest_count_by_commodity(&st->manifest, c) + frac;
+        if (st->_inventory_cache[c] < 0.0f) st->_inventory_cache[c] = 0.0f;
         st->manifest_dirty = true;
     }
     assert_finished_invariant(st, c);
@@ -612,7 +612,7 @@ int station_finished_accumulate(station_t *st, commodity_t c, float amount,
     /* Compute how many integer crossings this addition triggers. The
      * float currently holds: (manifest count) + (fractional residue).
      * After adding `amount`, the new int count is floor(old + amount). */
-    float before = st->inventory[c];
+    float before = st->_inventory_cache[c];
     float after  = before + amount;
     int int_before = (int)floorf(before + 0.0001f);
     int int_after  = (int)floorf(after + 0.0001f);
@@ -620,7 +620,7 @@ int station_finished_accumulate(station_t *st, commodity_t c, float amount,
 
     /* Update float first so any partial residue is preserved even if
      * minting partially fails (manifest cap). */
-    st->inventory[c] = after;
+    st->_inventory_cache[c] = after;
 
     if (delta <= 0) {
         assert_finished_invariant(st, c);

--- a/src/net_sync.c
+++ b/src/net_sync.c
@@ -141,7 +141,7 @@ void apply_remote_stations(uint8_t index, const float* inventory, float credit_p
     if (index >= MAX_STATIONS) return;
     station_t* st = &g.world.stations[index];
     for (int i = 0; i < COMMODITY_COUNT; i++)
-        st->inventory[i] = inventory[i];
+        st->_inventory_cache[i] = inventory[i];
     st->credit_pool = credit_pool;
 }
 

--- a/src/station_ui.c
+++ b/src/station_ui.c
@@ -304,7 +304,7 @@ void build_station_ui_state(station_ui_state_t* ui) {
         int need = (int)ceilf(upgrade_product_cost(&LOCAL_PLAYER.ship, slots[i].up));
         int in_cargo  = (int)floorf(LOCAL_PLAYER.ship.cargo[c] + 0.0001f);
         int at_station = ui->station
-            ? (int)floorf(ui->station->inventory[c] + 0.0001f) : 0;
+            ? (int)floorf(ui->station->_inventory_cache[c] + 0.0001f) : 0;
         int from_station = need - (need < in_cargo ? need : in_cargo);
         if (from_station < 0) from_station = 0;
         float credit = ui->station
@@ -323,7 +323,7 @@ void build_station_ui_state(station_ui_state_t* ui) {
     ui->ship_kits    = (int)floorf(LOCAL_PLAYER.ship.cargo[COMMODITY_REPAIR_KIT]
                                    + 0.0001f);
     ui->station_kits = (ui->station)
-        ? (int)floorf(ui->station->inventory[COMMODITY_REPAIR_KIT] + 0.0001f)
+        ? (int)floorf(ui->station->_inventory_cache[COMMODITY_REPAIR_KIT] + 0.0001f)
         : 0;
     int hp_needed = ui->hull_max - ui->hull_now;
     if (hp_needed < 0) hp_needed = 0;
@@ -634,7 +634,7 @@ int build_trade_rows(const station_t *st, const ship_t *ship,
         if (!station_produces(st, (commodity_t)c)) continue;
         float price_base = station_sell_price(st, (commodity_t)c);
         if (price_base <= FLOAT_EPSILON) continue;
-        int station_inv = (int)lroundf(st->inventory[c]);
+        int station_inv = (int)lroundf(st->_inventory_cache[c]);
         bool emitted_any_grade = false;
         for (int gi = 0; gi < MINING_GRADE_COUNT && row_count < max; gi++) {
             int stock = station_manifest_count_cg(st, (commodity_t)c, (mining_grade_t)gi);
@@ -682,7 +682,7 @@ int build_trade_rows(const station_t *st, const ship_t *ship,
         if (!station_consumes(st, (commodity_t)c)) continue;
         float price_base = station_buy_price(st, (commodity_t)c);
         if (price_base <= FLOAT_EPSILON) continue;
-        int station_total_inv = (int)lroundf(st->inventory[c]);
+        int station_total_inv = (int)lroundf(st->_inventory_cache[c]);
         bool station_full = station_total_inv >= capacity;
         /* Cargo float is authoritative for what's onboard. The manifest
          * can drift past it (wire desync), so cap held counts by cargo
@@ -797,7 +797,7 @@ static void draw_trade_view(const station_ui_state_t *ui,
              * non-empty storage output as "in flow" for any
              * commodity the station produces (best the data lets us
              * do without per-tick commodity tags). */
-            bool in_flow = (st->inventory[c] > 0.01f);
+            bool in_flow = (st->_inventory_cache[c] > 0.01f);
             if (!in_flow) {
                 for (int m = 0; m < st->module_count; m++) {
                     module_type_t mt = st->modules[m].type;
@@ -1485,7 +1485,7 @@ static void draw_yard_view(const station_ui_state_t *ui,
             commodity_t mat_type = module_build_material_lookup(t);
             float need = module_build_cost_lookup(t);
             float have = (p == 0 && nascent) ? nascent->build_amount : 0.0f;
-            float station_have = ui->station->inventory[mat_type];
+            float station_have = ui->station->_inventory_cache[mat_type];
             int got = (int)lroundf(have);
             int total = (int)lroundf(need);
             sdtx_pos(ui_text_pos(cx), ui_text_pos(ly));

--- a/src/tests/test_bug_regression.c
+++ b/src/tests/test_bug_regression.c
@@ -66,7 +66,7 @@ TEST(test_bug9_repair_cost_consistent) {
     memset(&st, 0, sizeof(st));
     st.modules[st.module_count++] = (station_module_t){ .type = MODULE_DOCK };
     st.base_price[COMMODITY_REPAIR_KIT] = 6.0f;
-    st.inventory[COMMODITY_REPAIR_KIT]  = MAX_PRODUCT_STOCK; /* full → 1× base */
+    st._inventory_cache[COMMODITY_REPAIR_KIT]  = MAX_PRODUCT_STOCK; /* full → 1× base */
     float cost = station_repair_cost(&ship, &st);
     ASSERT_EQ_FLOAT(cost, 20.0f * (6.0f + LABOR_FEE_PER_HP), 0.01f);
 }
@@ -228,11 +228,11 @@ TEST(test_bug22_hauler_stuck_at_empty_station) {
     world_reset(&w);
     /* Empty the refinery inventory so haulers can't load from home */
     for (int i = 0; i < COMMODITY_COUNT; i++)
-        w.stations[0].inventory[i] = 0.0f;
+        w.stations[0]._inventory_cache[i] = 0.0f;
     /* Put enough ingots at station 1 to exceed the hauler reserve, so
      * relocation can actually result in a load. */
-    w.stations[1].inventory[COMMODITY_FERRITE_INGOT] = 40.0f;
-    float initial_stock = w.stations[1].inventory[COMMODITY_FERRITE_INGOT];
+    w.stations[1]._inventory_cache[COMMODITY_FERRITE_INGOT] = 40.0f;
+    float initial_stock = w.stations[1]._inventory_cache[COMMODITY_FERRITE_INGOT];
     /* Run 60 seconds — haulers should relocate, load from station 1, and deliver */
     for (int i = 0; i < 7200; i++)
         world_sim_step(&w, SIM_DT);
@@ -244,7 +244,7 @@ TEST(test_bug22_hauler_stuck_at_empty_station) {
             hauler_relocated = true;
         }
     }
-    ASSERT(hauler_relocated || w.stations[1].inventory[COMMODITY_FERRITE_INGOT] < initial_stock);
+    ASSERT(hauler_relocated || w.stations[1]._inventory_cache[COMMODITY_FERRITE_INGOT] < initial_stock);
 }
 
 TEST(test_bug23_npc_cargo_stuck_when_hopper_full) {
@@ -252,7 +252,7 @@ TEST(test_bug23_npc_cargo_stuck_when_hopper_full) {
     world_reset(&w);
     /* Fill all hoppers to capacity */
     for (int i = 0; i < COMMODITY_RAW_ORE_COUNT; i++)
-        w.stations[0].inventory[i] = REFINERY_HOPPER_CAPACITY;
+        w.stations[0]._inventory_cache[i] = REFINERY_HOPPER_CAPACITY;
     /* Give miner some cargo and send it home */
     w.npc_ships[0].cargo[0] = 30.0f;
     w.npc_ships[0].state = NPC_STATE_RETURN_TO_STATION;
@@ -277,14 +277,14 @@ TEST(test_bug24_ingot_buffer_no_cap) {
     WORLD_DECL;
     world_reset(&w);
     /* Pre-fill dest ingot buffer near capacity */
-    w.stations[1].inventory[COMMODITY_FERRITE_INGOT] = 40.0f;
+    w.stations[1]._inventory_cache[COMMODITY_FERRITE_INGOT] = 40.0f;
     /* Hauler arrives with 40 more ingots — should be capped */
     w.npc_ships[3].cargo[COMMODITY_FERRITE_INGOT] = 40.0f;
     w.npc_ships[3].state = NPC_STATE_UNLOADING;
     w.npc_ships[3].state_timer = 0.01f;
     w.npc_ships[3].dest_station = 1;
     world_sim_step(&w, SIM_DT);
-    ASSERT(w.stations[1].inventory[COMMODITY_FERRITE_INGOT] <= 50.0f);
+    ASSERT(w.stations[1]._inventory_cache[COMMODITY_FERRITE_INGOT] <= 50.0f);
 }
 
 TEST(test_bug25_rng_deterministic_every_reset) {
@@ -305,7 +305,7 @@ TEST(test_bug26_hauler_unload_no_cap) {
     WORLD_DECL;
     world_reset(&w);
     /* Pre-fill dest ingot buffer */
-    w.stations[1].inventory[COMMODITY_FERRITE_INGOT] = 100.0f;
+    w.stations[1]._inventory_cache[COMMODITY_FERRITE_INGOT] = 100.0f;
     /* Hauler arrives with 40 more */
     w.npc_ships[3].cargo[COMMODITY_FERRITE_INGOT] = 40.0f;
     w.npc_ships[3].state = NPC_STATE_UNLOADING;
@@ -314,7 +314,7 @@ TEST(test_bug26_hauler_unload_no_cap) {
     world_sim_step(&w, SIM_DT);
     /* After fix: ingot_buffer should not exceed a cap.
      * FAILS because unloading has no cap — buffer becomes 140. */
-    ASSERT(w.stations[1].inventory[COMMODITY_FERRITE_INGOT] <= 100.0f);
+    ASSERT(w.stations[1]._inventory_cache[COMMODITY_FERRITE_INGOT] <= 100.0f);
 }
 
 TEST(test_bug27_cargo_negative_after_sell) {
@@ -992,7 +992,7 @@ TEST(test_bug51_npc_cargo_zeroed_on_dock) {
     WORLD_DECL;
     world_reset(&w);
     /* Fill hopper so only 5 units can be deposited */
-    w.stations[0].inventory[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY - 5.0f;
+    w.stations[0]._inventory_cache[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY - 5.0f;
     /* Give NPC 30 ferrite and send it home */
     w.npc_ships[0].cargo[COMMODITY_FERRITE_ORE] = 30.0f;
     w.npc_ships[0].state = NPC_STATE_RETURN_TO_STATION;
@@ -1019,7 +1019,7 @@ TEST(test_bug52_server_repair_cost_no_service_check) {
     w.players[0].current_station = 0;
     w.players[0].ship.hull = 50.0f;
     /* Drain any seeded kits to be sure both sources are empty. */
-    w.stations[0].inventory[COMMODITY_REPAIR_KIT] = 0.0f;
+    w.stations[0]._inventory_cache[COMMODITY_REPAIR_KIT] = 0.0f;
     w.players[0].ship.cargo[COMMODITY_REPAIR_KIT] = 0.0f;
     ledger_earn(&w.stations[0], w.players[0].session_token, 1000.0f);
     float bal_before = ledger_balance(&w.stations[0],
@@ -1083,7 +1083,7 @@ TEST(test_bug55_npc_deposits_at_non_refinery) {
      * Yard doesn't smelt. The ore sits forever. */
     /* After fix: NPC should only deposit ore at REFINERY stations,
      * or seek the nearest refinery to sell. */
-    ASSERT_EQ_FLOAT(w.stations[1].inventory[COMMODITY_FERRITE_ORE], 0.0f, 0.01f);
+    ASSERT_EQ_FLOAT(w.stations[1]._inventory_cache[COMMODITY_FERRITE_ORE], 0.0f, 0.01f);
 }
 
 TEST(test_bug56_asteroid_drag_constant) {

--- a/src/tests/test_commodity.c
+++ b/src/tests/test_commodity.c
@@ -118,22 +118,22 @@ TEST(test_station_buy_price) {
     /* Empty hopper = 1× base (station pays full price to attract sellers) */
     ASSERT_EQ_FLOAT(station_buy_price(&station, COMMODITY_FERRITE_ORE), 10.0f, 0.01f);
     /* Full hopper = 0.5× base (overstocked, pays less) */
-    station.inventory[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY;
+    station._inventory_cache[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY;
     ASSERT_EQ_FLOAT(station_buy_price(&station, COMMODITY_FERRITE_ORE), 5.0f, 0.01f);
     /* Half full: 1 - 0.5*0.5 = 0.75× base */
-    station.inventory[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY * 0.5f;
+    station._inventory_cache[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY * 0.5f;
     ASSERT_EQ_FLOAT(station_buy_price(&station, COMMODITY_FERRITE_ORE), 7.5f, 0.01f);
     ASSERT_EQ_FLOAT(station_buy_price(NULL, COMMODITY_FERRITE_ORE), 0.0f, 0.01f);
     /* Sell price: empty = 2× base, full = 1× base */
-    station.inventory[COMMODITY_FERRITE_ORE] = 0.0f;
+    station._inventory_cache[COMMODITY_FERRITE_ORE] = 0.0f;
     ASSERT_EQ_FLOAT(station_sell_price(&station, COMMODITY_FERRITE_ORE), 20.0f, 0.01f);
-    station.inventory[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY;
+    station._inventory_cache[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY;
     ASSERT_EQ_FLOAT(station_sell_price(&station, COMMODITY_FERRITE_ORE), 10.0f, 0.01f);
 }
 
 TEST(test_station_inventory_amount) {
     station_t station = {0};
-    station.inventory[COMMODITY_FERRITE_INGOT] = 25.0f;
+    station._inventory_cache[COMMODITY_FERRITE_INGOT] = 25.0f;
     ASSERT_EQ_FLOAT(station_inventory_amount(&station, COMMODITY_FERRITE_INGOT), 25.0f, 0.01f);
     ASSERT_EQ_FLOAT(station_inventory_amount(NULL, COMMODITY_FERRITE_INGOT), 0.0f, 0.01f);
 }

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -268,7 +268,7 @@ TEST(test_world_seed_station_manifests_matches_float) {
     world_seed_station_manifests(&w);
     for (int s = 0; s < 3; s++) {
         for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++) {
-            int expected = (int)floorf(w.stations[s].inventory[c] + 0.0001f);
+            int expected = (int)floorf(w.stations[s]._inventory_cache[c] + 0.0001f);
             int got = manifest_count_by_commodity(&w.stations[s].manifest,
                                                   (commodity_t)c);
             ASSERT_EQ_INT(got, expected);
@@ -813,7 +813,7 @@ TEST(test_scaffold_full_pipeline) {
      * step_module_activation will route it to the scaffold. */
     commodity_t mat = module_build_material_lookup(MODULE_FURNACE);
     float cost = module_build_cost_lookup(MODULE_FURNACE);
-    w.stations[outpost].inventory[mat] = cost;
+    w.stations[outpost]._inventory_cache[mat] = cost;
     for (int i = 0; i < 120; i++) world_sim_step(&w, SIM_DT);
     ASSERT(module_is_fully_supplied(m)); /* fully supplied, timer may have started */
 
@@ -994,13 +994,13 @@ TEST(test_placed_scaffold_supply_phase) {
     /* Deliver half the material */
     commodity_t mat = module_build_material_lookup(MODULE_FURNACE);
     float cost = module_build_cost_lookup(MODULE_FURNACE);
-    w.stations[outpost].inventory[mat] = cost * 0.5f;
+    w.stations[outpost]._inventory_cache[mat] = cost * 0.5f;
     for (int i = 0; i < 120; i++) world_sim_step(&w, SIM_DT);
     ASSERT(m->build_progress > 0.4f && m->build_progress < 0.6f);
     ASSERT(m->scaffold); /* still building */
 
     /* Deliver the rest */
-    w.stations[outpost].inventory[mat] = cost * 0.5f;
+    w.stations[outpost]._inventory_cache[mat] = cost * 0.5f;
     for (int i = 0; i < 120; i++) world_sim_step(&w, SIM_DT);
     ASSERT(module_is_fully_supplied(m)); /* fully supplied, timer may have started */
 
@@ -1058,7 +1058,7 @@ TEST(test_construction_contract_closes_on_activation) {
 
     /* Supply and activate */
     float cost = module_build_cost_lookup(MODULE_FURNACE);
-    w.stations[outpost].inventory[mat] = cost;
+    w.stations[outpost]._inventory_cache[mat] = cost;
     for (int i = 0; i < 120; i++) world_sim_step(&w, SIM_DT);
     ASSERT(module_is_fully_supplied(m)); /* fully supplied */
     /* Run build timer */
@@ -1089,7 +1089,7 @@ TEST(test_stale_contract_does_not_block_next_need) {
     /* Supply, build, activate */
     commodity_t mat = module_build_material_lookup(MODULE_FURNACE);
     float cost = module_build_cost_lookup(MODULE_FURNACE);
-    w.stations[outpost].inventory[mat] = cost;
+    w.stations[outpost]._inventory_cache[mat] = cost;
     for (int i = 0; i < 120; i++) world_sim_step(&w, SIM_DT);
     for (int i = 0; i < 2400; i++) world_sim_step(&w, SIM_DT);
     ASSERT(!m->scaffold);
@@ -1127,7 +1127,7 @@ TEST(test_construction_contract_checks_scaffold_not_threshold) {
     /* Deliver a partial amount (not enough to fully supply).
      * But make the station inventory exceed the 80% generic threshold
      * by adding a different commodity that fills the buffer. */
-    w.stations[outpost].inventory[mat] = cost * 0.3f; /* partial supply */
+    w.stations[outpost]._inventory_cache[mat] = cost * 0.3f; /* partial supply */
     world_sim_step(&w, SIM_DT);
 
     /* After one tick, step_module_activation routed the partial amount
@@ -1146,7 +1146,7 @@ TEST(test_construction_contract_checks_scaffold_not_threshold) {
     ASSERT(contract_alive);
 
     /* Now deliver the rest */
-    w.stations[outpost].inventory[mat] = cost;
+    w.stations[outpost]._inventory_cache[mat] = cost;
     for (int i = 0; i < 120; i++) world_sim_step(&w, SIM_DT);
     ASSERT(module_is_fully_supplied(m)); /* fully supplied */
 }
@@ -1316,7 +1316,7 @@ TEST(test_module_flow_same_ring_transfer) {
     ASSERT(w.stations[1].module_output[furnace_idx] < 10.0f);
     ASSERT(w.stations[1].module_input[press_idx] > 0.0f ||
            w.stations[1].module_output[press_idx] > 0.0f ||
-           w.stations[1].inventory[COMMODITY_FRAME] > 0.0f);
+           w.stations[1]._inventory_cache[COMMODITY_FRAME] > 0.0f);
 }
 
 TEST(test_module_flow_production_fills_buffers) {
@@ -1326,8 +1326,8 @@ TEST(test_module_flow_production_fills_buffers) {
     WORLD_DECL;
     world_reset(&w);
     /* Seed Kepler with frame-press input */
-    w.stations[1].inventory[COMMODITY_FERRITE_INGOT] = 50.0f;
-    float frames_before = w.stations[1].inventory[COMMODITY_FRAME];
+    w.stations[1]._inventory_cache[COMMODITY_FERRITE_INGOT] = 50.0f;
+    float frames_before = w.stations[1]._inventory_cache[COMMODITY_FRAME];
     /* Find frame press */
     int press_idx = -1;
     for (int i = 0; i < w.stations[1].module_count; i++) {
@@ -1342,10 +1342,10 @@ TEST(test_module_flow_production_fills_buffers) {
 
     /* Production should have pulled ferrite into the chain, and either
      * buffered or stocked some downstream result. */
-    ASSERT(w.stations[1].inventory[COMMODITY_FERRITE_INGOT] < 50.0f);
+    ASSERT(w.stations[1]._inventory_cache[COMMODITY_FERRITE_INGOT] < 50.0f);
     ASSERT(w.stations[1].module_input[press_idx] > 0.0f ||
            w.stations[1].module_output[press_idx] > 0.0f ||
-           w.stations[1].inventory[COMMODITY_FRAME] > frames_before);
+           w.stations[1]._inventory_cache[COMMODITY_FRAME] > frames_before);
 }
 
 TEST(test_module_flow_does_not_overflow_capacity) {
@@ -1398,10 +1398,10 @@ TEST(test_module_flow_storage_feeds_consumer) {
 
     /* Seed the hopper-side: put raw ferrite in station inventory and
      * verify it actually moves into the flow graph. */
-    w.stations[0].inventory[COMMODITY_FERRITE_ORE] = 50.0f;
+    w.stations[0]._inventory_cache[COMMODITY_FERRITE_ORE] = 50.0f;
     w.stations[0].module_output[hopper_idx] = 0.0f;
     w.stations[0].module_input[furnace_idx] = 0.0f;
-    float ore_before = w.stations[0].inventory[COMMODITY_FERRITE_ORE];
+    float ore_before = w.stations[0]._inventory_cache[COMMODITY_FERRITE_ORE];
 
     /* One second of sim — hopper should refill its output from inventory
      * and the flow stepper should push it onward. */
@@ -1412,8 +1412,8 @@ TEST(test_module_flow_storage_feeds_consumer) {
      * storage→flow is connected. */
     bool flowed = w.stations[0].module_output[hopper_idx] > 0.0f
                || w.stations[0].module_input[furnace_idx] > 0.0f
-               || w.stations[0].inventory[COMMODITY_FERRITE_INGOT] > 0.0f
-               || w.stations[0].inventory[COMMODITY_FERRITE_ORE] < ore_before - 0.5f;
+               || w.stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT] > 0.0f
+               || w.stations[0]._inventory_cache[COMMODITY_FERRITE_ORE] < ore_before - 0.5f;
     ASSERT(flowed);
 }
 

--- a/src/tests/test_econ_sim.c
+++ b/src/tests/test_econ_sim.c
@@ -19,10 +19,10 @@ TEST(test_econ_sim_npc_only_5min) {
             printf("    t=%.0fs: pools [%.0f, %.0f, %.0f]  ingots [FE=%.0f CU=%.0f CR=%.0f]  frames=%.0f\n",
                 t,
                 w->stations[0].credit_pool, w->stations[1].credit_pool, w->stations[2].credit_pool,
-                w->stations[0].inventory[COMMODITY_FERRITE_INGOT],
-                w->stations[2].inventory[COMMODITY_CUPRITE_INGOT],
-                w->stations[2].inventory[COMMODITY_CRYSTAL_INGOT],
-                w->stations[1].inventory[COMMODITY_FRAME]);
+                w->stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT],
+                w->stations[2]._inventory_cache[COMMODITY_CUPRITE_INGOT],
+                w->stations[2]._inventory_cache[COMMODITY_CRYSTAL_INGOT],
+                w->stations[1]._inventory_cache[COMMODITY_FRAME]);
             /* Diagnostic: contracts open per station, by commodity */
             int active = 0, claimed = 0;
             for (int k = 0; k < MAX_CONTRACTS; k++) {
@@ -42,9 +42,9 @@ TEST(test_econ_sim_npc_only_5min) {
                 active, claimed, npc_idle, npc_docked, npc_busy);
             /* Per-station ore inventory (raw input to smelters) */
             printf("        ore: prospect[FE=%.1f]  helios[CU=%.1f CR=%.1f]\n",
-                w->stations[0].inventory[COMMODITY_FERRITE_ORE],
-                w->stations[2].inventory[COMMODITY_CUPRITE_ORE],
-                w->stations[2].inventory[COMMODITY_CRYSTAL_ORE]);
+                w->stations[0]._inventory_cache[COMMODITY_FERRITE_ORE],
+                w->stations[2]._inventory_cache[COMMODITY_CUPRITE_ORE],
+                w->stations[2]._inventory_cache[COMMODITY_CRYSTAL_ORE]);
             /* Per-NPC: home, role, state, current cargo */
             for (int n = 0; n < MAX_NPC_SHIPS; n++) {
                 if (!w->npc_ships[n].active) continue;
@@ -125,7 +125,7 @@ TEST(test_econ_sim_credit_circulation) {
     /* Dock at Prospect and buy ferrite ingots (spends from station 0 ledger) */
     w.players[0].docked = true;
     w.players[0].current_station = 0;
-    w.stations[0].inventory[COMMODITY_FERRITE_INGOT] = 50.0f;
+    w.stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT] = 50.0f;
     w.players[0].input.buy_product = true;
     w.players[0].input.buy_commodity = COMMODITY_FERRITE_INGOT;
     world_sim_step(&w, SIM_DT);
@@ -156,7 +156,7 @@ TEST(test_econ_sim_credit_circulation) {
         bal1, w.stations[1].credit_pool);
 
     /* Buy frames from Kepler (spends from station 1 ledger) */
-    w.stations[1].inventory[COMMODITY_FRAME] = 20.0f;
+    w.stations[1]._inventory_cache[COMMODITY_FRAME] = 20.0f;
     w.players[0].input.buy_product = true;
     w.players[0].input.buy_commodity = COMMODITY_FRAME;
     world_sim_step(&w, SIM_DT);
@@ -217,7 +217,7 @@ TEST(test_bug312_1_docked_buy_honors_spend_failure) {
     w.players[0].connected = true;
     w.players[0].docked = true;
     w.players[0].current_station = kepler;
-    st->inventory[COMMODITY_FRAME] = 10.0f;
+    st->_inventory_cache[COMMODITY_FRAME] = 10.0f;
     float pool_before = st->credit_pool;
     float cargo_before = w.players[0].ship.cargo[COMMODITY_FRAME];
 
@@ -254,7 +254,7 @@ TEST(test_buy_finished_good_requires_manifest_unit) {
     station_t *st = &w.stations[kepler];
 
     /* Float says 10 frames, manifest is empty — the drift the fix guards. */
-    st->inventory[COMMODITY_FRAME] = 10.0f;
+    st->_inventory_cache[COMMODITY_FRAME] = 10.0f;
     /* Force-clear any frame manifest units the world reset seeded. */
     for (int i = (int)st->manifest.count - 1; i >= 0; i--) {
         if (st->manifest.units[i].commodity == (uint8_t)COMMODITY_FRAME) {
@@ -429,7 +429,7 @@ TEST(test_econ_invariant_player_session_conservation) {
     ASSERT_CONSERVED("after contract sell");
 
     /* Step 3: buy-product path — buy frames from Kepler */
-    w.stations[1].inventory[COMMODITY_FRAME] = 20.0f;
+    w.stations[1]._inventory_cache[COMMODITY_FRAME] = 20.0f;
     w.players[0].input.buy_product = true;
     w.players[0].input.buy_commodity = COMMODITY_FRAME;
     world_sim_step(&w, SIM_DT);
@@ -484,7 +484,7 @@ static float run_sell_with_grades(int g0, int g1, int g2,
     }
     if (kepler < 0) return -1.0f; /* WORLD_HEAP cleanup frees w. */
     station_t *st = &w->stations[kepler];
-    st->inventory[COMMODITY_FERRITE_INGOT] = 0.0f;
+    st->_inventory_cache[COMMODITY_FERRITE_INGOT] = 0.0f;
 
     uint8_t token[8] = {7,7,7,7,7,7,7,7};
     memcpy(w->players[0].session_token, token, 8);
@@ -576,16 +576,16 @@ TEST(test_e2e_kit_chain_converges) {
     }
     ASSERT(shipyard >= 0);
     /* Big buffer of inputs so fab never starves. */
-    w->stations[shipyard].inventory[COMMODITY_FRAME]          = 50.0f;
-    w->stations[shipyard].inventory[COMMODITY_LASER_MODULE]   = 50.0f;
-    w->stations[shipyard].inventory[COMMODITY_TRACTOR_MODULE] = 50.0f;
-    w->stations[shipyard].inventory[COMMODITY_REPAIR_KIT]     = 0.0f;
+    w->stations[shipyard]._inventory_cache[COMMODITY_FRAME]          = 50.0f;
+    w->stations[shipyard]._inventory_cache[COMMODITY_LASER_MODULE]   = 50.0f;
+    w->stations[shipyard]._inventory_cache[COMMODITY_TRACTOR_MODULE] = 50.0f;
+    w->stations[shipyard]._inventory_cache[COMMODITY_REPAIR_KIT]     = 0.0f;
     w->stations[shipyard].repair_kit_fab_timer = 0.0f;
 
     int ticks = (int)(300.0f / SIM_DT);
     for (int i = 0; i < ticks; i++) world_sim_step(w, SIM_DT);
 
-    float kits_now = w->stations[shipyard].inventory[COMMODITY_REPAIR_KIT];
+    float kits_now = w->stations[shipyard]._inventory_cache[COMMODITY_REPAIR_KIT];
     printf("    shipyard %d kits after 300s: %.0f (expect > 0)\n",
            shipyard, kits_now);
     ASSERT(kits_now > 0.0f);
@@ -593,9 +593,9 @@ TEST(test_e2e_kit_chain_converges) {
     /* Inputs should also be visibly drawn down — at least one batch
      * consumed of each input commodity (fewer than seed, > 0 means
      * something was minted but not all 50). */
-    ASSERT(w->stations[shipyard].inventory[COMMODITY_FRAME]        < 50.0f);
-    ASSERT(w->stations[shipyard].inventory[COMMODITY_LASER_MODULE] < 50.0f);
-    ASSERT(w->stations[shipyard].inventory[COMMODITY_TRACTOR_MODULE] < 50.0f);
+    ASSERT(w->stations[shipyard]._inventory_cache[COMMODITY_FRAME]        < 50.0f);
+    ASSERT(w->stations[shipyard]._inventory_cache[COMMODITY_LASER_MODULE] < 50.0f);
+    ASSERT(w->stations[shipyard]._inventory_cache[COMMODITY_TRACTOR_MODULE] < 50.0f);
 }
 
 TEST(test_e2e_npc_dock_auto_repair_drains_kits) {
@@ -617,7 +617,7 @@ TEST(test_e2e_npc_dock_auto_repair_drains_kits) {
     }
     ASSERT(shipyard >= 0);
     /* Stock the dock with kits so the auto-repair has something to drain. */
-    w->stations[shipyard].inventory[COMMODITY_REPAIR_KIT] = 100.0f;
+    w->stations[shipyard]._inventory_cache[COMMODITY_REPAIR_KIT] = 100.0f;
 
     /* Pick the first hauler that's currently homed at the shipyard,
      * wound it, and drop it just outside the dock approach radius. */
@@ -654,12 +654,12 @@ TEST(test_e2e_npc_dock_auto_repair_drains_kits) {
         hauler_ship->vel = v2(0.0f, 0.0f);
     }
 
-    float kits_before = w->stations[shipyard].inventory[COMMODITY_REPAIR_KIT];
+    float kits_before = w->stations[shipyard]._inventory_cache[COMMODITY_REPAIR_KIT];
     /* A handful of ticks — first one should land it at the berth and
      * fire the repair branch; subsequent ticks just sit at DOCKED. */
     for (int i = 0; i < 5; i++) world_sim_step(w, SIM_DT);
 
-    float kits_after = w->stations[shipyard].inventory[COMMODITY_REPAIR_KIT];
+    float kits_after = w->stations[shipyard]._inventory_cache[COMMODITY_REPAIR_KIT];
     printf("    hauler hull: %.1f -> %.1f (max %.1f), station kits %.0f -> %.0f\n",
            max_h - 20.0f, hauler->hull, max_h, kits_before, kits_after);
     /* Healed — could be partial if repaired tick fell short, but should be
@@ -687,7 +687,7 @@ TEST(test_e2e_kit_import_contract_lifecycle) {
     ASSERT(prospect >= 0);
 
     /* Phase 1: drain kits and run until a kit import contract is issued. */
-    w->stations[prospect].inventory[COMMODITY_REPAIR_KIT] = 0.0f;
+    w->stations[prospect]._inventory_cache[COMMODITY_REPAIR_KIT] = 0.0f;
     bool found_open = false;
     for (int i = 0; i < (int)(120.0f / SIM_DT); i++) {
         world_sim_step(w, SIM_DT);
@@ -710,7 +710,7 @@ TEST(test_e2e_kit_import_contract_lifecycle) {
      * higher bound is the only stable closed state. The fact that
      * those two thresholds don't agree is a real bug worth a separate
      * PR; this test pins current behaviour for now. */
-    w->stations[prospect].inventory[COMMODITY_REPAIR_KIT] = REPAIR_KIT_STOCK_CAP * 0.5f;
+    w->stations[prospect]._inventory_cache[COMMODITY_REPAIR_KIT] = REPAIR_KIT_STOCK_CAP * 0.5f;
     bool found_after_fill = true;
     for (int i = 0; i < (int)(60.0f / SIM_DT); i++) {
         world_sim_step(w, SIM_DT);

--- a/src/tests/test_economy.c
+++ b/src/tests/test_economy.c
@@ -3,23 +3,23 @@
 TEST(test_station_production_yard_makes_frames) {
     station_t station = {0};
     station.modules[station.module_count++] = (station_module_t){ .type = MODULE_FRAME_PRESS };
-    station.inventory[COMMODITY_FERRITE_INGOT] = 5.0f;
+    station._inventory_cache[COMMODITY_FERRITE_INGOT] = 5.0f;
     step_station_production(&station, 1, 1.0f);
-    ASSERT_EQ_FLOAT(station.inventory[COMMODITY_FERRITE_INGOT], 3.0f, 0.001f);
-    ASSERT_EQ_FLOAT(station.inventory[COMMODITY_FRAME], 1.0f, 0.001f);
+    ASSERT_EQ_FLOAT(station._inventory_cache[COMMODITY_FERRITE_INGOT], 3.0f, 0.001f);
+    ASSERT_EQ_FLOAT(station._inventory_cache[COMMODITY_FRAME], 1.0f, 0.001f);
 }
 
 TEST(test_station_production_beamworks_makes_modules) {
     station_t station = {0};
     station.modules[station.module_count++] = (station_module_t){ .type = MODULE_LASER_FAB };
     station.modules[station.module_count++] = (station_module_t){ .type = MODULE_TRACTOR_FAB };
-    station.inventory[COMMODITY_CUPRITE_INGOT] = 5.0f;
-    station.inventory[COMMODITY_CRYSTAL_INGOT] = 5.0f;
+    station._inventory_cache[COMMODITY_CUPRITE_INGOT] = 5.0f;
+    station._inventory_cache[COMMODITY_CRYSTAL_INGOT] = 5.0f;
     step_station_production(&station, 1, 1.0f);
-    ASSERT_EQ_FLOAT(station.inventory[COMMODITY_CUPRITE_INGOT], 3.5f, 0.001f);
-    ASSERT_EQ_FLOAT(station.inventory[COMMODITY_CRYSTAL_INGOT], 4.5f, 0.001f);
-    ASSERT_EQ_FLOAT(station.inventory[COMMODITY_LASER_MODULE], 0.5f, 0.001f);
-    ASSERT_EQ_FLOAT(station.inventory[COMMODITY_TRACTOR_MODULE], 0.5f, 0.001f);
+    ASSERT_EQ_FLOAT(station._inventory_cache[COMMODITY_CUPRITE_INGOT], 3.5f, 0.001f);
+    ASSERT_EQ_FLOAT(station._inventory_cache[COMMODITY_CRYSTAL_INGOT], 4.5f, 0.001f);
+    ASSERT_EQ_FLOAT(station._inventory_cache[COMMODITY_LASER_MODULE], 0.5f, 0.001f);
+    ASSERT_EQ_FLOAT(station._inventory_cache[COMMODITY_TRACTOR_MODULE], 0.5f, 0.001f);
 }
 
 TEST(test_station_repair_cost_no_damage) {
@@ -49,7 +49,7 @@ TEST(test_can_afford_upgrade_dock_fallback) {
     ship.hull_class = HULL_CLASS_MINER;
     station_t station = {0};
     station.services = STATION_SERVICE_UPGRADE_HOLD;
-    station.inventory[COMMODITY_FRAME] = 100.0f;
+    station._inventory_cache[COMMODITY_FRAME] = 100.0f;
     station.base_price[COMMODITY_FRAME] = 22.0f;
     ASSERT(can_afford_upgrade(&station, &ship, SHIP_UPGRADE_HOLD,10000.0f));
 }
@@ -61,7 +61,7 @@ TEST(test_can_afford_upgrade_no_credits_for_dock_fallback) {
     ship.hull_class = HULL_CLASS_MINER;
     station_t station = {0};
     station.services = STATION_SERVICE_UPGRADE_HOLD;
-    station.inventory[COMMODITY_FRAME] = 100.0f;
+    station._inventory_cache[COMMODITY_FRAME] = 100.0f;
     station.base_price[COMMODITY_FRAME] = 22.0f;
     ASSERT(!can_afford_upgrade(&station, &ship, SHIP_UPGRADE_HOLD,0.0f));
 }
@@ -72,7 +72,7 @@ TEST(test_can_afford_upgrade_no_product_anywhere) {
     ship.hull_class = HULL_CLASS_MINER;
     station_t station = {0};
     station.services = STATION_SERVICE_UPGRADE_HOLD;
-    station.inventory[COMMODITY_FRAME] = 0.0f;
+    station._inventory_cache[COMMODITY_FRAME] = 0.0f;
     ASSERT(!can_afford_upgrade(&station, &ship, SHIP_UPGRADE_HOLD,10000.0f));
 }
 
@@ -94,9 +94,9 @@ TEST(test_contract_generated_from_hopper_deficit) {
     WORLD_DECL;
     world_reset(&w);
     /* Make ferrite the biggest deficit by filling the others */
-    w.stations[0].inventory[COMMODITY_FERRITE_ORE] = 10.0f;
-    w.stations[0].inventory[COMMODITY_CUPRITE_ORE] = REFINERY_HOPPER_CAPACITY;
-    w.stations[0].inventory[COMMODITY_CRYSTAL_ORE] = REFINERY_HOPPER_CAPACITY;
+    w.stations[0]._inventory_cache[COMMODITY_FERRITE_ORE] = 10.0f;
+    w.stations[0]._inventory_cache[COMMODITY_CUPRITE_ORE] = REFINERY_HOPPER_CAPACITY;
+    w.stations[0]._inventory_cache[COMMODITY_CRYSTAL_ORE] = REFINERY_HOPPER_CAPACITY;
     world_sim_step(&w, SIM_DT);
     /* Find contract for station 0, ferrite ore */
     contract_t *found = NULL;
@@ -128,11 +128,11 @@ TEST(test_contract_closes_when_deficit_filled) {
      * SIM_EVENT_CONTRACT_COMPLETE. See fix for issue #461. */
     WORLD_DECL;
     world_reset(&w);
-    w.stations[0].inventory[COMMODITY_FERRITE_ORE] = 10.0f;
+    w.stations[0]._inventory_cache[COMMODITY_FERRITE_ORE] = 10.0f;
     world_sim_step(&w, SIM_DT); /* generates contract (deficit > threshold) */
 
     /* 85% should NOT close the contract anymore — it's between open (90%) and close (95%) */
-    w.stations[0].inventory[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY * 0.85f;
+    w.stations[0]._inventory_cache[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY * 0.85f;
     world_sim_step(&w, SIM_DT);
     bool still_active = false;
     for (int k = 0; k < MAX_CONTRACTS; k++) {
@@ -143,7 +143,7 @@ TEST(test_contract_closes_when_deficit_filled) {
     ASSERT(still_active);
 
     /* Above the 95% close threshold, contract closes */
-    w.stations[0].inventory[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY * 0.96f;
+    w.stations[0]._inventory_cache[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY * 0.96f;
     world_sim_step(&w, SIM_DT);
     bool still_active2 = false;
     for (int k = 0; k < MAX_CONTRACTS; k++) {
@@ -210,8 +210,8 @@ TEST(test_hauler_fills_highest_value_contract) {
         .base_price = 50.0f, .age = 0.0f,
     };
     /* Give home station (0) inventory of both */
-    w.stations[0].inventory[COMMODITY_FERRITE_INGOT] = 20.0f;
-    w.stations[0].inventory[COMMODITY_CUPRITE_INGOT] = 20.0f;
+    w.stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT] = 20.0f;
+    w.stations[0]._inventory_cache[COMMODITY_CUPRITE_INGOT] = 20.0f;
     /* Find the first hauler */
     npc_ship_t *hauler = NULL;
     for (int i = 0; i < MAX_NPC_SHIPS; i++) {
@@ -235,7 +235,7 @@ TEST(test_one_contract_per_station) {
     world_reset(&w);
     /* Empty all hoppers to create demand */
     for (int i = 0; i < COMMODITY_RAW_ORE_COUNT; i++)
-        w.stations[0].inventory[i] = 0.0f;
+        w.stations[0]._inventory_cache[i] = 0.0f;
     /* Run a few ticks to generate contracts */
     for (int i = 0; i < 120; i++) world_sim_step(&w, SIM_DT);
     /* Count contracts for station 0. Up to two are allowed per station:
@@ -306,16 +306,16 @@ TEST(test_dynamic_ore_price_deficit) {
     station_t st = {0};
     st.base_price[COMMODITY_FERRITE_ORE] = 10.0f;
     /* Buy price: empty=1× base, full=0.5× base */
-    st.inventory[COMMODITY_FERRITE_ORE] = 0.0f;
+    st._inventory_cache[COMMODITY_FERRITE_ORE] = 0.0f;
     ASSERT_EQ_FLOAT(station_buy_price(&st, COMMODITY_FERRITE_ORE), 10.0f, 0.1f);
-    st.inventory[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY;
+    st._inventory_cache[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY;
     ASSERT_EQ_FLOAT(station_buy_price(&st, COMMODITY_FERRITE_ORE), 5.0f, 0.1f);
-    st.inventory[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY * 0.5f;
+    st._inventory_cache[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY * 0.5f;
     ASSERT_EQ_FLOAT(station_buy_price(&st, COMMODITY_FERRITE_ORE), 7.5f, 0.1f);
     /* Sell price: empty=2× base, full=1× base */
-    st.inventory[COMMODITY_FERRITE_ORE] = 0.0f;
+    st._inventory_cache[COMMODITY_FERRITE_ORE] = 0.0f;
     ASSERT_EQ_FLOAT(station_sell_price(&st, COMMODITY_FERRITE_ORE), 20.0f, 0.1f);
-    st.inventory[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY;
+    st._inventory_cache[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY;
     ASSERT_EQ_FLOAT(station_sell_price(&st, COMMODITY_FERRITE_ORE), 10.0f, 0.1f);
 }
 
@@ -324,9 +324,9 @@ TEST(test_product_price_tracks_ore) {
     st.base_price[COMMODITY_FRAME] = 20.0f;
     /* Sell price: empty=2× base, full=1× base */
     ASSERT_EQ_FLOAT(station_sell_price(&st, COMMODITY_FRAME), 40.0f, 0.1f);
-    st.inventory[COMMODITY_FRAME] = MAX_PRODUCT_STOCK;
+    st._inventory_cache[COMMODITY_FRAME] = MAX_PRODUCT_STOCK;
     ASSERT_EQ_FLOAT(station_sell_price(&st, COMMODITY_FRAME), 20.0f, 0.1f);
-    st.inventory[COMMODITY_FRAME] = MAX_PRODUCT_STOCK * 0.5f;
+    st._inventory_cache[COMMODITY_FRAME] = MAX_PRODUCT_STOCK * 0.5f;
     ASSERT_EQ_FLOAT(station_sell_price(&st, COMMODITY_FRAME), 25.0f, 0.1f);
 }
 
@@ -421,7 +421,7 @@ TEST(test_no_passive_heal_without_kits) {
     w.players[0].ship.hull = 50.0f;
     w.players[0].docked = true;
     w.players[0].current_station = 0;
-    w.stations[0].inventory[COMMODITY_REPAIR_KIT] = 0.0f;
+    w.stations[0]._inventory_cache[COMMODITY_REPAIR_KIT] = 0.0f;
     w.players[0].ship.cargo[COMMODITY_REPAIR_KIT] = 0.0f;
     for (int i = 0; i < 120; i++) world_sim_step(&w, SIM_DT);
     ASSERT_EQ_FLOAT(w.players[0].ship.hull, 50.0f, 0.01f);
@@ -435,11 +435,11 @@ TEST(test_refinery_smelts_ore_in_inventory) {
     /* Verify Prospect has a furnace */
     ASSERT(station_has_module(&w.stations[0], MODULE_FURNACE));
     /* Put ore directly in station inventory (as if delivered by fragments) */
-    w.stations[0].inventory[COMMODITY_FERRITE_ORE] = 10.0f;
+    w.stations[0]._inventory_cache[COMMODITY_FERRITE_ORE] = 10.0f;
     /* Run sim for 10 seconds — should smelt ore into ingots */
     for (int i = 0; i < (int)(10.0f / SIM_DT); i++)
         world_sim_step(&w, SIM_DT);
-    float ingots = w.stations[0].inventory[COMMODITY_FERRITE_INGOT];
+    float ingots = w.stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT];
     ASSERT(ingots > 0.0f);
 }
 
@@ -455,18 +455,18 @@ TEST(test_kit_fab_requires_shipyard) {
     ASSERT(!station_has_module(&w.stations[0], MODULE_SHIPYARD));
     ASSERT(station_has_module(&w.stations[1], MODULE_SHIPYARD));
     for (int s = 0; s < 2; s++) {
-        w.stations[s].inventory[COMMODITY_FRAME]          = 5.0f;
-        w.stations[s].inventory[COMMODITY_LASER_MODULE]   = 5.0f;
-        w.stations[s].inventory[COMMODITY_TRACTOR_MODULE] = 5.0f;
-        w.stations[s].inventory[COMMODITY_REPAIR_KIT]     = 0.0f;
+        w.stations[s]._inventory_cache[COMMODITY_FRAME]          = 5.0f;
+        w.stations[s]._inventory_cache[COMMODITY_LASER_MODULE]   = 5.0f;
+        w.stations[s]._inventory_cache[COMMODITY_TRACTOR_MODULE] = 5.0f;
+        w.stations[s]._inventory_cache[COMMODITY_REPAIR_KIT]     = 0.0f;
         w.stations[s].repair_kit_fab_timer = 0.0f;
     }
     /* Run long enough for at least one fab cycle (REPAIR_KIT_FAB_PERIOD = 30s). */
     for (int i = 0; i < (int)(35.0f / SIM_DT); i++)
         world_sim_step(&w, SIM_DT);
     /* Shipyard station produces kits; dock-only station does not. */
-    ASSERT(w.stations[1].inventory[COMMODITY_REPAIR_KIT] > 0.0f);
-    ASSERT_EQ_FLOAT(w.stations[0].inventory[COMMODITY_REPAIR_KIT], 0.0f, 0.01f);
+    ASSERT(w.stations[1]._inventory_cache[COMMODITY_REPAIR_KIT] > 0.0f);
+    ASSERT_EQ_FLOAT(w.stations[0]._inventory_cache[COMMODITY_REPAIR_KIT], 0.0f, 0.01f);
 }
 
 TEST(test_kit_import_contract_at_consumer_station) {
@@ -479,7 +479,7 @@ TEST(test_kit_import_contract_at_consumer_station) {
     ASSERT(station_has_module(&w.stations[0], MODULE_DOCK));
     ASSERT(!station_has_module(&w.stations[0], MODULE_SHIPYARD));
     /* Drain Prospect's kit inventory to force the deficit. */
-    w.stations[0].inventory[COMMODITY_REPAIR_KIT] = 0.0f;
+    w.stations[0]._inventory_cache[COMMODITY_REPAIR_KIT] = 0.0f;
     /* Run a few seconds for the contract step to fire. */
     for (int i = 0; i < 120; i++) world_sim_step(&w, SIM_DT);
     bool found = false;
@@ -503,7 +503,7 @@ TEST(test_kit_import_contract_skips_shipyard_stations) {
     WORLD_DECL;
     world_reset(&w);
     ASSERT(station_has_module(&w.stations[1], MODULE_SHIPYARD));
-    w.stations[1].inventory[COMMODITY_REPAIR_KIT] = 0.0f;
+    w.stations[1]._inventory_cache[COMMODITY_REPAIR_KIT] = 0.0f;
     for (int i = 0; i < 120; i++) world_sim_step(&w, SIM_DT);
     for (int k = 0; k < MAX_CONTRACTS; k++) {
         contract_t *c = &w.contracts[k];
@@ -532,7 +532,7 @@ TEST(test_repair_drains_ship_cargo_first) {
 
     /* Force the repair service (default Prospect lacks REPAIR_BAY). */
     w.stations[0].services |= STATION_SERVICE_REPAIR;
-    w.stations[0].inventory[COMMODITY_REPAIR_KIT] = 100.0f;
+    w.stations[0]._inventory_cache[COMMODITY_REPAIR_KIT] = 100.0f;
     w.players[0].ship.cargo[COMMODITY_REPAIR_KIT] = 50.0f;
     float max_hull = ship_max_hull(&w.players[0].ship);
     w.players[0].ship.hull = max_hull - 30.0f; /* 30 HP missing */
@@ -545,7 +545,7 @@ TEST(test_repair_drains_ship_cargo_first) {
     /* Hull restored, ship cargo drained, station inventory untouched. */
     ASSERT_EQ_FLOAT(w.players[0].ship.hull, max_hull, 0.5f);
     ASSERT_EQ_FLOAT(w.players[0].ship.cargo[COMMODITY_REPAIR_KIT], 20.0f, 0.5f);
-    ASSERT_EQ_FLOAT(w.stations[0].inventory[COMMODITY_REPAIR_KIT], 100.0f, 0.5f);
+    ASSERT_EQ_FLOAT(w.stations[0]._inventory_cache[COMMODITY_REPAIR_KIT], 100.0f, 0.5f);
 
     /* Charge: only labor (no station retail). 30 HP * 1 cr/HP. */
     float bal_after = ledger_balance(&w.stations[0],
@@ -568,7 +568,7 @@ TEST(test_repair_falls_back_to_station_inventory) {
 
     w.stations[0].services |= STATION_SERVICE_REPAIR;
     w.stations[0].base_price[COMMODITY_REPAIR_KIT] = 6.0f;
-    w.stations[0].inventory[COMMODITY_REPAIR_KIT]  = MAX_PRODUCT_STOCK; /* full → 1× */
+    w.stations[0]._inventory_cache[COMMODITY_REPAIR_KIT]  = MAX_PRODUCT_STOCK; /* full → 1× */
     w.players[0].ship.cargo[COMMODITY_REPAIR_KIT]  = 0.0f;
     float max_hull = ship_max_hull(&w.players[0].ship);
     w.players[0].ship.hull = max_hull - 10.0f;
@@ -580,7 +580,7 @@ TEST(test_repair_falls_back_to_station_inventory) {
 
     /* 10 HP from station: 10 kits drained, charge = 10 * (6 + 1) = 70 cr. */
     ASSERT_EQ_FLOAT(w.players[0].ship.hull, max_hull, 0.5f);
-    ASSERT_EQ_FLOAT(w.stations[0].inventory[COMMODITY_REPAIR_KIT],
+    ASSERT_EQ_FLOAT(w.stations[0]._inventory_cache[COMMODITY_REPAIR_KIT],
                     MAX_PRODUCT_STOCK - 10.0f, 0.5f);
     float charged = bal_before - ledger_balance(&w.stations[0],
                                                 w.players[0].session_token);
@@ -602,7 +602,7 @@ TEST(test_repair_at_shipyard_no_labor_fee) {
 
     w.stations[1].services |= STATION_SERVICE_REPAIR;
     w.stations[1].base_price[COMMODITY_REPAIR_KIT] = 6.0f;
-    w.stations[1].inventory[COMMODITY_REPAIR_KIT]  = MAX_PRODUCT_STOCK;
+    w.stations[1]._inventory_cache[COMMODITY_REPAIR_KIT]  = MAX_PRODUCT_STOCK;
     w.players[0].ship.cargo[COMMODITY_REPAIR_KIT]  = 0.0f;
     float max_hull = ship_max_hull(&w.players[0].ship);
     w.players[0].ship.hull = max_hull - 10.0f;
@@ -630,7 +630,7 @@ TEST(test_repair_partial_when_kits_short) {
     w.players[0].docked = true;
     w.players[0].current_station = 0;
 
-    w.stations[0].inventory[COMMODITY_REPAIR_KIT] = 0.0f;
+    w.stations[0]._inventory_cache[COMMODITY_REPAIR_KIT] = 0.0f;
     w.players[0].ship.cargo[COMMODITY_REPAIR_KIT] = 0.0f;
     float max_hull = ship_max_hull(&w.players[0].ship);
     w.players[0].ship.hull = max_hull - 20.0f;
@@ -653,18 +653,18 @@ TEST(test_furnace_without_hopper_does_not_smelt) {
     rebuild_station_services(&w.stations[0]);
     w.stations[0].modules[0] = (station_module_t){ .type = MODULE_FURNACE, .ring = 2, .slot = 0, .scaffold = false, .build_progress = 1.0f };
     w.stations[0].module_count = 1;
-    w.stations[0].inventory[COMMODITY_FERRITE_ORE] = 100.0f;
-    float initial_ingots = w.stations[0].inventory[COMMODITY_FERRITE_INGOT];
+    w.stations[0]._inventory_cache[COMMODITY_FERRITE_ORE] = 100.0f;
+    float initial_ingots = w.stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT];
     for (int i = 0; i < (int)(5.0f / SIM_DT); i++)
         world_sim_step(&w, SIM_DT);
-    ASSERT_EQ_FLOAT(w.stations[0].inventory[COMMODITY_FERRITE_INGOT],
+    ASSERT_EQ_FLOAT(w.stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT],
                     initial_ingots, 0.001f);
     /* Add a hopper and let it run again — now it should smelt. */
     w.stations[0].modules[1] = (station_module_t){ .type = MODULE_HOPPER, .ring = 1, .slot = 0, .scaffold = false, .build_progress = 1.0f };
     w.stations[0].module_count = 2;
     for (int i = 0; i < (int)(5.0f / SIM_DT); i++)
         world_sim_step(&w, SIM_DT);
-    ASSERT(w.stations[0].inventory[COMMODITY_FERRITE_INGOT] > initial_ingots);
+    ASSERT(w.stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT] > initial_ingots);
 }
 
 TEST(test_commodity_volume_kit_dense) {

--- a/src/tests/test_protocol.c
+++ b/src/tests/test_protocol.c
@@ -221,11 +221,11 @@ TEST(test_roundtrip_stations) {
 
     /* Mark station 0 as active so it gets serialized */
     stations[0].signal_range = 2200.0f;
-    stations[0].inventory[0] = 45.5f;
-    stations[0].inventory[1] = 12.3f;
-    stations[0].inventory[2] = 78.9f;
-    stations[0].inventory[COMMODITY_FERRITE_INGOT] = 20.0f;
-    stations[0].inventory[COMMODITY_FRAME] = 15.5f;
+    stations[0]._inventory_cache[0] = 45.5f;
+    stations[0]._inventory_cache[1] = 12.3f;
+    stations[0]._inventory_cache[2] = 78.9f;
+    stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT] = 20.0f;
+    stations[0]._inventory_cache[COMMODITY_FRAME] = 15.5f;
 
     uint8_t buf[2 + MAX_STATIONS * STATION_RECORD_SIZE];
     int len = serialize_stations(buf, stations);

--- a/src/tests/test_save.c
+++ b/src/tests/test_save.c
@@ -22,13 +22,13 @@ TEST(test_player_save_load_roundtrip) {
 TEST(test_world_save_load_preserves_stations) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     world_reset(w);
-    w->stations[0].inventory[COMMODITY_FERRITE_ORE] = 42.0f;
-    w->stations[0].inventory[COMMODITY_FRAME] = 15.0f;
+    w->stations[0]._inventory_cache[COMMODITY_FERRITE_ORE] = 42.0f;
+    w->stations[0]._inventory_cache[COMMODITY_FRAME] = 15.0f;
     ASSERT(world_save(w, TMP("test_world.sav")));
     WORLD_HEAP loaded = calloc(1, sizeof(world_t));
     ASSERT(world_load(loaded, TMP("test_world.sav")));
-    ASSERT_EQ_FLOAT(loaded->stations[0].inventory[COMMODITY_FERRITE_ORE], 42.0f, 0.01f);
-    ASSERT_EQ_FLOAT(loaded->stations[0].inventory[COMMODITY_FRAME], 15.0f, 0.01f);
+    ASSERT_EQ_FLOAT(loaded->stations[0]._inventory_cache[COMMODITY_FERRITE_ORE], 42.0f, 0.01f);
+    ASSERT_EQ_FLOAT(loaded->stations[0]._inventory_cache[COMMODITY_FRAME], 15.0f, 0.01f);
     /* loaded auto-freed by WORLD_HEAP cleanup */
     /* w auto-freed by WORLD_HEAP cleanup */
     remove(TMP("test_world.sav"));
@@ -512,15 +512,15 @@ TEST(test_world_save_load_preserves_smelted_ingots) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     ASSERT(w != NULL);
     world_reset(w);
-    w->stations[0].inventory[COMMODITY_FERRITE_ORE] = 20.0f;
+    w->stations[0]._inventory_cache[COMMODITY_FERRITE_ORE] = 20.0f;
     for (int i = 0; i < (int)(10.0f / SIM_DT); i++) world_sim_step(w, SIM_DT);
-    float ingots_before = w->stations[0].inventory[COMMODITY_FERRITE_INGOT];
+    float ingots_before = w->stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT];
     ASSERT(ingots_before > 0.0f);
     ASSERT(world_save(w, TMP("test_ingots.sav")));
     WORLD_HEAP loaded = calloc(1, sizeof(world_t));
     ASSERT(loaded != NULL);
     ASSERT(world_load(loaded, TMP("test_ingots.sav")));
-    ASSERT_EQ_FLOAT(loaded->stations[0].inventory[COMMODITY_FERRITE_INGOT], ingots_before, 0.01f);
+    ASSERT_EQ_FLOAT(loaded->stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT], ingots_before, 0.01f);
     remove(TMP("test_ingots.sav"));
     /* loaded + w auto-freed by WORLD_HEAP cleanup */
 }
@@ -600,7 +600,7 @@ TEST(test_save_load_preserves_player_outpost) {
     ASSERT(station_exists(&w->stations[slot]));
     ASSERT(w->stations[slot].scaffold);
     /* Deliver some frames to advance progress */
-    w->stations[slot].inventory[COMMODITY_FRAME] = 30.0f;
+    w->stations[slot]._inventory_cache[COMMODITY_FRAME] = 30.0f;
     for (int i = 0; i < 600; i++) world_sim_step(w, SIM_DT);
     float progress = w->stations[slot].scaffold_progress;
     int mod_count = w->stations[slot].module_count;
@@ -633,13 +633,13 @@ TEST(test_save_backward_compat_version_accepted) {
      * Station identity comes from catalog, session data from world save. */
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     world_reset(w);
-    w->stations[0].inventory[COMMODITY_FERRITE_ORE] = 77.0f;
+    w->stations[0]._inventory_cache[COMMODITY_FERRITE_ORE] = 77.0f;
     ASSERT(station_catalog_save_all(w->stations, MAX_STATIONS, TMP("test_compatcat")));
     ASSERT(world_save(w, TMP("test_compat.sav")));
     WORLD_HEAP loaded = calloc(1, sizeof(world_t));
     station_catalog_load_all(loaded->stations, MAX_STATIONS, TMP("test_compatcat"));
     ASSERT(world_load(loaded, TMP("test_compat.sav")));
-    ASSERT_EQ_FLOAT(loaded->stations[0].inventory[COMMODITY_FERRITE_ORE], 77.0f, 0.01f);
+    ASSERT_EQ_FLOAT(loaded->stations[0]._inventory_cache[COMMODITY_FERRITE_ORE], 77.0f, 0.01f);
     /* loaded auto-freed by WORLD_HEAP cleanup */
     /* w auto-freed by WORLD_HEAP cleanup */
     remove(TMP("test_compat.sav"));

--- a/src/tests/test_world_sim.c
+++ b/src/tests/test_world_sim.c
@@ -172,11 +172,11 @@ TEST(test_world_sim_step_docking) {
 TEST(test_world_sim_step_refinery_produces_ingots) {
     WORLD_DECL;
     world_reset(&w);
-    w.stations[0].inventory[COMMODITY_FERRITE_ORE] = 50.0f;
+    w.stations[0]._inventory_cache[COMMODITY_FERRITE_ORE] = 50.0f;
     for (int i = 0; i < 600; i++)
         world_sim_step(&w, 1.0f / 120.0f);
-    ASSERT(w.stations[0].inventory[COMMODITY_FERRITE_INGOT] > 0.0f);
-    ASSERT(w.stations[0].inventory[COMMODITY_FERRITE_ORE] < 50.0f);
+    ASSERT(w.stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT] > 0.0f);
+    ASSERT(w.stations[0]._inventory_cache[COMMODITY_FERRITE_ORE] < 50.0f);
 }
 
 TEST(test_mining_class_prefix_round_trip) {
@@ -282,7 +282,7 @@ TEST(test_refinery_deposits_named_ingot) {
 
     /* Run sim until smelt completes (smelt_progress accumulates ~0.5/s). */
     int initial_manifest = w->stations[0].manifest.count;
-    float initial_bulk = w->stations[0].inventory[COMMODITY_FERRITE_INGOT];
+    float initial_bulk = w->stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT];
     for (int i = 0; i < 600 && w->asteroids[slot].active; i++)
         world_sim_step(w, 1.0f / 120.0f);
     /* Asteroid should be consumed. */
@@ -290,7 +290,7 @@ TEST(test_refinery_deposits_named_ingot) {
     /* Smelt always lands the units in the manifest now (single source
      * of truth — no separate named-ingot stockpile). The float
      * inventory bumps in lockstep. */
-    bool got_bulk = (w->stations[0].inventory[COMMODITY_FERRITE_INGOT] > initial_bulk);
+    bool got_bulk = (w->stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT] > initial_bulk);
     ASSERT(got_bulk);
     ASSERT_EQ_INT(w->stations[0].manifest.count - initial_manifest, 10);
     bool any_named = false;
@@ -346,7 +346,7 @@ TEST(test_station_production_dual_writes_frame_manifest) {
     ASSERT(press_idx >= 0);
 
     manifest_clear(&st->manifest);
-    memset(st->inventory, 0, sizeof(st->inventory));
+    memset(st->_inventory_cache, 0, sizeof(st->_inventory_cache));
     memset(st->module_input, 0, sizeof(st->module_input));
     memset(st->module_output, 0, sizeof(st->module_output));
 
@@ -359,7 +359,7 @@ TEST(test_station_production_dual_writes_frame_manifest) {
     st->module_input[press_idx] = 2.0f;
     sim_step_station_production(&w, 1.0f);
 
-    ASSERT_EQ_FLOAT(st->inventory[COMMODITY_FRAME], 1.0f, 0.001f);
+    ASSERT_EQ_FLOAT(st->_inventory_cache[COMMODITY_FRAME], 1.0f, 0.001f);
     ASSERT_EQ_INT(st->manifest.count, 1);
     ASSERT_EQ_INT(manifest_find(&st->manifest, inputs[0].pub), -1);
     ASSERT_EQ_INT(manifest_find(&st->manifest, inputs[1].pub), -1);
@@ -392,7 +392,7 @@ TEST(test_station_production_dual_writes_laser_manifest) {
     ASSERT(laser_idx >= 0);
 
     manifest_clear(&st->manifest);
-    memset(st->inventory, 0, sizeof(st->inventory));
+    memset(st->_inventory_cache, 0, sizeof(st->_inventory_cache));
     memset(st->module_input, 0, sizeof(st->module_input));
     memset(st->module_output, 0, sizeof(st->module_output));
 
@@ -403,11 +403,11 @@ TEST(test_station_production_dual_writes_laser_manifest) {
     ASSERT(manifest_push(&st->manifest, &inputs[1]));
 
     st->module_input[laser_idx] = 1.0f;
-    st->inventory[COMMODITY_CRYSTAL_INGOT] = 1.0f;
+    st->_inventory_cache[COMMODITY_CRYSTAL_INGOT] = 1.0f;
     sim_step_station_production(&w, 2.0f);
 
-    ASSERT_EQ_FLOAT(st->inventory[COMMODITY_LASER_MODULE], 1.0f, 0.001f);
-    ASSERT_EQ_FLOAT(st->inventory[COMMODITY_CRYSTAL_INGOT], 0.0f, 0.001f);
+    ASSERT_EQ_FLOAT(st->_inventory_cache[COMMODITY_LASER_MODULE], 1.0f, 0.001f);
+    ASSERT_EQ_FLOAT(st->_inventory_cache[COMMODITY_CRYSTAL_INGOT], 0.0f, 0.001f);
     ASSERT_EQ_INT(st->manifest.count, 1);
     ASSERT_EQ_INT(manifest_find(&st->manifest, inputs[0].pub), -1);
     ASSERT_EQ_INT(manifest_find(&st->manifest, inputs[1].pub), -1);
@@ -440,7 +440,7 @@ TEST(test_station_production_without_manifest_inputs_refuses_to_mint) {
     ASSERT(press_idx >= 0);
 
     manifest_clear(&st->manifest);
-    memset(st->inventory, 0, sizeof(st->inventory));
+    memset(st->_inventory_cache, 0, sizeof(st->_inventory_cache));
     memset(st->module_input, 0, sizeof(st->module_input));
     memset(st->module_output, 0, sizeof(st->module_output));
 
@@ -449,7 +449,7 @@ TEST(test_station_production_without_manifest_inputs_refuses_to_mint) {
 
     /* Float reverted by E1 fix: no manifest input → no manifest output
      * → no orphan float either. */
-    ASSERT_EQ_FLOAT(st->inventory[COMMODITY_FRAME], 0.0f, 0.001f);
+    ASSERT_EQ_FLOAT(st->_inventory_cache[COMMODITY_FRAME], 0.0f, 0.001f);
     ASSERT_EQ_INT(st->manifest.count, 0);
 }
 
@@ -550,7 +550,7 @@ TEST(test_scenario_full_mining_cycle) {
 
     /* Clear station ore inventory */
     for (int i = 0; i < COMMODITY_RAW_ORE_COUNT; i++)
-        w.stations[0].inventory[i] = 0.0f;
+        w.stations[0]._inventory_cache[i] = 0.0f;
 
     /* Stop rotation, place fragment at midpoint between furnace and silo */
     for (int a = 0; a < MAX_ARMS; a++) {
@@ -781,13 +781,13 @@ TEST(test_scenario_npc_economy_30_seconds) {
     bool any_ingot = false;
     for (int s = 0; s < MAX_STATIONS && !any_ingot; s++) {
         for (int i = COMMODITY_RAW_ORE_COUNT; i < COMMODITY_COUNT; i++) {
-            if (w.stations[s].inventory[i] > 0.0f) { any_ingot = true; break; }
+            if (w.stations[s]._inventory_cache[i] > 0.0f) { any_ingot = true; break; }
         }
     }
     bool ore_consumed = false;
     for (int s = 0; s < MAX_STATIONS && !ore_consumed; s++) {
         for (int i = 0; i < COMMODITY_RAW_ORE_COUNT; i++) {
-            if (w.stations[s].inventory[i] > 0.0f) { ore_consumed = true; break; }
+            if (w.stations[s]._inventory_cache[i] > 0.0f) { ore_consumed = true; break; }
         }
     }
     ASSERT(any_ingot || ore_consumed);
@@ -795,11 +795,11 @@ TEST(test_scenario_npc_economy_30_seconds) {
     /* Verify: no negative values anywhere */
     for (int s = 0; s < MAX_STATIONS; s++) {
         for (int i = 0; i < COMMODITY_RAW_ORE_COUNT; i++)
-            ASSERT(w.stations[s].inventory[i] >= 0.0f);
+            ASSERT(w.stations[s]._inventory_cache[i] >= 0.0f);
         for (int i = 0; i < COMMODITY_COUNT; i++)
-            ASSERT(w.stations[s].inventory[i] >= 0.0f);
+            ASSERT(w.stations[s]._inventory_cache[i] >= 0.0f);
         for (int i = 0; i < PRODUCT_COUNT; i++)
-            ASSERT(w.stations[s].inventory[COMMODITY_FRAME + i] >= 0.0f);
+            ASSERT(w.stations[s]._inventory_cache[COMMODITY_FRAME + i] >= 0.0f);
     }
     for (int n = 0; n < MAX_NPC_SHIPS; n++) {
         if (!w.npc_ships[n].active) continue;
@@ -838,7 +838,7 @@ TEST(test_scenario_upgrade_requires_products) {
     int level_before = w.players[0].ship.mining_level;
 
     /* Set inventory for PRODUCT_LASER_MODULE to 0 */
-    w.stations[2].inventory[COMMODITY_LASER_MODULE] = 0.0f;
+    w.stations[2]._inventory_cache[COMMODITY_LASER_MODULE] = 0.0f;
 
     /* Try upgrade_mining -- should fail (no product stock) */
     w.players[0].input.upgrade_mining = true;
@@ -902,17 +902,17 @@ TEST(test_scenario_product_cap_pauses_production) {
     world_reset(&w);
 
     /* Set station 1 (Kepler Yard) inventory[COMMODITY_FRAME] to MAX_PRODUCT_STOCK */
-    w.stations[1].inventory[COMMODITY_FRAME] = MAX_PRODUCT_STOCK;
+    w.stations[1]._inventory_cache[COMMODITY_FRAME] = MAX_PRODUCT_STOCK;
 
     /* Set ingot_buffer with some frame ingots */
-    w.stations[1].inventory[COMMODITY_FERRITE_INGOT] = 20.0f;
+    w.stations[1]._inventory_cache[COMMODITY_FERRITE_INGOT] = 20.0f;
 
     /* Run 120 ticks */
     for (int i = 0; i < 120; i++)
         world_sim_step(&w, SIM_DT);
 
     /* Verify inventory didn't exceed MAX_PRODUCT_STOCK */
-    ASSERT(w.stations[1].inventory[COMMODITY_FRAME] <= MAX_PRODUCT_STOCK + 0.01f);
+    ASSERT(w.stations[1]._inventory_cache[COMMODITY_FRAME] <= MAX_PRODUCT_STOCK + 0.01f);
 }
 
 TEST(test_signal_strength_at_station) {


### PR DESCRIPTION
Three independently-revertable hardening commits.

## Commits

### 1. `ci: add UBSan + ASan post-deploy verification job`
Adds `test-ubsan` to the post-deploy gate (mirrors `test-asan`, `needs: deploy`, main-only, 25 min). Builds with `-O1 -g -fsanitize=undefined,address`; sets `UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1` and `ASAN_OPTIONS=halt_on_error=1` so the first failure aborts with a stack.

Wiring up the job locally caught real UB: the spatial-grid hash multiplied a signed `int cx` by `73856093`, overflowing for `|cx| > 29`. Both call sites (`game_sim.c`, `game_sim.h` inline lookup) now do the multiplication in unsigned space (matches the `uint32_t` result), which is well-defined.

### 2. `sim: assert manifest/inventory invariant in finished-good accessors`
Adds a `static void assert_finished_invariant(st, c)` in `src/manifest.c` (gated on `NDEBUG`). Called at the end of `station_finished_{mint,drain,accumulate}` to verify `floor(inventory[c]+eps) == manifest_count_by_commodity(c)`. Also asserts `manifest->count <= manifest->cap` at the end of `manifest_push` and `manifest_reserve`.

The new assertion exposed a real pre-existing bug in `station_finished_mint`'s float-sync path: when `accumulate`'s `int_after = floor(after + 0.0001f)` rolled `0.99999...` up to `1`, mint would compute `frac = inv - floorf(inv) = 0.99999...`, then write `inventory[c] = manifest_count + 0.99999`, which lands one whole unit above manifest. Fix: apply the same `+0.0001` epsilon to the floor in mint's sync, matching `accumulate`'s rounding contract.

### 3. `sim: rename station_t::inventory to _inventory_cache`
Renames the field across `server/`, `src/`, `shared/` (25 files, ~290 line touches). The float is the cache layer of the manifest for finished goods — direct writes to finished-good slots silently break the manifest invariant. The rename:

- Surfaces every read/write at code review.
- Carries a docstring pointing at `station_finished_*` accessors in `shared/manifest.h`.
- Leaves raw-ore writes (the smelter hopper float-only state) untouched semantically.
- Wire format unchanged: `sim_save.c` serializes by bytes, not by C name. Save tests (file-size-stable, golden bytes, v21 remap, future-version reject) all pass.

Conversion of every existing direct write to an accessor is **not** in this commit — it's a larger behavioral change because float-only test fixtures rely on the existing in-tick reconciler that snaps drift up to manifest count. That work can be done per-site incrementally now that the field signals intent.

## Verification gate

| Build | Result |
|---|---|
| `make test` (default) | 340/340 |
| `-O0 -g` | 340/340 |
| `-Og -g` | 340/340 |
| `-O2 -g -DNDEBUG` | 340/340 |
| `-O1 -g -fsanitize=undefined,address` | 340/340 |
| `grep -rE -- "->inventory\\[" server/ src/ shared/` | zero matches |
| `grep -rE -- "->inventory\\b" .. | grep -v _inventory_cache` | zero matches |

## Test plan

- [ ] CI green on this branch.
- [ ] `test-ubsan` job appears in post-deploy and runs after the next merge to main.
- [ ] No regressions in save load (`test_save_*`).
- [ ] Manifest invariant assertions don't fire in any of the 340 tests at any optimization level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)