### PR TITLE
fix(docker): copy vendor/cenetex for sim_anchor.c merkle include

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -22,6 +22,7 @@ COPY shared/ ./shared/
 COPY src/ ./src/
 COPY server/ ./server/
 COPY vendor/tweetnacl/ ./vendor/tweetnacl/
+COPY vendor/cenetex/ ./vendor/cenetex/
 
 # Flags preserved from the old hand-rolled gcc invocation:
 #   -static                          (fully static musl binary)


### PR DESCRIPTION
## Summary

Follow-up to #518. After that PR landed, `build-server` got past the configure stage but fails compilation:

\`\`\`
/app/server/sim_anchor.c:10:10: fatal error: ../vendor/cenetex/merkle.h: No such file or directory
\`\`\`

#492 added `sim_anchor.c` with `#include "../vendor/cenetex/merkle.h"`. The Dockerfile copies only `vendor/tweetnacl/`, not `vendor/cenetex/`.

## Fix

`COPY vendor/cenetex/ ./vendor/cenetex/` — one line.

## Note

Two consecutive PRs hitting the same class of bug (vendor drift) means the Dockerfile's selective `COPY` list is fragile. The longer-term fix is one of:
- Single `COPY vendor/ ./vendor/` with `.dockerignore` patterns for the client-only vendor dirs (sokol, minimp3); or
- CI check that diffs `vendor/` usage in `server/`, `shared/`, `src/` against the Dockerfile.

Not in scope here. Will file a follow-up after main is green again.

## Test plan

- [x] All non-skipped jobs pass on this PR (build-server is gated to `main` only).
- [ ] After merge: `Build & Deploy` workflow on main goes fully green.

## Refs

- #515, #518 — earlier rounds of unbreaking main CI
- #492 — introduced the `vendor/cenetex/merkle.h` include

🤖 Generated with [Claude Code](https://claude.com/claude-code)