### PR TITLE
fix(docker): copy vendor/tweetnacl + skip tools target in server build

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,11 +14,14 @@ WORKDIR /app
 
 # Only the files the server target actually needs — vendor/sokol is
 # for the client, so we skip it (BUILD_SERVER_ONLY short-circuits the
-# client block before it's referenced).
+# client block before it's referenced). vendor/tweetnacl is required
+# since #497 (chain log Ed25519 signing) — signal_server links
+# ${SIGNAL_CRYPTO_SOURCES}.
 COPY CMakeLists.txt ./
 COPY shared/ ./shared/
 COPY src/ ./src/
 COPY server/ ./server/
+COPY vendor/tweetnacl/ ./vendor/tweetnacl/
 
 # Flags preserved from the old hand-rolled gcc invocation:
 #   -static                          (fully static musl binary)
@@ -33,6 +36,7 @@ RUN cmake -S . -B build \
       -DCMAKE_C_FLAGS_RELEASE="-O2 -DNDEBUG" \
       -DCMAKE_EXE_LINKER_FLAGS="-static" \
       -DBUILD_SERVER_ONLY=ON \
+      -DBUILD_TOOLS=OFF \
       -DGIT_HASH=${GIT_HASH} \
     && cmake --build build --target signal_server --parallel
 


### PR DESCRIPTION
## Summary

`build-server` is the last job keeping main red after #515. Two issues in `server/Dockerfile`:

1. **Missing vendor:** the Dockerfile only copies `shared/`, `src/`, `server/`. `signal_server` has linked `${SIGNAL_CRYPTO_SOURCES}` (= `vendor/tweetnacl/*.c`) since #497 landed Ed25519 chain-log signing.
2. **Configure validates a missing target:** `BUILD_TOOLS` defaults ON in `CMakeLists.txt`, so the configure step tries to register `tools/signal_verify.c` even when only the `signal_server` target will actually build. CMake fails before any compilation starts.

## Fix

- `COPY vendor/tweetnacl/ ./vendor/tweetnacl/` into the builder stage.
- Pass `-DBUILD_TOOLS=OFF` to skip the `signal_verify` add_executable.

## Test plan

- [ ] CI: `build-server` job green on this PR.
- [ ] After merge: `Build & Deploy` workflow on main goes fully green.
- [ ] `signal_server` binary still has working Ed25519 signing (chain log emits should sign correctly under the new image — exercised by the existing `verify-chain-logs` job which already passes).

## Refs

- #515 (the broader CI repair that this completes)
- #497 (chain log Layer C — the PR that introduced the tweetnacl link dependency)
- #508 (blocked on main going green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)