### PR TITLE
docs(decentralization): operator onboarding + architectural overview (Layer F of #479)

### DIFF
--- a/docs/decentralization.md
+++ b/docs/decentralization.md
@@ -1,0 +1,399 @@
+# Signal — Decentralization Architecture
+
+This document is the architectural overview for Signal's off-chain decentralization
+stack: the identity layers, the trust model, and what it means to run a station as
+an independent operator. It is the companion to
+[`operator-onboarding.md`](./operator-onboarding.md), which is the practical
+recipe-style guide.
+
+The work tracked here is the off-chain half of issue #479. The on-chain anchoring
+work (state-root commitments, wrap contracts, bounty payouts) lives in the Solana
+ticket #480 and is not implemented in this stack — anywhere this document says
+"future" or "post-#480" it means exactly that.
+
+The intended reader is a developer or operator who has been told "I'd like to host
+a Signal station" and wants to understand what they're signing up for before they
+generate a keypair and ship a server. The tone is technical. There is no
+marketing copy.
+
+## What is Signal?
+
+Signal is a multiplayer space-station game. Live build:
+[signal.ratimics.com/play](https://signal.ratimics.com/play). Players fly a small
+ship around an asteroid belt, fracture rocks for ore, smelt and refine at
+stations, and throw the leftover rocks at each other. The simulation is fully
+authoritative on the server, fixed-step at 120 Hz, and identical bit-for-bit
+across every machine that runs the same world seed.
+
+The relevant fact for this document is that there is no global player wallet and
+no global ledger. **Credits are per-station** (`station_t.ledger[]` in
+[`shared/types.h`](../shared/types.h)). Each station owns its own books, its own
+specialty supply chain, and — after Layer B of #479 — its own Ed25519 keypair.
+Federation is the natural extension of a primitive that was already in the
+codebase.
+
+## The identity stack
+
+Every long-lived object in Signal has a content-addressed identity: an asteroid,
+a fragment chipped off that asteroid, an ingot smelted from that fragment, a
+finished frame fabricated from that ingot, the player who initiated the chain,
+and the station that authored each transformation. The hashes nest. Knowing one
+layer is enough to verify the layer above it; knowing the chain log is enough to
+verify the lot.
+
+The layers, from substrate up:
+
+### `rock_pub` — terrain asteroids
+
+Seed-origin asteroids carry a stable 32-byte pubkey baked at world birth:
+`asteroid_t.rock_pub` ([`shared/types.h:509`](../shared/types.h)). The hash is
+deterministic in `(belt_seed, asteroid_index)` so every server with the same
+world seed agrees on every rock's identity. PRs #486 and #487 made this layer
+permanent; the rock-ledger is sorted and binary-searched at runtime.
+
+### `fragment_pub` — fracture children
+
+When a player fractures an asteroid, each child fragment gets its own pubkey:
+`asteroid_t.fragment_pub` ([`shared/types.h:498`](../shared/types.h)). The
+fragment hash binds in the parent's `rock_pub`, the fracture seed, and the
+fragment index, so the lineage from terrain rock to handheld pebble is auditable
+without trusting the server's word for it.
+
+Once a fragment claim resolves, the fragment is what downstream layers point at;
+`rock_pub` becomes zero on the fracture children themselves and is preserved
+only in the destroyed-records anchor.
+
+### `cargo_unit.pub` — ingots and finished goods
+
+PR #481 unified the named-ingot store and the bulk inventory under a single
+`cargo_unit_t`. Every ingot, every frame, every laser module, every tractor
+coil, every repair kit is one row in a per-holder manifest with a 32-byte
+content hash:
+
+```c
+typedef struct {
+    uint8_t  kind;              /* cargo_kind_t */
+    uint8_t  commodity;
+    uint8_t  grade;
+    uint8_t  prefix_class;
+    uint16_t recipe_id;
+    uint8_t  origin_station;
+    uint8_t  _pad;
+    uint64_t mined_block;
+    uint8_t  pub[32];           /* content hash */
+    uint8_t  parent_merkle[32]; /* sorted-input merkle root */
+} cargo_unit_t;                 /* 80 bytes */
+```
+
+(See [`shared/types.h:138`](../shared/types.h) for the canonical definition and
+[`shared/manifest.h`](../shared/manifest.h) for the helpers.)
+
+For ingots, `pub = hash_ingot(commodity, grade, fragment_pub, output_index)` —
+the smelt event's identity is fully determined by its inputs. For finished
+goods, `pub = hash_product(recipe_id, sorted_inputs, output_index)`. Identical
+inputs always yield the same `pub`; that is what makes the manifest portable
+between holders without a central authority renaming the rows.
+
+### Station authority — `station_pubkey`
+
+Layer B of #479 (PR #493) gave each station its own Ed25519 keypair, derived
+deterministically:
+
+- **Seeded stations** (Prospect Refinery, Kepler Yard, Helios Works — indices
+  0/1/2) derive their seed as
+  `SHA256("signal-station-v1" || world_seed_u32 || station_index_u32)`. Every
+  server running the same world seed agrees on every seeded station's pubkey
+  bit-for-bit. See
+  [`server/station_authority.c`](../server/station_authority.c) and the seeded
+  bootstrap in [`server/game_sim.c:4613`](../server/game_sim.c).
+- **Player-planted outposts** (indices 3+) derive their seed as
+  `SHA256("signal-outpost-v1" || founder_pub[32] || station_name[16] || planted_tick_u64)`.
+  An auditor with the founding event can rederive the outpost's pubkey from the
+  world state alone.
+
+The private key is rederivable on demand; it is **never** serialized to disk and
+**never** sent over the wire. The struct layout enforces this — `station_secret`
+is the last field of `station_t` and a `_Static_assert` keeps it that way
+([`shared/types.h:411`](../shared/types.h)). Losing the disk does not leak the
+private key.
+
+### Player identity — `player_identity_t`
+
+Layers A.1 through A.4 of #479 (PRs #484, #485, #488, #491) put a per-player
+Ed25519 keypair in the client. The client generates the keypair on first launch,
+persists it under a platform-appropriate path (POSIX:
+`$XDG_DATA_HOME/signal/identity.key` at mode 0600 inside a 0700 directory; macOS:
+`~/Library/Application Support/signal/identity.key`; web: `localStorage`), and
+sends the pubkey on connect. The server validates state-changing actions
+against the player's signature, keys the save file by pubkey, and offers a
+"claim my legacy save" handshake for pre-A.4 anonymous saves.
+
+See [`src/identity.h`](../src/identity.h) for the load/save surface and
+[`src/identity.c`](../src/identity.c) for the platform-path resolution.
+
+The HUD shows the first 8 base58 chars of the player's pubkey as their permanent
+identity. That prefix is the callsign.
+
+### The chain log — Layer C of #479
+
+Layer C (PR #497) closed the loop: every state-mutation event a station authors
+is signed by the station and chained to the previous event by SHA-256 hash. The
+file [`server/chain_log.h`](../server/chain_log.h) defines the schema; the
+implementation is [`server/chain_log.c`](../server/chain_log.c). The result is
+that any auditor with the on-disk chain log and the station's pubkey can prove
+that no event was inserted, removed, or altered after the fact.
+
+Event types currently emitted (from `chain_event_type_t` in
+[`chain_log.h:45`](../server/chain_log.h)):
+
+| Event | Meaning |
+| --- | --- |
+| `CHAIN_EVT_SMELT` | Fragment smelted into ingot at this station |
+| `CHAIN_EVT_CRAFT` | Ingots fabricated into a finished product |
+| `CHAIN_EVT_TRANSFER` | Cargo unit moved between holders |
+| `CHAIN_EVT_TRADE` | Transfer + ledger delta, atomic |
+| `CHAIN_EVT_LEDGER` | Station-side credit balance mutation |
+| `CHAIN_EVT_ROCK_DESTROY` | Asteroid fractured to terminal state |
+
+Every event is exactly 184 bytes of header followed by `uint16` payload length
+and the payload bytes. The header includes `epoch` (sim tick), `event_id`
+(monotonic per `(station, epoch)`), `type`, `authority` (the station's pubkey),
+`payload_hash` (SHA-256 of the payload), `prev_hash` (the SHA-256 of the
+previous event's full header), and a 64-byte Ed25519 `signature` over the
+unsigned header span. A `_Static_assert` pins the size to 184 bytes so the
+on-disk format cannot drift silently
+([`server/chain_log.c:31`](../server/chain_log.c)).
+
+## The trust model
+
+Three concentric circles. Each one is independently verifiable; each one widens
+the radius of mutual mistrust the system tolerates.
+
+### Inside the sim
+
+Clients trust the sim. The sim is deterministic, fixed-step at 120 Hz, and
+identical for everyone connected to the same server. There is no client-side
+authority over physics, mining outcomes, or production. Cheating against the
+sim is server-side enforcement and always has been; the identity stack does not
+change anything here.
+
+### Inside the chain log
+
+A chain log carries the station's signature on every event and a hash chain
+linking every event to its predecessor. Anyone with the on-disk log file plus
+the station's pubkey can replay the log, verify each signature, and verify the
+prev-hash linkage. This is the surface that `signal_verify` (Layer E, in flight)
+will expose as a standalone tool.
+
+The trust assumption shrinks to: "the operator who holds this station's private
+key is honest about what their station did." If they aren't, the chain log
+catches them — the sole remaining attack is a fork (the operator publishes two
+divergent logs to two audiences), which the on-chain anchoring work in #480 is
+designed to prevent.
+
+### Across federation
+
+When a second operator joins, they bring their own pubkey-keyed station, run
+their own chain log, and sign their own events. They do not have to trust the
+first operator's server; they only have to verify the first operator's
+signatures on the cargo units and receipts that cross the zone boundary. Layer
+D (cross-station settlement, in flight as a parallel PR) is what threads the
+needle: cargo units carry a chain of signed transfer receipts back to the
+originating event, and the destination station verifies the chain on dock
+before accepting the unit.
+
+Every station is sovereign within its zone. Prospect's operator decides
+Prospect's price curves. Helios's operator decides what Helios pays for
+crystal. The economy is per-zone because the authority is per-zone.
+
+## What stations actually are
+
+A station is, mechanically, a `station_t` ([`shared/types.h`](../shared/types.h))
+with:
+
+- A position, a ring layout, a slot grid, and a manifest of installed modules.
+- A per-station ledger keyed by player pubkey
+  (`station_t.ledger[]`, `station_t.currency_name`).
+- A 32-byte `station_pubkey`, a 64-byte `station_secret` (rederivable, not
+  serialized), and `chain_last_hash` + `chain_event_count` so the chain
+  survives restart.
+- For outposts: an `outpost_founder_pubkey` and `outpost_planted_tick` so the
+  keypair can be rederived deterministically on save load.
+
+Authority is structural: the keypair *is* the station. There is no separate
+operator identity registered with the station — whoever holds the private key
+*is* the operator. For seeded stations, the world seed itself is the custody
+authority: anyone with the same world seed can rederive every seeded station's
+keypair, which is why seeded stations are agreed-upon globally without any
+explicit registration. For outposts, the founder's pubkey + the station name +
+the planting tick is sufficient.
+
+## Per-station ledgers and per-zone economics
+
+The CLAUDE.md at the repo root has the canonical text on this; see the
+"Economy: per-station credits" section of
+[`/CLAUDE.md`](../CLAUDE.md). The summary, for federation:
+
+- A player has no global wallet. Credits earned at Prospect are spendable at
+  Prospect only. The string `currency_name` ("prospect credits", etc.) is
+  station-local, because the underlying authority is station-local.
+- Prices are dynamic on hopper fullness (buy 1.0× → 0.5×) and stock fullness
+  (sell 2.0× → 1.0×). See `station_buy_price` / `station_sell_price` and the
+  `test_dynamic_ore_price_*` tests.
+- Carrying value between stations means carrying *goods*, not currency.
+  Hauling is first-class, and the hauling primitive becomes a real
+  cryptographic asset transfer once Layer D lands.
+
+The reason this maps so cleanly onto federation is that the ledger was already
+per-station before any of the identity work. Layer B simply attached the
+authority to the ledger; Layer C simply attached the audit trail.
+
+## The signed event log on disk
+
+On-disk layout, per station:
+
+```
+chain/<base58(station_pubkey)>.log
+```
+
+The base directory defaults to `chain/` and can be overridden for tests via
+`chain_log_set_dir()` ([`server/chain_log.h:75`](../server/chain_log.h)). Each
+entry is the 184-byte header followed by `uint16 payload_len` and `payload_len`
+bytes of payload. Entries are append-only; existing entries are never
+rewritten.
+
+Write semantics: `chain_log_emit` opens the per-station log file in append
+mode, writes header + payload-length + payload, calls `fflush`, and closes.
+Crash safety relies on the append-only property — a partial last-entry write
+is detected on the next verify walk and treated as the truncation it is. The
+verifier reports the count of events successfully walked, regardless of
+whether the walk failed at the tail.
+
+In-memory state: `station_t.chain_last_hash` is the SHA-256 of the most
+recently authored event header. The next event's `prev_hash` is set to this
+value, linking the log into a hash chain. `chain_event_count` is the
+monotonic per-station counter, stamped into `event_id` on every emit. Both
+fields are persisted by the world save (v41+), so the chain survives a server
+restart cleanly. The actual event records live in the side files under
+`chain/` — they are not part of `world.sav`.
+
+Verification semantics (`chain_log_verify`,
+[`server/chain_log.h:108`](../server/chain_log.h)):
+
+1. Walk the on-disk log entry by entry.
+2. For each entry: verify the Ed25519 signature against the asserted authority
+   pubkey, which must equal the station's `station_pubkey`. Verify
+   `payload_hash` matches the SHA-256 of the stored payload bytes. Verify
+   `prev_hash` matches the SHA-256 of the previous entry's full header
+   (or zero for the first entry).
+3. If `out_event_count` is non-NULL, write the number of successfully walked
+   events through, regardless of whether the walk eventually failed. If
+   `out_last_hash` is non-NULL, write the SHA-256 of the last successfully
+   walked header through.
+4. Returns `true` iff every event verifies. A missing log file returns `true`
+   with zero events walked — the empty chain is trivially valid.
+
+## Cross-station settlement (Layer D — in flight)
+
+When Layer D lands, cargo units crossing a zone boundary will carry a chain
+of signed transfer receipts. The destination station will verify the chain
+before accepting the unit, and emit its own `CHAIN_EVT_TRANSFER` (and, if
+the dock-side trade is atomic, an accompanying `CHAIN_EVT_LEDGER`) into its
+own log.
+
+The schema fields are reserved already: `cargo_unit_t.parent_merkle`
+([`shared/types.h:148`](../shared/types.h)) is the sorted-input merkle root of
+the producing event, and the chain log entry whose hash matches it is the
+authoritative attestation that the unit was legitimately transferred.
+
+Until D lands, cargo movement *within* a zone is fully signed but
+*cross-zone* movement still relies on the same server holding both stations.
+This document will be updated when D ships.
+
+## The verifier tool (Layer E — in flight)
+
+Layer E will ship `signal_verify` as a standalone binary that takes a chain
+log file and a pubkey, and reports:
+
+- Total events walked and total bytes consumed.
+- First failed event (if any), with a short reason: `bad signature`,
+  `bad prev-hash linkage`, `payload hash mismatch`, `truncated tail`.
+- The final `chain_last_hash`, suitable for cross-checking against the
+  in-memory state of a running server.
+
+The verifier wraps the same `chain_log_verify` walker that runs at server
+startup; the only difference is the CLI surface and a non-zero exit code on
+failure for CI integration. Until E lands, the same verification is callable
+from C code by any tool that links `chain_log.c`.
+
+## Off-chain vs on-chain
+
+| Concern | Where it lives today |
+| --- | --- |
+| Player identity | Local Ed25519 keypair (PR #484) |
+| State-changing action authority | Player Ed25519 signature (PR #488) |
+| Save record key | Player pubkey (PR #491) |
+| Asteroid identity | Deterministic from world seed (#486–#487) |
+| Cargo unit identity | Content hash on `cargo_unit_t.pub` (#481) |
+| Station identity | Deterministic Ed25519 keypair (PR #493) |
+| Per-station event history | Signed chain log (PR #497) |
+| Cross-station verification | Cargo receipts (Layer D, in flight) |
+| Standalone verifier | `signal_verify` (Layer E, in flight) |
+| Cross-operator anchor | On-chain state-root commitment (#480, future) |
+| Asset extraction | On-chain wrap contract (#480, future) |
+| Bounty payouts | On-chain bounty program (#480, future) |
+
+Anything in the bottom three rows is explicitly *not* shipped. The off-chain
+stack stops at "anyone with a chain log file plus a pubkey can verify the
+station told the truth." The on-chain stack will close the remaining gap by
+periodically anchoring the chain-tip hash to a public ledger so a malicious
+operator cannot publish two divergent logs to two audiences.
+
+## Glossary
+
+- **`rock_pub`** — 32-byte content hash for a seed-origin asteroid, baked at
+  world birth, deterministic in `(belt_seed, index)`.
+- **`fragment_pub`** — 32-byte hash for a fracture child, binds parent
+  `rock_pub` + fracture seed + index.
+- **`cargo_unit`** — the unified manifest row for an ingot or finished good
+  ([`shared/types.h:138`](../shared/types.h)). Carries the content hash
+  `pub` and the input merkle root `parent_merkle`.
+- **`manifest`** — an array of cargo units owned by a holder (a player's
+  ship, a station's hold). [`shared/manifest.h`](../shared/manifest.h).
+- **`ledger`** — `station_t.ledger[]`, the per-station credit-balance table
+  keyed by player pubkey.
+- **`EVT_*` / `CHAIN_EVT_*`** — event types in the signed chain log. See
+  `chain_event_type_t` in [`server/chain_log.h:45`](../server/chain_log.h).
+- **callsign** — the first 8 base58 chars of the player's pubkey, shown in
+  the HUD as their permanent identity.
+- **prefix class** — the optional named-ingot prefix (`INGOT_PREFIX_RATI`,
+  etc.) carried on `cargo_unit_t.prefix_class`. Anonymous for non-ingot
+  kinds.
+- **RATi** — the named-ingot prefix reserved for the RATi Foundation's
+  bounty path. Currently a tag; bounty payouts attach to it post-#480.
+- **station authority** — the Ed25519 keypair bound to a station via
+  [`server/station_authority.h`](../server/station_authority.h).
+- **chain log** — the per-station append-only signed event log. File path:
+  `chain/<base58(station_pubkey)>.log`.
+- **federation** — the model in which different operators run different
+  stations under different keypairs and verify each other's chain logs at
+  the zone boundary.
+
+## Reading list
+
+- [`/CLAUDE.md`](../CLAUDE.md) — repo-level architecture notes, including the
+  canonical "Economy: per-station credits" text.
+- [`docs/operator-onboarding.md`](./operator-onboarding.md) — practical guide
+  to standing up a station.
+- [`server/chain_log.h`](../server/chain_log.h) — chain log schema and
+  verifier surface.
+- [`server/station_authority.h`](../server/station_authority.h) — per-station
+  keypair derivation.
+- [`shared/signal_crypto.h`](../shared/signal_crypto.h) — the Ed25519 surface.
+- [`shared/manifest.h`](../shared/manifest.h) — manifest helpers and the
+  finished-good lifecycle invariants.
+- [`src/identity.h`](../src/identity.h) — client-side player identity
+  load/save.
+- Issue #479 — the umbrella for off-chain decentralization.
+- Issue #480 — the on-chain follow-on.
+- Issue #496 — substrate-attached player birth (Layer A.5 of #479).

--- a/docs/operator-onboarding.md
+++ b/docs/operator-onboarding.md
@@ -1,0 +1,370 @@
+# Signal — Operator Onboarding
+
+You have decided to host a Signal station. This document is the practical
+recipe-style guide. For the architectural overview — what a station actually is,
+why each piece of the identity stack exists, what trust assumptions remain —
+read [`decentralization.md`](./decentralization.md) first.
+
+The off-chain federation stack is shipped through Layer F. The cross-operator
+handshake (different operators verifying each other's chain logs at the zone
+boundary) currently relies on Layer D being live for full cargo settlement and
+on the on-chain anchor in #480 for fork resistance. Both are in-flight or
+future. Where this guide says "post-#480" or "post-D", it means you can run
+the station today, but the multi-operator handshake will only become real once
+those merge.
+
+## What you're signing up for
+
+Operating a Signal station is, today, the same as operating any small game
+server: keep the process up, keep the disk healthy, keep an eye on the logs.
+Federation adds a few cryptographic responsibilities on top.
+
+- **Custody of the station's private key.** For a seeded station the key is
+  rederivable from the world seed, so custody is automatic. For an outpost
+  you operate, custody is the same as custody of the running server's
+  filesystem (the secret is rederivable from the founding event, which lives
+  in the save). Treat the world save like any other production state.
+- **Continuous chain log integrity.** Your station's chain log is the
+  authoritative history of every state mutation it authored. Don't truncate
+  it. Don't edit it. Don't replace it from a backup unless you also revert
+  the save to match — `chain_last_hash` and the on-disk tail must agree or
+  the next emit will be rejected (the verifier will reject it too).
+- **Periodic verification.** Run `signal_verify` (when Layer E lands) or the
+  in-process verifier on every server start to catch bit rot and partial
+  writes. The walker is cheap; running it on boot is the right default.
+- **Anchoring the chain tip (post-#480).** When the on-chain anchor lands,
+  you'll periodically post your chain-tip hash to a public ledger so other
+  operators can detect a fork. Until then, the only fork defense is "the
+  community is small and operators are known."
+- **Responding to fork claims (post-#480).** If another operator or a
+  player presents a chain log fragment they say is yours but doesn't match
+  your local log, you have to respond. The on-chain anchor will be the
+  resolving authority.
+
+## Hardware / cloud requirements
+
+These are loose estimates for the current sim.
+
+- **CPU.** The sim is fixed-step at 120 Hz and is comfortably single-core
+  bound. Anything modern (1 vCPU on a small cloud instance) is plenty for
+  the seeded station count and a handful of players.
+- **Memory.** A few hundred MB for the server process itself; the sim
+  state, the world snapshot, and the Mongoose websocket layer dominate.
+  512 MB is comfortable, 1 GB is generous.
+- **Disk for chain logs.** Each event is 184 bytes of header plus a small
+  payload (typically tens of bytes) plus the `uint16` payload length. Even
+  at a busy 10 events/sec, a station accumulates roughly 2 MB/hour of
+  chain log — under 50 MB/day per station. A 10 GB volume will last a
+  long time. Don't co-locate the chain log directory with anything that
+  might rotate or `truncate` it.
+- **Disk for saves.** The world save is one file (`world.sav`); player
+  saves live under `saves/pubkey/<base58(pubkey)>.sav` (and the legacy
+  fallback `saves/legacy/<token_hex>.sav`). Both grow slowly and cap at
+  small sizes. See `/CLAUDE.md` "Save layout" for the canonical
+  description.
+- **Network.** Mongoose's websocket layer; a few hundred kbps per
+  connected client is plenty. There are no large asset downloads —
+  geometry is procedural; only avatars, episodes, and music are assets,
+  and they ship with the client.
+- **OS.** Linux, macOS, and Windows are all supported. Production
+  instances are Linux (the Dockerfile and `task-definition.json` in
+  [`server/`](../server/) target Fargate).
+
+## Stand up your first station
+
+The full path is: pick a name, generate a keypair, decide which station-index
+slot you want it in (or plant an outpost), boot the server, verify the chain
+log is being written, and verify it parses cleanly.
+
+### 1. Pick a station name
+
+Free-form, max 16 characters (the outpost-seed derivation truncates/pads to
+exactly 16 bytes for hashing — see
+[`server/station_authority.h:50`](../server/station_authority.h)). The name
+shows up in the HUD and is part of the outpost's identity hash, so changing it
+later changes the keypair. Pick something you can live with.
+
+### 2. Generate a station keypair
+
+The keypair is derived deterministically from a 32-byte seed via
+`signal_crypto_keypair_from_seed` ([`shared/signal_crypto.h:44`](../shared/signal_crypto.h)).
+The seed itself comes from one of two recipes:
+
+- **Seeded slot (you operate one of indices 0/1/2).**
+  `seed = SHA256("signal-station-v1" || world_seed_u32 || station_index_u32)`.
+  Every server with the same world seed agrees on this seeded station's
+  keypair, which is the whole point — auditors can rederive it. The helper
+  is `station_authority_seeded_seed` and the bootstrap is
+  `station_authority_init_seeded`
+  ([`server/station_authority.h:45`](../server/station_authority.h)).
+- **Outpost (indices 3+).**
+  `seed = SHA256("signal-outpost-v1" || founder_pub[32] || station_name[16] || planted_tick_u64)`.
+  The founder is the player who planted the outpost, the name is the
+  station name, and the planted tick is `world.time * 120` at the moment
+  of planting. The helper is `station_authority_outpost_seed` and the
+  bootstrap is `station_authority_init_outpost`. Both founder and tick
+  are stamped onto `s->outpost_founder_pubkey` and
+  `s->outpost_planted_tick` so the secret can be rederived on save load.
+
+For stations you operate yourself, the world-seed-anchored derivation is the
+conventional path because it makes the keypair reproducible by anyone with the
+world seed; you do not have to publish anything separately. If your operational
+constraints require a keypair that is *not* derivable from the world (for
+example, a station that you want to revoke and re-key without changing the
+world seed), generate the seed by any other means and feed it to
+`signal_crypto_keypair_from_seed` directly — the contract is just "32 bytes
+of high-entropy seed in, deterministic Ed25519 keypair out."
+
+The private key is never written to disk and never sent over the wire. Layer B
+keeps `station_secret` as the last field of `station_t` and re-derives it on
+load via `station_authority_rederive_secret`
+([`server/station_authority.h:75`](../server/station_authority.h)).
+
+### 3. Wire your station's pubkey into the world
+
+The current world bootstrap derives all three seeded stations' pubkeys
+deterministically from `w->belt_seed` (which is `w->rng`, defaulting to
+`2037u`) — see [`server/game_sim.c:4613`](../server/game_sim.c). There is no
+external `world_seed.json`; the world seed is the integer baked into the world
+on `world_reset`.
+
+If you are running one of the three seeded stations on a fresh world, no
+extra wiring is required: the pubkey is already what you derived in step 2
+because both you and the server agreed on the seed.
+
+If you are planting an outpost, the founding event itself is the wiring:
+`station_authority_init_outpost` runs at plant time, stamps the founder + tick
+onto the station record, and the chain log emitted on plant carries the new
+pubkey forward. Subsequent server starts rederive the secret from the saved
+provenance.
+
+If you are joining an *existing* world as a second operator running an
+*additional* seeded slot, the world seed must be agreed upon before launch.
+Coordinate the world seed (or the seed-bytes-by-other-means override) with
+the existing operator out of band; once both servers boot with the same seed,
+the seeded-station pubkeys match by construction.
+
+### 4. Run the server
+
+Build:
+
+```sh
+cmake -S . -B build
+cmake --build build
+```
+
+Run:
+
+```sh
+./build/signal_server
+```
+
+Relevant environment variables (read in [`server/main.c`](../server/main.c)):
+
+- `PORT` — TCP port to bind. Defaults to a baked-in value if unset.
+- `SIGNAL_API_TOKEN` — admin API bearer; required for any admin endpoints
+  if `SIGNAL_REQUIRE_API_TOKEN` is set.
+- `SIGNAL_REQUIRE_API_TOKEN` — when set, refuses admin requests that don't
+  present `SIGNAL_API_TOKEN`.
+- `SIGNAL_ALLOWED_ORIGIN` — CORS allowlist for the websocket upgrade.
+
+The server creates `chain/` on its first emit and writes per-station log
+files into it. It creates `saves/pubkey/` and `saves/legacy/` lazily
+when the first save needs to be written.
+
+### 5. Verify your chain log
+
+Once the server has been up long enough to have authored a few state
+mutations (smelt one fragment, sell some ore, plant an outpost — anything
+that emits a `CHAIN_EVT_*`), confirm the log is present and verifies.
+
+When Layer E ships:
+
+```sh
+./build/signal_verify chain/<base58(your_pubkey)>.log
+```
+
+Until then, the same walker is callable from any C tool that links
+[`server/chain_log.c`](../server/chain_log.c); call `chain_log_verify` with
+the station record and check that it returns `true` and that
+`out_event_count` matches the in-memory `s->chain_event_count`.
+
+## Operational hygiene
+
+- **Backup the world save, not the keypair.** For seeded stations the
+  keypair is rederivable from the world seed alone; back up the world
+  seed (or the world.sav, which records `belt_seed`) and you can rebuild
+  the keypair from scratch. For outposts the founder pubkey + name +
+  planted tick live in the world.sav; back up the save.
+- **Monitor disk for chain log growth.** Expect ~2 MB/hour at busy times
+  per station. If it grows much faster, something is emitting more than
+  it should — investigate before it eats the volume.
+- **Verify on every server start.** Run `chain_log_verify` (or
+  `signal_verify` post-E) before serving any clients. A mismatched tail
+  is a real signal — either your previous run crashed mid-write, in
+  which case the verifier will tell you the count of events that
+  successfully walked, or someone tampered with the log file.
+- **Don't truncate, edit, or replace chain logs in place.** They are
+  append-only by contract. If you must reset, both `chain_last_hash`
+  and the on-disk tail have to be reset together — the canonical way is
+  `world_reset()`, which calls `chain_log_reset` for each seeded station
+  and zeroes the in-memory chain state ([`server/game_sim.c:4623`](../server/game_sim.c)).
+- **Keep the server's clock sane.** Events have monotonic `event_id`
+  per station and timestamps from `world.time`. A backwards clock jump
+  between restarts is mostly harmless because `event_id` increments
+  regardless, but it makes log analysis annoying. Run NTP.
+- **Don't co-locate the chain log directory with rotators.** A logrotate
+  rule that gzips and renames `chain/<pubkey>.log` will silently break
+  the chain. The directory is *data*, not *logs* in the syslog sense.
+
+## Federation handshake (forward-looking)
+
+When a second operator joins the federation:
+
+1. They generate a station keypair via the recipe in step 2 above.
+2. They publish their pubkey out of band (the world seed change, or a
+   federation manifest at the on-chain anchor post-#480).
+3. They run their own server, with their own chain log directory, on
+   their own infrastructure.
+4. Each operator periodically anchors their chain-tip hash to the public
+   ledger (post-#480). The anchor is the resolving authority for fork
+   claims.
+5. Cargo crossing the zone boundary carries a chain of signed transfer
+   receipts (post-D). The destination station verifies the chain before
+   accepting the unit.
+
+Until D and #480 land, federation is "informal" — it works in a small
+mutually-known operator set, but not against a Byzantine operator. Plan
+accordingly.
+
+## What if you mess up
+
+A non-exhaustive list of recoverable failure modes.
+
+### Lost the keypair
+
+For a **seeded station**: regenerate from the world seed. The seeded path is
+deterministic. Run the same world seed, and the same pubkey + secret falls out
+of `station_authority_init_seeded`.
+
+For an **outpost**: if you have the world.sav, the secret is rederivable from
+`outpost_founder_pubkey` + station name + `outpost_planted_tick`, all of which
+are persisted. Boot the server against the save and the secret is rederived
+automatically. If you have lost both the save and the founding event,
+the outpost's identity is gone — start fresh by planting a new outpost.
+
+### Server crash mid-event
+
+The chain log emitter writes header + payload-length + payload then `fflush`
+and closes ([`server/chain_log.c:204`](../server/chain_log.c)). The disk may
+contain a partial last entry. The verifier will walk up to the last good
+entry and report the count; the in-memory `chain_last_hash` is reset to that
+last good entry's hash on the next server start (via the verify-walk seeding
+the chain state during world load), and the truncated tail is overwritten by
+the next emit's append. There is no manual recovery step; verify on boot is
+sufficient.
+
+### `world.sav` corruption
+
+The chain log is the source of truth for state mutations. `world.sav` is a
+derived snapshot. Replay the chain log to rebuild a fresh `world.sav`:
+construct a fresh world, walk the per-station chain logs, and apply each
+event in `(epoch, event_id)` order. The verifier and the chain-log walker
+are the building blocks; full replay is not yet a one-shot CLI but the
+primitives are present in [`server/chain_log.c`](../server/chain_log.c).
+
+### Time desync
+
+`event_id` is monotonic per `(station, epoch)`, so a backwards wall-clock
+jump between restarts does not directly violate any chain invariant. What
+*does* break is `epoch`: `epoch_ticks = world.time * 120` at emit. If the
+saved `world.time` jumps backward between restarts, audit tools that group
+events by epoch will see weird ordering. Run NTP and don't restore old
+saves into a running federation; if you must restore, do it everywhere
+simultaneously.
+
+### Save corruption on `saves/pubkey/<...>.sav`
+
+A corrupted player save affects only that player. The legacy claim flow
+(`"claim-legacy-save-v1" || <token_hex>` signed by the player's identity
+secret — see PR #491 and `/CLAUDE.md` "Save layout") is the migration
+mechanism for legacy session-token saves; for already-pubkey-keyed saves,
+restore from backup and accept that the player loses any progress between
+the backup and the corruption.
+
+## Troubleshooting
+
+A handful of concrete debug recipes for the failure modes you'll actually
+hit.
+
+### "My chain log is empty"
+
+The station may not have authored anything yet. Smelt one fragment or sell
+some ore — anything that flips a `CHAIN_EVT_*`. If the file is still
+absent after that, check that the `chain/` directory exists and is
+writable; `chain_log_emit` calls `ensure_chain_dir()` on each emit but
+fails the emit if the `mkdir` fails. Look for `[chain] mkdir` warnings in
+the server log.
+
+### "The verifier reports event_count = 0 with no error"
+
+Either the log file is missing (verifier returns `true` with zero events
+for a missing log — the empty chain is trivially valid), or the file is
+present but empty. Check the file's size; if it is a multiple of zero,
+no event has been emitted. If the file is partially written but no full
+header has been written, the verifier returns zero events.
+
+### "Verifier reports `bad signature`"
+
+The asserted `authority` pubkey on the failing event does not match the
+station's `station_pubkey`. This usually means the chain log was authored
+by a *different* keypair — for example, the world seed changed between
+the run that authored the log and the current run, or you replaced an
+outpost's founding event. Identify the run that authored the log and
+restore the world seed (or founding event) it expects.
+
+### "Verifier reports `bad prev-hash linkage`"
+
+The on-disk tail does not match what the in-memory chain state thinks it
+is. Common cause: the server crashed after writing an event to disk but
+before persisting the world.sav, so on restart `chain_last_hash` came
+from an older save while the on-disk tail was newer. Resolution: walk
+the log forward from the start, take the verifier's `out_last_hash` as
+truth, and patch `station_t.chain_last_hash` from there before continuing
+emits. The chain log is the authoritative history.
+
+### "Server refuses to emit; SIM_LOG says self-verify failed"
+
+`chain_log_emit` runs a self-verify on the freshly-signed header before
+writing it to disk ([`server/chain_log.c:192`](../server/chain_log.c)).
+A failure here means the secret slot was zero or rederive failed. Check
+that the world load called `station_authority_rederive_secret` for every
+station. For seeded stations, the world seed must be set before
+`world_reset` runs the bootstrap. For outposts, the founder + tick must
+have been loaded from the save.
+
+### "Disk is filling up faster than expected"
+
+Chain logs grow append-only by design. Profile what's emitting: sort
+events by `type` from a recent log slice and see whether one event type
+dominates unexpectedly (a runaway `CHAIN_EVT_LEDGER` is a common
+suspect). Investigate the producer before reaching for any kind of log
+pruning — the chain is the audit trail and pruning it without an
+on-chain anchor in place destroys the audit.
+
+## Reading list
+
+- [`docs/decentralization.md`](./decentralization.md) — architectural
+  overview. Read first if you haven't.
+- Issue #479 — the umbrella for off-chain decentralization. Layers A
+  through F are tracked there.
+- Issue #480 — on-chain anchoring, wrap, and bounty. The forward-looking
+  half of federation.
+- Issue #496 — substrate-attached player birth (Layer A.5 of #479).
+- [`/CLAUDE.md`](../CLAUDE.md) — repo-level architecture notes,
+  authoritative for build commands, save layout, and economy invariants.
+- [`server/chain_log.h`](../server/chain_log.h) — schema and verifier.
+- [`server/station_authority.h`](../server/station_authority.h) — keypair
+  derivation.
+- [`shared/signal_crypto.h`](../shared/signal_crypto.h) — Ed25519 surface.
+- `signal_verify --help` (post-Layer E) — standalone verifier CLI.


### PR DESCRIPTION
## Summary

Layer F of the off-chain decentralization roadmap (#479). Two new markdown
files under `docs/`. Pure docs PR — no code, no test changes.

### `docs/decentralization.md`
Architectural overview aimed at a developer evaluating whether to host a
Signal station. Walks the identity stack from `rock_pub` through
`fragment_pub`, `cargo_unit.pub`, station authority, and the signed
chain log, with file:line citations. Covers the three-circle trust
model (inside the sim / inside the chain log / across federation),
explains what stations actually are post-Layer B, recaps the
per-station ledger primitive, documents the on-disk chain log layout
(`chain/<base58(pubkey)>.log`, 184-byte header + payload-len + payload,
append-only), and ends with a glossary plus an explicit off-chain vs
on-chain table.

### `docs/operator-onboarding.md`
Practical recipe-style guide for standing up a station. Covers the
operational responsibilities you sign up for, hardware/cloud sizing
(~2 MB/hour of chain log per busy station), the five-step bootstrap
(name → keypair seed → wire into the world → run the server → verify
the chain log), operational hygiene (don't truncate logs, run NTP,
verify on every boot), the forward-looking federation handshake, what
to do when things go wrong (lost keypair, mid-event crash, save
corruption, time desync), and a troubleshooting section with five
concrete debug recipes.

### What this completes
Off-chain stack, layers A through F:
- A.1 player keypair (#484), A.2 register on connect (#485),
  A.3 signed actions (#488), A.4 saves keyed by pubkey (#491)
- B station keypairs (#493)
- C signed chain log (#497)
- D cross-station settlement — *in flight, parallel PR*
- E `signal_verify` standalone tool — *in flight, parallel PR*
- F docs — *this PR*

The on-chain anchoring follow-on lives in #480 and is referenced as
"future" throughout. Substrate-attached player birth (#496, Layer A.5)
is also linked from both docs.

### Verification
- All file:line references cross-checked against the worktree
  (`shared/types.h`, `server/chain_log.{h,c}`,
  `server/station_authority.h`, `shared/signal_crypto.h`,
  `server/game_sim.c`).
- All PR references are real (cross-checked via `gh issue/pr view`).
- No code changes; test count unchanged.

## Test plan
- [ ] Both files render correctly in `gh pr view --web`.
- [ ] All inline links resolve (relative paths to `../shared/...`,
      `../server/...`, etc.).
- [ ] No promises of unshipped behavior — Layer D, Layer E, and
      anything `#480` is explicitly tagged as in-flight or future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)