### PR TITLE
feat(economy): prefix-class price multipliers — make lineage pay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,7 @@ if(NOT EMSCRIPTEN AND NOT BUILD_SERVER_ONLY)
         src/tests/test_signal_verify.c
         src/tests/test_cross_station_settlement.c
         src/tests/test_sovereign_ledger.c
+        src/tests/test_prefix_class_pricing.c
         src/identity.c
         ${SIGNAL_SIM_SOURCES}
         ${SIGNAL_SIM_HELPERS}

--- a/server/main.c
+++ b/server/main.c
@@ -14,6 +14,8 @@
 #include "sim_asteroid.h"
 #include "chain_log.h"  /* signed event emission (#479 C) */
 #include "cargo_receipt_issue.h"  /* portable cargo receipts (#479 D) */
+#include "commodity.h"  /* station_*_price_unit (#prefix-pricing) */
+#include <math.h>       /* lroundf */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -302,13 +304,13 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
             if (slot < 0) break;
             cargo_unit_t *src = &st->manifest.units[slot];
             if ((cargo_kind_t)src->kind != CARGO_KIND_INGOT) break;
-            int price;
-            switch ((ingot_prefix_t)src->prefix_class) {
-            case INGOT_PREFIX_RATI:         price = INGOT_PRICE_RATI; break;
-            case INGOT_PREFIX_COMMISSIONED: price = INGOT_PRICE_COMMISSIONED; break;
-            case INGOT_PREFIX_ANONYMOUS:    price = 0; break;
-            default:                        price = INGOT_PRICE_M; break;
-            }
+            /* Prefix-class price multipliers (#prefix-pricing): the
+             * specific unit's sale price scales by both the dynamic
+             * stock curve and the unit's prefix_class. Anonymous
+             * ingots aren't purchasable through this path — they're
+             * bulk material and have no named-collectible premium. */
+            if ((ingot_prefix_t)src->prefix_class == INGOT_PREFIX_ANONYMOUS) break;
+            int price = (int)lroundf(station_sell_price_unit(st, src));
             if (price <= 0) break;
             /* Use ledger_spend so the credit pool stays conserved. */
             if (!ledger_spend(st, world.players[pid].session_token, (float)price, ship)) break;
@@ -445,8 +447,16 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
             if (rcpts && hidx < (int)rcpts->count) {
                 (void)ship_receipts_remove(rcpts, (uint16_t)hidx, NULL);
             }
-            /* Pay delivery credit through the ledger so supply stays balanced. */
-            ledger_credit_supply(st, world.players[pid].session_token, (float)INGOT_DELIVERY_CREDIT);
+            /* Pay delivery credit through the ledger so supply stays
+             * balanced. Prefix-class price multipliers (#501): a specific
+             * delivered unit pays station_buy_price_unit, so M-class
+             * ingots pay 2× and RATi pays 50×. INGOT_DELIVERY_CREDIT is
+             * kept as the floor for low-base-price edge cases. */
+            float delivery_f = station_buy_price_unit(st, &copy);
+            float floor_f = (float)INGOT_DELIVERY_CREDIT;
+            if (delivery_f < floor_f) delivery_f = floor_f;
+            int delivery_int = (int)lroundf(delivery_f);
+            ledger_credit_supply(st, world.players[pid].session_token, (float)delivery_int);
             st->manifest_dirty = true;
             /* Layer C of #479: emit EVT_TRANSFER (player -> station) +
              * EVT_TRADE (delivery credit accrual on the station's
@@ -479,13 +489,15 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
                     cargo_receipt_pack(&receipt, &buf[3]);
                     ws_send(c, buf, sizeof(buf));
 
+                    /* Trade event records the actual prefix-scaled
+                     * delivery amount (#501), not a flat constant. */
                     struct __attribute__((packed)) {
                         uint64_t transfer_event_id;
                         int64_t  ledger_delta_signed;
                         uint8_t  ledger_pubkey[32];
                     } trade = {0};
                     trade.transfer_event_id = xfer_id;
-                    trade.ledger_delta_signed = (int64_t)INGOT_DELIVERY_CREDIT;
+                    trade.ledger_delta_signed = (int64_t)delivery_int;
                     memcpy(trade.ledger_pubkey, world.players[pid].pubkey, 32);
                     (void)chain_log_emit(&world, st, CHAIN_EVT_TRADE,
                                          &trade, (uint16_t)sizeof(trade));
