### PR TITLE
fix(sim): validate NPC role at save load + sign-compare in claim handler

### DIFF
--- a/server/main.c
+++ b/server/main.c
@@ -666,7 +666,7 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
          * "player_<slot>" form (anonymous slot fallback). Accept either:
          * try the literal name first, then with the historical prefix. */
         char basename[80];
-        if (hex_len + 1 > sizeof(basename)) goto claim_done;
+        if ((size_t)hex_len + 1 > sizeof(basename)) goto claim_done;
         memcpy(basename, hex, hex_len);
         basename[hex_len] = '\0';
 

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -583,6 +583,14 @@ static bool read_npc(FILE *f, npc_ship_t *n) {
          * had a token to credit anyway) are not retroactive. */
         memset(n->session_token, 0, sizeof(n->session_token));
     }
+    /* Validate after the full record is read so the file pointer is
+     * always past this NPC's bytes. An active slot with garbage role
+     * used to crashloop the server on first sim step (despawn check
+     * fired with an invalid role through character_free_for_npc).
+     * Drop the slot quietly; the spawn loop will refill it. */
+    if (n->active && ((int)n->role < 0 || (int)n->role > (int)NPC_ROLE_TOW)) {
+        memset(n, 0, sizeof(*n));
+    }
     return true;
 }
 


### PR DESCRIPTION
Two production crashes from corrupt-state load paths. `read_npc` accepted invalid roles (saw role=0x0B000007 in the wild, crashloop'd the server); claim_legacy_save sign-compare error blocked the docker build. See commit msg for details.