### PR TITLE
test: add --filter flag and validate make test-fast

### DIFF
--- a/src/test_main.c
+++ b/src/test_main.c
@@ -57,7 +57,10 @@ int main(int argc, char **argv) {
     /* --shard=K/N splits the suite across N workers; worker K runs
      * every Nth test starting at index K. Unset = run everything.
      * --quiet suppresses banners + per-test "ok" lines + [WARN] noise;
-     * a single FAIL line still prints with full file:line context. */
+     * a single FAIL line still prints with full file:line context.
+     * --filter=<substr> runs only tests whose name contains <substr>;
+     * composes with --shard (filter happens first, so filtered tests
+     * don't burn shard slots). */
     for (int i = 1; i < argc; i++) {
         if (strncmp(argv[i], "--shard=", 8) == 0) {
             int k = 0, n = 1;
@@ -68,6 +71,9 @@ int main(int argc, char **argv) {
             }
         } else if (strcmp(argv[i], "--quiet") == 0) {
             g_quiet = 1;
+        } else if (strncmp(argv[i], "--filter=", 9) == 0) {
+            g_filter = argv[i] + 9;
+            if (g_filter[0] == '\0') g_filter = NULL;
         }
     }
 

--- a/src/tests/test_harness.c
+++ b/src/tests/test_harness.c
@@ -17,6 +17,8 @@ int g_test_seq    = 0;
 int g_quiet = 0;
 int g_warnings = 0;
 
+const char *g_filter = NULL;
+
 bool parse_hex32(const char *hex, uint8_t out[32]) {
     static const char digits[] = "0123456789abcdef";
     if (!hex || strlen(hex) != 64) return false;

--- a/src/tests/test_harness.h
+++ b/src/tests/test_harness.h
@@ -48,6 +48,14 @@ extern int g_test_seq;
 extern int g_quiet;
 extern int g_warnings;
 
+/* Substring filter: when non-NULL, only tests whose name (the literal
+ * stringified token passed to RUN) contains this substring run. Set
+ * with --filter=<pat> on the command line. Composes with --shard: the
+ * filter check happens BEFORE the shard mod check, so filtered tests
+ * don't burn shard slots and `--filter=foo --shard=K/N` runs the Nth
+ * slice of matching tests, not the Nth slice of the full suite. */
+extern const char *g_filter;
+
 /* Auto-cleanup for world_t — frees the heap-allocated signal cache grid.
  * Uses __attribute__((cleanup)) on GCC/Clang; on MSVC, leaks are
  * acceptable in tests (no cleanup on early ASSERT return). */
@@ -77,6 +85,7 @@ static inline void server_player_auto_cleanup(server_player_t *sp) { ship_cleanu
  * and printed "ok" even after an ASSERT had already failed and bumped
  * tests_failed, causing the summary line to lie. (#261) */
 #define RUN(name) do { \
+    if (g_filter && !strstr(#name, g_filter)) break; \
     int _seq = g_test_seq++; \
     if ((_seq % g_shard_total) != g_shard_index) break; \
     int _failed_before = tests_failed; \


### PR DESCRIPTION
## Summary

- Adds a `--filter=<substr>` CLI flag to `signal_test` that runs only tests whose `RUN()` name contains the substring.
- Filter composes with `--shard`: the filter check fires **before** the shard mod, so filtered tests don't burn shard slots. `--filter=autopilot --shard=0/2` runs ~half the matching autopilot tests, not 1/2 of the full suite. Verified: `--filter=autopilot` alone matches 9 tests; `0/2` runs 5, `1/2` runs 4.
- Validates `make test-fast TEST_SHARDS=8` against latest `origin/main` — runs to completion in ~14s wallclock, reports `356 tests run, 356 passed, 0 failed (across 8 shards)`, exits 0. No repair needed at the moment; the recipe and test isolation already work on main.

## Why no `--skip-slow` / `RUN_SLOW`

The four heaviest tests (`test_e2e_kit_import_contract_lifecycle`, `test_autopilot_multiple_players`, `test_grade_aware_sell_pays_per_unit_grade`, `test_econ_invariant_npc_only_conservation`) are continuous-simulation soak tests — they belong in a separate CI job with per-tick invariant assertions, not the unit suite. A follow-up PR will move them out and introduce `make test-soak`. Tagging them `RUN_SLOW` here would just be churn that immediately gets reverted.

## Test plan

- [x] `make test` passes serially (356/356).
- [x] `make test-fast TEST_SHARDS=8` passes in parallel (356/356, ~14s wallclock).
- [x] `./build/signal_test --filter=test_world_save` runs only matching tests (6 tests).
- [x] `./build/signal_test --filter=autopilot --shard=0/2` + `--shard=1/2` sums to the unfiltered `--filter=autopilot` count (5+4 = 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>