@@ -565,14 +577,11 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
                     int slot = manifest_find(&st->manifest, payload);
                     if (slot >= 0) {
                         cargo_unit_t *src = &st->manifest.units[slot];
-                        if ((cargo_kind_t)src->kind == CARGO_KIND_INGOT) {
-                            int price;
-                            switch ((ingot_prefix_t)src->prefix_class) {
-                            case INGOT_PREFIX_RATI:         price = INGOT_PRICE_RATI; break;
-                            case INGOT_PREFIX_COMMISSIONED: price = INGOT_PRICE_COMMISSIONED; break;
-                            case INGOT_PREFIX_ANONYMOUS:    price = 0; break;
-                            default:                        price = INGOT_PRICE_M; break;
-                            }
+                        if ((cargo_kind_t)src->kind == CARGO_KIND_INGOT &&
+                            (ingot_prefix_t)src->prefix_class != INGOT_PREFIX_ANONYMOUS) {
+                            /* Prefix-class price multipliers (#prefix-pricing):
+                             * mirror the unsigned BUY_INGOT path above. */
+                            int price = (int)lroundf(station_sell_price_unit(st, src));
                             if (price > 0 &&
                                 ledger_spend(st, sp->session_token, (float)price, ship)) {
                                 cargo_unit_t copy = *src;

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -598,6 +598,46 @@ void step_furnace_smelting(world_t *w, float dt) {
             }
             float ore_value = a->ore * price;
 
+            /* Prefix-class price multipliers (#prefix-pricing): project
+             * the to-be-minted ingot units and lift ore_value by the
+             * mean prefix multiplier across them. Anonymous-class units
+             * (the bulk of mining output) have multiplier 1.0×, so the
+             * historical balance is unchanged in expectation; the rare
+             * M/RATi-class fragment lifts the whole payout.
+             *
+             * The minted-unit pubkeys are deterministic in
+             * (output, grade, fragment_pub, idx) — see hash_ingot — so
+             * projecting here picks the same prefixes the manifest push
+             * below will mint. We project against the OUTPUT ingot
+             * commodity, not the raw ore, because the lineage substrate
+             * tags ingots, not ore.
+             *
+             * Skipped on contract payouts — by_contract paths pay the
+             * flat per-unit contract_price by design (see #496 / spec
+             * out-of-scope: filtered contracts come in a follow-up PR). */
+            if (!by_contract) {
+                commodity_t proj_ingot = commodity_refined_form(a->commodity);
+                if (proj_ingot != a->commodity) {
+                    int proj_units = (int)floorf(a->ore + 0.0001f);
+                    if (proj_units > 0) {
+                        float sum_mult = 0.0f;
+                        int counted = 0;
+                        for (int idx = 0; idx < proj_units; idx++) {
+                            cargo_unit_t proj_u = {0};
+                            if (!hash_ingot(proj_ingot, (mining_grade_t)a->grade,
+                                            a->fragment_pub,
+                                            (uint16_t)idx, &proj_u))
+                                continue;
+                            sum_mult += prefix_class_price_multiplier(
+                                            (int)proj_u.prefix_class);
+                            counted++;
+                        }
+                        if (counted > 0)
+                            ore_value *= (sum_mult / (float)counted);
+                    }
+                }
+            }
+
             /* Credit fracturer and tower.
              *
              * Credit attribution is strictly token-based: we look up each

--- a/shared/economy_const.h
+++ b/shared/economy_const.h
@@ -7,6 +7,47 @@
 #ifndef ECONOMY_CONST_H
 #define ECONOMY_CONST_H
 
+/* This header is included by shared/types.h *after* the ingot_prefix_t
+ * enum is declared, so PREFIX_CLASS_PRICE_MULTIPLIER below can refer
+ * to INGOT_PREFIX_* symbols. Don't include this file directly without
+ * including types.h first. */
+
+/* Prefix-class price multipliers — the lineage substrate's economic
+ * dial. station_buy_price_unit() and station_sell_price_unit()
+ * multiply through this table when the cargo unit being priced has a
+ * non-anonymous prefix_class. Anonymous (the default for non-traceable
+ * goods) stays at 1.0× so existing economy assumptions hold for the
+ * bulk of trade.
+ *
+ * Values chosen so single-letter classes are noticeably premium but
+ * not universe-warping; RATi is a once-in-a-thousand-rocks event-
+ * pricing tier where finding one is news; commissioned is the RATi
+ * Foundation reserve tier (effectively unreachable through normal
+ * mining and serves as a top-end ceiling).
+ *
+ * Indexed by ingot_prefix_t. If you add a new class, add a multiplier
+ * here too — the table is sized to INGOT_PREFIX_COUNT and indices are
+ * range-checked at the callsite. */
+static const float PREFIX_CLASS_PRICE_MULTIPLIER[INGOT_PREFIX_COUNT] = {
+    [INGOT_PREFIX_ANONYMOUS]     = 1.0f,
+    [INGOT_PREFIX_M]             = 2.0f,
+    [INGOT_PREFIX_H]             = 2.0f,
+    [INGOT_PREFIX_T]             = 2.0f,
+    [INGOT_PREFIX_S]             = 2.0f,
+    [INGOT_PREFIX_F]             = 2.0f,
+    [INGOT_PREFIX_K]             = 2.5f,   /* slightly rarer letter */
+    [INGOT_PREFIX_RATI]          = 50.0f,  /* once-in-a-blue-moon tier */
+    [INGOT_PREFIX_COMMISSIONED]  = 100.0f, /* RATi Foundation reserved */
+};
+
+/* Helper: bounds-checked multiplier lookup. Returns 1.0× for any
+ * class outside the valid range so a malformed cargo_unit_t can't
+ * make a negative array index escape. */
+static inline float prefix_class_price_multiplier(int cls) {
+    if (cls < 0 || cls >= INGOT_PREFIX_COUNT) return 1.0f;
+    return PREFIX_CLASS_PRICE_MULTIPLIER[cls];
+}
+
 /* --- Refinery / station production --- */
 static const float REFINERY_HOPPER_CAPACITY = 500.0f;
 static const float REFINERY_BASE_SMELT_RATE = 2.0f;

--- a/src/client.h
+++ b/src/client.h
@@ -93,6 +93,10 @@ typedef struct {
     int            station_capacity;/* MAX_PRODUCT_STOCK */
     int            held;            /* player's cargo of this (commodity,grade) */
     uint8_t        block_reason;    /* see TRADE_BLOCK_* below; 0 if actionable */
+    uint8_t        prefix_class;    /* ingot_prefix_t for the row's representative
+                                      * unit; INGOT_PREFIX_ANONYMOUS = bulk row. Drives
+                                      * the M-/RATi-prefix indicator in the dock UI
+                                      * (#prefix-pricing). */
 } trade_row_t;
 
 /* Why an otherwise-valid row is non-actionable. Drives the status text

--- a/src/commodity.c
+++ b/src/commodity.c
@@ -194,3 +194,22 @@ float station_sell_price(const station_t* station, commodity_t commodity) {
 float station_inventory_amount(const station_t* station, commodity_t commodity) {
     return station != NULL ? station->_inventory_cache[commodity] : 0.0f;
 }
+
+/* Unit-aware variants: same dynamic stock curve as above, scaled by
+ * the unit's prefix_class. See PREFIX_CLASS_PRICE_MULTIPLIER in
+ * shared/economy_const.h for the table and rationale.
+ *
+ * Implementation pattern: chain through the commodity-only function
+ * so the stock-fill curve and base_price logic stay the single source
+ * of truth. The only thing layered on top is the prefix multiplier. */
+float station_buy_price_unit(const station_t* station, const cargo_unit_t* unit) {
+    if (!station || !unit) return 0.0f;
+    float base = station_buy_price(station, (commodity_t)unit->commodity);
+    return base * prefix_class_price_multiplier((int)unit->prefix_class);
+}
+
+float station_sell_price_unit(const station_t* station, const cargo_unit_t* unit) {
+    if (!station || !unit) return 0.0f;
+    float base = station_sell_price(station, (commodity_t)unit->commodity);
+    return base * prefix_class_price_multiplier((int)unit->prefix_class);
+}

--- a/src/commodity.h
+++ b/src/commodity.h
@@ -29,4 +29,19 @@ float station_buy_price(const station_t* station, commodity_t commodity);
 float station_sell_price(const station_t* station, commodity_t commodity);
 float station_inventory_amount(const station_t* station, commodity_t commodity);
 
+/* Unit-aware pricing — multiplies the commodity-level price by the
+ * cargo unit's prefix_class multiplier (PREFIX_CLASS_PRICE_MULTIPLIER
+ * in shared/economy_const.h). Anonymous-class units price identically
+ * to the commodity-only path, so callers that don't know about prefix
+ * classes degrade gracefully.
+ *
+ * Use these where a SPECIFIC cargo_unit_t is changing hands — the
+ * smelt-payout pathway (server/sim_production.c), BUY_INGOT /
+ * DELIVER_INGOT manifest transfers (server/main.c), and per-unit
+ * dock UI rows (src/station_ui.c). The original commodity-only
+ * functions remain for aggregate display rows where no specific unit
+ * is selected yet. */
+float station_buy_price_unit(const station_t* station, const cargo_unit_t* unit);
+float station_sell_price_unit(const station_t* station, const cargo_unit_t* unit);
+
 #endif

--- a/src/station_ui.c
+++ b/src/station_ui.c
@@ -624,6 +624,30 @@ static int ship_manifest_count_cg(const ship_t *ship,
     return n;
 }
 
+/* Highest prefix-class observed on the ship for a given (commodity,
+ * grade) bucket. Used by build_trade_rows to scale SELL prices and
+ * surface the M-/RATi- indicator on dock rows where the player is
+ * carrying named ingots. Returns INGOT_PREFIX_ANONYMOUS if no named
+ * units are present (the row is bulk material). */
+static int ship_manifest_top_prefix_cg(const ship_t *ship,
+                                       commodity_t commodity,
+                                       mining_grade_t grade)
+{
+    if (!ship || !ship->manifest.units) return (int)INGOT_PREFIX_ANONYMOUS;
+    int top = (int)INGOT_PREFIX_ANONYMOUS;
+    float top_mult = 1.0f;
+    for (uint16_t i = 0; i < ship->manifest.count; i++) {
+        const cargo_unit_t *u = &ship->manifest.units[i];
+        if (u->commodity != (uint8_t)commodity || u->grade != (uint8_t)grade) continue;
+        float m = prefix_class_price_multiplier((int)u->prefix_class);
+        if (m > top_mult) {
+            top_mult = m;
+            top = (int)u->prefix_class;
+        }
+    }
+    return top;
+}
+
 /* TRADE view — market. Unified list of rows; BUY rows (what the station
  * sells) first, then SELL rows (what the station buys). Hotkeys [1]..[5]
  * select a row on the current page. [F] pages forward; pages wrap at
@@ -717,8 +741,22 @@ int build_trade_rows(const station_t *st, const ship_t *ship,
             if (held <= 0) continue;
             if (held > cargo_units) held = cargo_units;
             emitted_any = true;
+            /* Prefix-class price multipliers (#prefix-pricing): if the
+             * player is carrying any non-anonymous-prefix unit in this
+             * (commodity, grade) bucket, surface the row at the higher
+             * prefix-scaled price. The matching unit will be the one
+             * the SELL hotkey transacts; bulk units in the same bucket
+             * still sell at the row's (higher) advertised rate, which
+             * is consistent with manifest_top_prefix_cg picking the
+             * MAX. The class also drives a row-side M-/RATi- indicator
+             * so the player sees why a price is suddenly higher. */
+            int top_cls = ship_manifest_top_prefix_cg(ship,
+                                                      (commodity_t)c,
+                                                      (mining_grade_t)gi);
+            float prefix_mult = prefix_class_price_multiplier(top_cls);
             int price = (int)lroundf(price_base
-                    * mining_payout_multiplier((mining_grade_t)gi));
+                    * mining_payout_multiplier((mining_grade_t)gi)
+                    * prefix_mult);
             uint8_t blk = TRADE_BLOCK_NONE;
             if (station_full) blk = TRADE_BLOCK_STATION_FULL;
             /* Per-grade station count — manifest entries of (c, gi) at
@@ -733,6 +771,7 @@ int build_trade_rows(const station_t *st, const ship_t *ship,
                 .actionable = (blk == TRADE_BLOCK_NONE), .is_float_fallback = false,
                 .station_stock = station_grade_count, .station_capacity = capacity,
                 .held = held, .block_reason = blk,
+                .prefix_class = (uint8_t)top_cls,
             };
         }
         /* Cargo says we have units but manifest empty -- fall back to a
@@ -957,11 +996,36 @@ static void draw_trade_view(const station_ui_state_t *ui,
             snprintf(total_buf, sizeof(total_buf), "%s", why);
         }
 
+        /* Prefix-class indicator (#prefix-pricing): drop "M-", "RATi-",
+         * etc. before the commodity name so the row's premium price is
+         * legible to the player. Anonymous-prefix rows render with no
+         * indicator and behave like the legacy bulk path. */
+        char commodity_label[32];
+        const char *cname = commodity_short_name(r->commodity);
+        const char *cls_prefix = NULL;
+        switch ((ingot_prefix_t)r->prefix_class) {
+        case INGOT_PREFIX_M:            cls_prefix = "M-"; break;
+        case INGOT_PREFIX_H:            cls_prefix = "H-"; break;
+        case INGOT_PREFIX_T:            cls_prefix = "T-"; break;
+        case INGOT_PREFIX_S:            cls_prefix = "S-"; break;
+        case INGOT_PREFIX_F:            cls_prefix = "F-"; break;
+        case INGOT_PREFIX_K:            cls_prefix = "K-"; break;
+        case INGOT_PREFIX_RATI:         cls_prefix = "RATi-"; break;
+        case INGOT_PREFIX_COMMISSIONED: cls_prefix = "RATi*-"; break;
+        case INGOT_PREFIX_ANONYMOUS:
+        default:                        cls_prefix = NULL; break;
+        }
+        if (cls_prefix) {
+            snprintf(commodity_label, sizeof(commodity_label), "%s%s", cls_prefix, cname);
+        } else {
+            snprintf(commodity_label, sizeof(commodity_label), "%s", cname);
+        }
+
         if (compact) {
             cell_t top[] = {
                 {  0, key_buf,                            row_rgb },
                 {  4, verb,                               row_rgb },
-                { 10, commodity_short_name(r->commodity), info_rgb },
+                { 10, commodity_label,                    info_rgb },
                 { 26, grade_label,                        grade_rgb_ptr },
             };
             draw_row_cells(cx, my, top, 4);
@@ -975,7 +1039,7 @@ static void draw_trade_view(const station_ui_state_t *ui,
             cell_t row[] = {
                 {  0, key_buf,                            row_rgb },
                 {  4, verb,                               row_rgb },
-                { 10, commodity_short_name(r->commodity), info_rgb },
+                { 10, commodity_label,                    info_rgb },
                 { 28, grade_label,                        grade_rgb_ptr },
                 { 35, status_buf,                         info_rgb },
             };

--- a/src/test_main.c
+++ b/src/test_main.c
@@ -58,6 +58,7 @@ void register_chain_log_tests(void);
 void register_signal_verify_tests(void);
 void register_cross_station_settlement_tests(void);
 void register_sovereign_ledger_tests(void);
+void register_prefix_class_pricing_tests(void);
 
 int main(int argc, char **argv) {
     setbuf(stdout, NULL); /* unbuffered so crash location is visible */
@@ -140,6 +141,7 @@ int main(int argc, char **argv) {
     register_signal_verify_tests();
     register_cross_station_settlement_tests();
     register_sovereign_ledger_tests();
+    register_prefix_class_pricing_tests();
 
     printf("\n%d tests run, %d passed, %d failed", tests_run, tests_passed, tests_failed);
     if (g_warnings > 0) printf(", %d warnings", g_warnings);

--- a/src/tests/test_prefix_class_pricing.c
+++ b/src/tests/test_prefix_class_pricing.c
@@ -1,0 +1,147 @@
+/* test_prefix_class_pricing.c — exercises the prefix-class price
+ * multiplier table (#prefix-pricing) and the unit-aware pricing
+ * functions station_buy_price_unit / station_sell_price_unit.
+ *
+ * The premise: a cargo unit's `prefix_class` (RATi / M / H / T / S /
+ * F / K / anonymous), previously cosmetic, now scales the dynamic
+ * station price. Anonymous-prefix units price identically to the
+ * commodity-only path so the bulk economy is unchanged. M-prefix
+ * doubles, RATi multiplies by 50, COMMISSIONED multiplies by 100.
+ *
+ * These tests pin the multiplier table values, the multiplicative
+ * compose with the existing stock-fill curve, and the manifest
+ * mixed-grade aggregate path. */
+#include "test_harness.h"
+
+/* Build a synthetic cargo_unit_t with a chosen commodity and prefix
+ * class. Tests don't need a real fragment_pub — the pricing functions
+ * read only commodity + prefix_class. */
+static cargo_unit_t make_unit(commodity_t commodity, ingot_prefix_t prefix) {
+    cargo_unit_t u = {0};
+    u.kind = (uint8_t)CARGO_KIND_INGOT;
+    u.commodity = (uint8_t)commodity;
+    u.grade = (uint8_t)MINING_GRADE_COMMON;
+    u.prefix_class = (uint8_t)prefix;
+    return u;
+}
+
+/* Test 1: anonymous-prefix unit prices identically to the commodity-
+ * only path. The whole multiplier system has to be transparent to
+ * existing callers that only ever produce anonymous-class cargo. */
+TEST(test_prefix_pricing_anonymous_baseline) {
+    station_t st = {0};
+    st.base_price[COMMODITY_FERRITE_INGOT] = 24.0f;
+    /* Empty stockpile: sell price = 2× base = 48; buy price = 1× = 24. */
+    cargo_unit_t anon = make_unit(COMMODITY_FERRITE_INGOT, INGOT_PREFIX_ANONYMOUS);
+    ASSERT_EQ_FLOAT(station_buy_price_unit(&st, &anon),
+                    station_buy_price(&st, COMMODITY_FERRITE_INGOT), 0.01f);
+    ASSERT_EQ_FLOAT(station_sell_price_unit(&st, &anon),
+                    station_sell_price(&st, COMMODITY_FERRITE_INGOT), 0.01f);
+}
+
+/* Test 2: M-class ferrite ingot prices at 2× the commodity-only base.
+ * Pins the M-row of the multiplier table. */
+TEST(test_prefix_pricing_m_class_2x) {
+    station_t st = {0};
+    st.base_price[COMMODITY_FERRITE_INGOT] = 24.0f;
+    cargo_unit_t m = make_unit(COMMODITY_FERRITE_INGOT, INGOT_PREFIX_M);
+    float base_buy = station_buy_price(&st, COMMODITY_FERRITE_INGOT);
+    float base_sell = station_sell_price(&st, COMMODITY_FERRITE_INGOT);
+    ASSERT_EQ_FLOAT(station_buy_price_unit(&st, &m),  2.0f * base_buy, 0.01f);
+    ASSERT_EQ_FLOAT(station_sell_price_unit(&st, &m), 2.0f * base_sell, 0.01f);
+}
+
+/* Test 3: RATi-class prices at 50× base. Pins the rare-tier value. */
+TEST(test_prefix_pricing_rati_class_50x) {
+    station_t st = {0};
+    st.base_price[COMMODITY_FERRITE_INGOT] = 24.0f;
+    cargo_unit_t r = make_unit(COMMODITY_FERRITE_INGOT, INGOT_PREFIX_RATI);
+    float base_buy = station_buy_price(&st, COMMODITY_FERRITE_INGOT);
+    ASSERT_EQ_FLOAT(station_buy_price_unit(&st, &r), 50.0f * base_buy, 0.01f);
+}
+
+/* Test 4: stock-fill multiplier and prefix multiplier compose
+ * multiplicatively — neither overrides the other. At 50% hopper fill
+ * the buy curve is 1 - 0.5*0.5 = 0.75×; under RATi prefix the
+ * combined factor is 0.75 × 50 = 37.5. */
+TEST(test_prefix_pricing_compose_with_stock_curve) {
+    station_t st = {0};
+    st.base_price[COMMODITY_FERRITE_INGOT] = 24.0f;
+    /* Half-full PRODUCT stockpile (capacity = MAX_PRODUCT_STOCK). */
+    st._inventory_cache[COMMODITY_FERRITE_INGOT] = MAX_PRODUCT_STOCK * 0.5f;
+    float base_buy = station_buy_price(&st, COMMODITY_FERRITE_INGOT);
+    /* Sanity: stock-fill curve gives 0.75× at 50% fill. */
+    ASSERT_EQ_FLOAT(base_buy, 24.0f * 0.75f, 0.01f);
+    cargo_unit_t r = make_unit(COMMODITY_FERRITE_INGOT, INGOT_PREFIX_RATI);
+    /* Composed: 24 * 0.75 * 50.0 = 900. */
+    ASSERT_EQ_FLOAT(station_buy_price_unit(&st, &r), 24.0f * 0.75f * 50.0f, 0.01f);
+}
+
+/* Test 5: K-class is 2.5× (rarer letter), commissioned is 100×. Pins
+ * the asymmetric row values so a future "make all classes 2x" change
+ * fails this test instead of silently flattening. */
+TEST(test_prefix_pricing_k_class_and_commissioned) {
+    station_t st = {0};
+    st.base_price[COMMODITY_CRYSTAL_INGOT] = 40.0f;
+    cargo_unit_t k = make_unit(COMMODITY_CRYSTAL_INGOT, INGOT_PREFIX_K);
+    cargo_unit_t cm = make_unit(COMMODITY_CRYSTAL_INGOT, INGOT_PREFIX_COMMISSIONED);
+    float base = station_buy_price(&st, COMMODITY_CRYSTAL_INGOT);
+    ASSERT_EQ_FLOAT(station_buy_price_unit(&st, &k),    2.5f  * base, 0.01f);
+    ASSERT_EQ_FLOAT(station_buy_price_unit(&st, &cm),  100.0f * base, 0.01f);
+}
+
+/* Test 6: NULL guards — defensive checks at the API boundary. Both
+ * NULL station and NULL unit return 0.0 without dereferencing. */
+TEST(test_prefix_pricing_null_guards) {
+    station_t st = {0};
+    st.base_price[COMMODITY_FERRITE_INGOT] = 24.0f;
+    cargo_unit_t u = make_unit(COMMODITY_FERRITE_INGOT, INGOT_PREFIX_M);
+    ASSERT_EQ_FLOAT(station_buy_price_unit(NULL, &u), 0.0f, 0.001f);
+    ASSERT_EQ_FLOAT(station_buy_price_unit(&st, NULL), 0.0f, 0.001f);
+    ASSERT_EQ_FLOAT(station_sell_price_unit(NULL, &u), 0.0f, 0.001f);
+    ASSERT_EQ_FLOAT(station_sell_price_unit(&st, NULL), 0.0f, 0.001f);
+}
+
+/* Test 7: out-of-range prefix_class falls back to 1.0× (anonymous).
+ * Defensive guard against malformed cargo_unit_t reaching pricing —
+ * we never want a negative array index to escape the multiplier
+ * lookup. */
+TEST(test_prefix_pricing_out_of_range_falls_back_to_baseline) {
+    station_t st = {0};
+    st.base_price[COMMODITY_FERRITE_INGOT] = 24.0f;
+    cargo_unit_t bad = make_unit(COMMODITY_FERRITE_INGOT, INGOT_PREFIX_ANONYMOUS);
+    bad.prefix_class = 0xFF;  /* invalid */
+    /* Falls back to 1.0× — same as commodity-only baseline. */
+    ASSERT_EQ_FLOAT(station_buy_price_unit(&st, &bad),
+                    station_buy_price(&st, COMMODITY_FERRITE_INGOT), 0.01f);
+}
+
+/* Test 8: manifest-style mixed-grade lineage. Sum of unit-scaled
+ * prices for one anonymous + one M-class + one RATi ferrite ingot
+ * matches the analytic 1+2+50 = 53× base. The intent is that haulers
+ * who bring rare lineage cargo see the scaling reflected in the
+ * aggregate sale value, not just the individual rows. */
+TEST(test_prefix_pricing_manifest_mixed_lineage_aggregates) {
+    station_t st = {0};
+    st.base_price[COMMODITY_FERRITE_INGOT] = 24.0f;
+    cargo_unit_t anon = make_unit(COMMODITY_FERRITE_INGOT, INGOT_PREFIX_ANONYMOUS);
+    cargo_unit_t m    = make_unit(COMMODITY_FERRITE_INGOT, INGOT_PREFIX_M);
+    cargo_unit_t r    = make_unit(COMMODITY_FERRITE_INGOT, INGOT_PREFIX_RATI);
+    float total = station_buy_price_unit(&st, &anon)
+                + station_buy_price_unit(&st, &m)
+                + station_buy_price_unit(&st, &r);
+    float base = station_buy_price(&st, COMMODITY_FERRITE_INGOT);
+    ASSERT_EQ_FLOAT(total, (1.0f + 2.0f + 50.0f) * base, 0.01f);
+}
+
+void register_prefix_class_pricing_tests(void) {
+    TEST_SECTION("Prefix-class price multiplier tests (#prefix-pricing):\n");
+    RUN(test_prefix_pricing_anonymous_baseline);
+    RUN(test_prefix_pricing_m_class_2x);
+    RUN(test_prefix_pricing_rati_class_50x);
+    RUN(test_prefix_pricing_compose_with_stock_curve);
+    RUN(test_prefix_pricing_k_class_and_commissioned);
+    RUN(test_prefix_pricing_null_guards);
+    RUN(test_prefix_pricing_out_of_range_falls_back_to_baseline);
+    RUN(test_prefix_pricing_manifest_mixed_lineage_aggregates);
+}


### PR DESCRIPTION
## Summary

Activates the cargo unit `prefix_class` field as a real economic dial. Until now the lineage substrate (RATi / M / H / T / S / F / K / commissioned) was purely cosmetic — the prefix told the player what hull class a unit could mint, but the dock price didn't move. After this PR, **RATi-prefix ingots literally pay more, at every transaction site, on every ledger.**

### The multiplier table

New `PREFIX_CLASS_PRICE_MULTIPLIER[]` in `shared/economy_const.h`:

| class | multiplier | rationale |
|-------|-----------:|-----------|
| anonymous   | 1.0×   | bulk material — existing economy unchanged |
| M / H / T / S / F | 2.0× | common single-letter classes |
| K           | 2.5×   | rarer letter |
| RATi        | 50.0×  | once-in-a-blue-moon strike — finding one is news |
| commissioned | 100.0× | Foundation-reserve top-end ceiling |

A bounds-checked accessor `prefix_class_price_multiplier(int)` falls back to 1.0× for any malformed/out-of-range index, so a corrupt cargo_unit_t can't escape the table.

### Pricing API

Two new functions in `src/commodity.{h,c}`:

```c
float station_buy_price_unit(const station_t*, const cargo_unit_t*);
float station_sell_price_unit(const station_t*, const cargo_unit_t*);
```

Both chain through the existing commodity-only pricing curve and layer the prefix multiplier on top. The original `station_buy_price` / `station_sell_price` are **unchanged** — they assume anonymous-class baseline, which is correct for aggregate display rows where no specific unit is selected.

### Composition

The dynamic stock-fill curve and the prefix multiplier compose **multiplicatively**:

- 50% hopper fill → buy curve = 0.75×
- RATi prefix → 50×
- combined → 24 × 0.75 × 50 = **900 cr** for one RATi ferrite ingot delivered to a half-full Prospect

Pinned by `test_prefix_pricing_compose_with_stock_curve`.

### Migrated callsites

- `server/main.c::NET_MSG_BUY_INGOT` and signed `BUY_INGOT` — replaced fixed `INGOT_PRICE_M/RATI/COMMISSIONED` with dynamic `station_sell_price_unit`. Anonymous units stay non-purchasable here.
- `server/main.c::NET_MSG_DELIVER_INGOT` — delivery credit scales by `station_buy_price_unit`; `INGOT_DELIVERY_CREDIT` is now a floor for anonymous-baseline edges.
- `server/sim_production.c::step_furnace_smelting` — smelt-payout projects the to-be-minted ingot units (deterministic via `hash_ingot`) and lifts `ore_value` by their mean prefix multiplier. Both player paths (tower-credit and fracturer-credit) inherit the lift. Skipped on `by_contract` paths by design.
- `src/station_ui.c::build_trade_rows` SELL rows — pick the highest prefix class observed in the (commodity, grade) bucket on the ship, scale the row's `unit_price`, and surface a class indicator (`M-FE Ingot`, `RATi-FE Ingot`, etc.) before the commodity name. `trade_row_t` gained a `prefix_class` field so the renderer and input handler walk the same data.

### Tests

8 new unit tests in `src/tests/test_prefix_class_pricing.c`:

1. anonymous-prefix unit prices identically to commodity-only baseline
2. M-class prices at 2.0× base
3. RATi-class prices at 50.0× base
4. stock-fill × prefix compose multiplicatively (24 × 0.75 × 50 = 900)
5. K-class = 2.5×; commissioned = 100×
6. NULL guards return 0.0 without dereferencing
7. out-of-range `prefix_class` falls back to 1.0× (anonymous baseline)
8. mixed-lineage manifest aggregates: 1 anon + 1 M + 1 RATi = 53× base

Total: **406 tests run / 406 pass** (was 398).

Native + wasm + signal_server + signal_test + signal_verify all build clean.

## Out of scope (follow-ups on top of this substrate)

- **Lineage-filtered contracts** — stations don't yet *demand* M-class specifically; they just *pay more* for it. Contract payouts pay flat `contract_price` (unchanged in this PR).
- **Origin-station premiums** — `cargo_unit_t.origin_station` doesn't yet drive geographic specialization (e.g. Kepler paying extra for Prospect-smelted ingots).
- **Player-class self-pricing** — a player whose pubkey has a high-class prefix doesn't yet receive any discount/premium on their own transactions.

Refs #479 (lineage substrate this enables), #496 (commission/contract work that becomes economically meaningful with this in place).

## Coordination

PR #500 (Layer D / cargo receipts) is being rebased against current main in parallel. That work touches `shared/cargo_receipt.{h,c}`, `server/main.c` BUY_INGOT/DELIVER_INGOT receipt-emit paths, and the save format. This PR only touches `server/main.c` ledger amounts (separate lines from receipt emission) and `src/economy.h`-area pricing — close-to-zero file overlap; rebase should be mechanical.

## Test plan

- [x] `cmake --build build --target signal_test` green
- [x] `./build/signal_test --quiet` → 406/406
- [x] `./build/signal_test --filter=prefix` → 8/8 new tests pass
- [x] native (`cmake --build build-native`) builds clean
- [x] wasm (`emcmake cmake -S . -B build-web && cmake --build build-web`) builds clean
- [ ] manual dock smoke: dock with a hold full of M-class ingots, verify SELL rows render with `M-FE Ingot` indicator and double the cr column
- [ ] manual smelt smoke: mine until an M-class fragment lands, watch ledger bump 2× anonymous baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)