### PR TITLE
ci(valgrind): bump timeout 45 → 60 min

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -186,7 +186,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy
     if: github.ref == 'refs/heads/main'
-    timeout-minutes: 45
+    # 60 min: under valgrind, the chain-log + crypto path runs through
+    # every test (sign/verify on every smelt/transfer/trade event).
+    # The 45-min budget overran twice on main even after #525 dropped
+    # `--track-origins=yes`. Sharding is the next step if this also
+    # tightens — see the `--shard=K/N` flag on signal_test for the
+    # hook. For now, bump the budget; valgrind minutes are cheap.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: Install valgrind


### PR DESCRIPTION
## Summary

Follow-up to #525. The flag-reduction wasn't enough — the post-#525 main run still hit exactly 45m and got cancelled.

Bumping to 60m gives ~33% headroom. Cheaper than sharding for now; sharding is the next escalation if 60m also tightens (\`signal_test --shard=K/N\` already exists).

This is the last thing keeping main runs from reaching overall conclusion=success, which the agent's \`blocked:main-broken\` gate on #508 keys off.

## Test plan

- [ ] After merge: \`test-valgrind\` on main completes within 60 minutes; run conclusion = success.
- [ ] Re-poke #508 once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)