### PR TITLE
fix(world_draw): guard against ghost local player during JOIN window

### DIFF
--- a/src/world_draw.c
+++ b/src/world_draw.c
@@ -1962,7 +1962,18 @@ void draw_remote_players(void) {
     };
     for (int i = 0; i < NET_MAX_PLAYERS; i++) {
         if (!players[i].active) continue;
+        /* Skip the local player — belt-and-suspenders: index match OR
+         * slot match OR colocated with the actual ship pos. The last
+         * guard catches the window between connect and JOIN arrival
+         * where neither id is populated yet and we'd otherwise draw
+         * a red/orange ghost ship on top of the local one. */
         if (i == (int)net_local_id()) continue;
+        if (i == g.local_player_slot) continue;
+        {
+            float dx = players[i].x - LOCAL_PLAYER.ship.pos.x;
+            float dy = players[i].y - LOCAL_PLAYER.ship.pos.y;
+            if (dx * dx + dy * dy < 4.0f) continue; /* within 2u = us */
+        }
         if (!on_screen(players[i].x, players[i].y, 50.0f)) continue;
         int ci = i % 6;
         float cr = colors[ci][0], cg = colors[ci][1], cb = colors[ci][2];


### PR DESCRIPTION
## Summary
- `draw_remote_players` only filtered the local player by `net_local_id()`, leaving a window between connect and JOIN ack where neither the net id nor slot id is populated and the local player rendered twice — once as the real ship, once as a colored ghost on top.
- Add two belt-and-suspenders guards: slot match against `g.local_player_slot`, and a 2u-radius colocation check against `LOCAL_PLAYER.ship.pos`.

## Test plan
- [x] `make test` (407/407 pass)
- [ ] Connect to live multiplayer; confirm no colored ghost ship appears at the local player's position during the JOIN handshake window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)