### PR TITLE
feat(cargo): repurpose cargo_unit_t._pad as quantity (slice 0/N)

### DIFF
--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -78,7 +78,16 @@ static uint32_t crc32_file(FILE *f) {
 }
 
 #define SAVE_MAGIC 0x5349474E  /* "SIGN" */
-#define SAVE_VERSION 44  /* MODULE_ORE_SILO (= 8) and MODULE_CARGO_BAY (= 10)
+#define SAVE_VERSION 45  /* cargo_unit_t._pad repurposed as quantity (u8).
+                          * v44 saves wrote zero into _pad on every unit;
+                          * loaders rewrite quantity == 0 → 1 so existing
+                          * named units stay individually addressable.
+                          * Foundation for the upcoming raw-ore-as-crate
+                          * migration; no production path emits ore-kind
+                          * units yet. The cargo_unit_t binary size is
+                          * unchanged (still 80 bytes), so PLY7 / chain-log
+                          * payloads stay byte-compatible.
+                          * v44: MODULE_ORE_SILO (= 8) and MODULE_CARGO_BAY (= 10)
                           * dropped; both remapped to MODULE_HOPPER (= 1)
                           * on load. The hopper now serves as the unified
                           * ore-intake-and-storage module. v43 saves load
@@ -384,6 +393,7 @@ static bool read_station_session(FILE *f, station_t *s) {
                 u.prefix_class = src->prefix_class;
                 u.recipe_id = (uint16_t)RECIPE_SMELT;
                 u.origin_station = src->origin_station;
+                u.quantity = 1;
                 u.mined_block = src->mined_block;
                 memcpy(u.pub, src->pubkey, 32);
                 (void)manifest_push(&s->manifest, &u);
@@ -404,6 +414,10 @@ static bool read_station_session(FILE *f, station_t *s) {
             for (uint16_t u = 0; u < manifest_count; u++)
                 READ_FIELD(f, s->manifest.units[u]);
             s->manifest.count = manifest_count;
+            /* v45 repurposed cargo_unit_t._pad as quantity. v44 and earlier
+             * wrote zero there; rewrite to 1 so units stay addressable. */
+            if (g_loaded_save_version < 45)
+                manifest_migrate_quantity(&s->manifest);
         }
     } else {
         /* Slice D: synthesize manifest entries from float inventory for
@@ -1433,6 +1447,7 @@ static void migrate_v4_ship(ship_t *dst, const ship_v4_t *src) {
         u.prefix_class = lg->prefix_class;
         u.recipe_id = (uint16_t)RECIPE_SMELT;
         u.origin_station = lg->origin_station;
+        u.quantity = 1;
         u.mined_block = lg->mined_block;
         memcpy(u.pub, lg->pubkey, 32);
         (void)manifest_push(&dst->manifest, &u);
@@ -1769,6 +1784,10 @@ static bool player_load_from_path(server_player_t *sp, world_t *w, const char *p
                 sp->ship.manifest.units[u] = cu;
             }
             sp->ship.manifest.count = manifest_count;
+            /* Cargo_unit_t byte 7 was _pad in pre-v45 saves and is now
+             * `quantity`. Idempotent rewrite: 0 → 1 leaves v45+ saves
+             * untouched and migrates the legacy zero to a valid count. */
+            manifest_migrate_quantity(&sp->ship.manifest);
         }
         /* PLY6+ last_signed_nonce. PLY5 saves end here; the nonce stays
          * at zero, which lets the first signed action after the migration

--- a/shared/manifest.h
+++ b/shared/manifest.h
@@ -93,6 +93,13 @@ bool manifest_migrate_legacy_inventory(manifest_t *manifest,
                                        size_t inventory_count,
                                        const uint8_t origin[8]);
 
+/* Slice 0 of crate unification: pre-v45 saves wrote zero into the
+ * cargo_unit_t._pad byte that's now repurposed as `quantity`. Walk
+ * `manifest` and rewrite quantity == 0 → 1 so legacy-loaded units stay
+ * individually addressable. Idempotent — safe to call on a manifest
+ * that's already been migrated or written by a v45+ producer. */
+void manifest_migrate_quantity(manifest_t *manifest);
+
 /* ---------------------------------------------------------------- */
 /* Manifest-as-truth helpers (PR: kill the float<->manifest drift)   */
 /* ---------------------------------------------------------------- */

