### PR TITLE
docs: reference C11 (not C99) — match what we actually compile with

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Signal — Claude Code Context
 
-Live at **[signal.ratimics.com/play](https://signal.ratimics.com/play)**. Multiplayer space-station game in C99 / Sokol. PvP rock-flinging is the hook; the rest of the systems feed that hook.
+Live at **[signal.ratimics.com/play](https://signal.ratimics.com/play)**. Multiplayer space-station game in C11 / Sokol. PvP rock-flinging is the hook; the rest of the systems feed that hook.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A space station game where you fight by smashing one another with rocks.
 
 **Play now:** [signal.ratimics.com/play](https://signal.ratimics.com/play)
 
-Signal is a multiplayer space mining game built in C99 with Sokol — no external
+Signal is a multiplayer space mining game built in C11 with Sokol — no external
 assets, no engine, just procedural geometry and physics. You launch from
 stations, fracture asteroids, haul ore, and expand the network by building
 outposts at the edge of signal range. Every AI dreams of being a space station.

--- a/server/chain_log.h
+++ b/server/chain_log.h
@@ -131,7 +131,7 @@ _Static_assert(sizeof(chain_payload_trade_t)        == 48,  "trade payload size"
 _Static_assert(sizeof(chain_payload_rock_destroy_t) == 96,  "rock_destroy payload size");
 
 /* Fixed-size event header — exactly 184 bytes on disk. The serialized
- * form matches this struct's natural C99 layout (verified by static
+ * form matches this struct's natural C11 layout (verified by static
  * assertion in chain_log.c). */
 typedef struct {
     uint64_t epoch;            /* sim tick when authored */

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -165,9 +165,9 @@ static bool read_station(FILE *f, station_t *s) {
     if (s->module_count > MAX_MODULES_PER_STATION) s->module_count = MAX_MODULES_PER_STATION;
     for (int m = 0; m < s->module_count; m++) {
         READ_FIELD(f, s->modules[m]);
-        /* Sanitize bool — old saves may have non-0/1 byte values which
-         * are undefined behavior when read as _Bool in C99. Read the
-         * raw byte to avoid UB on the load itself. */
+        /* Sanitize bool — old saves may have non-0/1 byte values, and
+         * reading those as _Bool is undefined behavior. Read the raw
+         * byte to avoid UB on the load itself. */
         { uint8_t raw; memcpy(&raw, &s->modules[m].scaffold, 1);
           s->modules[m].scaffold = (raw != 0); }
     }

--- a/shared/cargo_receipt.h
+++ b/shared/cargo_receipt.h
@@ -54,7 +54,7 @@ extern "C" {
  *
  * Layout is exactly 208 bytes; the unsigned region (everything except
  * the trailing 64-byte signature) is the 144-byte span fed into
- * Ed25519. We pack the field order so the natural C99 layout matches
+ * Ed25519. We pack the field order so the natural C11 layout matches
  * the on-wire byte order on every platform we ship to (32-byte
  * blocks first, then two u64 fields, then the prev-hash, then the
  * signature). A compile-time _Static_assert in cargo_receipt.c catches

--- a/shared/economy_const.h
+++ b/shared/economy_const.h
@@ -53,8 +53,10 @@ static const float REFINERY_HOPPER_CAPACITY = 500.0f;
 static const float REFINERY_BASE_SMELT_RATE = 2.0f;
 /* enum, not `static const int`, so MSVC accepts it as a constant
  * expression for sim_production.c's `int furnace_slots[REFINERY_MAX_FURNACES]`.
- * `static const int` is not a C99 constant expression — GCC/Clang
- * accept it via VLA fallback, MSVC rejects it. */
+ * `static const int` is not a constant expression in any C standard —
+ * GCC/Clang accept it as an array bound via VLA fallback (C11 makes
+ * VLAs optional but they keep the extension on by default), MSVC has
+ * no VLA support and rejects it. */
 enum { REFINERY_MAX_FURNACES = 3 };
 /* Production: ~1 unit/sec → conversions are visible inside 5-10s of docked
  * dwell time. Slower felt like nothing was happening. */


### PR DESCRIPTION
## Summary

Project compiles with `CMAKE_C_STANDARD 11`, but a handful of comments and the README/CLAUDE.md still claimed C99. PR #519's commit message even leaned on a "strict C99" framing that was wrong — `static const int` isn't a constant expression in *any* C standard, GCC/Clang just permissively fold it via VLA support that MSVC doesn't have.

## Changes

- **`README.md`** / **`CLAUDE.md`** — "built in C99" → "built in C11"
- **`shared/economy_const.h`** — REFINERY_MAX_FURNACES enum comment reworded: the `static const int` rule isn't standard-version-specific, it's about VLA support
- **`shared/cargo_receipt.h`** / **`server/chain_log.h`** — "natural C99 layout" → "natural C11 layout" (struct layout rules are the same across both, but the version pin should match what we compile with)
- **`server/sim_save.c`** — drop the "in C99" qualifier on the `_Bool` UB comment; the rule applies in C11 too

## Out of scope

- Vendor headers (`server/mongoose.{c,h}`) keep their own C99 references — those are vendored and not ours to edit.
- `.github/AGENT.md` already says "**C11, not C99.**" — no change needed.

## Test plan

- [x] No code paths touched (pure docs/comment edits)
- [x] `grep -rn "C99\|c99"` against own code now returns only the AGENT.md line that correctly says "C11, not C99"

---
_Generated by [Claude Code](https://claude.ai/code/session_0185uPJSaxLJdswso1ySPR6P)_