### PR TITLE
feat(identity): cross-station cargo receipts (Layer D of #479)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ set(SIGNAL_SIM_SOURCES
     server/station_authority.c
     server/chain_log.c
     server/chain_log_verify.c
+    server/cargo_receipt_issue.c
     server/sim_asteroid.c
     server/sim_physics.c
     server/sim_production.c
@@ -107,6 +108,7 @@ set(SIGNAL_SIM_HELPERS
     shared/belt.c
     shared/module_schema.c
     shared/station_util.c
+    shared/cargo_receipt.c
 )
 
 # Client-only: rendering, input, HUD, audio, network plumbing. Not
@@ -215,6 +217,7 @@ if(NOT EMSCRIPTEN AND NOT BUILD_SERVER_ONLY)
         src/tests/test_station_authority.c
         src/tests/test_chain_log.c
         src/tests/test_signal_verify.c
+        src/tests/test_cross_station_settlement.c
         src/identity.c
         ${SIGNAL_SIM_SOURCES}
         ${SIGNAL_SIM_HELPERS}

--- a/server/cargo_receipt_issue.c
+++ b/server/cargo_receipt_issue.c
@@ -1,0 +1,77 @@
+/*
+ * cargo_receipt_issue.c -- Server-side cargo_receipt_t issuance + emit.
+ *
+ * See cargo_receipt_issue.h for the public contract. This file glues
+ * shared/cargo_receipt.h (wire format + verify) to server-only
+ * primitives: station_authority signing and chain_log_emit.
+ */
+#include "cargo_receipt_issue.h"
+
+#include "game_sim.h"
+#include "station_authority.h"
+
+#include <string.h>
+
+bool cargo_receipt_issue(const station_t *s,
+                         uint64_t epoch,
+                         uint64_t event_id,
+                         const uint8_t cargo_pub[32],
+                         const uint8_t recipient_pubkey[32],
+                         const uint8_t prev_receipt_hash[32],
+                         cargo_receipt_t *out) {
+    if (!s || !out || !cargo_pub || !recipient_pubkey || !prev_receipt_hash)
+        return false;
+    static const uint8_t zero32[32] = {0};
+    if (memcmp(s->station_pubkey, zero32, 32) == 0) return false;
+
+    memset(out, 0, sizeof(*out));
+    memcpy(out->cargo_pub, cargo_pub, 32);
+    memcpy(out->authoring_station, s->station_pubkey, 32);
+    memcpy(out->recipient_pubkey, recipient_pubkey, 32);
+    out->event_id = event_id;
+    out->epoch = epoch;
+    memcpy(out->prev_receipt_hash, prev_receipt_hash, 32);
+
+    uint8_t blob[CARGO_RECEIPT_UNSIGNED_SIZE];
+    cargo_receipt_unsigned_pack(out, blob);
+    station_sign(s, blob, sizeof(blob), out->signature);
+    return true;
+}
+
+uint64_t cargo_receipt_emit_transfer(world_t *w, station_t *s,
+                                     const uint8_t from_pubkey[32],
+                                     const uint8_t to_pubkey[32],
+                                     const uint8_t cargo_pub[32],
+                                     uint8_t cargo_kind,
+                                     const uint8_t prev_receipt_hash[32],
+                                     cargo_receipt_t *out_receipt) {
+    if (!s || !out_receipt) return 0;
+    /* Wire-stable EVT_TRANSFER payload — same shape as the existing
+     * inlined struct in main.c, kept identical so the chain log byte
+     * format doesn't fork. */
+    struct __attribute__((packed)) {
+        uint8_t from_pubkey[32];
+        uint8_t to_pubkey[32];
+        uint8_t cargo_pub[32];
+        uint8_t kind;
+        uint8_t _pad[7];
+    } xfer = {0};
+    if (from_pubkey)   memcpy(xfer.from_pubkey, from_pubkey, 32);
+    if (to_pubkey)     memcpy(xfer.to_pubkey,   to_pubkey,   32);
+    if (cargo_pub)     memcpy(xfer.cargo_pub,   cargo_pub,   32);
+    xfer.kind = cargo_kind;
+
+    uint64_t event_id = chain_log_emit(w, s, CHAIN_EVT_TRANSFER,
+                                       &xfer, (uint16_t)sizeof(xfer));
+    if (event_id == 0) {
+        memset(out_receipt, 0, sizeof(*out_receipt));
+        return 0;
+    }
+    /* Epoch in ticks — same convention chain_log_emit used. */
+    uint64_t epoch_ticks = w ? (uint64_t)(w->time * 120.0) : 0;
+    if (!cargo_receipt_issue(s, epoch_ticks, event_id, cargo_pub,
+                             to_pubkey ? to_pubkey : (const uint8_t[32]){0},
+                             prev_receipt_hash, out_receipt))
+        return 0;
+    return event_id;
+}

--- a/server/cargo_receipt_issue.h
+++ b/server/cargo_receipt_issue.h
@@ -1,0 +1,70 @@
+/*
+ * cargo_receipt_issue.h -- Server-side issuance of cargo_receipt_t (Layer D of #479).
+ *
+ * Bridges the wire-stable cargo_receipt_t format (shared/cargo_receipt.h)
+ * with station-side signing (server/station_authority.h) and chain log
+ * anchoring (server/chain_log.h).
+ *
+ * This file lives in server/ — clients only verify receipts; they never
+ * sign new ones. The TweetNaCl signing key lives only on the server.
+ */
+#ifndef SERVER_CARGO_RECEIPT_ISSUE_H
+#define SERVER_CARGO_RECEIPT_ISSUE_H
+
+#include "cargo_receipt.h"
+#include "chain_log.h"  /* world_t, station_t, chain_event_type_t */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Issue a fresh cargo_receipt_t for a transfer authored by station `s`.
+ *
+ * Computes the unsigned span, signs with station_secret, fills out the
+ * signature field, and returns the result by value. The caller is
+ * responsible for forming the prev_receipt_hash:
+ *   - For the FIRST hop after smelt/craft, pass the SHA-256 of the
+ *     originating EVT_SMELT or EVT_CRAFT chain_event_header_t (use
+ *     chain_event_header_hash on the just-emitted header).
+ *   - For subsequent hops, pass cargo_receipt_hash() of the previous
+ *     receipt in the chain.
+ *
+ * `event_id` is the EVT_TRANSFER event_id from chain_log_emit (so the
+ * receipt and the chain event are stitched together).
+ *
+ * Returns true on success; on failure (e.g. unkeyed station) the
+ * receipt is zeroed and false is returned. */
+bool cargo_receipt_issue(const station_t *s,
+                         uint64_t epoch,
+                         uint64_t event_id,
+                         const uint8_t cargo_pub[32],
+                         const uint8_t recipient_pubkey[32],
+                         const uint8_t prev_receipt_hash[32],
+                         cargo_receipt_t *out);
+
+/* Convenience: emit an EVT_TRANSFER and produce the matching receipt
+ * in one call. The returned receipt's event_id matches the emitted
+ * event's id. The transfer payload is the canonical
+ * (from, to, cargo_pub, kind) shape used elsewhere in main.c.
+ *
+ * `prev_receipt_hash` follows the same rule as cargo_receipt_issue
+ * above. The caller chooses whether this transfer is "origin" (anchor
+ * to a SMELT/CRAFT event hash) or "hop N" (anchor to the previous
+ * receipt's hash).
+ *
+ * Returns the new chain event_id (>= 1) and writes the receipt
+ * through `out_receipt`. Returns 0 on failure (chain_log_emit failed
+ * or station unkeyed). */
+uint64_t cargo_receipt_emit_transfer(world_t *w, station_t *s,
+                                     const uint8_t from_pubkey[32],
+                                     const uint8_t to_pubkey[32],
+                                     const uint8_t cargo_pub[32],
+                                     uint8_t cargo_kind,
+                                     const uint8_t prev_receipt_hash[32],
+                                     cargo_receipt_t *out_receipt);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SERVER_CARGO_RECEIPT_ISSUE_H */

--- a/server/main.c
+++ b/server/main.c
@@ -13,6 +13,7 @@
 #include "signal_crypto.h"
 #include "sim_asteroid.h"
 #include "chain_log.h"  /* signed event emission (#479 C) */
+#include "cargo_receipt_issue.h"  /* portable cargo receipts (#479 D) */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -318,31 +319,49 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
             st->manifest_dirty = true;
             /* Layer C of #479: emit EVT_TRANSFER + EVT_TRADE. The two
              * are linked by transfer_event_id so a verifier can stitch
-             * them back into a single atomic move. */
+             * them back into a single atomic move.
+             * Layer D of #479: also issue a portable cargo_receipt_t the
+             * player carries with the cargo. The origin receipt's
+             * prev_receipt_hash is the station's chain_last_hash AFTER
+             * the EVT_TRANSFER emit — verifiable in isolation by
+             * walking the station's chain log to that exact event. */
             {
-                struct __attribute__((packed)) {
-                    uint8_t from_pubkey[32];
-                    uint8_t to_pubkey[32];
-                    uint8_t cargo_pub[32];
-                    uint8_t kind;
-                    uint8_t _pad[7];
-                } xfer = {0};
-                memcpy(xfer.from_pubkey, st->station_pubkey, 32);
-                memcpy(xfer.to_pubkey, world.players[pid].pubkey, 32);
-                memcpy(xfer.cargo_pub, copy.pub, 32);
-                xfer.kind = (uint8_t)CARGO_KIND_INGOT;
-                uint64_t xfer_id = chain_log_emit(&world, st, CHAIN_EVT_TRANSFER,
-                                                  &xfer, (uint16_t)sizeof(xfer));
-                struct __attribute__((packed)) {
-                    uint64_t transfer_event_id;
-                    int64_t  ledger_delta_signed;
-                    uint8_t  ledger_pubkey[32];
-                } trade = {0};
-                trade.transfer_event_id = xfer_id;
-                trade.ledger_delta_signed = -(int64_t)price;
-                memcpy(trade.ledger_pubkey, world.players[pid].pubkey, 32);
-                (void)chain_log_emit(&world, st, CHAIN_EVT_TRADE,
-                                     &trade, (uint16_t)sizeof(trade));
+                cargo_receipt_t receipt;
+                uint64_t xfer_id = cargo_receipt_emit_transfer(
+                    &world, st,
+                    st->station_pubkey,
+                    world.players[pid].pubkey,
+                    copy.pub,
+                    (uint8_t)CARGO_KIND_INGOT,
+                    st->chain_last_hash, /* anchor: post-emit hash */
+                    &receipt);
+                if (xfer_id != 0) {
+                    /* Attach receipt to the just-pushed manifest entry.
+                     * manifest_push appended at index manifest.count - 1. */
+                    ship_receipts_t *rcpts = ship_get_receipts(ship);
+                    if (rcpts) {
+                        (void)ship_receipts_push_chain(rcpts, &receipt, 1);
+                        /* Keep parity: receipts.count must mirror manifest.count. */
+                    }
+                    /* Fire NET_MSG_CARGO_RECEIPT_BUNDLE to the client. */
+                    uint8_t buf[3 + CARGO_RECEIPT_SIZE];
+                    buf[0] = NET_MSG_CARGO_RECEIPT_BUNDLE;
+                    buf[1] = 1;
+                    buf[2] = 0;
+                    cargo_receipt_pack(&receipt, &buf[3]);
+                    ws_send(c, buf, sizeof(buf));
+
+                    struct __attribute__((packed)) {
+                        uint64_t transfer_event_id;
+                        int64_t  ledger_delta_signed;
+                        uint8_t  ledger_pubkey[32];
+                    } trade = {0};
+                    trade.transfer_event_id = xfer_id;
+                    trade.ledger_delta_signed = -(int64_t)price;
+                    memcpy(trade.ledger_pubkey, world.players[pid].pubkey, 32);
+                    (void)chain_log_emit(&world, st, CHAIN_EVT_TRADE,
+                                         &trade, (uint16_t)sizeof(trade));
+                }
             }
             char cs[12]; mining_render_callsign(copy.pub, cs);
             char msg[96];
@@ -372,6 +391,31 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
             }
             if (hidx < 0) break;
             cargo_unit_t copy = ship->manifest.units[hidx];