--- a/shared/types.h
+++ b/shared/types.h
@@ -123,6 +123,11 @@ typedef enum {
     CARGO_KIND_LASER      = 2,
     CARGO_KIND_TRACTOR    = 3,
     CARGO_KIND_REPAIR_KIT = 4,
+    /* Raw mined fragment, pooled by quantity. Allocated by the kind
+     * but no production path uses it yet — that lands in the next
+     * slice (per-ore migration). Reserving the enum value here keeps
+     * the wire and save formats stable through the slice. */
+    CARGO_KIND_ORE        = 5,
     CARGO_KIND_COUNT
 } cargo_kind_t;
 
@@ -134,7 +139,14 @@ typedef enum {
  * identity for both ingots and finished goods.
  *
  * For non-ingot kinds prefix_class is INGOT_PREFIX_ANONYMOUS, mined_block
- * is 0, and origin_station is the station that crafted the unit. */
+ * is 0, and origin_station is the station that crafted the unit.
+ *
+ * `quantity` is the count of items in this crate. Finished goods (ingots,
+ * frames, lasers, tractors, kits) always have quantity == 1: each unit is
+ * individually addressable and tracked through the chain log. CARGO_KIND_ORE
+ * (raw mined fragments) supports quantity > 1 so an ore crate pools many
+ * fragments under one provenance signature without exploding the manifest.
+ * Cap is u8 (255) — beyond that the caller pushes a new crate. */
 typedef struct {
     uint8_t  kind;              /* cargo_kind_t */
     uint8_t  commodity;         /* commodity_t */
@@ -142,7 +154,10 @@ typedef struct {
     uint8_t  prefix_class;      /* ingot_prefix_t (anonymous for non-ingot kinds) */
     uint16_t recipe_id;         /* recipe_id_t */
     uint8_t  origin_station;    /* refinery/fabricator that produced it */
-    uint8_t  _pad;              /* reserved, zero */
+    uint8_t  quantity;          /* items in this crate. 1 for finished goods,
+                                 * 1..255 for ore. Was _pad pre-v45; legacy
+                                 * saves with quantity == 0 migrate to 1 on
+                                 * load. */
     uint64_t mined_block;       /* chain block id at mint (0 for non-ingot) */
     uint8_t  pub[32];           /* content hash */
     uint8_t  parent_merkle[32]; /* sorted-input merkle root */

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -489,6 +489,7 @@ bool hash_ingot(commodity_t commodity, mining_grade_t grade,
     out_unit->commodity = (uint8_t)commodity;
     out_unit->grade = (uint8_t)grade;
     out_unit->recipe_id = (uint16_t)RECIPE_SMELT;
+    out_unit->quantity = 1;  /* finished goods always pool-of-one */
     /* origin_station / mined_block default to 0; smelt-side caller fills
      * them in from the refinery context. */
     memcpy(out_unit->parent_merkle, fragment_pub, HASH_BYTES);
@@ -518,6 +519,7 @@ bool hash_product(recipe_id_t recipe_id, const cargo_unit_t *inputs,
     out_unit->commodity = (uint8_t)recipe->output_commodity;
     out_unit->grade = (uint8_t)min_input_grade(inputs, input_count);
     out_unit->recipe_id = (uint16_t)recipe_id;
+    out_unit->quantity = 1;  /* finished goods always pool-of-one */
     memcpy(out_unit->parent_merkle, merkle_root, HASH_BYTES);
     hash_recipe_pub(recipe_id, merkle_root, output_index, out_unit->pub);
     return true;
@@ -556,6 +558,7 @@ bool hash_legacy_migrate_unit(const uint8_t origin[8], commodity_t commodity,
     out_unit->commodity = (uint8_t)commodity;
     out_unit->grade     = (uint8_t)MINING_GRADE_COMMON;
     out_unit->recipe_id = (uint16_t)RECIPE_LEGACY_MIGRATE;
+    out_unit->quantity  = 1;  /* finished goods always pool-of-one */
     /* parent_merkle stays zero — legacy units have no provable parents. */
     sha256_bytes(buf, o, out_unit->pub);
     return true;
@@ -597,6 +600,14 @@ bool manifest_migrate_legacy_inventory(manifest_t *manifest,
         }
     }
     return true;
+}
+
+void manifest_migrate_quantity(manifest_t *manifest) {
+    if (!manifest || !manifest->units) return;
+    for (uint16_t u = 0; u < manifest->count; u++) {
+        if (manifest->units[u].quantity == 0)
+            manifest->units[u].quantity = 1;
+    }
 }
 
 /* ---------------------------------------------------------------- */

--- a/src/tests/test_manifest.c
+++ b/src/tests/test_manifest.c
@@ -171,6 +171,75 @@ TEST(test_manifest_migrate_legacy_inventory_synthesizes_entries) {
     manifest_free(&m);
 }
 
+TEST(test_hash_helpers_set_quantity_one) {
+    /* Slice 0 of crate unification: every cargo_unit_t produced by the
+     * three central hash helpers must have quantity = 1 by default —
+     * finished goods are pool-of-one. Raw ore (quantity > 1) lands in a
+     * later slice via dedicated paths. */
+    uint8_t fragment_pub[32] = { 0 };
+    uint8_t origin[8] = { 'T','E','S','T','Q','T','Y','1' };
+    cargo_unit_t ingot = {0}, frame = {0}, legacy = {0};
+
+    fragment_pub[0] = 0xAB;
+    ASSERT(hash_ingot(COMMODITY_FERRITE_INGOT, MINING_GRADE_COMMON,
+                      fragment_pub, 0, &ingot));
+    ASSERT_EQ_INT(ingot.quantity, 1);
+
+    cargo_unit_t inputs[2];
+    inputs[0] = ingot;
+    inputs[1] = ingot;  /* RECIPE_FRAME_BASIC: 2× ferrite ingot */
+    ASSERT(hash_product(RECIPE_FRAME_BASIC, inputs, 2, 0, &frame));
+    ASSERT_EQ_INT(frame.quantity, 1);
+
+    ASSERT(hash_legacy_migrate_unit(origin, COMMODITY_FRAME, 0, &legacy));
+    ASSERT_EQ_INT(legacy.quantity, 1);
+}
+
+TEST(test_manifest_migrate_quantity_rewrites_zero_to_one) {
+    /* Pre-v45 saves wrote zero into the byte that's now `quantity`.
+     * Loaders run manifest_migrate_quantity to rewrite 0 → 1. The pass
+     * is idempotent — entries with quantity already > 0 are untouched. */
+    manifest_t m = {0};
+    cargo_unit_t legacy_zero = {0};
+    cargo_unit_t modern_one = {0};
+    cargo_unit_t bulk_seven = {0};
+
+    ASSERT(manifest_init(&m, 4));
+
+    legacy_zero.kind = CARGO_KIND_INGOT;
+    legacy_zero.commodity = COMMODITY_FERRITE_INGOT;
+    legacy_zero.pub[0] = 0x01;
+    legacy_zero.quantity = 0;            /* simulates a v44 load */
+
+    modern_one.kind = CARGO_KIND_FRAME;
+    modern_one.commodity = COMMODITY_FRAME;
+    modern_one.pub[0] = 0x02;
+    modern_one.quantity = 1;             /* untouched by migration */
+
+    bulk_seven.kind = CARGO_KIND_ORE;
+    bulk_seven.commodity = COMMODITY_FERRITE_ORE;
+    bulk_seven.pub[0] = 0x03;
+    bulk_seven.quantity = 7;             /* untouched by migration */
+
+    ASSERT(manifest_push(&m, &legacy_zero));
+    ASSERT(manifest_push(&m, &modern_one));
+    ASSERT(manifest_push(&m, &bulk_seven));
+
+    manifest_migrate_quantity(&m);
+
+    ASSERT_EQ_INT(m.units[0].quantity, 1);  /* zero was rewritten */
+    ASSERT_EQ_INT(m.units[1].quantity, 1);  /* untouched */
+    ASSERT_EQ_INT(m.units[2].quantity, 7);  /* untouched */
+
+    /* Idempotent — second pass must be a no-op. */
+    manifest_migrate_quantity(&m);
+    ASSERT_EQ_INT(m.units[0].quantity, 1);
+    ASSERT_EQ_INT(m.units[1].quantity, 1);
+    ASSERT_EQ_INT(m.units[2].quantity, 7);
+
+    manifest_free(&m);
+}
+
 TEST(test_hash_merkle_root_sorts_and_duplicates_odd_leaf) {
     const uint8_t pubs[3][32] = {
         {
@@ -776,6 +845,8 @@ void register_manifest_tests(void) {
     RUN(test_hash_legacy_migrate_unit_deterministic);
     RUN(test_hash_legacy_migrate_unit_rejects_raw_ore);
     RUN(test_manifest_migrate_legacy_inventory_synthesizes_entries);
+    RUN(test_hash_helpers_set_quantity_one);
+    RUN(test_manifest_migrate_quantity_rewrites_zero_to_one);
     RUN(test_ship_copy_clones_manifest_storage);
     RUN(test_station_copy_clones_manifest_storage);
     RUN(test_hash_merkle_root_sorts_and_duplicates_odd_leaf);

--- a/src/tests/test_save.c
+++ b/src/tests/test_save.c
@@ -601,7 +601,7 @@ TEST(test_save_header_golden_bytes) {
     ASSERT_EQ_INT((int)fread(&spawn_timer, 4, 1, f), 1);
     fclose(f);
     ASSERT_EQ_INT((int)magic, (int)0x5349474E);    /* "SIGN" */
-    ASSERT_EQ_INT((int)version, 44);
+    ASSERT_EQ_INT((int)version, 45);
     ASSERT(rng != 0);  /* seed is set */
     ASSERT_EQ_FLOAT(time_val, 0.0f, 0.001f);
     ASSERT_EQ_FLOAT(spawn_timer, 0.0f, 0.001f);


### PR DESCRIPTION
## Summary

Slice 0 of N for the [crate-unification refactor](https://github.com/cenetex/signal/issues/496#issuecomment-?). Pure substrate — no semantic change yet. Foundation for the upcoming raw-ore-as-crate migration.

## Context

`cargo_unit_t` already covers all 8 finished commodities (ingots × 3, frame, laser, tractor, repair kit) as named units in the manifest, with full pubkey + parent_merkle + chain-log lineage. The remaining gap is **raw ore** (`FERRITE_ORE`, `CUPRITE_ORE`, `CRYSTAL_ORE`), which lives only in float arrays — no provenance, no chain log on transfer.

To close that gap, we need a `quantity > 1` field on `cargo_unit_t` so an ore crate can pool many fragments under one provenance signature without exploding the 32-entry ship manifest cap.

This PR is just the substrate. No production path emits ore-kind units yet; that lands in the next slice (per-ore migration, vertical-slice on ferrite first).

## Why this is byte-stable

`cargo_unit_t._pad` was a single zero byte at offset 7. We're repurposing it as `quantity` (u8). The struct **stays exactly 80 bytes** — wire format, chain-log payloads, and all existing `_Static_assert`s on layout pass unchanged. Existing v44 saves on disk are *byte-identical* to what a v45 producer would write for finished goods, except the value of byte 7. The migration treats `quantity == 0` as "legacy unmigrated, rewrite to 1," which is idempotent and falls out for free.

## Changes

| File | Change |
|---|---|
| `shared/types.h` | `cargo_unit_t._pad` → `quantity` (u8). New `CARGO_KIND_ORE = 5` reserved in enum (no consumer yet). |
| `src/manifest.c` | `hash_ingot`, `hash_product`, `hash_legacy_migrate_unit` all set `out_unit->quantity = 1`. New `manifest_migrate_quantity()` helper. |
| `shared/manifest.h` | Declare `manifest_migrate_quantity`. |
| `server/sim_save.c` | `SAVE_VERSION 44 → 45`. World save load gates migration on `g_loaded_save_version < 45`. Player save load runs it unconditionally (idempotent). Two legacy-migration init paths set `quantity = 1` explicitly. |
| `src/tests/test_manifest.c` | Two new tests: hash helpers default to `quantity = 1`, migrate helper rewrites 0→1 idempotently. |
| `src/tests/test_save.c` | Golden-bytes test bumped to expect v45. |

## Test plan

- [x] `cmake --build build-test` clean
- [x] `./build-test/signal_test --quiet` — **425/425 pass** (was 423; +2 new tests)
- [x] `sizeof(cargo_unit_t) == 80` verified via existing `_Static_assert`
- [ ] CI green on linux/macos/windows (PR will validate)

## Roadmap (the rest of the slices)

This is slice 0 of an estimated 6-slice refactor. The full plan, agreed before starting:

| # | Status | Title |
|---|---|---|
| **0** | this PR | Add `quantity` field + `CARGO_KIND_ORE` + helpers |
| 1 | next | Migrate **ferrite** ore: mining + selling + smelting use ORE-kind crates |
| 2 | | Migrate **cuprite** ore |
| 3 | | Migrate **crystal** ore |
| 4 | | Drop legacy `cargo[]` / `_inventory_cache[]` floats entirely |
| 5 | | Add `EVT_TRANSFER` chain events for ore movements |

Each slice is independently testable, revertable, and ships its own PR. Slices 1-3 are vertical (one commodity at a time) so we can ship-and-observe before touching the next.

---
_Generated by [Claude Code](https://claude.ai/code/session_0185uPJSaxLJdswso1ySPR6P)_