### PR TITLE
feat(visual): middle furnace glows by last-smelted ore

### DIFF
--- a/server/sim_construction.c
+++ b/server/sim_construction.c
@@ -39,6 +39,7 @@ void add_module_at(station_t *st, module_type_t type, uint8_t arm, uint8_t chain
     m->slot = chain_pos;
     m->scaffold = false;
     m->build_progress = 1.0f;
+    m->last_smelt_commodity = LAST_SMELT_NONE;
 }
 
 void activate_outpost(world_t *w, int station_idx) {

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -294,6 +294,17 @@ void sim_step_refinery_production(world_t *w, float dt) {
             origin[7] = (uint8_t)('0' + (s % 10));
             uint16_t pre_mft_count = st->manifest.count;
             station_finished_accumulate(st, ingot, consume, origin);
+            /* Tag the producing furnace with this ore for the dynamic
+             * middle-ring glow render (cuprite → blue, crystal →
+             * green, ferrite → uses inner-ring red anyway). For
+             * multi-furnace stations the smelt logic round-robins
+             * across furnace_slots[]; mark the round-robin slot.
+             * Single-furnace stations: tag the lone furnace. */
+            if (n_slots > 0 && consume > 0.001f) {
+                int chosen = furnace_slots[next_furnace % n_slots];
+                st->modules[chosen].last_smelt_commodity = (uint8_t)ore;
+                next_furnace++;
+            }
             /* Layer C of #479: one EVT_SMELT per ingot minted. The
              * payload binds (fragment_pub, ingot_pub, prefix_class,
              * mined_block) to the station's signature. We don't know

--- a/shared/types.h
+++ b/shared/types.h
@@ -273,12 +273,24 @@ static inline const char *commodity_short_label(commodity_t c) {
     }
 }
 
+/* Sentinel value for station_module_t::last_smelt_commodity meaning
+ * "this furnace hasn't smelted anything yet." Renders as the static
+ * white chunks-feeder color in middle-ring furnaces. */
+#define LAST_SMELT_NONE 0xFFu
+
 typedef struct {
-    module_type_t type;
-    uint8_t ring;           /* which ring tier (0xFF=core, 1=inner, 2=mid, 3=outer) */
-    uint8_t slot;           /* position within ring (0..STATION_RING_SLOTS[ring]-1) */
-    bool scaffold;          /* under construction */
-    float build_progress;   /* 0.0 to 1.0 */
+    module_type_t type;     /* 4 bytes — int enum */
+    uint8_t ring;           /* 1: which ring tier (0xFF=core, 1=inner, 2=mid, 3=outer) */
+    uint8_t slot;           /* 1: position within ring (0..STATION_RING_SLOTS[ring]-1) */
+    bool    scaffold;       /* 1: under construction */
+    /* Most recent smelt-input commodity processed by this module, or
+     * LAST_SMELT_NONE if it's never smelted. Drives the middle-ring
+     * furnace glow (see station_palette.h::station_palette_furnace_color):
+     * cuprite-input → blue, crystal-input → green, otherwise white.
+     * Stored in the natural alignment pad before build_progress so the
+     * struct stays 12 bytes — no save-format bump. */
+    uint8_t last_smelt_commodity; /* 1 byte (was implicit pad) */
+    float   build_progress; /* 0.0 to 1.0 */
 } station_module_t;
 
 enum {

--- a/src/station_palette.h
+++ b/src/station_palette.h
@@ -50,16 +50,36 @@ static inline void station_palette_furnace_color(const station_t *st,
         else                     PAL_UNPACK3(PAL_FURNACE_CUPRITE, *r, *g, *b);
         return;
     }
-    /* 3+ furnaces: inner=crystal, outer=cuprite, middle=chunks. */
+    /* 3+ furnaces: inner=crystal, outer=cuprite, middle=chunks. The
+     * middle ring's color is dynamic: glows blue when the most recent
+     * smelt at this furnace was cuprite, green when crystal, white
+     * otherwise (fresh furnace or recent ferrite smelt). Reads
+     * station_module_t::last_smelt_commodity (set in
+     * sim_production.c::sim_step_refinery_production). */
     if (my_ring == min_ring) {
         PAL_UNPACK3(PAL_FURNACE_CRYSTAL, *r, *g, *b);
     } else if (my_ring == max_ring) {
         PAL_UNPACK3(PAL_FURNACE_CUPRITE, *r, *g, *b);
     } else {
-        /* TODO(#chunks-feeder): sim behavior — middle-ring furnace
-         * tractors fragments inward to feed outer smelters. Today this
-         * is render-only; the simulation treats it as a normal furnace. */
-        PAL_UNPACK3(PAL_FURNACE_CHUNKS, *r, *g, *b);
+        const station_module_t *mod = NULL;
+        for (int i = 0; i < st->module_count; i++) {
+            if (st->modules[i].type == MODULE_FURNACE &&
+                (int)st->modules[i].ring == my_ring) {
+                mod = &st->modules[i];
+                break;
+            }
+        }
+        uint8_t last = mod ? mod->last_smelt_commodity : LAST_SMELT_NONE;
+        if (last == COMMODITY_CUPRITE_ORE) {
+            PAL_UNPACK3(PAL_FURNACE_CUPRITE, *r, *g, *b);
+        } else if (last == COMMODITY_CRYSTAL_ORE) {
+            PAL_UNPACK3(PAL_FURNACE_CRYSTAL, *r, *g, *b);
+        } else {
+            /* TODO(#chunks-feeder): sim behavior — middle-ring furnace
+             * tractors fragments inward to feed outer smelters. Today
+             * the simulation treats it as a normal furnace. */
+            PAL_UNPACK3(PAL_FURNACE_CHUNKS, *r, *g, *b);
+        }
     }
 }
 

--- a/src/tests/test_furnace_color.c
+++ b/src/tests/test_furnace_color.c
@@ -35,6 +35,7 @@ static void make_station(station_t *st,
         st->modules[i].slot = (uint8_t)i;
         st->modules[i].scaffold = false;
         st->modules[i].build_progress = 1.0f;
+        st->modules[i].last_smelt_commodity = LAST_SMELT_NONE;
     }
 }
 
@@ -198,6 +199,48 @@ TEST(test_prospect_modules_after_silo_cleanup) {
     ASSERT_EQ_INT(has_silo, 0); /* dropped — hopper plays the intake role */
 }
 
+/* (6) Middle-ring dynamic glow: the helper reads
+ *     last_smelt_commodity on the matching middle-ring furnace and
+ *     renders blue (cuprite) / green (crystal) / white (other or
+ *     LAST_SMELT_NONE). */
+TEST(test_furnace_color_middle_ring_glows_by_last_smelt) {
+    station_t *st = calloc(1, sizeof(*st));
+    ASSERT(st != NULL);
+    module_type_t types[] = { MODULE_FURNACE, MODULE_FURNACE, MODULE_FURNACE };
+    uint8_t       rings[] = { 1, 2, 3 };
+    make_station(st, types, rings, 3);
+
+    /* Default (LAST_SMELT_NONE on all three): middle ring is white. */
+    float r = 0, g = 0, b = 0;
+    station_palette_furnace_color(st, 2, &r, &g, &b);
+    EXPECT_RGB(r, g, b, 0.85f, 0.85f, 0.90f);
+
+    /* Tag middle as cuprite-recent → middle glows blue. */
+    st->modules[1].last_smelt_commodity = (uint8_t)COMMODITY_CUPRITE_ORE;
+    station_palette_furnace_color(st, 2, &r, &g, &b);
+    EXPECT_RGB(r, g, b, 0.25f, 0.50f, 0.90f);
+
+    /* Tag middle as crystal-recent → middle glows green. */
+    st->modules[1].last_smelt_commodity = (uint8_t)COMMODITY_CRYSTAL_ORE;
+    station_palette_furnace_color(st, 2, &r, &g, &b);
+    EXPECT_RGB(r, g, b, 0.30f, 0.80f, 0.35f);
+
+    /* Ferrite or any other ore → falls back to white (no special
+     * inner-ring meaning at the middle). */
+    st->modules[1].last_smelt_commodity = (uint8_t)COMMODITY_FERRITE_ORE;
+    station_palette_furnace_color(st, 2, &r, &g, &b);
+    EXPECT_RGB(r, g, b, 0.85f, 0.85f, 0.90f);
+
+    /* Outer + inner are unaffected by middle's last_smelt setting. */
+    st->modules[1].last_smelt_commodity = (uint8_t)COMMODITY_CUPRITE_ORE;
+    station_palette_furnace_color(st, 1, &r, &g, &b);
+    EXPECT_RGB(r, g, b, 0.30f, 0.80f, 0.35f); /* inner stays crystal green */
+    station_palette_furnace_color(st, 3, &r, &g, &b);
+    EXPECT_RGB(r, g, b, 0.25f, 0.50f, 0.90f); /* outer stays cuprite blue */
+
+    free(st);
+}
+
 void register_furnace_color_tests(void) {
     TEST_SECTION("\nFurnace per-ring color render variants:\n");
     RUN(test_furnace_color_prospect_is_ferrite_red);
@@ -205,4 +248,5 @@ void register_furnace_color_tests(void) {
     RUN(test_furnace_color_outpost_growth_reshuffles);
     RUN(test_furnace_color_non_furnace_modules_unaffected);
     RUN(test_prospect_modules_after_silo_cleanup);
+    RUN(test_furnace_color_middle_ring_glows_by_last_smelt);
 }


### PR DESCRIPTION
## Summary
Builds on #509. Replaces the static-white middle-ring "chunks-feeder" furnace at multi-furnace stations with a glow that tracks the most recent smelt:
- cuprite ore → blue
- crystal ore → green
- ferrite ore (or none yet) → white

The simulation tracks this via a new \`uint8_t station_module_t.last_smelt_commodity\` field. Set in \`sim_step_refinery_production\` each smelt tick. Read by \`station_palette_furnace_color\` at render time.

## No save format bump
The new field is slotted into the existing alignment pad before \`build_progress\`, so \`sizeof(station_module_t)\` stays at 12 bytes. v43 saves load unchanged; new saves persist the value automatically.

## Verification
- 419/419 fast tests pass.
- New \`test_furnace_color_middle_ring_glows_by_last_smelt\` covers all four glow states.
- Inner/outer rings unaffected by middle-ring smelt history (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)