### PR TITLE
feat(callsign): derive player callsign from pubkey, alphanumeric format

### DIFF
--- a/shared/mining.h
+++ b/shared/mining.h
@@ -365,4 +365,42 @@ static inline void mining_render_callsign(const uint8_t pub[MINING_PUBKEY_BYTES]
     }
 }
 
+/* Render a pubkey as an alphanumeric callsign in `XXX-XXX` style for
+ * player display. Deterministic; same pubkey always produces the same
+ * callsign across machines / restarts.
+ *
+ * Format: 6 chars from the alphanumeric alphabet (no I, O, l, 0 to keep
+ * it visually unambiguous — 32 chars total), with a dash inserted at a
+ * deterministic position 1..5. Output is always exactly 7 chars + null.
+ *
+ * Class-prefix is intentionally NOT preserved here: that signal already
+ * lives in mining_render_callsign() (RATi-/M-/H-/etc. for cargo lineage).
+ * Player-display callsigns are pure alphanumeric noise — easy to type,
+ * easy to read, no character-set surprises. Collisions in 32^6 ≈ 1.07B
+ * are vanishingly rare for a single-server universe.
+ *
+ * Caller buffer must be at least 8 bytes. */
+static inline void mining_alphanumeric_callsign(const uint8_t pub[MINING_PUBKEY_BYTES],
+                                                char out[8]) {
+    /* 32-char alphabet — A-Z minus I/O, plus digits 2-9 (no 0/1).
+     * Power of two so byte→index is just a mask. Declared without
+     * room for the trailing null so the array stays exactly 32. */
+    static const char ALNUM[32] = {
+        'A','B','C','D','E','F','G','H','J','K','L','M','N','P','Q','R',
+        'S','T','U','V','W','X','Y','Z','2','3','4','5','6','7','8','9'
+    };
+    char body[6];
+    for (int i = 0; i < 6; i++)
+        body[i] = ALNUM[pub[i] & 0x1F];
+    /* Dash position 1..5, derived from a different pub byte so it
+     * doesn't correlate with the first body char. */
+    int dash = 1 + (pub[6] % 5);
+    int ci = 0;
+    for (int i = 0; i < 7; i++) {
+        if (i == dash) out[i] = '-';
+        else           out[i] = body[ci++];
+    }
+    out[7] = '\0';
+}
+
 #endif /* SHARED_MINING_H */

--- a/src/hud.c
+++ b/src/hud.c
@@ -10,6 +10,7 @@
 #include "world_draw.h"
 #include "avatar.h"
 #include "mining_client.h"
+#include "mining.h"  /* mining_alphanumeric_callsign — pubkey-derived */
 #include "signal_model.h"
 #include "palette.h"
 
@@ -327,15 +328,17 @@ static void hud_draw_alpha_banner_and_mp_indicator(float screen_w, bool compact)
         sdtx_color3b(PAL_TEXT_GREY);
         sdtx_printf("v%s", client_hash);
     }