+            /* Layer D of #479: validate any attached receipt chain
+             * before accepting. If the chain fails verification, refuse
+             * the deliver — federation invariant: a station only takes
+             * cargo whose lineage is signed all the way back. If no
+             * receipt chain is attached (legacy / pre-D save / cargo
+             * smelted on-station with no transfer history), accept
+             * unconditionally — the station treats the loading-state
+             * cargo as origin-attested and signs a fresh receipt. */
+            ship_receipts_t *rcpts = ship_get_receipts(ship);
+            if (rcpts && hidx < (int)rcpts->count) {
+                const cargo_receipt_chain_t *attached = &rcpts->chains[hidx];
+                if (attached->len > 0) {
+                    cargo_receipt_result_t vr = cargo_receipt_chain_verify(
+                        attached->links, attached->len, copy.pub);
+                    if (vr != CARGO_RECEIPT_OK) {
+                        printf("[server] receipt_chain_invalid: deliver from player %d, reason=%d\n",
+                               pid, (int)vr);
+                        break; /* refuse the deliver */
+                    }
+                    if (attached->len >= CARGO_RECEIPT_CHAIN_MAX_LEN) {
+                        printf("[server] receipt_chain_cap_exceeded: deliver from player %d\n", pid);
+                        break;
+                    }
+                }
+            }
             /* FIFO-evict the oldest manifest entry on full station, mirroring
              * the smelt rotation path. The evicted unit's pubkey is voided
              * so it can never be re-deposited. */
@@ -386,37 +430,66 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
                 }
             }
             if (!manifest_push(&st->manifest, &copy)) break;
+            /* Capture last receipt hash (for the new station-issued
+             * receipt's prev_receipt_hash) BEFORE removing. */
+            uint8_t prev_hash[32] = {0};
+            bool have_prev = false;
+            if (rcpts && hidx < (int)rcpts->count) {
+                const cargo_receipt_chain_t *attached = &rcpts->chains[hidx];
+                if (attached->len > 0) {
+                    cargo_receipt_hash(&attached->links[attached->len - 1], prev_hash);
+                    have_prev = true;
+                }
+            }
             (void)manifest_remove(&ship->manifest, (uint16_t)hidx, NULL);
+            if (rcpts && hidx < (int)rcpts->count) {
+                (void)ship_receipts_remove(rcpts, (uint16_t)hidx, NULL);
+            }
             /* Pay delivery credit through the ledger so supply stays balanced. */
             ledger_credit_supply(st, world.players[pid].session_token, (float)INGOT_DELIVERY_CREDIT);
             st->manifest_dirty = true;
             /* Layer C of #479: emit EVT_TRANSFER (player -> station) +
              * EVT_TRADE (delivery credit accrual on the station's
-             * ledger). */
+             * ledger).
+             * Layer D of #479: also issue station's own receipt. The
+             * receipt's prev_receipt_hash is the SHA-256 of the player's
+             * presented chain head if there was one — this hop closes
+             * the chain at the destination station. If no prior chain,
+             * anchor to the station's own chain_last_hash post-emit. */
             {
-                struct __attribute__((packed)) {
-                    uint8_t from_pubkey[32];
-                    uint8_t to_pubkey[32];
-                    uint8_t cargo_pub[32];
-                    uint8_t kind;
-                    uint8_t _pad[7];
-                } xfer = {0};
-                memcpy(xfer.from_pubkey, world.players[pid].pubkey, 32);
-                memcpy(xfer.to_pubkey, st->station_pubkey, 32);
-                memcpy(xfer.cargo_pub, copy.pub, 32);
-                xfer.kind = (uint8_t)CARGO_KIND_INGOT;
-                uint64_t xfer_id = chain_log_emit(&world, st, CHAIN_EVT_TRANSFER,
-                                                  &xfer, (uint16_t)sizeof(xfer));
-                struct __attribute__((packed)) {
-                    uint64_t transfer_event_id;
-                    int64_t  ledger_delta_signed;
-                    uint8_t  ledger_pubkey[32];
-                } trade = {0};
-                trade.transfer_event_id = xfer_id;
-                trade.ledger_delta_signed = (int64_t)INGOT_DELIVERY_CREDIT;
-                memcpy(trade.ledger_pubkey, world.players[pid].pubkey, 32);
-                (void)chain_log_emit(&world, st, CHAIN_EVT_TRADE,
-                                     &trade, (uint16_t)sizeof(trade));
+                cargo_receipt_t receipt;
+                uint64_t xfer_id = cargo_receipt_emit_transfer(
+                    &world, st,
+                    world.players[pid].pubkey,
+                    st->station_pubkey,
+                    copy.pub,
+                    (uint8_t)CARGO_KIND_INGOT,
+                    have_prev ? prev_hash : st->chain_last_hash,
+                    &receipt);
+                if (xfer_id != 0) {
+                    /* Send the destination's reissued receipt back to
+                     * the player. The cargo is now in the station; the
+                     * receipt is what the player would carry if the
+                     * cargo ever flowed back to them. For now it's a
+                     * confirmation token. */
+                    uint8_t buf[3 + CARGO_RECEIPT_SIZE];
+                    buf[0] = NET_MSG_CARGO_RECEIPT_BUNDLE;
+                    buf[1] = 1;
+                    buf[2] = 0;
+                    cargo_receipt_pack(&receipt, &buf[3]);
+                    ws_send(c, buf, sizeof(buf));
+
+                    struct __attribute__((packed)) {
+                        uint64_t transfer_event_id;
+                        int64_t  ledger_delta_signed;
+                        uint8_t  ledger_pubkey[32];
+                    } trade = {0};
+                    trade.transfer_event_id = xfer_id;
+                    trade.ledger_delta_signed = (int64_t)INGOT_DELIVERY_CREDIT;
+                    memcpy(trade.ledger_pubkey, world.players[pid].pubkey, 32);
+                    (void)chain_log_emit(&world, st, CHAIN_EVT_TRADE,
+                                         &trade, (uint16_t)sizeof(trade));
+                }
             }
             char cs[12]; mining_render_callsign(copy.pub, cs);
             char msg[96];

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -78,13 +78,16 @@ static uint32_t crc32_file(FILE *f) {
 }
 
 #define SAVE_MAGIC 0x5349474E  /* "SIGN" */
-#define SAVE_VERSION 41  /* Layer C of #479 — per-station chain log state
-                          * (chain_last_hash 32B + chain_event_count 8B)
-                          * appended to the session block. The actual
-                          * event records live in side files under
-                          * chain/<base58(pubkey)>.log and are NOT part
-                          * of world.sav. v40 saves migrate forward as
-                          * empty chains (see chain_log.h). */
+#define SAVE_VERSION 42  /* Layer D of #479 — per-ship cargo_receipt_t chains
+                          * persisted alongside the ship manifest tail in
+                          * each player save (PLY7). v41 saves migrate
+                          * forward with empty receipt chains; the loading
+                          * station treats existing cargo as origin-attested
+                          * and signs a fresh receipt on the next
+                          * transaction. world.sav format itself is
+                          * unchanged at v42 (layout matches v41).
+                          * v41 (Layer C): per-station chain log state
+                          * (chain_last_hash 32B + chain_event_count 8B). */
 /* v40: Layer B of #479 — per-station Ed25519 pubkey + outpost
  * provenance tail in the session block. The matching private key is
  * rederivable from the world seed (or saved provenance, for outposts)
@@ -1233,7 +1236,8 @@ bool world_load(world_t *w, const char *path) {
 /* Player persistence                                                  */
 /* ================================================================== */
 
-#define PLAYER_MAGIC    0x504C5936u  /* "PLY6" — #479 A.3: appends last_signed_nonce */
+#define PLAYER_MAGIC    0x504C5937u  /* "PLY7" — #479 D: appends per-ship receipt chains */
+#define PLAYER_MAGIC_V6 0x504C5936u  /* "PLY6" — #479 A.3: appends last_signed_nonce */
 #define PLAYER_MAGIC_V5 0x504C5935u  /* "PLY5" — #339 A.2: adds ship.manifest tail */
 #define PLAYER_MAGIC_V4 0x504C5934u  /* "PLY4" — explicit ship payload, no runtime manifest pointers */
 #define PLAYER_MAGIC_V3 0x504C5933u  /* "PLY3" — v25: station-local credits (#312) */
@@ -1622,6 +1626,31 @@ bool player_save(const server_player_t *sp, const char *dir, int slot) {
         ok = fwrite(&nonce, sizeof(nonce), 1, f) == 1;
         if (ok) crc = crc32_update(crc, &nonce, sizeof(nonce));
     }
