### PR TITLE
feat(chain_log): emit EVT_SMELT on the fragment-tow smelt path

### DIFF
--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -227,8 +227,27 @@ bool sim_can_smelt_ore(const station_t *st, commodity_t ore) {
 /* Refinery production                                                 */
 /* ------------------------------------------------------------------ */
 
-/* Per-furnace smelting: any furnace smelts ore from station inventory into ingots.
- * Rate split across active furnaces to avoid instant consumption. */
+/* Per-furnace smelting from the station's bulk-ore float
+ * (`_inventory_cache[ORE]`).
+ *
+ * SUSPECTED DEAD CODE post-#259. Players no longer carry raw ore in
+ * `ship.cargo[]` (fragments ride in `ship.towed_fragments[]` instead),
+ * NPCs don't deposit raw ore either (they use `npc_ship_t.towed_fragment`
+ * and deliver via the fragment-tow path in `step_furnace_smelting`),
+ * and no other code path appears to populate `_inventory_cache[ORE]`.
+ * The early-skip at the float-zero check (line ~250) means this
+ * function does nothing in normal multiplayer play.
+ *
+ * It is still wired into the per-tick world step (`game_sim.c`) and
+ * still emits EVT_SMELT events with `fragment_pub = 0` (broken lineage)
+ * if ore somehow lands in the float — which is why we keep it for now
+ * rather than ripping it out: removing it would also need to migrate
+ * `last_smelt_commodity` (set at line ~299, drives the dynamic furnace
+ * glow render) onto the fragment-tow path AND retire the
+ * `_inventory_cache[ORE]`-populating tests. That's a follow-up PR.
+ *
+ * See docs/cargo-architecture.md for the larger architectural picture.
+ */
 void sim_step_refinery_production(world_t *w, float dt) {
     for (int s = 0; s < MAX_STATIONS; s++) {
         station_t *st = &w->stations[s];
@@ -799,6 +818,33 @@ void step_furnace_smelting(world_t *w, float dt) {
                     u->mined_block = signal_channel_post(w, smelt_station, text, "");
                 }
                 (void)ingot; /* unused now — kept above for the inventory write */
+
+                /* Layer C of #479: emit EVT_SMELT for each newly-minted
+                 * ingot. fragment_pub is populated from the consumed
+                 * asteroid record so the chain log captures real
+                 * provenance — every downstream verifier can walk back
+                 * to the source rock.
+                 *
+                 * The hopper-float smelt path
+                 * (sim_step_refinery_production) also emits EVT_SMELT,
+                 * but with fragment_pub = 0 because there's no source
+                 * fragment on that path. That path is suspected dead
+                 * post-#259 (nothing populates _inventory_cache[ORE]
+                 * any more); see docs/cargo-architecture.md and the
+                 * docstring on sim_step_refinery_production. */
+                if (pushed > 0) {
+                    uint16_t first_new = (uint16_t)((int)st->manifest.count - pushed);
+                    for (uint16_t u = first_new; u < st->manifest.count; u++) {
+                        const cargo_unit_t *unit = &st->manifest.units[u];
+                        chain_payload_smelt_t payload = {0};
+                        memcpy(payload.fragment_pub, a->fragment_pub, 32);
+                        memcpy(payload.ingot_pub, unit->pub, 32);
+                        payload.prefix_class = unit->prefix_class;
+                        payload.mined_block = unit->mined_block;
+                        (void)chain_log_emit(w, st, CHAIN_EVT_SMELT,
+                                             &payload, (uint16_t)sizeof(payload));
+                    }
+                }
             }
 
             clear_asteroid(a);

--- a/src/tests/test_chain_log.c
+++ b/src/tests/test_chain_log.c
@@ -261,6 +261,107 @@ TEST(test_chain_log_smelt_emits_event) {
     chain_test_teardown();
 }
 
+TEST(test_chain_log_smelt_emits_event_fragment_path) {
+    /* The richer smelt path: spawn a physical fragment between a
+     * furnace and an adjacent module, run the sim until the beam
+     * smelts it, then verify the chain log gained an EVT_SMELT whose
+     * fragment_pub matches the consumed asteroid's record. This is
+     * what the (suspected-dead) hopper-float path could never do —
+     * fragment-attributed lineage on the smelt event itself. */
+    chain_test_setup("smelt_fragment");
+    WORLD_HEAP w = calloc(1, sizeof(world_t));
+    ASSERT(w != NULL);
+    w->rng = 9100u;
+    world_reset(w);
+    chain_test_wipe_logs(w);
+    for (int i = 0; i < MAX_NPC_SHIPS; i++) w->npc_ships[i].active = false;
+    w->stations[0].chain_event_count = 0;
+    memset(w->stations[0].chain_last_hash, 0, 32);
+
+    /* Find Prospect's furnace + an adjacent-ring module to anchor
+     * the smelt midpoint. */
+    int furnace_idx = -1, silo_idx = -1;
+    for (int m = 0; m < w->stations[0].module_count; m++) {
+        if (w->stations[0].modules[m].type == MODULE_FURNACE) furnace_idx = m;
+        if (w->stations[0].modules[m].type == MODULE_HOPPER) silo_idx = m;
+    }
+    ASSERT(furnace_idx >= 0 && silo_idx >= 0);
+
+    vec2 furnace_pos = module_world_pos_ring(&w->stations[0],
+        w->stations[0].modules[furnace_idx].ring,
+        w->stations[0].modules[furnace_idx].slot);
+    vec2 silo_pos = module_world_pos_ring(&w->stations[0],
+        w->stations[0].modules[silo_idx].ring,
+        w->stations[0].modules[silo_idx].slot);
+    vec2 midpoint = v2_scale(v2_add(furnace_pos, silo_pos), 0.5f);
+
+    /* Place a fragment exactly on the midpoint. fracture_seed varies
+     * so fragment_pub derivation produces a non-trivial value. */
+    int slot = -1;
+    for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        if (!w->asteroids[i].active) { slot = i; break; }
+    }
+    ASSERT(slot >= 0);
+    asteroid_t *a = &w->asteroids[slot];
+    memset(a, 0, sizeof(*a));
+    a->active = true;
+    a->tier = ASTEROID_TIER_S;
+    a->commodity = COMMODITY_FERRITE_ORE;
+    a->ore = 3.0f;
+    a->max_ore = 3.0f;
+    a->radius = 6.0f;
+    a->fracture_child = true;
+    for (int b = 0; b < 32; b++) a->fracture_seed[b] = (uint8_t)(b * 13 + 7);
+    a->grade = (uint8_t)MINING_GRADE_COMMON;
+    a->pos = midpoint;
+    a->vel = v2(0, 0);
+
+    /* Run sim until the fragment smelts (smelt_progress accumulates
+     * at ~0.5/s; cap at a generous 10 s of sim time). */
+    for (int i = 0; i < 1200 && w->asteroids[slot].active; i++)
+        world_sim_step(w, 1.0f / 120.0f);
+    ASSERT(!w->asteroids[slot].active);
+
+    /* Chain log must have gained EVT_SMELT events. */
+    ASSERT(w->stations[0].chain_event_count >= 1);
+
+    uint64_t walked = 0;
+    ASSERT(chain_log_verify(&w->stations[0], &walked, NULL));
+    ASSERT(walked == w->stations[0].chain_event_count);
+
+    /* Walk the on-disk log and confirm at least one EVT_SMELT carries
+     * a non-zero fragment_pub — that's the gap the fragment-tow path
+     * just closed. The hopper-float path emits with fragment_pub = 0,
+     * so any non-zero is positive proof the fragment-tow path fired. */
+    char path[256];
+    ASSERT(chain_log_path_for(w->stations[0].station_pubkey,
+                              path, sizeof(path)));
+    FILE *fp = fopen(path, "rb");
+    ASSERT(fp != NULL);
+    bool saw_fragment_attributed = false;
+    while (!feof(fp)) {
+        chain_event_header_t hdr;
+        if (fread(&hdr, sizeof(hdr), 1, fp) != 1) break;
+        uint16_t plen = 0;
+        if (fread(&plen, sizeof(plen), 1, fp) != 1) break;
+        if (hdr.type == CHAIN_EVT_SMELT && plen == sizeof(chain_payload_smelt_t)) {
+            chain_payload_smelt_t pl;
+            if (fread(&pl, sizeof(pl), 1, fp) != 1) break;
+            uint8_t zero[32] = {0};
+            if (memcmp(pl.fragment_pub, zero, 32) != 0) {
+                saw_fragment_attributed = true;
+                break;
+            }
+        } else {
+            fseek(fp, plen, SEEK_CUR);
+        }
+    }
+    fclose(fp);
+    ASSERT(saw_fragment_attributed);
+
+    chain_test_teardown();
+}
+
 TEST(test_chain_log_rock_destroy_emits_event) {
     chain_test_setup("rockdestroy");
     WORLD_HEAP w = calloc(1, sizeof(world_t));
@@ -314,5 +415,6 @@ void register_chain_log_tests(void) {
     RUN(test_chain_log_save_load_continuity);
     RUN(test_chain_log_cross_station_independent);
     RUN(test_chain_log_smelt_emits_event);
+    RUN(test_chain_log_smelt_emits_event_fragment_path);
     RUN(test_chain_log_rock_destroy_emits_event);
 }


### PR DESCRIPTION
## Summary

Closes the audit-log gap surfaced in PR #533 (the cargo architecture ADR): the **fragment-tow smelt path mints ingots with full lineage but emitted no chain event**, while the (suspected-dead) hopper-float path emits `EVT_SMELT` with `fragment_pub = 0` because the float has no source fragment to attribute to.

Net effect today: the chain log is dominated by zero-lineage events on a path that's probably never exercised, and missing events for the path that actually runs in normal play.

## Changes

**`server/sim_production.c`**
- Add `EVT_SMELT` emission to the fragment-tow smelt block in `step_furnace_smelting()`. Populates `fragment_pub` from the consumed asteroid record (`a->fragment_pub`). One event per newly-minted ingot; matches the existing hopper-path emit shape so verifiers don't need to special-case.
- Update the docstring on `sim_step_refinery_production` to flag it as suspected dead post-#259 and point at `docs/cargo-architecture.md` for context. **Not removed in this PR** — removal needs to migrate `last_smelt_commodity` (set inside the dead function, drives the dynamic furnace-glow render) onto the fragment-tow path AND retire the `_inventory_cache[ORE]`-populating tests. That's a follow-up.

**`src/tests/test_chain_log.c`**
- New test `test_chain_log_smelt_emits_event_fragment_path`. Spawns a fragment at the furnace+adjacent-module midpoint, runs the sim until it smelts, then walks the on-disk log and asserts at least one `EVT_SMELT` carries a non-zero `fragment_pub`. Since the hopper-path always emits zero, any non-zero is positive proof the new fragment-path emission fired.

## What this *doesn't* do

- ❌ Delete `sim_step_refinery_production`. Needs `last_smelt_commodity` migration first, plus retiring the test that pre-loads `_inventory_cache[FERRITE_ORE]` to force a smelt. Filed as follow-up.
- ❌ Touch the player-facing display layer. That's a separate, larger PR (gap 3 in the ADR).
- ❌ Add fragment in-flight events (`EVT_FRAGMENT_TOW`/`DEPOSIT`/`LOST`). Different gap, separate PR.

## Test plan

- [x] `cmake --build build-test` clean
- [x] `./build-test/signal_test --quiet` — **426/426 pass** (was 425, +1 new)
- [x] `signal_verify` against the committed chain-log fixture: counts unchanged, status OK (the fixture is generated by `tools/gen_chain_fixture.c` independently of the runtime smelt path, so this PR doesn't drift it)
- [ ] CI green (PR will validate)

## References

- Architectural context: PR #533 (`docs/cargo-architecture.md`)
- Original substrate work: PR #526 (`cargo_unit_t.quantity`)
- Slated follow-up: deletion of `sim_step_refinery_production` + `last_smelt_commodity` migration

---
_Generated by [Claude Code](https://claude.ai/code/session_0185uPJSaxLJdswso1ySPR6P)_