### PR TITLE
chore(economy): remove credit_pool starting seed (=10000)

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -4667,9 +4667,12 @@ void world_reset(world_t *w) {
     w->stations[0].ring_offset[0] = 0.0f;
     w->stations[0].ring_offset[1] = 1.05f;  /* ~60° offset — unique silhouette */
     rebuild_station_services(&w->stations[0]);
-    /* No inventory handout — the chain has to be earned. Stations only
-     * start with a credit pool to pay miners + haulers. */
-    w->stations[0].credit_pool = 10000.0f;
+    /* Stations are sovereign currency issuers; pool starts at 0 and
+     * tracks net issuance from genesis. Conservation invariant:
+     * credit_pool + Σ(player_balances_at_this_station) is constant
+     * per station. Pool can go arbitrarily negative as issuance
+     * outpaces redemption — that's the model, not a bug. */
+    w->stations[0].credit_pool = 0.0f;
     snprintf(w->stations[0].station_slug, sizeof(w->stations[0].station_slug), "prospect");
     snprintf(w->stations[0].currency_name, sizeof(w->stations[0].currency_name), "prospect vouchers");
     snprintf(w->stations[0].hail_message, sizeof(w->stations[0].hail_message),
@@ -4705,7 +4708,8 @@ void world_reset(world_t *w) {
     w->stations[1].ring_offset[0] = 0.0f;
     w->stations[1].ring_offset[1] = 2.40f;  /* ~137° offset */
     rebuild_station_services(&w->stations[1]);
-    w->stations[1].credit_pool = 10000.0f;
+    /* Sovereign issuer — see Prospect comment above. */
+    w->stations[1].credit_pool = 0.0f;
     snprintf(w->stations[1].station_slug, sizeof(w->stations[1].station_slug), "kepler");
     snprintf(w->stations[1].currency_name, sizeof(w->stations[1].currency_name), "kepler bonds");
     snprintf(w->stations[1].hail_message, sizeof(w->stations[1].hail_message),
@@ -4758,7 +4762,8 @@ void world_reset(world_t *w) {
     w->stations[2].ring_offset[1] = 0.52f;  /* ~30° offset */
     w->stations[2].ring_offset[2] = 1.83f;  /* ~105° offset */
     rebuild_station_services(&w->stations[2]);
-    w->stations[2].credit_pool = 10000.0f;
+    /* Sovereign issuer — see Prospect comment above. */
+    w->stations[2].credit_pool = 0.0f;
     snprintf(w->stations[2].station_slug, sizeof(w->stations[2].station_slug), "helios");
     snprintf(w->stations[2].currency_name, sizeof(w->stations[2].currency_name), "helios credits");
     snprintf(w->stations[2].hail_message, sizeof(w->stations[2].hail_message),

--- a/server/main.c
+++ b/server/main.c
@@ -1850,12 +1850,8 @@ static void load_world_state(void) {
         printf("[server] loaded session from %s\n", SAVE_PATH);
     } else {
         printf("[server] no session save -- fresh economy\n");
-        if (catalog_count > 0) {
-            for (int i = 0; i < MAX_STATIONS; i++) {
-                if (station_exists(&world.stations[i]) && world.stations[i].credit_pool == 0.0f)
-                    world.stations[i].credit_pool = 10000.0f;
-            }
-        }
+        /* Stations are sovereign currency issuers; no seed pool. The
+         * pool just tracks net issuance from genesis. */
         world_seed_station_manifests(&world);
     }
 

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -208,9 +208,9 @@ static bool read_station(FILE *f, station_t *s) {
     if (g_loaded_save_version >= 23) {
         READ_FIELD(f, s->credit_pool);
     } else {
-        /* Pre-v23 saves don't have this field — seed starter stations
-         * (indices 0-2) with a pool, others start at zero. */
-        s->credit_pool = (s->signal_range > 0.0f) ? 10000.0f : 0.0f;
+        /* Pre-v23 saves don't have this field. Stations are sovereign
+         * currency issuers; pool starts at 0 and floats with issuance. */
+        s->credit_pool = 0.0f;
     }
     return true;
 }

--- a/src/tests/test_sovereign_ledger.c
+++ b/src/tests/test_sovereign_ledger.c
@@ -131,29 +131,19 @@ TEST(test_sovereign_player_cannot_overspend_on_buy) {
  * really a smoke check that the sim's own logging doesn't somehow
  * funnel through TEST_WARN. With no in-code path emitting "pool low"
  * warnings, this should always hold.) */
-TEST(test_sovereign_no_spurious_warnings_on_positive_pool) {
+TEST(test_sovereign_no_spurious_warnings_on_normal_run) {
+    /* After the credit_pool seed was removed, all stations begin at 0
+     * and trend negative as miners get paid. The original test asserted
+     * "pool stayed positive AND no warning fired"; under the sovereign-
+     * issuer model, pool floats freely in either direction and the
+     * warning-free claim should hold regardless of sign. */
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     ASSERT(w != NULL);
     world_reset(w);
     int warnings_before = g_warnings;
-    /* Run for 30 sim-seconds. With no players, pools may drift down as
-     * NPCs deliver ore — we explicitly assert pool stays above zero
-     * over the run, so we're checking the "pool stayed positive AND no
-     * warning fired" regime. */
     for (int i = 0; i < (int)(30.0f / SIM_DT); i++) {
         world_sim_step(w, SIM_DT);
     }
-    /* Sanity: at least one station's pool stayed above its starting
-     * threshold. (We don't pin a specific number — just assert the run
-     * was in the "positive pool" regime, which is the precondition for
-     * the warning-free claim.) */
-    bool any_positive = false;
-    for (int s = 0; s < MAX_STATIONS; s++) {
-        if (w->stations[s].id != 0 && w->stations[s].credit_pool > 0.0f) {
-            any_positive = true; break;
-        }
-    }
-    ASSERT(any_positive);
     ASSERT_EQ_INT(g_warnings, warnings_before);
 }
 
@@ -186,6 +176,6 @@ void register_sovereign_ledger_tests(void) {
     RUN(test_sovereign_pool_can_go_negative);
     RUN(test_sovereign_negative_pool_still_pays_miner);
     RUN(test_sovereign_player_cannot_overspend_on_buy);
-    RUN(test_sovereign_no_spurious_warnings_on_positive_pool);
+    RUN(test_sovereign_no_spurious_warnings_on_normal_run);
     RUN(test_sovereign_save_load_preserves_negative_pool);
 }


### PR DESCRIPTION
## Summary
Stations were seeded with \`credit_pool = 10000.0f\` at \`world_reset\` and again on session-save fallback. The seed muddied the sovereign-issuer model — a station's pool tracks **net issuance from genesis**, not a 10k handout no one issued.

After this PR, stations begin at pool = 0 and float from there as miners get paid and players spend back. Conservation per station still holds.

## Depends on
- #502 (sovereign-station-ledgers, merged) — removed the \`credit_pool < 100\` floor checks on hauler respawn and contract generation. Without those removals, stations starting at 0 would refuse to spawn haulers or generate contracts.

## Changes
- \`server/game_sim.c\`: 3 station seed lines → 0.
- \`server/main.c\`: drop the post-load fallback that backfills 10000 when \`catalog_count > 0\`.
- \`server/sim_save.c\`: pre-v23 migration default → 0.
- \`src/tests/test_sovereign_ledger.c\`: renamed \`test_sovereign_no_spurious_warnings_on_positive_pool\` → \`_on_normal_run\`; the precondition (pool stays positive) no longer holds, but the warning-free claim does regardless of sign.

## Tests
412/412 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)