+    /* PLY7 tail (#479 D): per-cargo receipt chains, one per manifest
+     * unit, in manifest order. Each chain on disk is
+     *   [len:u8] + len × cargo_receipt_t.
+     * Empty chains (len=0) are valid — they signify "cargo never had
+     * a receipt attached" (e.g. legacy migration) so the next transfer
+     * mints a fresh origin-attested receipt. */
+    if (ok) {
+        const ship_receipts_t *rcpts = ship_get_receipts_const(&sp->ship);
+        uint16_t mc = sp->ship.manifest.count;
+        for (uint16_t u = 0; ok && u < mc; u++) {
+            uint8_t len = 0;
+            if (rcpts && u < rcpts->count) {
+                len = rcpts->chains[u].len;
+                if (len > CARGO_RECEIPT_CHAIN_MAX_LEN)
+                    len = CARGO_RECEIPT_CHAIN_MAX_LEN;
+            }
+            ok = fwrite(&len, sizeof(len), 1, f) == 1;
+            if (ok) crc = crc32_update(crc, &len, sizeof(len));
+            for (uint8_t k = 0; ok && k < len; k++) {
+                const cargo_receipt_t *r = &rcpts->chains[u].links[k];
+                ok = fwrite(r, sizeof(*r), 1, f) == 1;
+                if (ok) crc = crc32_update(crc, r, sizeof(*r));
+            }
+        }
+    }
     if (ok) {
         uint32_t crc_magic = 0x43524332u; /* "CRC2" */
         ok = fwrite(&crc_magic, sizeof(crc_magic), 1, f) == 1 &&
@@ -1674,8 +1703,9 @@ static bool player_load_from_path(server_player_t *sp, world_t *w, const char *p
 
     ship_cleanup(&sp->ship);
 
-    if (magic == PLAYER_MAGIC || magic == PLAYER_MAGIC_V5) {
-        /* PLY5 (manifest tail) and PLY6 (manifest + last_signed_nonce). */
+    if (magic == PLAYER_MAGIC || magic == PLAYER_MAGIC_V6 || magic == PLAYER_MAGIC_V5) {
+        /* PLY5 (manifest tail), PLY6 (manifest + last_signed_nonce),
+         * PLY7 (manifest + last_signed_nonce + receipt chains). */
         player_save_data_t data;
         if (fread(&data, sizeof(data), 1, f) != 1) { fclose(f); return false; }
         migrate_v4_ship(&sp->ship, &data.ship);
@@ -1700,16 +1730,67 @@ static bool player_load_from_path(server_player_t *sp, world_t *w, const char *p
             }
             sp->ship.manifest.count = manifest_count;
         }
-        /* PLY6 last_signed_nonce. PLY5 saves end here; the nonce stays
+        /* PLY6+ last_signed_nonce. PLY5 saves end here; the nonce stays
          * at zero, which lets the first signed action after the migration
          * use any non-zero nonce. */
         sp->last_signed_nonce = 0;
-        if (magic == PLAYER_MAGIC) {
+        if (magic == PLAYER_MAGIC || magic == PLAYER_MAGIC_V6) {
             uint64_t nonce = 0;
             if (fread(&nonce, sizeof(nonce), 1, f) != 1) {
                 fclose(f); return false;
             }
             sp->last_signed_nonce = nonce;
+        }
+        /* PLY7 (#479 D): per-ship cargo_receipt_t chains. The store
+         * mirrors ship.manifest, so we expect exactly manifest_count
+         * chains. Each chain is [len:u8] + len × CARGO_RECEIPT_SIZE.
+         * v6 saves stop short here — the receipt store stays empty;
+         * the next BUY/DELIVER for that cargo will sign a fresh
+         * origin-attested receipt (one-time migration cost). */
+        if (magic == PLAYER_MAGIC) {
+            ship_receipts_t *rcpts = ship_get_receipts(&sp->ship);
+            if (!rcpts) { fclose(f); return false; }
+            ship_receipts_clear(rcpts);
+            if (manifest_count > 0) {
+                if (!ship_receipts_reserve(rcpts, manifest_count)) {
+                    fclose(f); return false;
+                }
+                for (uint16_t u = 0; u < manifest_count; u++) {
+                    uint8_t link_count = 0;
+                    if (fread(&link_count, sizeof(link_count), 1, f) != 1) {
+                        fclose(f); return false;
+                    }
+                    if (link_count > CARGO_RECEIPT_CHAIN_MAX_LEN) {
+                        fclose(f); return false; /* corrupt */
+                    }
+                    cargo_receipt_t links[CARGO_RECEIPT_CHAIN_MAX_LEN];
+                    for (uint8_t k = 0; k < link_count; k++) {
+                        if (fread(&links[k], sizeof(cargo_receipt_t), 1, f) != 1) {
+                            fclose(f); return false;
+                        }
+                    }
+                    if (link_count > 0) {
+                        if (!ship_receipts_push_chain(rcpts, links, link_count)) {
+                            fclose(f); return false;
+                        }
+                    } else {
+                        /* Empty chain — push a zero placeholder so the
+                         * count stays parity with manifest. We push len=1
+                         * is wrong; instead, special-case: append an empty
+                         * slot directly. ship_receipts_push_chain rejects
+                         * len==0, so we manually grow count. */
+                        if (rcpts->count >= rcpts->cap) {
+                            if (!ship_receipts_reserve(rcpts,
+                                    (uint16_t)(rcpts->cap > 0 ? rcpts->cap * 2 : 32))) {
+                                fclose(f); return false;
+                            }
+                        }
+                        memset(&rcpts->chains[rcpts->count], 0,
+                               sizeof(rcpts->chains[rcpts->count]));
+                        rcpts->count++;
+                    }
+                }
+            }
         }
         manifest_already_loaded = true;
         fclose(f);

--- a/shared/cargo_receipt.c
+++ b/shared/cargo_receipt.c
@@ -1,0 +1,196 @@
+/*
+ * cargo_receipt.c -- Layer D of #479. See cargo_receipt.h for design.
+ */
+#include "cargo_receipt.h"
+
+#include "sha256.h"
+#include "signal_crypto.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* Compile-time guarantee that the on-wire size matches the struct
+ * size. If anyone reorders fields or changes alignment this fires
+ * before the byte format silently drifts on disk / wire. */
+_Static_assert(sizeof(cargo_receipt_t) == CARGO_RECEIPT_SIZE,
+               "cargo_receipt_t must be exactly 232 bytes");
+_Static_assert(CARGO_RECEIPT_UNSIGNED_SIZE == CARGO_RECEIPT_SIZE - 64,
+               "unsigned span = full size minus 64-byte signature");
+
+/* ---------------- Pack ---------------------------------------------- */
+
+void cargo_receipt_unsigned_pack(const cargo_receipt_t *r,
+                                 uint8_t out[CARGO_RECEIPT_UNSIGNED_SIZE]) {
+    size_t off = 0;
+    memcpy(&out[off], r->cargo_pub, 32);          off += 32;
+    memcpy(&out[off], r->authoring_station, 32);  off += 32;
+    memcpy(&out[off], r->recipient_pubkey, 32);   off += 32;
+    /* event_id u64 LE */
+    for (int i = 0; i < 8; i++)
+        out[off + i] = (uint8_t)(r->event_id >> (i * 8));
+    off += 8;
+    /* epoch u64 LE */
+    for (int i = 0; i < 8; i++)
+        out[off + i] = (uint8_t)(r->epoch >> (i * 8));
+    off += 8;
+    memcpy(&out[off], r->prev_receipt_hash, 32);  off += 32;
+    /* off should now equal CARGO_RECEIPT_UNSIGNED_SIZE (144) */
+    (void)off;
+}
+
+void cargo_receipt_pack(const cargo_receipt_t *r,
+                        uint8_t out[CARGO_RECEIPT_SIZE]) {
+    cargo_receipt_unsigned_pack(r, out);
+    memcpy(&out[CARGO_RECEIPT_UNSIGNED_SIZE], r->signature, 64);
+}
+
+void cargo_receipt_hash(const cargo_receipt_t *r, uint8_t out[32]) {
+    uint8_t packed[CARGO_RECEIPT_SIZE];
+    cargo_receipt_pack(r, packed);
+    sha256_bytes(packed, CARGO_RECEIPT_SIZE, out);
+}
+
+/* ---------------- Verify -------------------------------------------- */
+
+bool cargo_receipt_verify_signature(const cargo_receipt_t *r) {
+    static const uint8_t zero32[32] = {0};
+    if (memcmp(r->authoring_station, zero32, 32) == 0) return false;
+    uint8_t blob[CARGO_RECEIPT_UNSIGNED_SIZE];
+    cargo_receipt_unsigned_pack(r, blob);
+    return signal_crypto_verify(r->signature, blob, sizeof(blob),
+                                r->authoring_station);
+}
+
+cargo_receipt_result_t cargo_receipt_chain_verify(
+    const cargo_receipt_t *chain, size_t count,
+    const uint8_t *expected_cargo_pub) {
+    static const uint8_t zero32[32] = {0};
+    if (count == 0 || !chain) return CARGO_RECEIPT_REJECT_EMPTY;
+    if (count > CARGO_RECEIPT_CHAIN_MAX_LEN)
+        return CARGO_RECEIPT_REJECT_TOO_LONG;
+
+    /* The origin (oldest) receipt's prev_receipt_hash must NOT be all
+     * zero — that field carries the SHA-256 of the originating
+     * SMELT/CRAFT chain event header, which is non-zero by
+     * construction (SHA-256 of any input is overwhelmingly non-zero).
+     * An all-zero pin means the receipt was not anchored to anything,
+     * so reject. */
+    if (memcmp(chain[0].prev_receipt_hash, zero32, 32) == 0)
+        return CARGO_RECEIPT_REJECT_ZERO_ORIGIN;
+
+    for (size_t i = 0; i < count; i++) {
+        const cargo_receipt_t *r = &chain[i];
+        if (memcmp(r->authoring_station, zero32, 32) == 0)
+            return CARGO_RECEIPT_REJECT_ZERO_AUTHORITY;
+        if (expected_cargo_pub &&
+            memcmp(r->cargo_pub, expected_cargo_pub, 32) != 0)
+            return CARGO_RECEIPT_REJECT_CARGO_MISMATCH;
+        if (!cargo_receipt_verify_signature(r))
+            return CARGO_RECEIPT_REJECT_BAD_SIGNATURE;
+        if (i > 0) {
+            uint8_t prev_hash[32];
+            cargo_receipt_hash(&chain[i - 1], prev_hash);
+            if (memcmp(prev_hash, r->prev_receipt_hash, 32) != 0)
+                return CARGO_RECEIPT_REJECT_BROKEN_LINKAGE;
+        }
+    }
+    return CARGO_RECEIPT_OK;
+}
+
+/* ---------------- ship_receipts_t storage --------------------------- */
+
+bool ship_receipts_init(ship_receipts_t *r, uint16_t cap) {
+    if (!r) return false;
+    memset(r, 0, sizeof(*r));
+    if (cap == 0) return true;
+    r->chains = (cargo_receipt_chain_t *)calloc(cap, sizeof(*r->chains));
+    if (!r->chains) return false;
+    r->cap = cap;
+    return true;
+}
+
+void ship_receipts_free(ship_receipts_t *r) {
+    if (!r) return;
+    free(r->chains);
+    r->chains = NULL;
+    r->count = 0;
+    r->cap = 0;
+}
+
+void ship_receipts_clear(ship_receipts_t *r) {
+    if (!r) return;
+    if (r->chains && r->cap > 0)
+        memset(r->chains, 0, r->cap * sizeof(*r->chains));
+    r->count = 0;
+}
+
+bool ship_receipts_reserve(ship_receipts_t *r, uint16_t cap) {
+    if (!r) return false;
+    if (cap <= r->cap) return true;
+    cargo_receipt_chain_t *grown =
+        (cargo_receipt_chain_t *)realloc(r->chains,
+                                         (size_t)cap * sizeof(*grown));
+    if (!grown) return false;
+    /* Zero the new tail so undefined fields don't leak. */
+    memset(&grown[r->cap], 0,
+           (size_t)(cap - r->cap) * sizeof(*grown));
+    r->chains = grown;
+    r->cap = cap;
+    return true;
+}
+
+bool ship_receipts_clone(ship_receipts_t *dst, const ship_receipts_t *src) {
+    if (!dst || !src) return false;
+    if (dst == src) return true;
+    ship_receipts_t tmp = {0};
+    if (!ship_receipts_init(&tmp, src->cap > 0 ? src->cap : 1)) return false;
+    if (src->count > 0 && src->chains)
+        memcpy(tmp.chains, src->chains,
+               (size_t)src->count * sizeof(*src->chains));
+    tmp.count = src->count;
+    ship_receipts_free(dst);
+    *dst = tmp;
+    return true;
+}
+
+bool ship_receipts_push_chain(ship_receipts_t *r,
+                              const cargo_receipt_t *chain, uint8_t len) {
+    if (!r) return false;
+    if (len == 0 || len > CARGO_RECEIPT_CHAIN_MAX_LEN) return false;
+    if (!chain) return false;
+    if (r->count >= r->cap) {
+        uint16_t new_cap = r->cap > 0 ? (uint16_t)(r->cap * 2u) : 32;
+        if (new_cap <= r->cap) return false;
+        if (!ship_receipts_reserve(r, new_cap)) return false;
+    }
+    cargo_receipt_chain_t *slot = &r->chains[r->count];
+    memset(slot, 0, sizeof(*slot));
+    memcpy(slot->links, chain, (size_t)len * sizeof(*chain));
+    slot->len = len;
+    r->count++;
+    return true;
+}
+
+bool ship_receipts_remove(ship_receipts_t *r, uint16_t index,
+                          cargo_receipt_chain_t *out_chain) {
+    if (!r || index >= r->count || !r->chains) return false;
+    if (out_chain) *out_chain = r->chains[index];
+    if ((uint16_t)(index + 1) < r->count) {
+        memmove(&r->chains[index], &r->chains[index + 1],
+                (size_t)(r->count - index - 1) * sizeof(*r->chains));
+    }
+    r->count--;
+    /* Zero the now-unused tail so stale data doesn't surface in a
+     * later push that doesn't fully overwrite the slot. */
+    memset(&r->chains[r->count], 0, sizeof(*r->chains));
+    return true;
+}
+
+bool ship_receipts_extend(ship_receipts_t *r, uint16_t index,
+                          const cargo_receipt_t *next) {
+    if (!r || !next || index >= r->count || !r->chains) return false;
+    cargo_receipt_chain_t *slot = &r->chains[index];
+    if (slot->len >= CARGO_RECEIPT_CHAIN_MAX_LEN) return false;
+    slot->links[slot->len++] = *next;
+    return true;
+}

--- a/shared/cargo_receipt.h
+++ b/shared/cargo_receipt.h
@@ -1,0 +1,205 @@
+/*
+ * cargo_receipt.h -- Portable cargo provenance receipts (Layer D of #479).
+ *
+ * After Layer C every state-mutating event lands in the *origin
+ * station's* signed chain log. That is enough for an auditor reading
+ * the origin log, but a *destination* station that only sees the cargo
+ * arrive has no proof of what produced it. Layer D fills that gap by
+ * making cargo carry a portable, station-signed receipt chain.
+ *
+ *   cargo_receipt_t — one signed link in a receipt chain.
+ *
+ * When station A transfers cargo C to recipient R (a player or another
+ * station), A signs a cargo_receipt_t binding (cargo, recipient, prior
+ * link). The recipient holds onto that receipt. When the recipient
+ * later transfers C to station B, B verifies the chain end-to-end
+ * before accepting:
+ *
+ *   1. Each receipt's signature verifies against the claimed
+ *      authoring_station pubkey.
+ *   2. Each receipt's prev_receipt_hash equals SHA-256(prev_receipt).
+ *   3. The chain bottoms out at an "origin" receipt whose
+ *      prev_receipt_hash is the SHA-256 of the originating SMELT or
+ *      CRAFT chain event header (so the origin point is itself
+ *      verifiable in isolation against the authoring station's chain
+ *      log — no need to read foreign logs at validate time).
+ *
+ * If any step fails the destination refuses the transfer. On accept,
+ * the destination signs and returns its OWN receipt — the chain grows
+ * by one hop.
+ *
+ * Cap: a chain may not exceed CARGO_RECEIPT_CHAIN_MAX_LEN links. Beyond
+ * that the receiving station refuses with cap-exceeded; merkle
+ * compaction of pruned receipts is a follow-up.
+ *
+ * IMPORTANT: this header is in shared/ because both the server (issues
+ * + validates) and the client (carries + presents) speak the same wire
+ * format. The crypto helpers wrap the existing signal_crypto + sha256
+ * primitives; this file does not introduce any new dependency.
+ */
+#ifndef SHARED_CARGO_RECEIPT_H
+#define SHARED_CARGO_RECEIPT_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "types.h"  /* cargo_unit_t */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Wire-stable receipt record.
+ *
+ * Layout is exactly 208 bytes; the unsigned region (everything except
+ * the trailing 64-byte signature) is the 144-byte span fed into
+ * Ed25519. We pack the field order so the natural C99 layout matches
+ * the on-wire byte order on every platform we ship to (32-byte
+ * blocks first, then two u64 fields, then the prev-hash, then the
+ * signature). A compile-time _Static_assert in cargo_receipt.c catches
+ * any future drift. */
+typedef struct {
+    uint8_t  cargo_pub[32];          /* the cargo_unit_t.pub being transferred */
+    uint8_t  authoring_station[32];  /* station that signed this receipt */
+    uint8_t  recipient_pubkey[32];   /* player or station receiving */
+    uint64_t event_id;               /* matches the EVT_TRANSFER event_id
+                                      * in the authoring station's log;
+                                      * 0 for synthetic receipts */
+    uint64_t epoch;                  /* sim tick */
+    uint8_t  prev_receipt_hash[32];  /* SHA-256 of previous receipt
+                                      * header, OR — for an origin
+                                      * receipt — SHA-256 of the
+                                      * originating SMELT/CRAFT chain
+                                      * event header (chain_event_header_t).
+                                      * All-zero is invalid post-D. */
+    uint8_t  signature[64];          /* Ed25519 over the unsigned span */
+} cargo_receipt_t;
+
+#define CARGO_RECEIPT_SIZE          208
+#define CARGO_RECEIPT_UNSIGNED_SIZE 144 /* 208 - 64 */
+#define CARGO_RECEIPT_CHAIN_MAX_LEN 16  /* hard cap; refuse beyond */
+
+/* Validation result codes — surfaced from cargo_receipt_chain_verify so
+ * the caller can log which invariant fired. Wire-stable for chain log
+ * payloads. */
+typedef enum {
+    CARGO_RECEIPT_OK                      = 0,
+    CARGO_RECEIPT_REJECT_EMPTY            = 1, /* zero-length chain */
+    CARGO_RECEIPT_REJECT_TOO_LONG         = 2, /* > CHAIN_MAX_LEN */
+    CARGO_RECEIPT_REJECT_BAD_SIGNATURE    = 3, /* sig fails verify */
+    CARGO_RECEIPT_REJECT_BROKEN_LINKAGE   = 4, /* prev_receipt_hash mismatch */
+    CARGO_RECEIPT_REJECT_CARGO_MISMATCH   = 5, /* receipt cargo_pub != requested cargo */
+    CARGO_RECEIPT_REJECT_ZERO_AUTHORITY   = 6, /* authoring_station all zero */
+    CARGO_RECEIPT_REJECT_ZERO_ORIGIN      = 7  /* origin receipt's prev hash is all zero */
+} cargo_receipt_result_t;
+
+/* Pack the unsigned span (the 168 bytes that get signed / hashed) into
+ * a canonical little-endian byte buffer. Same mechanism as
+ * chain_event_header_pack — independent of host endianness. */
+void cargo_receipt_unsigned_pack(const cargo_receipt_t *r,
+                                 uint8_t out[CARGO_RECEIPT_UNSIGNED_SIZE]);
+
+/* Pack the FULL 232-byte record (unsigned span + 64-byte signature). */
+void cargo_receipt_pack(const cargo_receipt_t *r,
+                        uint8_t out[CARGO_RECEIPT_SIZE]);
+
+/* SHA-256 of the full 232-byte packed record. This is what the NEXT
+ * receipt's prev_receipt_hash must equal. */
+void cargo_receipt_hash(const cargo_receipt_t *r, uint8_t out[32]);
+
+/* Verify a single receipt's Ed25519 signature using the
+ * authoring_station field as the public key. Does NOT walk the chain. */
+bool cargo_receipt_verify_signature(const cargo_receipt_t *r);
+
+/* Walk a presented chain and verify every link.
+ *
+ * `chain` is in chronological order — chain[0] is the origin (oldest)
+ * receipt, chain[count-1] is the most recent.
+ *
+ * Each receipt[i].prev_receipt_hash for i > 0 must equal
+ * SHA-256(receipt[i-1]). receipt[0].prev_receipt_hash is the "origin
+ * pin" — it's expected to be SHA-256 of the originating SMELT/CRAFT
+ * chain event header. This function does NOT consult any chain log on
+ * disk; the caller is responsible for cross-checking the origin pin
+ * against an EVT_SMELT/EVT_CRAFT entry if it has access to the
+ * authoring station's log. The chain itself, however, is fully
+ * verifiable in isolation: signatures + linkage are checked.
+ *
+ * `expected_cargo_pub` (32 bytes, may be NULL): if non-NULL every
+ * receipt in the chain must reference this exact cargo_pub. NULL skips
+ * that check (used by tests + tooling that already trust the cargo
+ * binding). */
+cargo_receipt_result_t cargo_receipt_chain_verify(
+    const cargo_receipt_t *chain, size_t count,
+    const uint8_t *expected_cargo_pub /* nullable, 32 bytes */);
+
+/* ---------------- ship_receipts_t ---------------------------------- */
+
+/* Per-cargo receipt store running parallel to ship_t.manifest.
+ *
+ *   entries[i] is the most-recent receipt for manifest unit i.
+ *   The full chain is walked by chasing prev_receipt_hash backwards
+ *   *if* the bearer is asked to present it; in this layer we keep the
+ *   last-N receipts inline because cargo_unit_t has no room for a
+ *   pointer-to-chain. The *server* validates a full chain at the
+ *   bearer's presentation time (NET_MSG_PRESENT_RECEIPT_CHAIN sends
+ *   the ordered chain, not just one entry).
+ *
+ *   For the in-process server (singleplayer + tests) we keep the full
+ *   ordered chain attached on the *ship* side keyed by manifest index.
+ *   Multi-link chains are stored in `chains[]` — each entry is a
+ *   small sequence whose final element matches `entries[i]`. This is
+ *   memory-cheap (capacity == manifest.cap, MAX 16 receipts per
+ *   chain), persists alongside the manifest, and gives us the bytes
+ *   we ship in NET_MSG_PRESENT_RECEIPT_CHAIN with no extra round-trip.
+ *
+ * Invariant after a consistent op: count == ship->manifest.count, and
+ * for every i in [0, count) chains[i].len in [1, CHAIN_MAX_LEN].
+ *
+ * "Consistent op" means: any code path that pushes a cargo_unit_t into
+ * ship.manifest must also push the matching receipt into ship.receipts
+ * (and vice versa for remove). The verifier asserts this in tests. */
+typedef struct {
+    cargo_receipt_t links[CARGO_RECEIPT_CHAIN_MAX_LEN];
+    uint8_t         len; /* in [0, CHAIN_MAX_LEN]; 0 = no chain attached */
+} cargo_receipt_chain_t;
+
+typedef struct {
+    cargo_receipt_chain_t *chains; /* heap-allocated, capacity == cap */
+    uint16_t count;                /* must mirror manifest.count */
+    uint16_t cap;
+} ship_receipts_t;
+
+/* Lifecycle helpers. ship_receipts_init/_free are pure ship_receipts_t
+ * operations; the ship-level wrappers in shared/manifest.h call them
+ * inside ship_manifest_bootstrap / ship_cleanup so the receipt store
+ * always exists alongside the manifest. */
+bool ship_receipts_init(ship_receipts_t *r, uint16_t cap);
+void ship_receipts_free(ship_receipts_t *r);
+void ship_receipts_clear(ship_receipts_t *r);
+bool ship_receipts_reserve(ship_receipts_t *r, uint16_t cap);
+bool ship_receipts_clone(ship_receipts_t *dst, const ship_receipts_t *src);
+
+/* Append a chain (1..CHAIN_MAX_LEN receipts) to the receipts store.
+ * Mirrors manifest_push. Returns false if cap would overflow or `len`
+ * is 0/too long. */
+bool ship_receipts_push_chain(ship_receipts_t *r,
+                              const cargo_receipt_t *chain, uint8_t len);
+
+/* Remove receipts at index, mirroring manifest_remove. If `out_chain`
+ * is non-NULL the removed chain is copied there. */
+bool ship_receipts_remove(ship_receipts_t *r, uint16_t index,
+                          cargo_receipt_chain_t *out_chain);
+
+/* Append a single new receipt to the chain at index, growing it by one
+ * hop. Returns false if cap-exceeded (the chain has hit
+ * CARGO_RECEIPT_CHAIN_MAX_LEN already). */
+bool ship_receipts_extend(ship_receipts_t *r, uint16_t index,
+                          const cargo_receipt_t *next);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SHARED_CARGO_RECEIPT_H */

--- a/shared/manifest.h
+++ b/shared/manifest.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 
 #include "types.h"
+#include "cargo_receipt.h"  /* ship_receipts_t — accessor return type */
 
 _Static_assert(sizeof(cargo_unit_t) == 80, "cargo_unit_t must stay 80 bytes");
 _Static_assert(offsetof(cargo_unit_t, mined_block) == 8,
@@ -47,6 +48,14 @@ int manifest_consume_by_commodity(manifest_t *manifest,
 void ship_cleanup(ship_t *ship);
 bool ship_manifest_bootstrap(ship_t *ship);
 bool ship_copy(ship_t *dst, const ship_t *src);
+
+/* Layer D of #479 — typed accessors for the parallel receipt store
+ * stashed in ship_t.receipts_opaque. The ship_receipts_t type itself
+ * lives in shared/cargo_receipt.h; these accessors return pointers
+ * the caller must NOT free (lifetime tracks the ship). Returns NULL
+ * if ship_manifest_bootstrap hasn't been called yet. */
+ship_receipts_t *ship_get_receipts(ship_t *ship);
+const ship_receipts_t *ship_get_receipts_const(const ship_t *ship);
 void station_cleanup(station_t *station);
 bool station_manifest_bootstrap(station_t *station);
 bool station_copy(station_t *dst, const station_t *src);

--- a/shared/protocol.h
+++ b/shared/protocol.h
@@ -98,6 +98,39 @@ enum {
                                             * 8 ASCII bytes of the legacy save's hex token name —
                                             * enough to identify it for a claim, not full disclosure
                                             * of the original session token. */
+    NET_MSG_CARGO_RECEIPT_BUNDLE   = 0x36, /* server -> client. Layer D of #479.
+                                            *
+                                            * Sent immediately after a BUY_INGOT or
+                                            * BUY_PRODUCT response that resulted in a
+                                            * cargo transfer to the player. The client
+                                            * appends each receipt to ship.receipts so
+                                            * subsequent sells/deliveries can present
+                                            * the chain to destination stations.
+                                            *
+                                            *   [type:1=0x36][count:u16]
+                                            *     count × cargo_receipt_t (232 bytes each)
+                                            *
+                                            * `count` is the number of fresh
+                                            * receipts; each receipt corresponds 1:1
+                                            * with a cargo unit added to the ship
+                                            * manifest in this transaction. */
+    NET_MSG_PRESENT_RECEIPT_CHAIN  = 0x37, /* client -> server. Layer D of #479.
+                                            *
+                                            *   [type:1=0x37][cargo_pub:32][chain_len:u16]
+                                            *     chain_len × cargo_receipt_t
+                                            *
+                                            * Sent alongside a SIGNED_ACTION_SELL_CARGO
+                                            * or SIGNED_ACTION_DELIVER for the cargo
+                                            * being sold. The destination station
+                                            * walks the chain, verifies each
+                                            * receipt's signature against its
+                                            * authoring_station pubkey, verifies
+                                            * prev_receipt_hash linkage, and refuses
+                                            * the transfer on any failure. On
+                                            * success the destination signs and
+                                            * issues its OWN receipt back to the
+                                            * player (next BUY_BACK / DELIVER cycle
+                                            * grows the chain by one). */
     NET_MSG_CLAIM_LEGACY_SAVE      = 0x35, /* client -> server. Layer A.4 of #479.
                                             *
                                             *   [type:1=0x35][token_hex_len:1][token_hex:N]

--- a/shared/types.h
+++ b/shared/types.h
@@ -208,6 +208,20 @@ typedef struct {
      * hold_ingots[] / named_ingot_t dual store was collapsed in the
      * "unify ingot identity" PR. */
     manifest_t    manifest;
+    /* Layer D of #479 — portable cargo receipts.
+     *
+     * Parallel to `manifest`: receipts.chains[i] is the per-cargo-unit
+     * receipt chain attached to manifest.units[i]. Mutated in lockstep
+     * with the manifest by every BUY / SELL / DELIVER / TRANSFER path —
+     * receipts.count must equal manifest.count after every consistent
+     * op. Bootstrapped alongside the manifest (see ship_manifest_bootstrap).
+     *
+     * Stored as a void pointer to keep types.h independent of
+     * cargo_receipt.h (avoids a header cycle); shared/cargo_receipt.h
+     * defines the ship_receipts_t shape and shared/manifest.c casts
+     * through it. The on-disk save format (v42+) round-trips through
+     * the cargo_receipt_t wire layout. */
+    void          *receipts_opaque; /* ship_receipts_t* — see cargo_receipt.h */
 } ship_t;
 
 typedef enum {

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1,4 +1,5 @@
 #include "manifest.h"
+#include "cargo_receipt.h"  /* Layer D of #479 — ship receipt store */
 
 #include <assert.h>
 #include <math.h>
@@ -246,27 +247,87 @@ bool manifest_clone(manifest_t *dst, const manifest_t *src) {
     return true;
 }
 
+/* Layer D of #479 — receipt store helpers. Kept inline here so
+ * ship_cleanup/_bootstrap/_copy maintain the manifest+receipt parity
+ * invariant in lockstep. */
+static ship_receipts_t *ship_receipts_alloc(void) {
+    ship_receipts_t *r = (ship_receipts_t *)calloc(1, sizeof(*r));
+    if (!r) return NULL;
+    if (!ship_receipts_init(r, SHIP_MANIFEST_DEFAULT_CAP)) {
+        free(r);
+        return NULL;
+    }
+    return r;
+}
+
+static void ship_receipts_destroy(ship_receipts_t *r) {
+    if (!r) return;
+    ship_receipts_free(r);
+    free(r);
+}
+
+ship_receipts_t *ship_get_receipts(ship_t *ship) {
+    if (!ship) return NULL;
+    return (ship_receipts_t *)ship->receipts_opaque;
+}
+
+const ship_receipts_t *ship_get_receipts_const(const ship_t *ship) {
+    if (!ship) return NULL;
+    return (const ship_receipts_t *)ship->receipts_opaque;
+}
+
 void ship_cleanup(ship_t *ship) {
     if (!ship) return;
     manifest_free(&ship->manifest);
+    if (ship->receipts_opaque) {
+        ship_receipts_destroy((ship_receipts_t *)ship->receipts_opaque);
+        ship->receipts_opaque = NULL;
+    }
 }
 
 bool ship_manifest_bootstrap(ship_t *ship) {
     if (!ship) return false;
-    if (ship->manifest.cap == SHIP_MANIFEST_DEFAULT_CAP && ship->manifest.units) return true;
-    manifest_free(&ship->manifest);
-    return manifest_init(&ship->manifest, SHIP_MANIFEST_DEFAULT_CAP);
+    bool manifest_ok = (ship->manifest.cap == SHIP_MANIFEST_DEFAULT_CAP &&
+                        ship->manifest.units);
+    if (!manifest_ok) {
+        manifest_free(&ship->manifest);
+        if (!manifest_init(&ship->manifest, SHIP_MANIFEST_DEFAULT_CAP))
+            return false;
+    }
+    /* Bootstrap the parallel receipt store. Idempotent. */
+    if (!ship->receipts_opaque) {
+        ship->receipts_opaque = ship_receipts_alloc();
+        if (!ship->receipts_opaque) return false;
+    }
+    return true;
 }
 
 bool ship_copy(ship_t *dst, const ship_t *src) {
     manifest_t manifest = {0};
+    ship_receipts_t *receipts_dup = NULL;
 
     if (!dst || !src) return false;
     if (dst == src) return true;
     if (!manifest_clone(&manifest, &src->manifest)) return false;
+    /* Clone receipts if the source has any. Failure to clone is fatal
+     * for the copy because we must keep manifest+receipt parity. */
+    if (src->receipts_opaque) {
+        receipts_dup = (ship_receipts_t *)calloc(1, sizeof(*receipts_dup));
+        if (!receipts_dup) {
+            manifest_free(&manifest);
+            return false;
+        }
+        if (!ship_receipts_clone(receipts_dup,
+                                 (const ship_receipts_t *)src->receipts_opaque)) {
+            free(receipts_dup);
+            manifest_free(&manifest);
+            return false;
+        }
+    }
     ship_cleanup(dst);
     *dst = *src;
     dst->manifest = manifest;
+    dst->receipts_opaque = receipts_dup;
     return true;
 }
 

--- a/src/test_main.c
+++ b/src/test_main.c
@@ -56,6 +56,7 @@ void register_save_keyed_by_pubkey_tests(void);
 void register_station_authority_tests(void);
 void register_chain_log_tests(void);
 void register_signal_verify_tests(void);
+void register_cross_station_settlement_tests(void);
 
 int main(int argc, char **argv) {
     setbuf(stdout, NULL); /* unbuffered so crash location is visible */
@@ -136,6 +137,7 @@ int main(int argc, char **argv) {
     register_station_authority_tests();
     register_chain_log_tests();
     register_signal_verify_tests();
+    register_cross_station_settlement_tests();
 
     printf("\n%d tests run, %d passed, %d failed", tests_run, tests_passed, tests_failed);
     if (g_warnings > 0) printf(", %d warnings", g_warnings);

--- a/src/tests/test_cross_station_settlement.c
+++ b/src/tests/test_cross_station_settlement.c
@@ -1,0 +1,479 @@
+/*
+ * test_cross_station_settlement.c -- Layer D of #479: portable cargo
+ * receipts. See server/cargo_receipt_issue.h + shared/cargo_receipt.h
+ * for the design.
+ *
+ * Tests exercise the receipt issuance + verification machinery
+ * directly (the WS handler in server/main.c is the user). The flow:
+ *
+ *   1. Station A signs a receipt for cargo C bound to player P.
+ *   2. P presents that receipt to station B.
+ *   3. B verifies the chain end-to-end before accepting and issues
+ *      its OWN receipt for the receiving leg.
+ *
+ * We synthesize each hop via cargo_receipt_emit_transfer (the same
+ * primitive main.c calls), then verify the resulting chain.
+ */
+#include "test_harness.h"
+
+#include "cargo_receipt.h"
+#include "cargo_receipt_issue.h"
+#include "chain_log.h"
+#include "station_authority.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#if defined(_WIN32)
+#  include <direct.h>
+#else
+#  include <sys/stat.h>
+#  include <sys/types.h>
+#endif
+
+/* Per-test scratch dir helpers — mirror the chain_test_setup pattern
+ * used by test_chain_log.c so concurrent shards stay isolated. */
+static void crs_setup(const char *suffix) {
+    char path[256];
+    snprintf(path, sizeof(path), "%s_crs_%s", TMP("crs"), suffix);
+    chain_log_set_dir(path);
+}
+
+static void crs_teardown(void) {
+    chain_log_set_dir(NULL);
+}
+
+static void crs_wipe_logs(world_t *w) {
+    for (int s = 0; s < MAX_STATIONS; s++)
+        chain_log_reset(&w->stations[s]);
+}
+
+/* Initialize an already-allocated world with seeded chain state so
+ * each test starts from a clean per-station chain head.
+ * Caller owns the world_t (typically via WORLD_HEAP / calloc). */
+static void crs_world_init(world_t *w, uint32_t seed) {
+    w->rng = seed;
+    world_reset(w);
+    crs_wipe_logs(w);
+    for (int s = 0; s < 3; s++) {
+        w->stations[s].chain_event_count = 0;
+        memset(w->stations[s].chain_last_hash, 0, 32);
+    }
+}
+
+/* Synthesize a deterministic player pubkey + cargo pub for a test. */
+static void fill_test_pubkey(uint8_t out[32], uint8_t seed) {
+    for (int i = 0; i < 32; i++) out[i] = (uint8_t)(seed + i);
+}
+
+/* ---------------- Test 1: single-hop receipt ----------------------- */
+
+TEST(test_cross_station_single_hop_receipt) {
+    crs_setup("single_hop");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL); crs_world_init(w, 0xD001);
+    ASSERT(w != NULL);
+
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0x10);
+    uint8_t cargo_pk[32];  fill_test_pubkey(cargo_pk,  0x40);
+
+    /* Helios (idx 2) issues a receipt for cargo to the player. */
+    station_t *helios = &w->stations[2];
+    cargo_receipt_t r;
+    uint64_t event_id = cargo_receipt_emit_transfer(
+        w, helios,
+        helios->station_pubkey, player_pk,
+        cargo_pk, (uint8_t)CARGO_KIND_INGOT,
+        helios->chain_last_hash, /* origin pin to event already in log? — empty log → 0
+                                    * — use a non-zero string-of-zeros placeholder via SMELT first */
+        &r);
+    /* chain_last_hash is all-zero for an empty log; the helper uses it
+     * as the origin pin. cargo_receipt_chain_verify rejects all-zero
+     * pins, so first emit a synthetic "anchor" event so the receipt's
+     * origin pin is the hash of THAT event. */
+    ASSERT(event_id == 0 || event_id >= 1);
+    /* If the empty-log path triggered, redo with a SMELT seed first. */
+    if (event_id != 0) {
+        /* Receipt was issued; verify signature in isolation first. */
+        ASSERT(cargo_receipt_verify_signature(&r));
+        /* prev_receipt_hash equals the post-emit chain_last_hash, which
+         * is the hash of THIS transfer event itself (anchored). */
+    } else {
+        /* Re-emit a SMELT first so the chain has a non-zero last hash. */
+        ASSERT(chain_log_emit(w, helios, CHAIN_EVT_SMELT, "x", 1) >= 1);
+        event_id = cargo_receipt_emit_transfer(
+            w, helios,
+            helios->station_pubkey, player_pk,
+            cargo_pk, (uint8_t)CARGO_KIND_INGOT,
+            helios->chain_last_hash, &r);
+        ASSERT(event_id >= 1);
+        ASSERT(cargo_receipt_verify_signature(&r));
+    }
+    /* Receipt fields are populated correctly. */
+    ASSERT(memcmp(r.cargo_pub, cargo_pk, 32) == 0);
+    ASSERT(memcmp(r.recipient_pubkey, player_pk, 32) == 0);
+    ASSERT(memcmp(r.authoring_station, helios->station_pubkey, 32) == 0);
+    /* Single-hop chain verifies. */
+    ASSERT(cargo_receipt_chain_verify(&r, 1, cargo_pk) == CARGO_RECEIPT_OK);
+
+    crs_teardown();
+}
+
+/* ---------------- Test 2: two-hop receipt chain --------------------- */
+
+/* Helper: emit cargo issuance from station + first hop receipt for player. */
+static bool crs_first_hop(world_t *w, station_t *st, const uint8_t player_pk[32],
+                          const uint8_t cargo_pk[32], cargo_receipt_t *out) {
+    /* Anchor: emit a synthetic SMELT first so chain_last_hash is non-zero. */
+    if (chain_log_emit(w, st, CHAIN_EVT_SMELT, "smelt", 5) == 0) return false;
+    uint64_t id = cargo_receipt_emit_transfer(
+        w, st, st->station_pubkey, player_pk, cargo_pk,
+        (uint8_t)CARGO_KIND_INGOT, st->chain_last_hash, out);
+    return id != 0;
+}
+
+/* Helper: emit destination-station receipt for the second hop. */
+static bool crs_next_hop(world_t *w, station_t *dst, const uint8_t from_pk[32],
+                         const uint8_t cargo_pk[32],
+                         const cargo_receipt_t *prev, cargo_receipt_t *out) {
+    uint8_t prev_hash[32];
+    cargo_receipt_hash(prev, prev_hash);
+    uint64_t id = cargo_receipt_emit_transfer(
+        w, dst, from_pk, dst->station_pubkey, cargo_pk,
+        (uint8_t)CARGO_KIND_INGOT, prev_hash, out);
+    return id != 0;
+}
+
+TEST(test_cross_station_two_hop_chain) {
+    crs_setup("two_hop");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL); crs_world_init(w, 0xD002);
+    ASSERT(w != NULL);
+
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0x20);
+    uint8_t cargo_pk[32];  fill_test_pubkey(cargo_pk,  0x50);
+
+    /* Hop 1: Helios -> player. */
+    station_t *helios = &w->stations[2];
+    cargo_receipt_t r1;
+    ASSERT(crs_first_hop(w, helios, player_pk, cargo_pk, &r1));
+
+    /* Hop 2: player -> Kepler. Kepler verifies r1 then signs r2 whose
+     * prev_receipt_hash = SHA-256(r1). */
+    station_t *kepler = &w->stations[1];
+    cargo_receipt_t r2;
+    ASSERT(crs_next_hop(w, kepler, player_pk, cargo_pk, &r1, &r2));
+
+    /* Two-hop chain verifies. */
+    cargo_receipt_t chain[2] = { r1, r2 };
+    ASSERT(cargo_receipt_chain_verify(chain, 2, cargo_pk) == CARGO_RECEIPT_OK);
+
+    /* Each hop is signed by the right station. */
+    ASSERT(memcmp(r1.authoring_station, helios->station_pubkey, 32) == 0);
+    ASSERT(memcmp(r2.authoring_station, kepler->station_pubkey, 32) == 0);
+    /* Kepler's chain log has the EVT_TRANSFER in it. */
+    uint64_t walked = 0;
+    ASSERT(chain_log_verify(kepler, &walked, NULL));
+    ASSERT(walked >= 1);
+
+    crs_teardown();
+}
+
+/* ---------------- Test 3: forged receipt rejection ------------------ */
+
+TEST(test_cross_station_forged_receipt_rejected) {
+    crs_setup("forged");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL); crs_world_init(w, 0xD003);
+    ASSERT(w != NULL);
+
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0x30);
+    uint8_t cargo_pk[32];  fill_test_pubkey(cargo_pk,  0x60);
+
+    /* Hop 1: Helios -> player. */
+    station_t *helios = &w->stations[2];
+    station_t *prospect = &w->stations[0];
+    cargo_receipt_t r1;
+    ASSERT(crs_first_hop(w, helios, player_pk, cargo_pk, &r1));
+
+    /* Tamper: rewrite r1.authoring_station to claim it was Prospect.
+     * Signature was made with Helios's secret over a body that named
+     * Helios. After this overwrite, Prospect's pubkey gets fed to
+     * Ed25519 verify against Helios's signature → should fail. */
+    memcpy(r1.authoring_station, prospect->station_pubkey, 32);
+    ASSERT(!cargo_receipt_verify_signature(&r1));
+    ASSERT(cargo_receipt_chain_verify(&r1, 1, cargo_pk)
+           == CARGO_RECEIPT_REJECT_BAD_SIGNATURE);
+
+    crs_teardown();
+}
+
+/* ---------------- Test 4: tampered chain rejection ------------------ */
+
+TEST(test_cross_station_tampered_cargo_pub_rejected) {
+    crs_setup("tampered");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL); crs_world_init(w, 0xD004);
+    ASSERT(w != NULL);
+
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0x40);
+    uint8_t cargo_pk[32];  fill_test_pubkey(cargo_pk,  0x70);
+
+    station_t *helios = &w->stations[2];
+    cargo_receipt_t r1;
+    ASSERT(crs_first_hop(w, helios, player_pk, cargo_pk, &r1));
+
+    /* Flip a bit in cargo_pub — the signature was over the original
+     * 144-byte unsigned span, so verify must fail. */
+    r1.cargo_pub[7] ^= 0xFF;
+    ASSERT(!cargo_receipt_verify_signature(&r1));
+    ASSERT(cargo_receipt_chain_verify(&r1, 1, NULL)
+           == CARGO_RECEIPT_REJECT_BAD_SIGNATURE);
+
+    crs_teardown();
+}
+
+/* ---------------- Test 5: broken linkage rejection ------------------ */
+
+TEST(test_cross_station_broken_linkage_rejected) {
+    crs_setup("linkage");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL); crs_world_init(w, 0xD005);
+    ASSERT(w != NULL);
+
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0x50);
+    uint8_t cargo_pk[32];  fill_test_pubkey(cargo_pk,  0x80);
+
+    station_t *helios = &w->stations[2];
+    station_t *kepler = &w->stations[1];
+    cargo_receipt_t r1, r2;
+    ASSERT(crs_first_hop(w, helios, player_pk, cargo_pk, &r1));
+    ASSERT(crs_next_hop(w, kepler, player_pk, cargo_pk, &r1, &r2));
+
+    /* Replace r1 with a different first-hop receipt issued by Helios
+     * for the same cargo but in a fresh chain (different chain_last_hash
+     * → different prev_receipt_hash). r2's prev_receipt_hash still
+     * points at the original r1, so the linkage check must fail. */
+    cargo_receipt_t r1_alt;
+    ASSERT(chain_log_emit(w, helios, CHAIN_EVT_SMELT, "alt", 3) >= 1);
+    uint64_t alt_id = cargo_receipt_emit_transfer(
+        w, helios, helios->station_pubkey, player_pk, cargo_pk,
+        (uint8_t)CARGO_KIND_INGOT, helios->chain_last_hash, &r1_alt);
+    ASSERT(alt_id != 0);
+    /* Sanity: the alternative receipt verifies on its own. */
+    ASSERT(cargo_receipt_verify_signature(&r1_alt));
+
+    cargo_receipt_t chain[2] = { r1_alt, r2 };
+    ASSERT(cargo_receipt_chain_verify(chain, 2, cargo_pk)
+           == CARGO_RECEIPT_REJECT_BROKEN_LINKAGE);
+
+    crs_teardown();
+}
+
+/* ---------------- Test 6: three-hop chain --------------------------- */
+
+TEST(test_cross_station_three_hop_chain) {
+    crs_setup("three_hop");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL); crs_world_init(w, 0xD006);
+    ASSERT(w != NULL);
+
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0x60);
+    uint8_t cargo_pk[32];  fill_test_pubkey(cargo_pk,  0x90);
+
+    /* Hop 1: Prospect -> player. */
+    station_t *prospect = &w->stations[0];
+    station_t *kepler   = &w->stations[1];
+    station_t *helios   = &w->stations[2];
+
+    cargo_receipt_t r1, r2, r3;
+    ASSERT(crs_first_hop(w, prospect, player_pk, cargo_pk, &r1));
+    /* Hop 2: player -> Kepler. */
+    ASSERT(crs_next_hop(w, kepler, player_pk, cargo_pk, &r1, &r2));
+    /* Hop 3: player -> Helios (re-extract from Kepler back through
+     * the player; in real flow Kepler issues to player, player carries
+     * to Helios). */
+    ASSERT(crs_next_hop(w, helios, player_pk, cargo_pk, &r2, &r3));
+
+    cargo_receipt_t chain[3] = { r1, r2, r3 };
+    ASSERT(cargo_receipt_chain_verify(chain, 3, cargo_pk) == CARGO_RECEIPT_OK);
+    ASSERT(memcmp(r1.authoring_station, prospect->station_pubkey, 32) == 0);
+    ASSERT(memcmp(r2.authoring_station, kepler->station_pubkey, 32) == 0);
+    ASSERT(memcmp(r3.authoring_station, helios->station_pubkey, 32) == 0);
+
+    crs_teardown();
+}
+
+/* ---------------- Test 7: NPC-mediated transfer -------------------- */
+/* The wire path for NPC haulers is the same primitive — they issue
+ * via cargo_receipt_emit_transfer just like a player does. We model
+ * an NPC by using a deterministic NPC pubkey instead of a player one;
+ * the math is identical. */
+
+TEST(test_cross_station_npc_mediated_transfer) {
+    crs_setup("npc");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL); crs_world_init(w, 0xD007);
+    ASSERT(w != NULL);
+
+    uint8_t npc_pk[32];   fill_test_pubkey(npc_pk,   0x70);
+    uint8_t cargo_pk[32]; fill_test_pubkey(cargo_pk, 0xA0);
+
+    station_t *helios = &w->stations[2];
+    station_t *kepler = &w->stations[1];
+
+    cargo_receipt_t r1, r2;
+    ASSERT(crs_first_hop(w, helios, npc_pk, cargo_pk, &r1));
+    ASSERT(crs_next_hop(w, kepler, npc_pk, cargo_pk, &r1, &r2));
+
+    /* Kepler accepts: chain validates. */
+    cargo_receipt_t chain[2] = { r1, r2 };
+    ASSERT(cargo_receipt_chain_verify(chain, 2, cargo_pk) == CARGO_RECEIPT_OK);
+    /* Recipient on the first leg is the NPC; on the second leg, Kepler. */
+    ASSERT(memcmp(r1.recipient_pubkey, npc_pk, 32) == 0);
+    ASSERT(memcmp(r2.recipient_pubkey, kepler->station_pubkey, 32) == 0);
+
+    crs_teardown();
+}
+
+/* ---------------- Test 8: save/load preserves receipts -------------- */
+
+TEST(test_cross_station_save_load_preserves_receipts) {
+    crs_setup("save_load");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL); crs_world_init(w, 0xD008);
+    ASSERT(w != NULL);
+
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0x80);
+    uint8_t cargo_pk[32];  fill_test_pubkey(cargo_pk,  0xB0);
+
+    station_t *helios = &w->stations[2];
+    station_t *kepler = &w->stations[1];
+
+    /* Build a 2-hop chain and attach to ship.manifest + ship.receipts
+     * for player slot 0. */
+    server_player_t *sp = &w->players[0];
+    player_init_ship(sp, w);
+    sp->connected = true;
+    ASSERT(ship_manifest_bootstrap(&sp->ship));
+    ship_receipts_t *rcpts = ship_get_receipts(&sp->ship);
+    ASSERT(rcpts != NULL);
+
+    cargo_unit_t cu = {0};
+    cu.kind = CARGO_KIND_INGOT;
+    cu.commodity = COMMODITY_FERRITE_INGOT;
+    cu.grade = MINING_GRADE_COMMON;
+    cu.recipe_id = RECIPE_SMELT;
+    cu.prefix_class = INGOT_PREFIX_M;
+    memcpy(cu.pub, cargo_pk, 32);
+    ASSERT(manifest_push(&sp->ship.manifest, &cu));
+
+    cargo_receipt_t r1, r2;
+    ASSERT(crs_first_hop(w, helios, player_pk, cargo_pk, &r1));
+    ASSERT(crs_next_hop(w, kepler, player_pk, cargo_pk, &r1, &r2));
+    cargo_receipt_t chain[2] = { r1, r2 };
+    ASSERT(ship_receipts_push_chain(rcpts, chain, 2));
+    /* Parity: receipts.count == manifest.count == 1. */
+    ASSERT_EQ_INT((int)rcpts->count, 1);
+    ASSERT_EQ_INT((int)sp->ship.manifest.count, 1);
+
+    /* Persist + reload via player_save / player_load. */
+    char dir[256];
+    snprintf(dir, sizeof(dir), "%s_crs_save", TMP("crs_dir"));
+    /* Ensure dir exists; player_save creates the file but not a fresh dir hierarchy. */
+    /* Use legacy save path (token-keyed) since no pubkey is registered. */
+    /* The token must be set so player_save_path picks legacy path. */
+    for (int i = 0; i < 8; i++) sp->session_token[i] = (uint8_t)(0x42 + i);
+    sp->session_ready = true;
+
+    /* world_save handles the world-side state; player_save persists
+     * the ship + manifest + receipts tail. */
+    ASSERT(world_save(w, TMP("crs_world.sav")));
+    /* player_save's ensure_save_subdirs only creates pubkey/ and
+     * legacy/ INSIDE `dir`; it does NOT create `dir` itself. The
+     * test_tmp_path scratch root already exists, but our nested
+     * directory under it does not — create it before saving. */
+    {
+#if defined(_WIN32)
+        (void)_mkdir(dir);
+#else
+        (void)mkdir(dir, 0700);
+#endif
+    }
+    ASSERT(player_save(sp, dir, 0));
+
+    /* Fresh load. */
+    WORLD_HEAP w2 = calloc(1, sizeof(world_t));
+    ASSERT(w2 != NULL);
+    ASSERT(world_load(w2, TMP("crs_world.sav")));
+    server_player_t sp2 = {0};
+    memcpy(sp2.session_token, sp->session_token, 8);
+    sp2.session_ready = true;
+    ASSERT(player_load_by_token(&sp2, w2, dir, sp->session_token));
+
+    ASSERT_EQ_INT((int)sp2.ship.manifest.count, 1);
+    ship_receipts_t *rcpts2 = ship_get_receipts(&sp2.ship);
+    ASSERT(rcpts2 != NULL);
+    ASSERT_EQ_INT((int)rcpts2->count, 1);
+    ASSERT_EQ_INT((int)rcpts2->chains[0].len, 2);
+    /* The reloaded chain must still verify end-to-end. */
+    ASSERT(cargo_receipt_chain_verify(rcpts2->chains[0].links,
+                                      rcpts2->chains[0].len, cargo_pk)
+           == CARGO_RECEIPT_OK);
+
+    /* Cleanup. */
+    ship_cleanup(&sp2.ship);
+    remove(TMP("crs_world.sav"));
+    crs_teardown();
+}
+
+/* ---------------- Test 9: chain length cap -------------------------- */
+
+TEST(test_cross_station_chain_length_cap) {
+    crs_setup("cap");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL); crs_world_init(w, 0xD009);
+    ASSERT(w != NULL);
+
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0x90);
+    uint8_t cargo_pk[32];  fill_test_pubkey(cargo_pk,  0xC0);
+
+    /* Try to build a 17-hop chain. The 17th transfer must be refused
+     * by ship_receipts_extend (cap = 16). We check both: the verifier
+     * rejects a 17-element chain and ship_receipts_extend refuses to
+     * grow beyond 16. */
+    cargo_receipt_t chain[CARGO_RECEIPT_CHAIN_MAX_LEN + 1];
+
+    station_t *st = &w->stations[2];
+    ASSERT(crs_first_hop(w, st, player_pk, cargo_pk, &chain[0]));
+    for (int i = 1; i <= CARGO_RECEIPT_CHAIN_MAX_LEN; i++) {
+        /* Alternate stations 1 and 2 for each subsequent hop so each
+         * hop is signed by a real keyed station. */
+        station_t *next = &w->stations[(i % 2 == 0) ? 2 : 1];
+        ASSERT(crs_next_hop(w, next, player_pk, cargo_pk,
+                            &chain[i - 1], &chain[i]));
+    }
+    /* The 17-element chain trips the TOO_LONG cap in chain_verify. */
+    ASSERT(cargo_receipt_chain_verify(chain, CARGO_RECEIPT_CHAIN_MAX_LEN + 1,
+                                      cargo_pk)
+           == CARGO_RECEIPT_REJECT_TOO_LONG);
+    /* The 16-element prefix verifies. */
+    ASSERT(cargo_receipt_chain_verify(chain, CARGO_RECEIPT_CHAIN_MAX_LEN,
+                                      cargo_pk)
+           == CARGO_RECEIPT_OK);
+
+    /* ship_receipts_extend refuses past the cap. */
+    ship_receipts_t r = {0};
+    ASSERT(ship_receipts_init(&r, 4));
+    ASSERT(ship_receipts_push_chain(&r, chain, CARGO_RECEIPT_CHAIN_MAX_LEN));
+    /* Attempting to extend a CHAIN_MAX_LEN-deep chain by one more must fail. */
+    ASSERT(!ship_receipts_extend(&r, 0, &chain[CARGO_RECEIPT_CHAIN_MAX_LEN]));
+    ship_receipts_free(&r);
+
+    crs_teardown();
+}
+
+void register_cross_station_settlement_tests(void);
+void register_cross_station_settlement_tests(void) {
+    TEST_SECTION("\n--- Cross-Station Settlement (#479 D) ---\n");
+    RUN(test_cross_station_single_hop_receipt);
+    RUN(test_cross_station_two_hop_chain);
+    RUN(test_cross_station_forged_receipt_rejected);
+    RUN(test_cross_station_tampered_cargo_pub_rejected);
+    RUN(test_cross_station_broken_linkage_rejected);
+    RUN(test_cross_station_three_hop_chain);
+    RUN(test_cross_station_npc_mediated_transfer);
+    RUN(test_cross_station_save_load_preserves_receipts);
+    RUN(test_cross_station_chain_length_cap);
+}

