### PR TITLE
refactor(economy): credit_pool is derived from ledger, not stored

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -65,6 +65,20 @@ float ledger_balance(const station_t *st, const uint8_t *token) {
     return 0.0f;
 }
 
+/* Net currency this station has issued, derived from the ledger
+ * (single source of truth). Equal to -Σ(balance) over all entries.
+ * A positive value means the station has more in player accounts
+ * than has been redeemed — i.e. it's in net debt to its players.
+ *
+ * Was previously a stored `station_t::credit_pool` field with its
+ * own +=/-= mutations paired with ledger writes. The field is gone;
+ * conservation is structural now. */
+float station_credit_pool(const station_t *st) {
+    float total = 0.0f;
+    for (int i = 0; i < st->ledger_count; i++) total += st->ledger[i].balance;
+    return -total;
+}
+
 void ledger_earn(station_t *st, const uint8_t *token, float amount) {
     int idx = ledger_find_or_create(st, token);
     if (idx < 0) return;
@@ -79,36 +93,32 @@ bool ledger_spend(station_t *st, const uint8_t *token, float amount, ship_t *shi
     st->ledger[idx].balance -= amount;
     if (st->ledger[idx].balance < 0.0f) st->ledger[idx].balance = 0.0f;
     ship->stat_credits_spent += amount;
-    st->credit_pool += amount;
     return true;
 }
 
 /* Force a debit through even when the balance can't cover it. The
  * shortfall pushes the ledger into negative — the player owes the
  * station. Use for unrefusable services (spawn fee, mandatory repair)
- * where rejecting the spend would leave the ship in a worse state.
- * Conservation still holds: the station's credit_pool gains exactly
- * what the player loses. */
+ * where rejecting the spend would leave the ship in a worse state. */
 void ledger_force_debit(station_t *st, const uint8_t *token, float amount, ship_t *ship) {
     if (amount <= 0.0f) return;
     int idx = ledger_find_or_create(st, token);
     if (idx < 0) return;
     st->ledger[idx].balance -= amount;
     if (ship) ship->stat_credits_spent += amount;
-    st->credit_pool += amount;
 }
 
-/* Full-price transfer from the station's credit_pool to a ledger
- * entry — used for inter-station contract deliveries (no smelt cut,
- * unlike ledger_credit_supply). Pool may go negative; conservation
- * still holds. Caller is responsible for contract bookkeeping. */
+/* Full-price transfer from station to player ledger — used for
+ * inter-station contract deliveries (no smelt cut, unlike
+ * ledger_credit_supply). The credit appears on the player's ledger;
+ * the station's derived pool decreases by the same amount. Caller is
+ * responsible for contract bookkeeping. */
 void ledger_earn_from_pool(station_t *st, const uint8_t *token, float amount) {
     if (amount <= 0.0f) return;
     int idx = ledger_find_or_create(st, token);
     if (idx < 0) return;
     st->ledger[idx].balance += amount;
     st->ledger[idx].lifetime_supply += amount;
-    st->credit_pool -= amount;
 }
 
 void emit_event(world_t *w, sim_event_t ev) {
@@ -1068,7 +1078,9 @@ static bool try_sell_one_unit(world_t *w, server_player_t *sp,
         st->_inventory_cache[commodity] = MAX_PRODUCT_STOCK;
     manifest_mark_station_dirty(w, &st->manifest);
 
-    st->credit_pool -= graded_price;
+    /* Pool decrement is implicit via ledger_earn; pool is now derived
+     * from -Σ(balance), so the credit on the player's ledger naturally
+     * shows up as a deeper net-issuance for the station. */
     ledger_earn(st, sp->session_token, graded_price);
     sp->ship.stat_credits_earned += graded_price;
     SIM_LOG("[sim] player %d sold 1× %s (grade %d) for %.0f cr at %s\n",
@@ -1224,10 +1236,9 @@ static void try_sell_station_cargo(world_t *w, server_player_t *sp) {
     }
 
     if (payout > 0.01f) {
-        /* Stations carry the debt — pool may go negative; conservation
-         * still holds because the credit minted on the player ledger
-         * is matched by the deficit on the station pool. */
-        st->credit_pool -= payout;
+        /* Stations carry the debt — pool is derived from -Σ(balance),
+         * so crediting the player's ledger naturally pushes the station's
+         * net issuance more negative. Conservation is structural. */
         {
             ledger_earn(st, sp->session_token, payout);
             sp->ship.stat_credits_earned += payout;
@@ -2491,9 +2502,10 @@ static void step_mining_system(world_t *w, server_player_t *sp, float dt, bool m
 
 /* Find or create a ledger entry for a player at a station.
  * When the 16-slot table is full, evict the entry with the smallest
- * lifetime_supply (the least-active contributor). Their remaining
- * balance is returned to the station's credit_pool so the money
- * supply stays conserved. */
+ * lifetime_supply (the least-active contributor). Their balance is
+ * dropped on eviction; since pool is derived from -Σ(balance),
+ * removing an entry naturally absorbs its balance back into the
+ * station's net issuance. */
 static int ledger_find_or_create(station_t *st, const uint8_t *token) {
     for (int i = 0; i < st->ledger_count; i++) {
         if (memcmp(st->ledger[i].player_token, token, 8) == 0) return i;
@@ -2511,7 +2523,6 @@ static int ledger_find_or_create(station_t *st, const uint8_t *token) {
                 evict = i;
             }
         }
-        st->credit_pool += st->ledger[evict].balance;
         idx = evict;
     }
     memcpy(st->ledger[idx].player_token, token, 8);
@@ -2531,7 +2542,8 @@ float ledger_credit_supply_amount(station_t *st, const uint8_t *token, float ore
     /* Station keeps 35% cut for smelting — supplier gets 65% */
     float supplier_share = ore_value * 0.65f;
     if (supplier_share < 0.01f) return 0.0f;
-    st->credit_pool -= supplier_share;
+    /* Pool is derived from -Σ(balance); crediting the supplier here
+     * automatically pushes the station's net issuance more negative. */
     st->ledger[idx].balance += supplier_share;
     st->ledger[idx].lifetime_supply += ore_value;
     return supplier_share;
@@ -3530,7 +3542,7 @@ static void step_contracts(world_t *w, float dt) {
 
         /* Pool factor: rich stations offer better prices.
          * 0.2x at 1000 cr, 1.0x at 5000 cr, 1.5x at 10000+ cr */
-        float pool_factor = st->credit_pool / 5000.0f;
+        float pool_factor = station_credit_pool(st) / 5000.0f;
         if (pool_factor < 0.2f) pool_factor = 0.2f;
         if (pool_factor > 1.5f) pool_factor = 1.5f;
 
@@ -4667,12 +4679,10 @@ void world_reset(world_t *w) {
     w->stations[0].ring_offset[0] = 0.0f;
     w->stations[0].ring_offset[1] = 1.05f;  /* ~60° offset — unique silhouette */
     rebuild_station_services(&w->stations[0]);
-    /* Stations are sovereign currency issuers; pool starts at 0 and
-     * tracks net issuance from genesis. Conservation invariant:
-     * credit_pool + Σ(player_balances_at_this_station) is constant
-     * per station. Pool can go arbitrarily negative as issuance
-     * outpaces redemption — that's the model, not a bug. */
-    w->stations[0].credit_pool = 0.0f;
+    /* Stations are sovereign currency issuers. Net issuance is derived
+     * from -Σ(ledger.balance) via station_credit_pool(); conservation
+     * is structural. No initial pool seed — issuance starts at 0 and
+     * floats freely as miners get paid and players spend back. */
     snprintf(w->stations[0].station_slug, sizeof(w->stations[0].station_slug), "prospect");
     snprintf(w->stations[0].currency_name, sizeof(w->stations[0].currency_name), "prospect vouchers");
     snprintf(w->stations[0].hail_message, sizeof(w->stations[0].hail_message),
@@ -4708,8 +4718,6 @@ void world_reset(world_t *w) {
     w->stations[1].ring_offset[0] = 0.0f;
     w->stations[1].ring_offset[1] = 2.40f;  /* ~137° offset */
     rebuild_station_services(&w->stations[1]);
-    /* Sovereign issuer — see Prospect comment above. */
-    w->stations[1].credit_pool = 0.0f;
     snprintf(w->stations[1].station_slug, sizeof(w->stations[1].station_slug), "kepler");
     snprintf(w->stations[1].currency_name, sizeof(w->stations[1].currency_name), "kepler bonds");
     snprintf(w->stations[1].hail_message, sizeof(w->stations[1].hail_message),
@@ -4762,8 +4770,6 @@ void world_reset(world_t *w) {
     w->stations[2].ring_offset[1] = 0.52f;  /* ~30° offset */
     w->stations[2].ring_offset[2] = 1.83f;  /* ~105° offset */
     rebuild_station_services(&w->stations[2]);
-    /* Sovereign issuer — see Prospect comment above. */
-    w->stations[2].credit_pool = 0.0f;
     snprintf(w->stations[2].station_slug, sizeof(w->stations[2].station_slug), "helios");
     snprintf(w->stations[2].currency_name, sizeof(w->stations[2].currency_name), "helios credits");
     snprintf(w->stations[2].hail_message, sizeof(w->stations[2].hail_message),

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -644,15 +644,18 @@ vec2 station_approach_target(const station_t *st, vec2 from);
 void emit_event(world_t *w, sim_event_t ev);
 /* Station-local ledger economy */
 float ledger_balance(const station_t *st, const uint8_t *token);
+/* Net currency a station has issued, derived from the ledger as
+ * -Σ(balance) over all entries. Replaces the old stored credit_pool
+ * field; conservation is now structural. */
+float station_credit_pool(const station_t *st);
 void ledger_earn(station_t *st, const uint8_t *token, float amount);
 void ledger_credit_supply(station_t *st, const uint8_t *token, float ore_value);
 /* Like ledger_credit_supply but returns the actual amount credited
- * (post 35% smelt cut, post credit_pool cap). Use when emitting +N
- * popup events so they reflect what the player actually got. */
+ * (post 35% smelt cut). Use when emitting +N popup events so they
+ * reflect what the player actually got. */
 float ledger_credit_supply_amount(station_t *st, const uint8_t *token, float ore_value);
 /* Returns false if the player can't afford `amount` at this station;
- * otherwise debits the ledger, refunds the credit_pool, and bumps the
- * ship's stat_credits_spent. */
+ * otherwise debits the ledger and bumps the ship's stat_credits_spent. */
 bool ledger_spend(station_t *st, const uint8_t *token, float amount, ship_t *ship);
 /* Always-succeeds debit for unrefusable services (spawn, repair).
  * Allows the balance to go negative (debt). */

--- a/server/net_protocol.h
+++ b/server/net_protocol.h
@@ -474,7 +474,9 @@ static inline int serialize_stations(uint8_t *buf, const station_t *stations) {
         p[0] = (uint8_t)i;
         for (int c = 0; c < COMMODITY_COUNT; c++)
             write_f32_le(&p[1 + c * 4], st->_inventory_cache[c]);
-        write_f32_le(&p[1 + COMMODITY_COUNT * 4], st->credit_pool);
+        /* Derived from -Σ(ledger.balance); the field was removed but
+         * the wire shape is preserved so old clients still parse. */
+        write_f32_le(&p[1 + COMMODITY_COUNT * 4], station_credit_pool(st));
         count++;
     }
     buf[0] = NET_MSG_WORLD_STATIONS;

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -78,14 +78,15 @@ static uint32_t crc32_file(FILE *f) {
 }
 
 #define SAVE_MAGIC 0x5349474E  /* "SIGN" */
-#define SAVE_VERSION 42  /* Layer D of #479 — per-ship cargo_receipt_t chains
-                          * persisted alongside the ship manifest tail in
-                          * each player save (PLY7). v41 saves migrate
-                          * forward with empty receipt chains; the loading
-                          * station treats existing cargo as origin-attested
-                          * and signs a fresh receipt on the next
-                          * transaction. world.sav format itself is
-                          * unchanged at v42 (layout matches v41).
+#define SAVE_VERSION 43  /* credit_pool field eliminated — pool is now derived
+                          * from -Σ(ledger.balance) via station_credit_pool().
+                          * world.sav drops 4 bytes per existing station in
+                          * write_station_session; v42 saves still load (the
+                          * stored value is read into a discard then ignored —
+                          * the value is recomputable from the loaded ledger).
+                          * v42 (Layer D #479): per-ship cargo_receipt_t
+                          * chains persisted alongside the ship manifest
+                          * tail in each player save (PLY7).
                           * v41 (Layer C): per-station chain log state
                           * (chain_last_hash 32B + chain_event_count 8B). */
 /* v40: Layer B of #479 — per-station Ed25519 pubkey + outpost
@@ -204,13 +205,12 @@ static bool read_station(FILE *f, station_t *s) {
     READ_FIELD(f, s->planned);
     { uint8_t raw; memcpy(&raw, &s->planned, 1); s->planned = (raw != 0); }
     READ_FIELD(f, s->planned_owner);
-    /* v23: station credit pool */
-    if (g_loaded_save_version >= 23) {
-        READ_FIELD(f, s->credit_pool);
-    } else {
-        /* Pre-v23 saves don't have this field. Stations are sovereign
-         * currency issuers; pool starts at 0 and floats with issuance. */
-        s->credit_pool = 0.0f;
+    /* credit_pool field was stored in v23..v42 but is derived now (#refactor).
+     * Read and discard for older saves; v43+ doesn't include it on disk. */
+    if (g_loaded_save_version >= 23 && g_loaded_save_version <= 42) {
+        float discard;
+        READ_FIELD(f, discard);
+        (void)discard;
     }
     return true;
 }
@@ -231,8 +231,7 @@ static bool write_station_session(FILE *f, const station_t *s) {
         WRITE_FIELD(f, s->module_input[m]);
     for (int m = 0; m < MAX_MODULES_PER_STATION; m++)
         WRITE_FIELD(f, s->module_output[m]);
-    /* Station credit pool */
-    WRITE_FIELD(f, s->credit_pool);
+    /* (credit_pool field removed in v43 — derived from ledger now.) */
     /* Economy ledger */
     WRITE_FIELD(f, s->ledger_count);
     for (int i = 0; i < 16; i++) {
@@ -301,8 +300,14 @@ static bool read_station_session(FILE *f, station_t *s) {
         READ_FIELD(f, s->module_input[m]);
     for (int m = 0; m < MAX_MODULES_PER_STATION; m++)
         READ_FIELD(f, s->module_output[m]);
-    /* Station credit pool */
-    READ_FIELD(f, s->credit_pool);
+    /* credit_pool was stored v23..v42; dropped in v43 (derived field).
+     * For older saves, read and discard; the value is recoverable from
+     * the ledger entries below. */
+    if (g_loaded_save_version >= 23 && g_loaded_save_version <= 42) {
+        float discard;
+        READ_FIELD(f, discard);
+        (void)discard;
+    }
     /* Economy ledger */
     READ_FIELD(f, s->ledger_count);
     if (s->ledger_count < 0) s->ledger_count = 0;

--- a/shared/types.h
+++ b/shared/types.h
@@ -352,9 +352,9 @@ typedef struct {
      * manufacture). Service modules leave both at 0. */
     float module_input[MAX_MODULES_PER_STATION];
     float module_output[MAX_MODULES_PER_STATION];
-    /* Station credit pool: fixed money supply, no inflation.
-     * Smelting pays from pool, player spending refills it. */
-    float credit_pool;
+    /* (credit_pool field removed — derived from -Σ(ledger.balance) via
+     *  station_credit_pool() in server/game_sim.h. Conservation is
+     *  structural now; there is no separate stored aggregate.) */
     /* Station cargo manifest — single source of identity for stocked
      * units (named ingots + fabricated goods). Refinery pushes a unit
      * per smelt; shipyards consume units to mint hulls bound to the

--- a/src/net_sync.c
+++ b/src/net_sync.c
@@ -138,11 +138,14 @@ void apply_remote_npcs(const NetNpcState* npcs, int count) {
 }
 
 void apply_remote_stations(uint8_t index, const float* inventory, float credit_pool) {
+    /* credit_pool is now derived server-side from -Σ(ledger.balance);
+     * still arrives over the wire for protocol stability but no client
+     * code reads it, so we discard it here. */
+    (void)credit_pool;
     if (index >= MAX_STATIONS) return;
     station_t* st = &g.world.stations[index];
     for (int i = 0; i < COMMODITY_COUNT; i++)
         st->_inventory_cache[i] = inventory[i];
-    st->credit_pool = credit_pool;
 }
 
 /* Phase 2 wire: server → client station manifest summary. Fully

--- a/src/tests/test_econ_sim.c
+++ b/src/tests/test_econ_sim.c
@@ -6,9 +6,9 @@ TEST(test_econ_sim_npc_only_5min) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     ASSERT(w != NULL);
     world_reset(w);
-    float pool0 = w->stations[0].credit_pool;
-    float pool1 = w->stations[1].credit_pool;
-    float pool2 = w->stations[2].credit_pool;
+    float pool0 = station_credit_pool(&w->stations[0]);
+    float pool1 = station_credit_pool(&w->stations[1]);
+    float pool2 = station_credit_pool(&w->stations[2]);
     printf("    t=0: pools [%.0f, %.0f, %.0f]\n", pool0, pool1, pool2);
 
     int ticks = (int)(300.0f / SIM_DT); /* 5 minutes */
@@ -18,7 +18,7 @@ TEST(test_econ_sim_npc_only_5min) {
             float t = (float)i * SIM_DT;
             printf("    t=%.0fs: pools [%.0f, %.0f, %.0f]  ingots [FE=%.0f CU=%.0f CR=%.0f]  frames=%.0f\n",
                 t,
-                w->stations[0].credit_pool, w->stations[1].credit_pool, w->stations[2].credit_pool,
+                station_credit_pool(&w->stations[0]), station_credit_pool(&w->stations[1]), station_credit_pool(&w->stations[2]),
                 w->stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT],
                 w->stations[2]._inventory_cache[COMMODITY_CUPRITE_INGOT],
                 w->stations[2]._inventory_cache[COMMODITY_CRYSTAL_INGOT],
@@ -73,14 +73,14 @@ TEST(test_econ_sim_npc_only_5min) {
         }
     }
     printf("    t=300s: pools [%.0f, %.0f, %.0f]\n",
-        w->stations[0].credit_pool, w->stations[1].credit_pool, w->stations[2].credit_pool);
+        station_credit_pool(&w->stations[0]), station_credit_pool(&w->stations[1]), station_credit_pool(&w->stations[2]));
     printf("    total credits: %.0f (started at %.0f)\n",
-        w->stations[0].credit_pool + w->stations[1].credit_pool + w->stations[2].credit_pool,
+        station_credit_pool(&w->stations[0]) + station_credit_pool(&w->stations[1]) + station_credit_pool(&w->stations[2]),
         pool0 + pool1 + pool2);
 
     /* Invariant: total credits in station pools should not increase
      * (NPC smelting pays from pool, no player spending to refill) */
-    float total_now = w->stations[0].credit_pool + w->stations[1].credit_pool + w->stations[2].credit_pool;
+    float total_now = station_credit_pool(&w->stations[0]) + station_credit_pool(&w->stations[1]) + station_credit_pool(&w->stations[2]);
     ASSERT(total_now <= pool0 + pool1 + pool2 + 0.01f);
     /* w auto-freed by WORLD_HEAP cleanup */
 }
@@ -98,8 +98,8 @@ TEST(test_econ_sim_credit_circulation) {
     player_seed_credits(&w.players[0], &w);
     w.players[0].connected = true;
 
-    float initial_pool_0 = w.stations[0].credit_pool;
-    float initial_pool_1 = w.stations[1].credit_pool;
+    float initial_pool_0 = station_credit_pool(&w.stations[0]);
+    float initial_pool_1 = station_credit_pool(&w.stations[1]);
 
     float bal0 = ledger_balance(&w.stations[0], token);
     printf("    initial: bal@prospect=%.0f  prospect=%.0f  kepler=%.0f\n",
@@ -109,7 +109,7 @@ TEST(test_econ_sim_credit_circulation) {
     ledger_credit_supply(&w.stations[0], token, 100.0f); /* 100 cr ore value */
 
     printf("    after smelt: prospect pool=%.0f (paid out from pool)\n",
-        w.stations[0].credit_pool);
+        station_credit_pool(&w.stations[0]));
 
     /* Hail at Prospect — informational only, no withdrawal */
     w.players[0].ship.pos = w.stations[0].pos;
@@ -120,7 +120,7 @@ TEST(test_econ_sim_credit_circulation) {
 
     bal0 = ledger_balance(&w.stations[0], token);
     printf("    after hail: bal@prospect=%.0f  prospect pool=%.0f\n",
-        bal0, w.stations[0].credit_pool);
+        bal0, station_credit_pool(&w.stations[0]));
 
     /* Dock at Prospect and buy ferrite ingots (spends from station 0 ledger) */
     w.players[0].docked = true;
@@ -133,7 +133,7 @@ TEST(test_econ_sim_credit_circulation) {
 
     bal0 = ledger_balance(&w.stations[0], token);
     printf("    after buy at prospect: bal@prospect=%.0f  prospect pool=%.0f  cargo FE=%0.f\n",
-        bal0, w.stations[0].credit_pool,
+        bal0, station_credit_pool(&w.stations[0]),
         w.players[0].ship.cargo[COMMODITY_FERRITE_INGOT]);
 
     /* Deliver ingots to Kepler via contract */
@@ -153,7 +153,7 @@ TEST(test_econ_sim_credit_circulation) {
 
     float bal1 = ledger_balance(&w.stations[1], token);
     printf("    after deliver to kepler: bal@kepler=%.0f  kepler pool=%.0f\n",
-        bal1, w.stations[1].credit_pool);
+        bal1, station_credit_pool(&w.stations[1]));
 
     /* Buy frames from Kepler (spends from station 1 ledger) */
     w.stations[1]._inventory_cache[COMMODITY_FRAME] = 20.0f;
@@ -165,21 +165,21 @@ TEST(test_econ_sim_credit_circulation) {
     bal0 = ledger_balance(&w.stations[0], token);
     bal1 = ledger_balance(&w.stations[1], token);
     printf("    after buy frames: bal@kepler=%.0f  kepler pool=%.0f  cargo frames=%.0f\n",
-        bal1, w.stations[1].credit_pool,
+        bal1, station_credit_pool(&w.stations[1]),
         w.players[0].ship.cargo[COMMODITY_FRAME]);
 
     /* Total system credits = all station pools + all player ledger balances */
     float total_credits = bal0 + bal1
-        + w.stations[0].credit_pool
-        + w.stations[1].credit_pool
-        + w.stations[2].credit_pool;
+        + station_credit_pool(&w.stations[0])
+        + station_credit_pool(&w.stations[1])
+        + station_credit_pool(&w.stations[2]);
     /* Total = all station pools + all player ledger balances.
      * initial_pool_0 already reflects the spawn fee being added to the
      * pool by player_seed_credits — so the player's starting balance
      * is the negative of that fee, and conservation is the sum of
      * pools + the negative seed. */
     float initial_seed = -(float)station_spawn_fee(&w.stations[0]);
-    float initial_total = initial_seed + initial_pool_0 + initial_pool_1 + w.stations[2].credit_pool;
+    float initial_total = initial_seed + initial_pool_0 + initial_pool_1 + station_credit_pool(&w.stations[2]);
     printf("    total system credits: %.0f (started at %.0f)\n",
         total_credits, initial_total);
 
@@ -218,7 +218,7 @@ TEST(test_bug312_1_docked_buy_honors_spend_failure) {
     w.players[0].docked = true;
     w.players[0].current_station = kepler;
     st->_inventory_cache[COMMODITY_FRAME] = 10.0f;
-    float pool_before = st->credit_pool;
+    float pool_before = station_credit_pool(st);
     float cargo_before = w.players[0].ship.cargo[COMMODITY_FRAME];
 
     w.players[0].input.buy_product = true;
@@ -233,7 +233,7 @@ TEST(test_bug312_1_docked_buy_honors_spend_failure) {
      * because ledger_spend still returns false — the whole point is
      * "cargo moved without payment"). */
     ASSERT_EQ_FLOAT(w.players[0].ship.cargo[COMMODITY_FRAME], cargo_before, 0.001f);
-    ASSERT_EQ_FLOAT(st->credit_pool, pool_before, 0.001f);
+    ASSERT_EQ_FLOAT(station_credit_pool(st), pool_before, 0.001f);
 }
 
 TEST(test_buy_finished_good_requires_manifest_unit) {
@@ -322,7 +322,7 @@ TEST(test_bug312_2_ledger_balance_matches_by_token) {
 TEST(test_bug312_3_init_ship_does_not_seed_with_zero_token) {
     WORLD_DECL;
     world_reset(&w);
-    float pool_before = w.stations[0].credit_pool;
+    float pool_before = station_credit_pool(&w.stations[0]);
     int ledger_before = w.stations[0].ledger_count;
 
     /* Intentionally leave session_token zeroed — simulates the race
@@ -333,7 +333,7 @@ TEST(test_bug312_3_init_ship_does_not_seed_with_zero_token) {
 
     /* Post-fix: no ledger entry, no pool withdrawal. */
     ASSERT_EQ_INT(w.stations[0].ledger_count, ledger_before);
-    ASSERT_EQ_FLOAT(w.stations[0].credit_pool, pool_before, 0.001f);
+    ASSERT_EQ_FLOAT(station_credit_pool(&w.stations[0]), pool_before, 0.001f);
 
     /* Now set the real token and seed — the spawn-fee debit should
      * land on the real token, push it into debt, and no zero-token
@@ -347,12 +347,12 @@ TEST(test_bug312_3_init_ship_does_not_seed_with_zero_token) {
     ASSERT_EQ_FLOAT(ledger_balance(&w.stations[0], token), -(float)fee, 0.001f);
     uint8_t zero[8] = {0};
     ASSERT_EQ_FLOAT(ledger_balance(&w.stations[0], zero), 0.0f, 0.001f);
-    ASSERT_EQ_FLOAT(w.stations[0].credit_pool, pool_before + (float)fee, 0.001f);
+    ASSERT_EQ_FLOAT(station_credit_pool(&w.stations[0]), pool_before + (float)fee, 0.001f);
 
     /* Re-seed is idempotent (guard against double-charge on reconnect). */
     player_seed_credits(&w.players[0], &w);
     ASSERT_EQ_FLOAT(ledger_balance(&w.stations[0], token), -(float)fee, 0.001f);
-    ASSERT_EQ_FLOAT(w.stations[0].credit_pool, pool_before + (float)fee, 0.001f);
+    ASSERT_EQ_FLOAT(station_credit_pool(&w.stations[0]), pool_before + (float)fee, 0.001f);
 }
 
 TEST(test_econ_invariant_npc_only_conservation) {

--- a/src/tests/test_harness.c
+++ b/src/tests/test_harness.c
@@ -188,7 +188,7 @@ double econ_total_credits(const world_t *w) {
     for (int s = 0; s < MAX_STATIONS; s++) {
         const station_t *st = &w->stations[s];
         if (st->id == 0) continue;
-        total += (double)st->credit_pool;
+        total += (double)station_credit_pool(st);
         for (int i = 0; i < st->ledger_count; i++)
             total += (double)st->ledger[i].balance;
     }

--- a/src/tests/test_save.c
+++ b/src/tests/test_save.c
@@ -564,7 +564,8 @@ TEST(test_world_save_load_preserves_smelted_ingots) {
  * (chain_last_hash 32B + chain_event_count 8B) = +40B per station ×
  * MAX_STATIONS=64 = +2560 bytes. The chain event records themselves
  * live in side files under chain/<pubkey>.log, NOT in world.sav. */
-#define EXPECTED_SAVE_SIZE ((269292 - (4 + 64 * 56) * 64) + 4 + 4 + 2 + 64 * 104 + 64 * 40) /* v41 */
+/* v43: credit_pool field dropped (-4 bytes × 64 stations = -256). */
+#define EXPECTED_SAVE_SIZE ((269292 - (4 + 64 * 56) * 64) + 4 + 4 + 2 + 64 * 104 + 64 * 40 - 64 * 4)
 
 TEST(test_save_file_size_stable) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
@@ -601,7 +602,7 @@ TEST(test_save_header_golden_bytes) {
     ASSERT_EQ_INT((int)fread(&spawn_timer, 4, 1, f), 1);
     fclose(f);
     ASSERT_EQ_INT((int)magic, (int)0x5349474E);    /* "SIGN" */
-    ASSERT_EQ_INT((int)version, 42);
+    ASSERT_EQ_INT((int)version, 43);
     ASSERT(rng != 0);  /* seed is set */
     ASSERT_EQ_FLOAT(time_val, 0.0f, 0.001f);
     ASSERT_EQ_FLOAT(spawn_timer, 0.0f, 0.001f);

--- a/src/tests/test_sovereign_ledger.c
+++ b/src/tests/test_sovereign_ledger.c
@@ -26,7 +26,7 @@ TEST(test_sovereign_pool_can_go_negative) {
     world_reset(w);
 
     station_t *st = &w->stations[0];
-    float start_pool = st->credit_pool;
+    float start_pool = station_credit_pool(st);
     /* Pay out far more than the starting pool so we cross zero. */
     uint8_t token[8] = {0xAA,1,2,3,4,5,6,7};
     /* Each ledger_credit_supply pays 65% of ore_value to the player and
@@ -35,7 +35,7 @@ TEST(test_sovereign_pool_can_go_negative) {
     float ore_value = (start_pool + 10000.0f) / 0.65f;
     float credited = ledger_credit_supply_amount(st, token, ore_value);
     ASSERT(credited > 0.0f);
-    ASSERT(st->credit_pool < 0.0f);
+    ASSERT(station_credit_pool(st) < 0.0f);
     /* And the player's ledger entry got the full supplier share — not
      * clamped because the pool would have gone negative. */
     ASSERT_EQ_FLOAT(ledger_balance(st, token), credited, 0.01f);
@@ -45,7 +45,7 @@ TEST(test_sovereign_pool_can_go_negative) {
     for (int i = 0; i < 240; i++) world_sim_step(w, SIM_DT);
     /* Pool should still be a finite number (could have moved further
      * negative as NPCs delivered more ore). */
-    ASSERT(isfinite(st->credit_pool));
+    ASSERT(isfinite(station_credit_pool(st)));
 }
 
 /* Test 2: a station with deeply negative pool still pays a miner.
@@ -58,8 +58,13 @@ TEST(test_sovereign_negative_pool_still_pays_miner) {
     world_reset(w);
 
     station_t *st = &w->stations[0];
-    st->credit_pool = -5000.0f;
-    float pool_before = st->credit_pool;
+    /* Drive the pool to ~ -5000 by minting that much in a sentinel
+     * ledger entry. Pool is now derived from -Σ(balance), so the
+     * straightforward way to "set" it is to credit a victim balance. */
+    uint8_t seed_token[8] = {0xCC,0,0,0,0,0,0,0};
+    ledger_earn(st, seed_token, 5000.0f);
+    float pool_before = station_credit_pool(st);
+    ASSERT_EQ_FLOAT(pool_before, -5000.0f, 0.5f);
 
     uint8_t token[8] = {0xBB,1,2,3,4,5,6,7};
     float supplier_share = ledger_credit_supply_amount(st, token, 100.0f);
@@ -68,8 +73,8 @@ TEST(test_sovereign_negative_pool_still_pays_miner) {
     ASSERT_EQ_FLOAT(supplier_share, 65.0f, 0.5f);
     ASSERT_EQ_FLOAT(ledger_balance(st, token), supplier_share, 0.01f);
     /* Pool moved by exactly the supplier share — not clamped at any floor. */
-    ASSERT_EQ_FLOAT(st->credit_pool, pool_before - supplier_share, 0.5f);
-    ASSERT(st->credit_pool < pool_before);
+    ASSERT_EQ_FLOAT(station_credit_pool(st), pool_before - supplier_share, 0.5f);
+    ASSERT(station_credit_pool(st) < pool_before);
 }
 
 /* Test 3: players still cannot go negative on a BUY.
@@ -149,14 +154,17 @@ TEST(test_sovereign_no_spurious_warnings_on_normal_run) {
 
 /* Test 5: save/load round-trips a negative pool exactly.
  *
- * Pre-fix, no path could produce a negative pool, so the save format
- * was effectively only validated against non-negative floats. Pin that
- * the float field round-trips precisely for negative values too. */
+ * Pool is now derived from -Σ(ledger.balance), so we can't write a
+ * float directly. Mint a known balance into a sentinel ledger entry,
+ * verify the implied pool, save, load, verify the ledger entry is
+ * preserved and the pool re-derives to the same value. */
 TEST(test_sovereign_save_load_preserves_negative_pool) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     ASSERT(w != NULL);
     world_reset(w);
-    w->stations[0].credit_pool = -1234.5f;
+    uint8_t token[8] = {0xDD,1,2,3,4,5,6,7};
+    ledger_earn(&w->stations[0], token, 1234.5f);
+    ASSERT_EQ_FLOAT(station_credit_pool(&w->stations[0]), -1234.5f, 0.001f);
 
     ASSERT(station_catalog_save_all(w->stations, MAX_STATIONS, TMP("sov_cat")));
     ASSERT(world_save(w, TMP("sov_neg.sav")));
@@ -166,7 +174,8 @@ TEST(test_sovereign_save_load_preserves_negative_pool) {
     station_catalog_load_all(loaded->stations, MAX_STATIONS, TMP("sov_cat"));
     ASSERT(world_load(loaded, TMP("sov_neg.sav")));
 
-    ASSERT_EQ_FLOAT(loaded->stations[0].credit_pool, -1234.5f, 0.001f);
+    ASSERT_EQ_FLOAT(ledger_balance(&loaded->stations[0], token), 1234.5f, 0.001f);
+    ASSERT_EQ_FLOAT(station_credit_pool(&loaded->stations[0]), -1234.5f, 0.001f);
 
     remove(TMP("sov_neg.sav"));
 }


### PR DESCRIPTION
## Summary
The \`station_t::credit_pool\` field is gone. Pool is now derived on-demand via \`station_credit_pool(st)\` returning \`-Σ(balance)\` over the station's ledger entries. Conservation becomes structural instead of a convention upheld by paired \`+=\`/\`-=\` mutations.

## Why this works
Every live mutation site was already conservation-preserving:
- \`ledger_spend\` / \`ledger_force_debit\`: balance↓ paired with pool↑.
- \`ledger_earn_from_pool\` / supplier_share: balance↑ paired with pool↓.
- Eviction sweep: removed entry's balance returned to pool.
- Standalone \`pool -= price\` lines at sales sites: paired with the next-line \`ledger_earn(amount)\`.

The only unpaired callsite was the pre-v23 save migration's \`ledger_earn\` (minted balances with no pool counterparty). Post-refactor that becomes consistent: minting a balance makes the station's net issuance more negative.

## Wire & save
- Wire shape unchanged. Server computes \`station_credit_pool(st)\` and writes; old clients parse the same 41-byte station record. Client side discards the value (no UI uses it).
- SAVE_VERSION 42 → 43. v23..v42 saves had a 4-byte credit_pool field per station; v43 drops it. Migration reads-and-discards from older saves; the value is recoverable from the loaded ledger.
- EXPECTED_SAVE_SIZE shrinks by 4 × 64 = 256 bytes.

## Verification
- 420/420 tests pass at -O2.
- Native client, signal_server, wasm all build clean.
- v42 save migration validated by the existing test_save backward-compat path.

## Coordination notes
This PR is the conceptual sibling of #505 (seed removal) and #502 (sovereign ledgers): together they collapse credit_pool from "a stored money-supply scalar" to "a derived view over the per-station ledger." The model now matches the user's guidance: stations are sovereign issuers; debt is currency; conservation is structural.

🤖 Generated with [Claude Code](https://claude.com/claude-code)