### PR TITLE
fix(chain_log): portable PACKED macro + named payload typedefs (closes #517)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -557,11 +557,8 @@ jobs:
             name: linux
           - os: macos-latest
             name: macos
-          # windows-latest temporarily removed — chain-log payloads use
-          # `struct __attribute__((packed))` which MSVC rejects.
-          # Tracked in #517: lift those into named typed structs with a
-          # single portable PACKED macro. Restore this matrix entry
-          # once #517 lands so Windows builds again.
+          - os: windows-latest
+            name: windows
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/server/cargo_receipt_issue.c
+++ b/server/cargo_receipt_issue.c
@@ -46,16 +46,10 @@ uint64_t cargo_receipt_emit_transfer(world_t *w, station_t *s,
                                      const uint8_t prev_receipt_hash[32],
                                      cargo_receipt_t *out_receipt) {
     if (!s || !out_receipt) return 0;
-    /* Wire-stable EVT_TRANSFER payload — same shape as the existing
-     * inlined struct in main.c, kept identical so the chain log byte
-     * format doesn't fork. */
-    struct __attribute__((packed)) {
-        uint8_t from_pubkey[32];
-        uint8_t to_pubkey[32];
-        uint8_t cargo_pub[32];
-        uint8_t kind;
-        uint8_t _pad[7];
-    } xfer = {0};
+    /* Wire-stable EVT_TRANSFER payload — typedef'd in chain_log.h so
+     * the on-disk byte format has a single source of truth across
+     * every emit site. */
+    chain_payload_transfer_t xfer = {0};
     if (from_pubkey)   memcpy(xfer.from_pubkey, from_pubkey, 32);
     if (to_pubkey)     memcpy(xfer.to_pubkey,   to_pubkey,   32);
     if (cargo_pub)     memcpy(xfer.cargo_pub,   cargo_pub,   32);

--- a/server/chain_log.h
+++ b/server/chain_log.h
@@ -30,6 +30,7 @@
 #ifndef SERVER_CHAIN_LOG_H
 #define SERVER_CHAIN_LOG_H
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -42,6 +43,21 @@
 extern "C" {
 #endif
 
+/* Portable struct-packing primitives. MSVC rejects the GCC/Clang
+ * `__attribute__((packed))` spelling; both compilers do accept the
+ * `#pragma pack(push, 1)` / `pop` form. Use SIGNAL_PACK_PUSH /
+ * SIGNAL_PACK_POP around the typedef, and tag the struct with
+ * SIGNAL_PACKED for the GCC/Clang side. */
+#if defined(_MSC_VER)
+#  define SIGNAL_PACK_PUSH __pragma(pack(push, 1))
+#  define SIGNAL_PACK_POP  __pragma(pack(pop))
+#  define SIGNAL_PACKED
+#else
+#  define SIGNAL_PACK_PUSH
+#  define SIGNAL_PACK_POP
+#  define SIGNAL_PACKED __attribute__((packed))
+#endif
+
 typedef enum {
     CHAIN_EVT_NONE         = 0,
     CHAIN_EVT_SMELT        = 1,  /* fragment -> ingot at this station */
@@ -52,6 +68,67 @@ typedef enum {
     CHAIN_EVT_ROCK_DESTROY = 6,  /* asteroid fractured to terminal state */
     CHAIN_EVT_TYPE_COUNT
 } chain_event_type_t;
+
+/* On-disk payload schemas — one per event type. Field order, sizes, and
+ * padding are wire-stable and verified by static_assert below. The
+ * existing inline anonymous structs at the emit sites used the same
+ * layout; these typedefs are the single source of truth so the byte
+ * format can't drift across the seven historical callsites. */
+
+SIGNAL_PACK_PUSH
+typedef struct {
+    uint8_t  fragment_pub[32];
+    uint8_t  ingot_pub[32];
+    uint8_t  prefix_class;
+    uint8_t  _pad[7];
+    uint64_t mined_block;
+} SIGNAL_PACKED chain_payload_smelt_t;
+SIGNAL_PACK_POP
+
+SIGNAL_PACK_PUSH
+typedef struct {
+    uint16_t recipe_id;
+    uint8_t  input_count;
+    uint8_t  _pad[5];
+    uint8_t  output_pub[32];
+    uint8_t  input_pubs[2][32];
+} SIGNAL_PACKED chain_payload_craft_t;
+SIGNAL_PACK_POP
+
+SIGNAL_PACK_PUSH
+typedef struct {
+    uint8_t from_pubkey[32];
+    uint8_t to_pubkey[32];
+    uint8_t cargo_pub[32];
+    uint8_t kind;
+    uint8_t _pad[7];
+} SIGNAL_PACKED chain_payload_transfer_t;
+SIGNAL_PACK_POP
+
+SIGNAL_PACK_PUSH
+typedef struct {
+    uint64_t transfer_event_id;
+    int64_t  ledger_delta_signed;
+    uint8_t  ledger_pubkey[32];
+} SIGNAL_PACKED chain_payload_trade_t;
+SIGNAL_PACK_POP
+
+SIGNAL_PACK_PUSH
+typedef struct {
+    uint8_t rock_pub[32];
+    uint8_t fracturing_player_pub[32];
+    uint8_t station_pubkey[32];
+} SIGNAL_PACKED chain_payload_rock_destroy_t;
+SIGNAL_PACK_POP
+
+/* Wire-format guards: any field-list change that shifts these sizes
+ * forks the chain log byte format and must be paired with a
+ * versioning story (or accepted as a hard break). */
+_Static_assert(sizeof(chain_payload_smelt_t)        == 80,  "smelt payload size");
+_Static_assert(sizeof(chain_payload_craft_t)        == 104, "craft payload size");
+_Static_assert(sizeof(chain_payload_transfer_t)     == 104, "transfer payload size");
+_Static_assert(sizeof(chain_payload_trade_t)        == 48,  "trade payload size");
+_Static_assert(sizeof(chain_payload_rock_destroy_t) == 96,  "rock_destroy payload size");
 
 /* Fixed-size event header — exactly 184 bytes on disk. The serialized
  * form matches this struct's natural C99 layout (verified by static

--- a/server/main.c
+++ b/server/main.c
@@ -353,11 +353,7 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
                     cargo_receipt_pack(&receipt, &buf[3]);
                     ws_send(c, buf, sizeof(buf));
 
-                    struct __attribute__((packed)) {
-                        uint64_t transfer_event_id;
-                        int64_t  ledger_delta_signed;
-                        uint8_t  ledger_pubkey[32];
-                    } trade = {0};
+                    chain_payload_trade_t trade = {0};
                     trade.transfer_event_id = xfer_id;
                     trade.ledger_delta_signed = -(int64_t)price;
                     memcpy(trade.ledger_pubkey, world.players[pid].pubkey, 32);
@@ -491,11 +487,7 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
 
                     /* Trade event records the actual prefix-scaled
                      * delivery amount (#501), not a flat constant. */
-                    struct __attribute__((packed)) {
-                        uint64_t transfer_event_id;
-                        int64_t  ledger_delta_signed;
-                        uint8_t  ledger_pubkey[32];
-                    } trade = {0};
+                    chain_payload_trade_t trade = {0};
                     trade.transfer_event_id = xfer_id;
                     trade.ledger_delta_signed = (int64_t)delivery_int;
                     memcpy(trade.ledger_pubkey, world.players[pid].pubkey, 32);

--- a/server/sim_asteroid.c
+++ b/server/sim_asteroid.c
@@ -451,11 +451,7 @@ void fracture_asteroid(world_t *w, int idx, vec2 outward_dir, int8_t fractured_b
                     w->players[fractured_by].connected) {
                     memcpy(player_pub, w->players[fractured_by].pubkey, 32);
                 }
-                struct __attribute__((packed)) {
-                    uint8_t rock_pub[32];
-                    uint8_t fracturing_player_pub[32];
-                    uint8_t station_pubkey[32];
-                } payload = {0};
+                chain_payload_rock_destroy_t payload = {0};
                 memcpy(payload.rock_pub, parent.rock_pub, 32);
                 memcpy(payload.fracturing_player_pub, player_pub, 32);
                 memcpy(payload.station_pubkey,

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -151,13 +151,7 @@ static bool station_manifest_craft_product(world_t *w, station_t *st,
      * mutation succeeds. Payload binds the recipe id, output pubkey,
      * and input pubkeys (up to 2) to the station's signature. */
     {
-        struct __attribute__((packed)) {
-            uint16_t recipe_id;
-            uint8_t  input_count;
-            uint8_t  _pad[5];
-            uint8_t  output_pub[32];
-            uint8_t  input_pubs[2][32];
-        } payload = {0};
+        chain_payload_craft_t payload = {0};
         payload.recipe_id = (uint16_t)recipe_id;
         payload.input_count = (uint8_t)recipe->input_count;
         memcpy(payload.output_pub, product.pub, 32);
@@ -313,13 +307,7 @@ void sim_step_refinery_production(world_t *w, float dt) {
              * can distinguish. */
             for (uint16_t u = pre_mft_count; u < st->manifest.count; u++) {
                 const cargo_unit_t *unit = &st->manifest.units[u];
-                struct __attribute__((packed)) {
-                    uint8_t  fragment_pub[32];
-                    uint8_t  ingot_pub[32];
-                    uint8_t  prefix_class;
-                    uint8_t  _pad[7];
-                    uint64_t mined_block;
-                } payload = {0};
+                chain_payload_smelt_t payload = {0};
                 memcpy(payload.ingot_pub, unit->pub, 32);
                 payload.prefix_class = unit->prefix_class;
                 payload.mined_block = unit->mined_block;

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -1567,7 +1567,7 @@ int player_save_list_legacy(const char *dir,
                             int cap) {
     int count = 0;
 #ifdef _WIN32
-    (void)dir; (void)prefixes; (void)names; (void)cap;
+    (void)dir; (void)prefixes; (void)names; (void)cap; (void)count;
     return 0;
 #else
     char path[512];

--- a/shared/economy_const.h
+++ b/shared/economy_const.h
@@ -51,7 +51,11 @@ static inline float prefix_class_price_multiplier(int cls) {
 /* --- Refinery / station production --- */
 static const float REFINERY_HOPPER_CAPACITY = 500.0f;
 static const float REFINERY_BASE_SMELT_RATE = 2.0f;
-static const int   REFINERY_MAX_FURNACES = 3;
+/* enum, not `static const int`, so MSVC accepts it as a constant
+ * expression for sim_production.c's `int furnace_slots[REFINERY_MAX_FURNACES]`.
+ * `static const int` is not a C99 constant expression — GCC/Clang
+ * accept it via VLA fallback, MSVC rejects it. */
+enum { REFINERY_MAX_FURNACES = 3 };
 /* Production: ~1 unit/sec → conversions are visible inside 5-10s of docked
  * dwell time. Slower felt like nothing was happening. */
 static const float STATION_PRODUCTION_RATE = 1.0f;

--- a/src/net.c
+++ b/src/net.c
@@ -16,6 +16,11 @@
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
+#ifdef _WIN32
+/* GetSystemTimePreciseAsFileTime — sub-microsecond wall clock on Win8+. */
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
 
 /* ---------- Shared state ------------------------------------------------- */
 
@@ -227,6 +232,14 @@ static uint64_t next_signed_action_nonce(void) {
     /* Date.now() has ms resolution; multiply to keep us in the same
      * units as native. */
     now_us = (uint64_t)emscripten_get_now() * 1000ULL;
+#elif defined(_WIN32)
+    /* MSVC has no clock_gettime/CLOCK_REALTIME. GetSystemTimePreciseAsFileTime
+     * returns 100-ns ticks since 1601-01-01 UTC; subtract the 1601→1970
+     * delta and divide to microseconds since the Unix epoch. */
+    FILETIME ft;
+    GetSystemTimePreciseAsFileTime(&ft);
+    uint64_t ticks_100ns = ((uint64_t)ft.dwHighDateTime << 32) | ft.dwLowDateTime;
+    now_us = (ticks_100ns - 116444736000000000ULL) / 10ULL;
 #else
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);

--- a/src/tests/test_harness.c
+++ b/src/tests/test_harness.c
@@ -1,6 +1,8 @@
 #include "tests/test_harness.h"
 
-#ifndef _WIN32
+#ifdef _WIN32
+#include <process.h>  /* _getpid */
+#else
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <errno.h>

--- a/src/tests/test_save_keyed_by_pubkey.c
+++ b/src/tests/test_save_keyed_by_pubkey.c
@@ -27,6 +27,11 @@
 #ifdef _WIN32
 #include <direct.h>
 #define rmdir _rmdir
+/* MSVC's <sys/stat.h> doesn't define S_ISREG. The mode-bit value matches
+ * POSIX semantics; the macro shape is the standard fallback. */
+#ifndef S_ISREG
+#define S_ISREG(m) (((m) & _S_IFMT) == _S_IFREG)
+#endif
 #else
 #include <unistd.h>
 #endif

--- a/src/tests/test_signal_verify.c
+++ b/src/tests/test_signal_verify.c
@@ -84,7 +84,8 @@ TEST(test_signal_verify_byte_tamper) {
     w->stations[0].chain_event_count = 0;
     memset(w->stations[0].chain_last_hash, 0, 32);
 
-    uint8_t pl[8] = "tamper--";
+    uint8_t pl[8];
+    memcpy(pl, "tamper--", 8);
     for (int i = 0; i < 5; i++)
         ASSERT(chain_log_emit(w, &w->stations[0], CHAIN_EVT_LEDGER, pl, sizeof(pl)) == (uint64_t)(i+1));
 
@@ -122,7 +123,8 @@ TEST(test_signal_verify_signature_corruption) {
     w->stations[0].chain_event_count = 0;
     memset(w->stations[0].chain_last_hash, 0, 32);
 
-    uint8_t pl[8] = "sig-test";
+    uint8_t pl[8];
+    memcpy(pl, "sig-test", 8);
     ASSERT(chain_log_emit(w, &w->stations[0], CHAIN_EVT_LEDGER, pl, sizeof(pl)) == 1);
 
     /* Header layout: signature occupies the last 64 bytes of the
@@ -161,7 +163,8 @@ TEST(test_signal_verify_mid_log_splice) {
     w->stations[0].chain_event_count = 0;
     memset(w->stations[0].chain_last_hash, 0, 32);
 
-    uint8_t pl[8] = "splice--";
+    uint8_t pl[8];
+    memcpy(pl, "splice--", 8);
     for (int i = 0; i < 5; i++)
         ASSERT(chain_log_emit(w, &w->stations[0], CHAIN_EVT_LEDGER, pl, sizeof(pl)) == (uint64_t)(i+1));
 

--- a/src/tests/test_signal_verify.c
+++ b/src/tests/test_signal_verify.c
@@ -240,13 +240,7 @@ TEST(test_signal_verify_multi_station_independent) {
     /* Same cargo_pub appears on both station 0 (sender TRANSFER) and
      * station 2 (receiver TRANSFER) — what cross-station provenance
      * looks like in real traffic. */
-    struct __attribute__((packed)) {
-        uint8_t from_pubkey[32];
-        uint8_t to_pubkey[32];
-        uint8_t cargo_pub[32];
-        uint8_t kind;
-        uint8_t _pad[7];
-    } xfer = {0};
+    chain_payload_transfer_t xfer = {0};
     for (int b = 0; b < 32; b++) xfer.cargo_pub[b] = (uint8_t)(0x80 + b);
     memcpy(xfer.from_pubkey, w->stations[0].station_pubkey, 32);
     memcpy(xfer.to_pubkey, w->stations[2].station_pubkey, 32);


### PR DESCRIPTION
## Summary

Re-enables `windows-latest` in CI by replacing every `struct __attribute__((packed))` chain-log payload with a portable equivalent. MSVC rejects the GCC/Clang attribute spelling; both compilers do accept `#pragma pack(push, 1)` / `pop`. Tracked in #517 — the matrix entry was disabled in #515 (~30 commits ago) so this is what unblocks Windows.

## Changes

- **`server/chain_log.h`**
  - New `SIGNAL_PACK_PUSH` / `SIGNAL_PACK_POP` / `SIGNAL_PACKED` macro trio that expands to the right spelling per compiler.
  - Lifts the seven inlined anonymous payload structs into named typedefs: `chain_payload_smelt_t`, `chain_payload_craft_t`, `chain_payload_transfer_t`, `chain_payload_trade_t`, `chain_payload_rock_destroy_t`. Single source of truth for the on-disk wire format.
  - `_Static_assert` guards on every payload size — any future field change that would silently fork the byte format now fails the build (80 / 104 / 104 / 48 / 96 bytes respectively).
- **Callsites** — replace seven inline anonymous struct declarations with the typedefs:
  - `server/sim_production.c` (CRAFT, SMELT)
  - `server/main.c` (TRADE × 2)
  - `server/sim_asteroid.c` (ROCK_DESTROY)
  - `server/cargo_receipt_issue.c` (TRANSFER)
  - `src/tests/test_signal_verify.c` (TRANSFER)
- **`.github/workflows/deploy.yml`** — re-add `windows-latest` to the native build matrix.

## Wire format

No change. Each typedef reproduces the original anonymous struct's field order, alignment padding, and packing exactly. The static_asserts pin the sizes that the existing chain logs were already written with.

## Test plan

- [x] `cmake --build build-test` clean (all static_asserts hold)
- [x] `./build-test/signal_test --quiet` — 423/423 pass
- [ ] CI confirms windows-latest now builds green (will show up on this PR)
- [ ] Linux + macOS native build remain green

---
_Generated by [Claude Code](https://claude.ai/code/session_0185uPJSaxLJdswso1ySPR6P)_