-    /* Pubkey prefix — faint, just under the version. Layer A.1 of #479:
-     * each player owns a persistent Ed25519 keypair; this is the first
-     * 8 chars of its base58 form so the player can see/share their own
-     * identity. The wire protocol still uses session_token; later layers
-     * promote this to a real on-connect identifier. */
-    if (g.identity_pub_b58[0] != '\0') {
+    /* Player callsign — derived from the Ed25519 pubkey via
+     * mining_alphanumeric_callsign(). Same pubkey → same callsign
+     * forever, across machines / reconnects / server restarts. This is
+     * also the wire-callsign (sent to server in session-init), so what
+     * shows here is what other players see on the chain log. */
+    if (g.identity.pubkey[0] != 0 || g.identity.pubkey[1] != 0) {
+        char callsign[8];
+        mining_alphanumeric_callsign(g.identity.pubkey, callsign);
         sdtx_pos(info_x, ui_text_pos(20.0f));
         sdtx_color3b(PAL_TEXT_FADED);
-        sdtx_printf("id %.8s", g.identity_pub_b58);
+        sdtx_printf("id %s", callsign);
     }
 
     /* Alpha banner: repeating ticker across the top. */

--- a/src/net.c
+++ b/src/net.c
@@ -6,6 +6,7 @@
  */
 #include "net.h"
 #include "mining_client.h"
+#include "mining.h"  /* mining_alphanumeric_callsign — pubkey-derived */
 #include "signal_crypto.h"
 
 #include <string.h>
@@ -157,43 +158,17 @@ const uint8_t* net_local_session_token(void) {
 
 static void ensure_callsign(void) {
     if (net_state.callsign_ready) return;
-    /* 6 alphanumeric chars with a dash at a random position (1-5).
-     * Mix of uppercase letters (no I,O) and digits. e.g. SK-2a9 */
-#ifdef __EMSCRIPTEN__
-    const char *cs = emscripten_run_script_string(
-        "(function(){"
-        "var k='signal_callsign',s=localStorage.getItem(k);"
-        "if(s&&s.length===7)return s;"
-        "var A='ABCDEFGHJKLMNPQRSTUVWXYZ0123456789';"
-        "var chars=[];for(var i=0;i<6;i++)chars.push(A[Math.floor(Math.random()*34)]);"
-        "var d=1+Math.floor(Math.random()*5);"
-        "chars.splice(d,0,'-');"
-        "var c=chars.join('');"
-        "localStorage.setItem(k,c);return c;"
-        "})()"
-    );
-    if (cs && strlen(cs) == 7) {
-        memcpy(net_state.callsign, cs, 7);
-        net_state.callsign[7] = '\0';
+    /* Callsign is now derived from the player's Ed25519 pubkey via
+     * mining_alphanumeric_callsign(). Same pubkey → same callsign on
+     * every machine forever, no localStorage cache needed. The legacy
+     * random/localStorage path is gone. */
+    if (!net_state.identity_pubkey_ready) {
+        /* Pubkey not yet provided — defer; main.c installs it before
+         * net_init via net_set_identity_pubkey(). Leave callsign as-is
+         * (zeroed); ensure_callsign() will be called again. */
+        return;
     }
-#else
-    /* Native: generate random callsign */
-    static const char alnum[] = "ABCDEFGHJKLMNPQRSTUVWXYZ0123456789";
-    uint32_t seed = (uint32_t)time(NULL) ^ (uint32_t)(uintptr_t)&net_state;
-    char chars[6];
-    for (int i = 0; i < 6; i++) {
-        seed = seed * 1103515245u + 12345u;
-        chars[i] = alnum[(seed >> 16) % 34];
-    }
-    seed = seed * 1103515245u + 12345u;
-    int dash = 1 + (int)((seed >> 16) % 5); /* dash at position 1-5 */
-    int ci = 0;
-    for (int i = 0; i < 7; i++) {
-        if (i == dash) net_state.callsign[i] = '-';
-        else net_state.callsign[i] = chars[ci++];
-    }
-    net_state.callsign[7] = '\0';
-#endif
+    mining_alphanumeric_callsign(net_state.identity_pubkey, net_state.callsign);
     net_state.callsign_ready = true;
     printf("[net] callsign: %s\n", net_state.callsign);
 }
@@ -221,6 +196,11 @@ void net_set_identity_pubkey(const uint8_t pubkey[32]) {
     }
     memcpy(net_state.identity_pubkey, pubkey, 32);
     net_state.identity_pubkey_ready = true;
+    /* Now that we have a pubkey, the callsign can be derived. If
+     * ensure_callsign() ran earlier and bailed because the pubkey
+     * wasn't set yet, the callsign[] is still zeroed — clear the
+     * ready flag so the next ensure_callsign() call does the work. */
+    net_state.callsign_ready = false;
 }
 
 void net_set_identity_secret(const uint8_t secret[64]) {


### PR DESCRIPTION
Players were seeing two unrelated identifiers in the HUD: a base58 `id` from their Ed25519 pubkey, and a random alphanumeric callsign with no connection to anything cryptographic. Replaced the random one with a deterministic derivation from the pubkey. Same pubkey → same callsign on every machine, every restart, every reconnect.

Format: 6 alphanumeric chars + 1 dash. Alphabet is 32 chars (A-Z minus I/O, digits 2-9 minus 0/1). Class-prefix signal (M/H/T/S/F/K/RATi) preserved separately for cargo via existing `mining_render_callsign`.

419/419 tests pass; native + server + wasm clean.