### PR TITLE
feat(modules): drop MODULE_ORE_SILO and MODULE_CARGO_BAY

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -4706,10 +4706,11 @@ void world_reset(world_t *w) {
     /* Kepler imports laser/tractor modules for its dock kit fab. */
     w->stations[1].base_price[COMMODITY_LASER_MODULE]   = 30.0f;
     w->stations[1].base_price[COMMODITY_TRACTOR_MODULE] = 38.0f;
-    /* Ring 1: dock + relay + ore silo */
+    /* Ring 1: dock + relay (slot 2 left empty — Kepler doesn't smelt
+     * so the storage that lived here was redundant; ORE_SILO was
+     * dropped along with MODULE_CARGO_BAY in the silo cleanup). */
     add_module_at(&w->stations[1], MODULE_DOCK, 1, 0);
     add_module_at(&w->stations[1], MODULE_SIGNAL_RELAY, 1, 1);
-    add_module_at(&w->stations[1], MODULE_ORE_SILO, 1, 2);
     /* Ring 2 (industrial): fabrication + services */
     add_module_at(&w->stations[1], MODULE_FRAME_PRESS, 2, 0);
     add_module_at(&w->stations[1], MODULE_LASER_FAB, 2, 1);
@@ -4755,17 +4756,15 @@ void world_reset(world_t *w) {
     add_module_at(&w->stations[2], MODULE_DOCK, 1, 0);
     add_module_at(&w->stations[2], MODULE_SIGNAL_RELAY, 1, 1);
     add_module_at(&w->stations[2], MODULE_FURNACE, 1, 2);
-    /* Ring 2: hopper + furnace + fabs + storage */
+    /* Ring 2: hopper + furnace + fabs (silo at slot 4 dropped — hopper
+     * absorbs the ore-storage role now that ORE_SILO is gone). */
     add_module_at(&w->stations[2], MODULE_HOPPER, 2, 0);
     add_module_at(&w->stations[2], MODULE_FURNACE, 2, 1);
     add_module_at(&w->stations[2], MODULE_LASER_FAB, 2, 2);
     add_module_at(&w->stations[2], MODULE_TRACTOR_FAB, 2, 3);
-    add_module_at(&w->stations[2], MODULE_ORE_SILO, 2, 4);
-    /* Ring 3: furnace + shipyard + overflow silos */
+    /* Ring 3: furnace + shipyard (overflow silos at slots 2-3 dropped). */
     add_module_at(&w->stations[2], MODULE_FURNACE, 3, 0);
     add_module_at(&w->stations[2], MODULE_SHIPYARD, 3, 1);
-    add_module_at(&w->stations[2], MODULE_ORE_SILO, 3, 2);
-    add_module_at(&w->stations[2], MODULE_ORE_SILO, 3, 3);
     w->stations[2].arm_count = 3;
     w->stations[2].arm_speed[0] = STATION_RING_SPEED;
     w->stations[2].ring_offset[0] = 0.0f;

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -78,7 +78,12 @@ static uint32_t crc32_file(FILE *f) {
 }
 
 #define SAVE_MAGIC 0x5349474E  /* "SIGN" */
-#define SAVE_VERSION 43  /* credit_pool field eliminated — pool is now derived
+#define SAVE_VERSION 44  /* MODULE_ORE_SILO (= 8) and MODULE_CARGO_BAY (= 10)
+                          * dropped; both remapped to MODULE_HOPPER (= 1)
+                          * on load. The hopper now serves as the unified
+                          * ore-intake-and-storage module. v43 saves load
+                          * with the remap applied automatically.
+                          * v43: credit_pool field eliminated — pool is now derived
                           * from -Σ(ledger.balance) via station_credit_pool().
                           * world.sav drops 4 bytes per existing station in
                           * write_station_session; v42 saves still load (the
@@ -1146,6 +1151,36 @@ bool world_load(world_t *w, const char *path) {
             int old_t = (int)w->scaffolds[i].module_type;
             if (old_t >= 0 && old_t < 13)
                 w->scaffolds[i].module_type = (module_type_t)FURNACE_REMAP[old_t];
+        }
+    }
+
+    /* v44 silo cleanup: MODULE_ORE_SILO (was 8) and MODULE_CARGO_BAY
+     * (was 10) were dropped; HOPPER absorbs both storage roles. The
+     * other enum positions stayed put (DOCK=0, HOPPER=1, FURNACE=2,
+     * REPAIR_BAY=3, SIGNAL_RELAY=4, FRAME_PRESS=5, LASER_FAB=6,
+     * TRACTOR_FAB=7, SHIPYARD=9), so the only operation needed is
+     * remapping any module/scaffold/plan that used 8 or 10 → 1. */
+    if (version < 44) {
+        for (int i = 0; i < MAX_STATIONS; i++) {
+            station_t *st = &w->stations[i];
+            for (int m = 0; m < st->module_count; m++) {
+                int t = (int)st->modules[m].type;
+                if (t == 8 || t == 10) st->modules[m].type = MODULE_HOPPER;
+            }
+            for (int p = 0; p < st->pending_scaffold_count; p++) {
+                int t = (int)st->pending_scaffolds[p].type;
+                if (t == 8 || t == 10) st->pending_scaffolds[p].type = MODULE_HOPPER;
+            }
+            for (int p = 0; p < st->placement_plan_count; p++) {
+                int t = (int)st->placement_plans[p].type;
+                if (t == 8 || t == 10) st->placement_plans[p].type = MODULE_HOPPER;
+            }
+            rebuild_station_services(st);
+        }
+        for (int i = 0; i < MAX_SCAFFOLDS; i++) {
+            if (!w->scaffolds[i].active) continue;
+            int t = (int)w->scaffolds[i].module_type;
+            if (t == 8 || t == 10) w->scaffolds[i].module_type = MODULE_HOPPER;
         }
     }
 

--- a/shared/module_schema.c
+++ b/shared/module_schema.c
@@ -119,19 +119,6 @@ const module_schema_t MODULE_SCHEMA[MODULE_COUNT] = {
         .variant_count = 0,
         .prerequisite = MODULE_FURNACE, /* tier 5 — needs cr ingots from a 3+ furnace stack */
     },
-    [MODULE_ORE_SILO] = {
-        .name = "Ore Silo",
-        .kind = MODULE_KIND_STORAGE,
-        .input = COMMODITY_FERRITE_ORE, /* primary; accepts all ore */
-        .output = COMMODITY_COUNT,
-        .rate = 0.0f, .buffer_capacity = 60.0f, /* big buffer */
-        .build_material = 30.0f, .build_commodity = COMMODITY_FRAME,
-        .order_fee = 25,
-        .services = 0,
-        .valid_rings = MODULE_RINGS_OUTER,
-        .variant_count = 0,
-        .prerequisite = MODULE_FURNACE, /* tier 3 — overflow storage */
-    },
     [MODULE_SHIPYARD] = {
         .name = "Shipyard",
         .kind = MODULE_KIND_SHIPYARD,
@@ -144,19 +131,6 @@ const module_schema_t MODULE_SCHEMA[MODULE_COUNT] = {
         .valid_rings = MODULE_RINGS_INDUSTRIAL,
         .variant_count = 0,
         .prerequisite = MODULE_FRAME_PRESS, /* tier 4 — needs frames */
-    },
-    [MODULE_CARGO_BAY] = {
-        .name = "Cargo Bay",
-        .kind = MODULE_KIND_STORAGE,
-        .input = COMMODITY_FERRITE_INGOT, /* generic — accepts any commodity in flow graph */
-        .output = COMMODITY_COUNT,
-        .rate = 0.0f, .buffer_capacity = 120.0f, /* large storage */
-        .build_material = 60.0f, .build_commodity = COMMODITY_FRAME,
-        .order_fee = 60,
-        .services = 0,
-        .valid_rings = MODULE_RINGS_OUTER,
-        .variant_count = 0,
-        .prerequisite = MODULE_FURNACE, /* tier 3 — needs production to store */
     },
 };
 

--- a/shared/types.h
+++ b/shared/types.h
@@ -236,24 +236,29 @@ typedef enum {
 /* ------------------------------------------------------------------ */
 
 typedef enum {
-    MODULE_DOCK,
-    MODULE_HOPPER,            /* ore intake + beam anchor for furnaces */
+    MODULE_DOCK = 0,
+    MODULE_HOPPER = 1,        /* ore intake + storage + smelt-unlock for furnaces.
+                               * Absorbs the legacy ORE_SILO and CARGO_BAY storage
+                               * roles — those subtypes were dropped in the
+                               * silo cleanup. Save migration in sim_save.c
+                               * remaps both back to MODULE_HOPPER. */
     /* Single-type furnace: which ores it can smelt is determined by the
      * station's furnace count, not the module subtype. 1 furnace ⇒
      * ferrite only; 2 ⇒ cuprite (ferrite blocked); 3 ⇒ cuprite + crystal
      * (ferrite still blocked). The MODULE_FURNACE_CU and MODULE_FURNACE_CR
      * subtypes were collapsed away in the count-tier rework — save
      * migration in sim_save.c remaps both back to MODULE_FURNACE. */
-    MODULE_FURNACE,
-    MODULE_REPAIR_BAY,
-    MODULE_SIGNAL_RELAY,
-    MODULE_FRAME_PRESS,
-    MODULE_LASER_FAB,
-    MODULE_TRACTOR_FAB,
-    MODULE_ORE_SILO,
-    MODULE_SHIPYARD,
-    MODULE_CARGO_BAY,         /* generic large storage */
-    MODULE_COUNT
+    MODULE_FURNACE = 2,
+    MODULE_REPAIR_BAY = 3,
+    MODULE_SIGNAL_RELAY = 4,
+    MODULE_FRAME_PRESS = 5,
+    MODULE_LASER_FAB = 6,
+    MODULE_TRACTOR_FAB = 7,
+    /* enum values 8 (was ORE_SILO) and 10 (was CARGO_BAY) are gone;
+     * see SAVE_VERSION 44 migration. SHIPYARD pinned to its old value
+     * to keep the migration table simple. */
+    MODULE_SHIPYARD = 9,
+    MODULE_COUNT = 10
 } module_type_t;
 
 /* module_type_name moved to module_schema.h — reads from schema. */

--- a/src/input.c
+++ b/src/input.c
@@ -615,7 +615,9 @@ static void plan_mode_handle_cycle_type(input_intent_t *intent) {
     static const module_type_t plannable[] = {
         MODULE_FURNACE,
         MODULE_FRAME_PRESS, MODULE_LASER_FAB, MODULE_TRACTOR_FAB,
-        MODULE_ORE_SILO, MODULE_CARGO_BAY,
+        /* MODULE_ORE_SILO + MODULE_CARGO_BAY were dropped — HOPPER
+         * absorbs the storage role. */
+        MODULE_HOPPER,
         MODULE_REPAIR_BAY, MODULE_SIGNAL_RELAY, MODULE_DOCK,
         MODULE_SHIPYARD,
     };

--- a/src/palette.h
+++ b/src/palette.h
@@ -164,7 +164,6 @@
 #define PAL_MODULE_SHIPYARD  0.85f, 0.70f, 0.20f
 
 /* Shared neutral modules */
-#define PAL_MODULE_ORE_SILO  0.45f, 0.48f, 0.50f
 #define PAL_MODULE_LASER_FAB 0.55f, 0.45f, 0.50f
 #define PAL_MODULE_TRACTOR_FAB 0.45f, 0.50f, 0.48f
 #define PAL_MODULE_SIGNAL_RELAY 0.35f, 0.55f, 0.50f

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -1200,7 +1200,6 @@ TEST(test_module_schema_basic_kinds) {
     ASSERT_EQ_INT(module_kind(MODULE_FRAME_PRESS), MODULE_KIND_PRODUCER);
     ASSERT_EQ_INT(module_kind(MODULE_LASER_FAB), MODULE_KIND_PRODUCER);
     ASSERT_EQ_INT(module_kind(MODULE_HOPPER), MODULE_KIND_STORAGE);
-    ASSERT_EQ_INT(module_kind(MODULE_ORE_SILO), MODULE_KIND_STORAGE);
     ASSERT_EQ_INT(module_kind(MODULE_SHIPYARD), MODULE_KIND_SHIPYARD);
 }
 
@@ -1250,7 +1249,6 @@ TEST(test_module_schema_helpers) {
     ASSERT(module_is_service(MODULE_REPAIR_BAY));
     ASSERT(!module_is_service(MODULE_FURNACE));
     ASSERT(module_is_storage(MODULE_HOPPER));
-    ASSERT(module_is_storage(MODULE_ORE_SILO));
     ASSERT(module_is_shipyard(MODULE_SHIPYARD));
     ASSERT(!module_is_dead(MODULE_FURNACE));
 }

--- a/src/tests/test_furnace_color.c
+++ b/src/tests/test_furnace_color.c
@@ -181,14 +181,13 @@ TEST(test_prospect_modules_after_silo_cleanup) {
     ASSERT(w != NULL);
     world_reset(w);
     ASSERT_EQ_INT((int)w->stations[0].module_count, 4);
-    int has_dock = 0, has_relay = 0, has_furnace = 0, has_hopper = 0, has_silo = 0;
+    int has_dock = 0, has_relay = 0, has_furnace = 0, has_hopper = 0;
     for (int i = 0; i < w->stations[0].module_count; i++) {
         switch (w->stations[0].modules[i].type) {
         case MODULE_DOCK:         has_dock++; break;
         case MODULE_SIGNAL_RELAY: has_relay++; break;
         case MODULE_FURNACE:      has_furnace++; break;
         case MODULE_HOPPER:       has_hopper++; break;
-        case MODULE_ORE_SILO:     has_silo++; break;
         default: break;
         }
     }
@@ -196,7 +195,8 @@ TEST(test_prospect_modules_after_silo_cleanup) {
     ASSERT_EQ_INT(has_relay, 1);
     ASSERT_EQ_INT(has_furnace, 1);
     ASSERT_EQ_INT(has_hopper, 1);
-    ASSERT_EQ_INT(has_silo, 0); /* dropped — hopper plays the intake role */
+    /* MODULE_ORE_SILO and MODULE_CARGO_BAY were dropped entirely;
+     * hopper now serves as the unified ore-intake-and-storage. */
 }
 
 /* (6) Middle-ring dynamic glow: the helper reads

--- a/src/tests/test_save.c
+++ b/src/tests/test_save.c
@@ -601,7 +601,7 @@ TEST(test_save_header_golden_bytes) {
     ASSERT_EQ_INT((int)fread(&spawn_timer, 4, 1, f), 1);
     fclose(f);
     ASSERT_EQ_INT((int)magic, (int)0x5349474E);    /* "SIGN" */
-    ASSERT_EQ_INT((int)version, 43);
+    ASSERT_EQ_INT((int)version, 44);
     ASSERT(rng != 0);  /* seed is set */
     ASSERT_EQ_FLOAT(time_val, 0.0f, 0.001f);
     ASSERT_EQ_FLOAT(spawn_timer, 0.0f, 0.001f);

--- a/src/world_draw.c
+++ b/src/world_draw.c
@@ -297,8 +297,7 @@ void draw_signal_borders(void) {
 static void module_color(module_type_t type, float *r, float *g, float *b) {
     switch (type) {
     case MODULE_FURNACE:      PAL_UNPACK3(PAL_MODULE_FURNACE,      *r, *g, *b); return;
-    case MODULE_HOPPER:    PAL_UNPACK3(PAL_MODULE_HOPPER,    *r, *g, *b); return;
-    case MODULE_ORE_SILO:     PAL_UNPACK3(PAL_MODULE_ORE_SILO,     *r, *g, *b); return;
+    case MODULE_HOPPER:       PAL_UNPACK3(PAL_MODULE_HOPPER,       *r, *g, *b); return;
     case MODULE_FRAME_PRESS:  PAL_UNPACK3(PAL_MODULE_FRAME_PRESS,  *r, *g, *b); return;
     case MODULE_LASER_FAB:    PAL_UNPACK3(PAL_MODULE_LASER_FAB,    *r, *g, *b); return;
     case MODULE_TRACTOR_FAB:  PAL_UNPACK3(PAL_MODULE_TRACTOR_FAB,  *r, *g, *b); return;
@@ -413,10 +412,8 @@ static void draw_module_shape(module_type_t type, float mr, float mg, float mb, 
         break;
     }
 
-    /* ---- INTAKE (hopper+silo): Triangle ---- */
-    case MODULE_HOPPER:
-    case MODULE_ORE_SILO:
-    case MODULE_CARGO_BAY: {
+    /* ---- INTAKE (hopper): Triangle ---- */
+    case MODULE_HOPPER: {
         /* Triangle pointing outward (-Y) = funnel mouth */
         sgl_c4f(mr*0.30f, mg*0.30f, mb*0.30f, alpha);
         sgl_begin_triangles();
@@ -944,10 +941,11 @@ void draw_station_rings(const station_t* station, bool is_current, bool is_nearb
                         if (mi2 == mod_idx[i]) continue;
                         if (station->modules[mi2].scaffold) continue;
                         module_type_t st = station->modules[mi2].type;
-                        /* Suppliers: furnaces, silos, or other producers */
+                        /* Suppliers: furnaces or hoppers (the latter
+                         * absorbed the legacy ORE_SILO/CARGO_BAY storage
+                         * roles). */
                         bool is_supplier = (st == MODULE_FURNACE ||
-                                           st == MODULE_ORE_SILO ||
-                                           st == MODULE_CARGO_BAY);
+                                           st == MODULE_HOPPER);
                         if (!is_supplier) continue;
                         vec2 sp = module_world_pos_ring(station, station->modules[mi2].ring,
                                                        station->modules[mi2].slot);
@@ -1364,7 +1362,7 @@ void draw_hopper_tractors(void) {
         for (int m = 0; m < st->module_count; m++) {
             if (st->modules[m].scaffold) continue;
             module_type_t mt = st->modules[m].type;
-            if (mt != MODULE_FURNACE && mt != MODULE_ORE_SILO) continue;
+            if (mt != MODULE_FURNACE && mt != MODULE_HOPPER) continue;
             vec2 mp = module_world_pos_ring(st, st->modules[m].ring, st->modules[m].slot);
             if (!on_screen(mp.x, mp.y, pull_range + 50.0f)) continue;
 


### PR DESCRIPTION
Both were generic storage modules with the same triangle shape as MODULE_HOPPER and no unique mechanic. Silo = pure overflow; cargo_bay had 5 refs codebase-wide and wasn't seeded anywhere. **HOPPER now serves as the unified ore-intake-and-storage module.**

## Changes
- Enum entries removed (positions 8 and 10); remaining types keep their old values for clean migration.
- World_reset seeds: 1× silo dropped at Kepler, 3× silo dropped at Helios.
- Schema, palette, render, plan-mode picker all updated.
- SAVE_VERSION 43 → 44 with a remap that retypes any stored 8 or 10 → MODULE_HOPPER on load. Existing v43 saves load cleanly.

## Verification
- 419/419 fast tests pass.
- Native + signal_server + wasm + signal_verify build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)