### PR TITLE
ci(valgrind): drop --track-origins=yes to fit 45-min budget

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -197,13 +197,17 @@ jobs:
           cmake -S . -B build-valgrind -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS_ONLY=ON
           cmake --build build-valgrind
           ulimit -s 16384
+          # `--track-origins=yes` adds ~30% overhead; the suite outgrew the
+          # 45-min job budget after the chain-log/crypto expansion in #497
+          # / #500 / #519. Drop it — leaks are still detected by
+          # `--leak-check=full`. `--quiet` on signal_test cuts stdout so
+          # valgrind's interleaved logs don't dominate runtime via I/O.
           valgrind --error-exitcode=1 \
             --leak-check=full \
             --show-leak-kinds=definite \
             --errors-for-leak-kinds=definite \
-            --track-origins=yes \
             --main-stacksize=16777216 \
-            ./build-valgrind/signal_test 2>&1 | tail -30
+            ./build-valgrind/signal_test --quiet 2>&1 | tail -30
 
   # CRAP score (complexity * uncovered). Tested-code report GATES the
   # deploy at threshold 25 — the codebase already passes this, so the


### PR DESCRIPTION
## Summary

Last remaining issue keeping main runs from reaching overall **success**: \`test-valgrind\` times out at the 45-minute mark. The other 13 jobs all pass; only valgrind hits the wall.

The agent's \`blocked:main-broken\` gate on #508 keys off the run's overall conclusion. \"Cancelled by timeout\" reads as red, even though every substantive job is green.

## Why it slowed down

The chain-log + crypto path (#497, #500, #519) added Ed25519 sign/verify into the hot path of every test — chain events emit on every smelt, transfer, trade, ledger mutation. Under valgrind that's amplified ~5-20×. \`--track-origins=yes\` adds another ~30% on top.

## Fix

1. Drop \`--track-origins=yes\`. Leaks are still detected by \`--leak-check=full\` with definite-leak gating.
2. Add \`--quiet\` to signal_test invocation. Cuts stdout so valgrind's interleaved log writes don't burn time on I/O.

If we ever need origin tracking for a specific bug hunt, do it as a one-off nightly job, not a per-PR gate.

## Test plan

- [x] \`signal_test --quiet\` runs locally and produces the expected silent-on-success output.
- [ ] After merge: \`test-valgrind\` on main completes within 45 minutes, run conclusion = \`success\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)