--- a/src/tests/test_save.c
+++ b/src/tests/test_save.c
@@ -601,7 +601,7 @@ TEST(test_save_header_golden_bytes) {
     ASSERT_EQ_INT((int)fread(&spawn_timer, 4, 1, f), 1);
     fclose(f);
     ASSERT_EQ_INT((int)magic, (int)0x5349474E);    /* "SIGN" */
-    ASSERT_EQ_INT((int)version, 41);
+    ASSERT_EQ_INT((int)version, 42);
     ASSERT(rng != 0);  /* seed is set */
     ASSERT_EQ_FLOAT(time_val, 0.0f, 0.001f);
     ASSERT_EQ_FLOAT(spawn_timer, 0.0f, 0.001f);


### PR DESCRIPTION
## Summary

Layer D of #479 — cargo carries portable, station-signed receipts so a destination station can verify cargo's lineage without trusting the origin operator. Cornerstone of per-zone federation: Kepler accepts cargo from Helios because Helios's signature on the transfer is verifiable, not because Kepler trusts the same server runs both.

## What's new

- **`shared/cargo_receipt.{h,c}`** — wire-stable `cargo_receipt_t` (208 B = 144 B unsigned span + 64 B Ed25519 sig). Carries `cargo_pub`, `authoring_station`, `recipient_pubkey`, `event_id`, `epoch`, `prev_receipt_hash`, `signature`. Chain validation via `cargo_receipt_chain_verify` walks signatures + linkage end-to-end.
- **`server/cargo_receipt_issue.{h,c}`** — server-only issuance helper. `cargo_receipt_emit_transfer` emits the EVT_TRANSFER and produces the matching signed receipt in one call; the receipt's `event_id` matches the chain entry so a verifier can stitch them.
- **`ship_t.receipts_opaque`** — parallel store (`ship_receipts_t`) running 1:1 with `ship.manifest`. Bootstrapped/cleaned/cloned alongside the manifest in `ship_manifest_bootstrap` / `ship_cleanup` / `ship_copy`.
- **Wire messages** — `NET_MSG_CARGO_RECEIPT_BUNDLE` (0x36, server → client, sent after BUY/DELIVER) and `NET_MSG_PRESENT_RECEIPT_CHAIN` (0x37, client → server).
- **Server instrumentation** — `server/main.c` BUY_INGOT issues a receipt to the buyer and pushes it to `ship.receipts`; DELIVER_INGOT validates any attached chain before accepting and signs the receiving leg.
- **Save format** — `SAVE_VERSION` bumped 41 → 42; player magic `PLY6` → `PLY7` appends per-cargo receipt chains after the manifest tail. v41/PLY6 saves load with empty receipt chains; the next transfer mints a fresh origin-attested receipt (one-time migration cost).

## Cap and out-of-scope

- **16-hop cap** — `cargo_receipt_chain_verify` rejects chains longer than `CARGO_RECEIPT_CHAIN_MAX_LEN`. Merkle compaction of pruned receipts is deferred — a 17th transfer attempt fails closed.
- **Cross-operator settlement** — receipts are still single-operator; verifying them across operator boundaries needs `signal_anchor` (#480).
- **Player-side transfer signatures** — receipts are station-signed. The existing SIGNED_ACTION wrapping from #488 already covers BUY/SELL/DELIVER intent.

## Test plan

- [x] All existing tests pass — 391 → 400, ./build-test/signal_test --quiet green
- [x] Native build green (cmake --build build --target signal)
- [x] Server build green (cmake --build build --target signal_server)
- [x] WASM build green (emcmake + cmake --build build-web)
- [x] 9 new test cases in src/tests/test_cross_station_settlement.c:
  - single-hop receipt issuance + signature verify
  - two-hop chain (Helios → player → Kepler) verifies
  - forged authoring_station rejected
  - tampered cargo_pub rejected
  - broken `prev_receipt_hash` linkage rejected
  - three-hop chain (Prospect → Kepler → Helios) verifies
  - NPC-mediated transfer parity with player path
  - save/load round-trip preserves the receipt chain
  - 17-hop chain refused; `ship_receipts_extend` past 16 fails

Refs #479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)