### PR TITLE
Batch sync: tractor + laser primitives, ring physics, identity audit, demand primitive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ set(SIGNAL_SIM_HELPERS
     shared/module_schema.c
     shared/station_util.c
     shared/cargo_receipt.c
+    shared/tractor.c
 )
 
 # Client-only: rendering, input, HUD, audio, network plumbing. Not
@@ -210,6 +211,7 @@ if(NOT EMSCRIPTEN AND NOT BUILD_SERVER_ONLY)
         src/tests/test_bug_regression.c
         src/tests/test_save.c
         src/tests/test_construction.c
+        src/tests/test_tractor.c
         src/tests/test_navigation.c
         src/tests/test_econ_sim.c
         src/tests/test_asteroid.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ set(SIGNAL_SIM_HELPERS
     shared/station_util.c
     shared/cargo_receipt.c
     shared/tractor.c
+    shared/laser.c
 )
 
 # Client-only: rendering, input, HUD, audio, network plumbing. Not
@@ -212,6 +213,7 @@ if(NOT EMSCRIPTEN AND NOT BUILD_SERVER_ONLY)
         src/tests/test_save.c
         src/tests/test_construction.c
         src/tests/test_tractor.c
+        src/tests/test_laser.c
         src/tests/test_navigation.c
         src/tests/test_econ_sim.c
         src/tests/test_asteroid.c

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -777,10 +777,17 @@ static void emergency_recover_ship(world_t *w, server_player_t *sp) {
      * a bankrupt player still gets a ship — the negative balance becomes
      * the next-run mining target, which is the whole point of the debt
      * loop. Unlike player_seed_credits, this fires on EVERY respawn so
-     * the cost of dying is visible and recurring. */
+     * the cost of dying is visible and recurring. Identity-aware:
+     * registered players debit their pubkey entry (the same one that
+     * carries their earnings); legacy players use session-token. */
     int fee = station_spawn_fee(&w->stations[best]);
-    ledger_force_debit(&w->stations[best], sp->session_token,
-                       (float)fee, &sp->ship);
+    if (sp->pubkey_set) {
+        ledger_force_debit_by_pubkey(&w->stations[best], sp->pubkey,
+                                     (float)fee, &sp->ship);
+    } else {
+        ledger_force_debit(&w->stations[best], sp->session_token,
+                           (float)fee, &sp->ship);
+    }
 
     sim_event_t death_ev = {
         .type = SIM_EVENT_DEATH, .player_id = sp->id,
@@ -5476,18 +5483,36 @@ void player_seed_credits(server_player_t *sp, world_t *w) {
     int st = sp->current_station;
     if (st < 0 || st >= MAX_STATIONS) st = 0;
     /* Already established a ledger here? Skip — debt and earnings
-     * carry across reconnects and respawns. We probe by entry
-     * existence (any nonzero balance, positive or negative) since
-     * fresh entries always start at exactly 0.
+     * carry across reconnects and respawns.
      *
-     * Token-based path (via pseudo-pubkey shim) so pre-Layer-A.1
-     * anonymous players still get a stable ledger row keyed on their
-     * 8B session token. Layer-A.1 players additionally have a real
-     * 32B pubkey on sp->pubkey; once they register, ledger entries
-     * migrate via the v45→v46 save path (sim_save.c). */
+     * Identity-aware lookup: pubkey-registered players match the
+     * full 32-byte pubkey entry (the same one their earnings credit
+     * to). Legacy session-token players match the SHA256-of-token
+     * pseudokey via the existing ledger_balance shim. The OLD code
+     * here did `memcmp(ledger.player_pubkey, session_token, 8)` —
+     * comparing the first 8 bytes of a 32-byte sha256 against the
+     * raw session token, which never matches even for legacy
+     * players, so the fee was charged on every reconnect. */
+    if (sp->pubkey_set) {
+        for (int i = 0; i < w->stations[st].ledger_count; i++) {
+            if (memcmp(w->stations[st].ledger[i].player_pubkey,
+                       sp->pubkey, 32) == 0) {
+                return;
+            }
+        }
+        int fee = station_spawn_fee(&w->stations[st]);
+        ledger_force_debit_by_pubkey(&w->stations[st], sp->pubkey,
+                                     (float)fee, &sp->ship);
+        return;
+    }
+    /* Legacy: derive the pseudokey via the same helper ledger_balance
+     * uses, then compare full 32 bytes. token_to_pseudo_pubkey copies
+     * 8 bytes of token + 24 zero bytes — NOT a sha256. */
+    uint8_t pseudo[32];
+    token_to_pseudo_pubkey(sp->session_token, pseudo);
     for (int i = 0; i < w->stations[st].ledger_count; i++) {
         if (memcmp(w->stations[st].ledger[i].player_pubkey,
-                   sp->session_token, 8) == 0) {
+                   pseudo, 32) == 0) {
             return;
         }
     }

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -3720,12 +3720,19 @@ static void step_contracts(world_t *w, float dt) {
                 if (deficit > worst_deficit) { worst_deficit = deficit; worst_ore = c; }
             }
             if (worst_ore >= 0) {
+                /* Demand multiplier: 1.0× when at target, up to 1.5× at
+                 * total starvation. Layered on top of pool_factor so a
+                 * starved-but-broke station still posts a sensible
+                 * price. station_demand_for shares its severity
+                 * definition with the priority-3 deficit calc above —
+                 * they cannot disagree about who is starving. */
+                float dmult = station_demand_for(st, (commodity_t)worst_ore).price_mult;
                 need = (contract_t){
                     .active = true, .action = CONTRACT_TRACTOR,
                     .station_index = (uint8_t)s,
                     .commodity = (commodity_t)worst_ore,
                     .quantity_needed = 0.0f, /* inventory-driven, not delivery-driven */
-                    .base_price = st->base_price[worst_ore] * pool_factor,
+                    .base_price = st->base_price[worst_ore] * pool_factor * dmult,
                     .target_index = -1, .claimed_by = -1,
                 };
             }
@@ -3764,12 +3771,13 @@ static void step_contracts(world_t *w, float dt) {
                 if (deficit > worst_deficit) { worst_deficit = deficit; worst_idx = j; }
             }
             if (worst_idx >= 0) {
+                float dmult = station_demand_for(st, checks[worst_idx].ingot).price_mult;
                 need = (contract_t){
                     .active = true, .action = CONTRACT_TRACTOR,
                     .station_index = (uint8_t)s,
                     .commodity = checks[worst_idx].ingot,
                     .quantity_needed = worst_deficit,
-                    .base_price = st->base_price[checks[worst_idx].ingot] * 1.15f * pool_factor,
+                    .base_price = st->base_price[checks[worst_idx].ingot] * 1.15f * pool_factor * dmult,
                     .target_index = -1, .claimed_by = -1,
                 };
             }
@@ -3798,14 +3806,15 @@ static void step_contracts(world_t *w, float dt) {
             }
             if (worst_idx >= 0) {
                 commodity_t mat = kit_inputs[worst_idx].c;
+                float dmult = station_demand_for(st, mat).price_mult;
                 kit_need = (contract_t){
                     .active = true, .action = CONTRACT_TRACTOR,
                     .station_index = (uint8_t)s,
                     .commodity = mat,
                     .quantity_needed = worst_deficit,
-                    .base_price = st->base_price[mat] > 0.0f
+                    .base_price = (st->base_price[mat] > 0.0f
                                   ? st->base_price[mat] * 1.25f * pool_factor
-                                  : 28.0f * pool_factor,
+                                  : 28.0f * pool_factor) * dmult,
                     .target_index = -1, .claimed_by = -1,
                 };
             }
@@ -3826,12 +3835,13 @@ static void step_contracts(world_t *w, float dt) {
                 float seed = st->base_price[COMMODITY_REPAIR_KIT] > 0.0f
                              ? st->base_price[COMMODITY_REPAIR_KIT]
                              : 6.0f;
+                float dmult = station_demand_for(st, COMMODITY_REPAIR_KIT).price_mult;
                 need = (contract_t){
                     .active = true, .action = CONTRACT_TRACTOR,
                     .station_index = (uint8_t)s,
                     .commodity = COMMODITY_REPAIR_KIT,
                     .quantity_needed = deficit,
-                    .base_price = seed * 1.5f * pool_factor,
+                    .base_price = seed * 1.5f * pool_factor * dmult,
                     .target_index = -1, .claimed_by = -1,
                 };
             }

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -4976,9 +4976,21 @@ void world_reset(world_t *w) {
     add_module_at(&w->stations[0], MODULE_DOCK,         1, 0);
     add_module_at(&w->stations[0], MODULE_SIGNAL_RELAY, 1, 1);
     add_furnace_for(&w->stations[0], 1, 2, COMMODITY_FERRITE_INGOT);
-    /* Ring 2: one ferrite-ore hopper, the only input the lone
-     * furnace needs. Renders rusty red. */
+    /* Ring 2: ferrite-ore intake at slot 4 (240°, cross-ring opposite
+     * the furnace at ring 1 slot 2), ferrite-ingot output at slot 0
+     * (0°, on the dock's radial axis). Slot choice for the new output
+     * hopper is load-bearing — slot 0 is the only ring-2 slot that
+     * doesn't perturb NPC docking pathways. Empirically, adding any
+     * hopper at slots 1/2/3/5 stalls the NPC mining cycle in
+     * test_scenario_npc_economy_30s; slot 0 alone preserves it.
+     * (The A* nav mesh is rebuilt by station_rebuild_all_nav at end
+     * of world_reset, so it's not stale; the stall comes from the
+     * ring's annular-sector corridor geometry between this slot and
+     * the existing slot-4 hopper. Slot 0's corridor sweeps through
+     * empty slot 5 and terminates on the dock radial — a region NPCs
+     * already vacate when undocking.) */
     add_hopper_for(&w->stations[0], 2, 4, COMMODITY_FERRITE_ORE);
+    add_hopper_for(&w->stations[0], 2, 0, COMMODITY_FERRITE_INGOT);
     w->stations[0].arm_count = 2;
     /* Ring 2 (idx 1) is the driver — ring 2 spins, ring 1 is dragged
      * along by the cross-ring spoke spring. Prospect has only one

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -22,6 +22,7 @@
  */
 #include "game_sim.h"
 #include "tractor.h"
+#include "laser.h"
 #include "manifest.h"
 #include "ship.h"
 #include "sim_ai.h"
@@ -2373,23 +2374,30 @@ static bool find_scan_target(world_t *w, server_player_t *sp, vec2 muzzle, vec2 
     sp->scan_target_index = -1;
     sp->scan_module_index = -1;
 
+    /* Each circle-target test reuses the same laser_ray. We compare the
+     * `along` distance returned by laser_target_in_beam against best_dist
+     * manually rather than tightening the ray's range each time, so a
+     * larger target whose center sits past best_dist but whose radius
+     * extends within still has a chance to register — preserving the
+     * legacy behavior where best_dist gated on projected-center distance. */
+    laser_ray_t ray = {
+        .source_pos = muzzle, .source_dir = forward,
+        .range = MINING_RANGE, .cone_half_angle = 0.0f,
+    };
+
     /* Check station modules */
     for (int si = 0; si < MAX_STATIONS; si++) {
         const station_t *st = &w->stations[si];
         if (st->signal_range <= 0.0f) continue;
         /* Check core */
-        vec2 to_core = v2_sub(st->pos, muzzle);
-        float proj = v2_dot(to_core, forward);
-        if (proj > 0.0f && proj < best_dist) {
-            vec2 closest = v2_add(muzzle, v2_scale(forward, proj));
-            float perp = v2_len(v2_sub(closest, st->pos));
-            if (perp < st->radius) {
-                best_dist = proj;
-                sp->scan_target_type = 1;
-                sp->scan_target_index = si;
-                sp->scan_module_index = -1; /* core */
-                sp->beam_end = v2_sub(st->pos, v2_scale(v2_norm(to_core), st->radius * 0.9f));
-            }
+        vec2 hit; float along;
+        if (laser_target_in_beam(&ray, st->pos, st->radius, &hit, &along)
+            && along < best_dist) {
+            best_dist = along;
+            sp->scan_target_type = 1;
+            sp->scan_target_index = si;
+            sp->scan_module_index = -1; /* core */
+            sp->beam_end = hit;
         }
         /* Check structural rings — ray vs annulus. Each station ring
          * is a thin band of girders at STATION_RING_RADIUS[r]. Cast the
@@ -2425,18 +2433,14 @@ static bool find_scan_target(world_t *w, server_player_t *sp, vec2 muzzle, vec2 
         for (int mi = 0; mi < st->module_count; mi++) {
             if (st->modules[mi].scaffold) continue;
             vec2 mp = module_world_pos_ring(st, st->modules[mi].ring, st->modules[mi].slot);
-            vec2 to_mod = v2_sub(mp, muzzle);
-            float mproj = v2_dot(to_mod, forward);
-            if (mproj > 0.0f && mproj < best_dist) {
-                vec2 closest = v2_add(muzzle, v2_scale(forward, mproj));
-                float perp = v2_len(v2_sub(closest, mp));
-                if (perp < STATION_MODULE_COL_RADIUS) {
-                    best_dist = mproj;
-                    sp->scan_target_type = 1;
-                    sp->scan_target_index = si;
-                    sp->scan_module_index = mi;
-                    sp->beam_end = v2_sub(mp, v2_scale(v2_norm(to_mod), STATION_MODULE_COL_RADIUS * 0.9f));
-                }
+            vec2 hit; float along;
+            if (laser_target_in_beam(&ray, mp, STATION_MODULE_COL_RADIUS, &hit, &along)
+                && along < best_dist) {
+                best_dist = along;
+                sp->scan_target_type = 1;
+                sp->scan_target_index = si;
+                sp->scan_module_index = mi;
+                sp->beam_end = hit;
             }
         }
     }
@@ -2445,19 +2449,15 @@ static bool find_scan_target(world_t *w, server_player_t *sp, vec2 muzzle, vec2 
     for (int ni = 0; ni < MAX_NPC_SHIPS; ni++) {
         const npc_ship_t *npc = &w->npc_ships[ni];
         if (!npc->active) continue;
-        vec2 to_npc = v2_sub(npc->ship.pos, muzzle);
-        float proj = v2_dot(to_npc, forward);
         float npc_r = npc_hull_def(npc)->render_scale * 16.0f;
-        if (proj > 0.0f && proj < best_dist) {
-            vec2 closest = v2_add(muzzle, v2_scale(forward, proj));
-            float perp = v2_len(v2_sub(closest, npc->ship.pos));
-            if (perp < npc_r) {
-                best_dist = proj;
-                sp->scan_target_type = 2;
-                sp->scan_target_index = ni;
-                sp->scan_module_index = -1;
-                sp->beam_end = v2_sub(npc->ship.pos, v2_scale(v2_norm(to_npc), npc_r * 0.9f));
-            }
+        vec2 hit; float along;
+        if (laser_target_in_beam(&ray, npc->ship.pos, npc_r, &hit, &along)
+            && along < best_dist) {
+            best_dist = along;
+            sp->scan_target_type = 2;
+            sp->scan_target_index = ni;
+            sp->scan_module_index = -1;
+            sp->beam_end = hit;
         }
     }
 
@@ -2465,19 +2465,15 @@ static bool find_scan_target(world_t *w, server_player_t *sp, vec2 muzzle, vec2 
     for (int pi = 0; pi < MAX_PLAYERS; pi++) {
         const server_player_t *other = &w->players[pi];
         if (!other->connected || other->id == sp->id) continue;
-        vec2 to_p = v2_sub(other->ship.pos, muzzle);
-        float proj = v2_dot(to_p, forward);
         float pr = ship_hull_def(&other->ship)->ship_radius;
-        if (proj > 0.0f && proj < best_dist) {
-            vec2 closest = v2_add(muzzle, v2_scale(forward, proj));
-            float perp = v2_len(v2_sub(closest, other->ship.pos));
-            if (perp < pr) {
-                best_dist = proj;
-                sp->scan_target_type = 3;
-                sp->scan_target_index = pi;
-                sp->scan_module_index = -1;
-                sp->beam_end = v2_sub(other->ship.pos, v2_scale(v2_norm(to_p), pr * 0.9f));
-            }
+        vec2 hit; float along;
+        if (laser_target_in_beam(&ray, other->ship.pos, pr, &hit, &along)
+            && along < best_dist) {
+            best_dist = along;
+            sp->scan_target_type = 3;
+            sp->scan_target_index = pi;
+            sp->scan_module_index = -1;
+            sp->beam_end = hit;
         }
     }
 

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -2898,6 +2898,17 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
             float bal = sp->pubkey_set
                 ? ledger_balance_by_pubkey(docked_st, sp->pubkey)
                 : ledger_balance(docked_st, sp->session_token);
+            SIM_LOG("[buy-bal] player %d at station %d: pubkey_set=%d pk_prefix=%02x%02x%02x%02x bal=%.2f ledger_count=%d\n",
+                    sp->id, sp->current_station, sp->pubkey_set ? 1 : 0,
+                    sp->pubkey[0], sp->pubkey[1], sp->pubkey[2], sp->pubkey[3],
+                    bal, docked_st->ledger_count);
+            for (int li = 0; li < docked_st->ledger_count; li++) {
+                const uint8_t *lpk = docked_st->ledger[li].player_pubkey;
+                (void)lpk;
+                SIM_LOG("[buy-bal]   ledger[%d] pk=%02x%02x%02x%02x bal=%.2f\n",
+                        li, lpk[0], lpk[1], lpk[2], lpk[3],
+                        docked_st->ledger[li].balance);
+            }
             float afford = (price_per > 0.01f) ? floorf(bal / price_per) : 0.0f;
             /* Per-press unit cap scales by commodity density: standard
              * goods (vol = 1.0) buy 1 per press; dense goods like

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -4972,10 +4972,10 @@ void world_reset(world_t *w) {
     w->stations[0].base_price[COMMODITY_LASER_MODULE]   = 30.0f;
     w->stations[0].base_price[COMMODITY_TRACTOR_MODULE] = 38.0f;
     w->stations[0].signal_range = 18000.0f;
-    /* Ring 1: dock + relay + ferrite furnace. */
+    /* Ring 1: dock + relay + ferrite furnace (tagged FERRITE_INGOT). */
     add_module_at(&w->stations[0], MODULE_DOCK,         1, 0);
     add_module_at(&w->stations[0], MODULE_SIGNAL_RELAY, 1, 1);
-    add_module_at(&w->stations[0], MODULE_FURNACE,      1, 2);
+    add_furnace_for(&w->stations[0], 1, 2, COMMODITY_FERRITE_INGOT);
     /* Ring 2: one ferrite-ore hopper, the only input the lone
      * furnace needs. Renders rusty red. */
     add_hopper_for(&w->stations[0], 2, 4, COMMODITY_FERRITE_ORE);
@@ -5058,10 +5058,10 @@ void world_reset(world_t *w) {
     w->stations[2].base_price[COMMODITY_FERRITE_INGOT]  = 0.0f;
     /* Producers spread across all three rings; commodity-tagged
      * hoppers feed them all. */
-    /* Ring 1: dock + relay + furnace. */
+    /* Ring 1: dock + relay + cuprite furnace. */
     add_module_at(&w->stations[2], MODULE_DOCK,         1, 0);
     add_module_at(&w->stations[2], MODULE_SIGNAL_RELAY, 1, 1);
-    add_module_at(&w->stations[2], MODULE_FURNACE,      1, 2);
+    add_furnace_for(&w->stations[2], 1, 2, COMMODITY_CUPRITE_INGOT);
     /* Ring 2: fabs + paired ingot hoppers. LASER_FAB needs both
      * cuprite and crystal ingots → 2 spokes from it. TRACTOR_FAB
      * just cuprite → 1 spoke. */
@@ -5069,13 +5069,17 @@ void world_reset(world_t *w) {
     add_hopper_for(&w->stations[2], 2, 1, COMMODITY_CUPRITE_INGOT);
     add_hopper_for(&w->stations[2], 2, 3, COMMODITY_CRYSTAL_INGOT);
     add_module_at(&w->stations[2], MODULE_TRACTOR_FAB,  2, 5);
-    /* Ring 3: 2 more furnaces + cuprite/crystal ore hoppers feeding
-     * all 3 furnaces' smelt path. With 3 furnaces total Helios is
-     * tier-3 → smelts cuprite + crystal (ferrite gated). */
+    /* Ring 3: 2 more furnaces (cuprite + crystal output) + cuprite /
+     * crystal ore intake hoppers + laser/tractor module output hoppers
+     * for the ring-2 fabs. All 5 slots used here are well clear of the
+     * dock approach axis (slot 0 = 0° aligns with the dock; we sit
+     * elsewhere on the 9-slot ring). */
     add_hopper_for(&w->stations[2], 3, 0, COMMODITY_CUPRITE_ORE);
-    add_module_at(&w->stations[2], MODULE_FURNACE,      3, 1);
-    add_module_at(&w->stations[2], MODULE_FURNACE,      3, 4);
+    add_furnace_for(&w->stations[2],   3, 1, COMMODITY_CUPRITE_INGOT);
+    add_hopper_for(&w->stations[2], 3, 2, COMMODITY_LASER_MODULE);   /* LASER_FAB output */
+    add_furnace_for(&w->stations[2],   3, 4, COMMODITY_CRYSTAL_INGOT);
     add_hopper_for(&w->stations[2], 3, 6, COMMODITY_CRYSTAL_ORE);
+    add_hopper_for(&w->stations[2], 3, 7, COMMODITY_TRACTOR_MODULE); /* TRACTOR_FAB output */
     w->stations[2].arm_count = 3;
     w->stations[2].arm_speed[1] = STATION_RING_SPEED; /* ring 2 drives */
     rebuild_station_services(&w->stations[2]);

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -4644,9 +4644,12 @@ void step_station_ring_dynamics(world_t *w, float dt) {
             if (st->arm_omega[idx] >  RING_OMEGA_MAX) st->arm_omega[idx] =  RING_OMEGA_MAX;
             if (st->arm_omega[idx] < -RING_OMEGA_MAX) st->arm_omega[idx] = -RING_OMEGA_MAX;
             st->arm_rotation[idx] += st->arm_omega[idx] * dt;
-
-            while (st->arm_rotation[idx] >  TWO_PI_F) st->arm_rotation[idx] -= TWO_PI_F;
-            while (st->arm_rotation[idx] < -TWO_PI_F) st->arm_rotation[idx] += TWO_PI_F;
+            /* No 2π wrap — sin/cos are periodic in the renderer, and
+             * wrapping server-side caused visible "snap-back" artifacts
+             * for clients interpolating across snapshots that landed on
+             * opposite sides of the wrap boundary. arm_rotation grows
+             * unbounded; f32 precision holds for years of session time
+             * at typical drift rates (~0.04 rad/s). */
         }
     }
 }
@@ -5063,10 +5066,11 @@ void world_reset(world_t *w) {
     add_module_at(&w->stations[0], MODULE_SIGNAL_RELAY, 1, 1);
     add_furnace_for(&w->stations[0], 1, 2, COMMODITY_FERRITE_INGOT);
     /* Ring 2: ferrite-ore intake at slot 4 (240°, cross-ring opposite
-     * the furnace at ring 1 slot 2), ferrite-ingot output at slot 0
-     * (0°, on the dock's radial axis). */
+     * the furnace at ring 1 slot 2). No output hopper — Prospect has
+     * no downstream local consumer of ferrite ingots (no frame press
+     * here), so smelt-completed ingots go straight to station
+     * inventory and ride out via haulers to Kepler. */
     add_hopper_for(&w->stations[0], 2, 4, COMMODITY_FERRITE_ORE);
-    add_hopper_for(&w->stations[0], 2, 0, COMMODITY_FERRITE_INGOT);
     w->stations[0].arm_count = 2;
     /* Drift bias on ring 2 — under the all-passive Slice 1.5a dynamics
      * this is the per-ring ambient torque. Ring 1 co-rotates via the

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -663,6 +663,37 @@ vec2 station_approach_target(const station_t *st, vec2 from) {
     return best_pos;
 }
 
+/* Exit target: pick the dock module nearest `from`, project a waypoint
+ * past the outermost ring along that dock's current radial. NPCs (and
+ * eventually player autopilot) steer through this waypoint as their
+ * UNDOCKING phase, ensuring they clear ring-corridor obstacles before
+ * heading to their real destination. */
+vec2 station_exit_target(const station_t *st, vec2 from) {
+    /* Push 160u past the outermost ring radius — comfortably clear of
+     * the ring corridor band's lookahead cone (which fires at ring_r
+     * +/- ship_radius + 40u). */
+    const float exit_pad = STATION_RING_RADIUS[STATION_NUM_RINGS] + 160.0f;
+    int best_i = -1;
+    float best_d = 1e18f;
+    for (int i = 0; i < st->module_count; i++) {
+        if (st->modules[i].type != MODULE_DOCK) continue;
+        if (st->modules[i].scaffold) continue;
+        vec2 mp = module_world_pos_ring(st, st->modules[i].ring, st->modules[i].slot);
+        float d = v2_dist_sq(from, mp);
+        if (d < best_d) { best_d = d; best_i = i; }
+    }
+    if (best_i < 0) {
+        /* No dock — emit a stable fallback past the outer ring. */
+        return v2_add(st->pos, v2(exit_pad, 0.0f));
+    }
+    vec2 mp = module_world_pos_ring(st, st->modules[best_i].ring,
+                                    st->modules[best_i].slot);
+    vec2 outward = v2_sub(mp, st->pos);
+    float len = v2_len(outward);
+    if (len < 1.0f) return v2_add(st->pos, v2(exit_pad, 0.0f));
+    return v2_add(st->pos, v2_scale(outward, exit_pad / len));
+}
+
 /* ================================================================== */
 /* Player ship helpers                                                */
 /* ================================================================== */

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -4424,33 +4424,31 @@ const signal_channel_msg_t *signal_channel_at(const world_t *w, int i) {
 }
 
 /* Spoke spring + drag dynamics constants. Tuned so the steady-state
- * phase lag at STATION_RING_SPEED is a visible 15-25° per spoke
+ * phase lag at the drift-bias velocity is a visible 15-25° per spoke
  * group — enough to read as "the ring is being dragged" but well
  * shy of 90° where the spring would flip. Per-spoke stiffness sums
  * linearly: a station with many spokes between two rings tracks
  * tightly, a station with one is loose. */
-#define RING_SPOKE_K     2.5f   /* spring constant per spoke (torque/rad) */
-#define RING_DRAG_MU     0.6f   /* angular drag coefficient (torque per rad/s) */
-#define RING_INERTIA_I   1.0f   /* moment of inertia per ring */
+#define RING_SPOKE_K        2.5f   /* spring constant per spoke (torque/rad) */
+#define RING_DRAG_MU        0.6f   /* angular drag coefficient (torque per rad/s) */
+#define RING_INERTIA_I      1.0f   /* moment of inertia per ring */
+/* Drift bias: ambient torque applied per ring. arm_speed[r] * this
+ * keeps a perfectly balanced station drifting (so an idle station
+ * still rotates) and matches the legacy kinematic driver — at zero
+ * spoke load, omega settles at arm_speed[r] * BIAS / DRAG_MU. With
+ * BIAS = DRAG_MU, the steady-state omega equals arm_speed exactly,
+ * so the legacy seed code (`arm_speed[1] = STATION_RING_SPEED`)
+ * keeps Prospect's ring-2 spinning at the same rate as before. */
+#define RING_DRIVE_BIAS_K   0.6f
+/* Hard clamp on per-ring angular velocity. Prevents pathologically
+ * asymmetric station layouts from driving a ring into a runaway
+ * positive-feedback loop while still letting normal spoke balance
+ * settle freely. ~4× the legacy STATION_RING_SPEED (0.04 rad/s). */
+#define RING_OMEGA_MAX      0.16f
 /* How long after a producer's last activity its tractor beam keeps
  * pulling (and rendering) at full strength. Pulse decays linearly
  * to 0 over this many seconds. */
 #define RING_PULSE_LINGER_SEC 1.5f
-
-/* Pick the ring this station drives kinematically. Default ring 2;
- * fall back to ring 1 (small outposts that haven't grown to ring 2
- * yet) and finally ring 3 (degenerate but defensive). */
-static int station_driver_ring_idx(const station_t *st) {
-    int has_ring[STATION_NUM_RINGS + 1] = {0};
-    for (int m = 0; m < st->module_count; m++) {
-        int r = (int)st->modules[m].ring;
-        if (r >= 1 && r <= STATION_NUM_RINGS) has_ring[r] = 1;
-    }
-    if (has_ring[2]) return 1;
-    if (has_ring[1]) return 0;
-    if (has_ring[3]) return 2;
-    return -1;
-}
 
 /* Station jostle constants. Personal space = (a.dock_radius +
  * b.dock_radius) × FACTOR; below that, a spring force scaled by
@@ -4529,70 +4527,88 @@ void step_station_ring_dynamics(world_t *w, float dt) {
         station_t *st = &w->stations[s];
         if (!station_exists(st)) continue;
 
-        int driver_idx = station_driver_ring_idx(st);
-        if (driver_idx < 0) continue;
-        int driver_ring = driver_idx + 1;
-        float driver_speed = st->arm_speed[driver_idx];
+        /* All-passive ring dynamics (Slice 1.5a). Every ring is a
+         * passive ring receiving torque from its spokes; per-ring
+         * arm_speed[r] becomes a "drift bias" so a perfectly balanced
+         * station still rotates instead of locking up. There is no
+         * kinematic driver — passive rings balance against each other
+         * naturally.
+         *
+         * Spoke set: every active producer contributes one spoke per
+         * declared input commodity AND one spoke for its output
+         * commodity (when one exists — SHIPYARD is exempt; output is a
+         * physical scaffold body). Each spoke applies equal-and-opposite
+         * spring torque to its two endpoints; spokes whose endpoints
+         * sit on the same ring net to zero, which is correct. */
+        float net_torque[STATION_NUM_RINGS] = {0};
 
-        /* Driver: kinematic update from arm_speed. */
-        st->arm_rotation[driver_idx] += driver_speed * dt;
-        st->arm_omega[driver_idx] = driver_speed;
+        for (int m = 0; m < st->module_count; m++) {
+            const station_module_t *prod = &st->modules[m];
+            if (prod->scaffold) continue;
+            float pulse = st->module_active_pulse[m];
+            if (pulse <= 0.0f) continue;
 
-        for (int idx = 0; idx < STATION_NUM_RINGS && idx < MAX_ARMS; idx++) {
-            if (idx == driver_idx) continue;
-            int ring = idx + 1;
+            int ra = (int)prod->ring;
+            if (ra < 1 || ra > STATION_NUM_RINGS) continue;
+            int slots_a = STATION_RING_SLOTS[ra];
+            if (slots_a <= 0) continue;
+            float alpha_a = TWO_PI_F * (float)prod->slot / (float)slots_a;
+            float wa = st->arm_rotation[ra-1] + alpha_a;
 
-            float net_torque = 0.0f;
-            for (int m = 0; m < st->module_count; m++) {
-                const station_module_t *prod = &st->modules[m];
-                if (prod->scaffold) continue;
-                module_inputs_t req = module_required_inputs(prod->type);
-                if (req.count == 0) continue;
+            /* Add a spoke contribution from producer `prod` to the
+             * module at index `hop` (must satisfy ring/slot bounds).
+             * Equal-and-opposite torque on the two endpoint rings. */
+            #define ADD_SPOKE(hop) do {                                    \
+                if ((hop) >= 0) {                                          \
+                    const station_module_t *hm = &st->modules[(hop)];      \
+                    if (!hm->scaffold) {                                   \
+                        int rb = (int)hm->ring;                            \
+                        if (rb >= 1 && rb <= STATION_NUM_RINGS && rb != ra) { \
+                            int slots_b = STATION_RING_SLOTS[rb];          \
+                            if (slots_b > 0) {                             \
+                                float alpha_b = TWO_PI_F * (float)hm->slot \
+                                                / (float)slots_b;          \
+                                float wb = st->arm_rotation[rb-1] + alpha_b; \
+                                float dr = wb - wa;                        \
+                                while (dr > PI_F)  dr -= TWO_PI_F;         \
+                                while (dr < -PI_F) dr += TWO_PI_F;         \
+                                float T = pulse * RING_SPOKE_K * sinf(dr); \
+                                net_torque[ra-1] += T;                     \
+                                net_torque[rb-1] -= T;                     \
+                            }                                              \
+                        }                                                  \
+                    }                                                      \
+                }                                                          \
+            } while (0)
 
-                /* Spring strength scales with the producer's activity
-                 * pulse — an idle producer's beams go slack, the
-                 * passive ring loses those anchors and re-equilibriums
-                 * under whatever beams remain hot. */
-                float pulse = st->module_active_pulse[m];
-                if (pulse <= 0.0f) continue;
-
-                /* One spoke per (producer, input commodity). Each
-                 * spoke contributes spring torque when it spans this
-                 * passive ring + the driver. */
-                for (int i = 0; i < req.count; i++) {
-                    int hop = station_find_hopper_for(st, req.commodities[i]);
-                    if (hop < 0) continue;
-                    const station_module_t *hm = &st->modules[hop];
-                    int ra = (int)prod->ring, rb = (int)hm->ring;
-                    if (!((ra == ring && rb == driver_ring) ||
-                          (rb == ring && ra == driver_ring))) continue;
-                    int sa = (int)prod->slot, sb = (int)hm->slot;
-                    int slots_a = STATION_RING_SLOTS[ra];
-                    int slots_b = STATION_RING_SLOTS[rb];
-                    float alpha_a = TWO_PI_F * (float)sa / (float)slots_a;
-                    float alpha_b = TWO_PI_F * (float)sb / (float)slots_b;
-                    float wa = st->arm_rotation[ra-1] + alpha_a;
-                    float wb = st->arm_rotation[rb-1] + alpha_b;
-                    float dr = (ra == ring) ? (wb - wa) : (wa - wb);
-                    while (dr > PI_F)  dr -= TWO_PI_F;
-                    while (dr < -PI_F) dr += TWO_PI_F;
-                    net_torque += pulse * RING_SPOKE_K * sinf(dr);
-                }
+            /* Input spokes — each declared input commodity. */
+            module_inputs_t req = module_required_inputs(prod->type);
+            for (int i = 0; i < req.count; i++) {
+                ADD_SPOKE(station_find_hopper_for(st, req.commodities[i]));
             }
+            /* Output spoke (Slice 1 — cargo-in-space schema). SHIPYARD
+             * has no commodity output and is naturally skipped: its
+             * module_instance_output() returns COMMODITY_COUNT, and
+             * station_find_output_hopper_for_module returns -1. */
+            ADD_SPOKE(station_find_output_hopper_for_module(st, prod));
 
-            /* Drag opposes absolute angular velocity. The phase lag at
-             * steady state is arcsin(mu*omega / (k*N_spokes)). */
-            net_torque -= RING_DRAG_MU * st->arm_omega[idx];
+            #undef ADD_SPOKE
+        }
 
-            st->arm_omega[idx] += (net_torque / RING_INERTIA_I) * dt;
+        /* Per-ring integrate: drift bias + drag, semi-implicit Euler. */
+        for (int idx = 0; idx < STATION_NUM_RINGS && idx < MAX_ARMS; idx++) {
+            float bias = st->arm_speed[idx] * RING_DRIVE_BIAS_K;
+            float damp = RING_DRAG_MU * st->arm_omega[idx];
+            float tau  = net_torque[idx] + bias - damp;
+
+            st->arm_omega[idx] += (tau / RING_INERTIA_I) * dt;
+            if (st->arm_omega[idx] >  RING_OMEGA_MAX) st->arm_omega[idx] =  RING_OMEGA_MAX;
+            if (st->arm_omega[idx] < -RING_OMEGA_MAX) st->arm_omega[idx] = -RING_OMEGA_MAX;
             st->arm_rotation[idx] += st->arm_omega[idx] * dt;
 
             while (st->arm_rotation[idx] >  TWO_PI_F) st->arm_rotation[idx] -= TWO_PI_F;
             while (st->arm_rotation[idx] < -TWO_PI_F) st->arm_rotation[idx] += TWO_PI_F;
         }
-
-        while (st->arm_rotation[driver_idx] >  TWO_PI_F) st->arm_rotation[driver_idx] -= TWO_PI_F;
-        while (st->arm_rotation[driver_idx] < -TWO_PI_F) st->arm_rotation[driver_idx] += TWO_PI_F;
     }
 }
 
@@ -5186,6 +5202,18 @@ void world_reset(world_t *w) {
     spawn_npc(w, 1, NPC_ROLE_HAULER);   /* Kepler -> Helios frames */
     spawn_npc(w, 2, NPC_ROLE_HAULER);   /* Helios -> Prospect repair kits */
     spawn_npc(w, 1, NPC_ROLE_TOW);      /* Kepler shipyard (only shipyard) */
+
+    /* Bootstrap each station's per-ring angular velocity to its drift
+     * bias. Under the all-passive Slice 1.5a dynamics, omega ramps to
+     * (arm_speed * RING_DRIVE_BIAS_K / RING_DRAG_MU) over a ~1.7s time
+     * constant. Pre-loading omega = arm_speed avoids a visible "spin
+     * up" transient on world_reset and keeps the legacy steady-state
+     * (omega == arm_speed when BIAS_K == DRAG_MU). */
+    for (int s = 0; s < MAX_STATIONS; s++) {
+        for (int r = 0; r < MAX_ARMS; r++) {
+            w->stations[s].arm_omega[r] = w->stations[s].arm_speed[r];
+        }
+    }
 
     /* Precompute station nav meshes now that geometry is finalized. */
     station_rebuild_all_nav(w);

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -2682,7 +2682,11 @@ static void handle_hail(world_t *w, server_player_t *sp) {
     }
 
     if (nearest_in >= 0) {
-        float balance = ledger_balance(&w->stations[nearest_in], sp->session_token);
+        /* Hail-credits display must read the same identity the player's
+         * earnings landed on — pubkey when registered, else session token. */
+        float balance = sp->pubkey_set
+            ? ledger_balance_by_pubkey(&w->stations[nearest_in], sp->pubkey)
+            : ledger_balance(&w->stations[nearest_in], sp->session_token);
         int contract_idx = hail_find_or_issue_contract(w, sp, nearest_in);
         emit_event(w, (sim_event_t){
             .type = SIM_EVENT_HAIL_RESPONSE,
@@ -2885,7 +2889,15 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
              * even though manifest_transfer falls back to other grades
              * once the named ones run out. Bulk-buy can come back as
              * an explicit `buy_quantity` intent if/when needed. */
-            float bal = ledger_balance(docked_st, sp->session_token);
+            /* Balance and spend MUST use the same identity the SELL path
+             * credits — pubkey when registered (the real Ed25519 entry),
+             * else the session-token-hashed pseudokey. Mismatch here was
+             * the "client predicts buy, server snaps it back" bug:
+             * earnings landed on the pubkey ledger entry but the buy
+             * path was reading the (empty) session-token entry. */
+            float bal = sp->pubkey_set
+                ? ledger_balance_by_pubkey(docked_st, sp->pubkey)
+                : ledger_balance(docked_st, sp->session_token);
             float afford = (price_per > 0.01f) ? floorf(bal / price_per) : 0.0f;
             /* Per-press unit cap scales by commodity density: standard
              * goods (vol = 1.0) buy 1 per press; dense goods like
@@ -2923,7 +2935,13 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
                 charge_amount = (float)moved;
                 charge_cost = charge_amount * price_per;
             }
-            if (charge_amount > 0.01f && ledger_spend(docked_st, sp->session_token, charge_cost, &sp->ship)) {
+            bool spent = false;
+            if (charge_amount > 0.01f) {
+                spent = sp->pubkey_set
+                    ? ledger_spend_by_pubkey(docked_st, sp->pubkey, charge_cost, &sp->ship)
+                    : ledger_spend(docked_st, sp->session_token, charge_cost, &sp->ship);
+            }
+            if (spent) {
                 sp->ship.cargo[c] += charge_amount;
                 docked_st->_inventory_cache[c] -= charge_amount;
                 if (docked_st->_inventory_cache[c] < 0.0f) docked_st->_inventory_cache[c] = 0.0f;
@@ -3185,12 +3203,19 @@ static void step_player(world_t *w, server_player_t *sp, float dt) {
                         ? mining_payout_multiplier((mining_grade_t)sp->input.buy_grade)
                         : 1.0f;
                     float price_per = base * gmult;
-                    float nbal = ledger_balance(nearby_st, sp->session_token);
+                    /* Same pubkey-vs-session-token identity rule as the
+                     * docked-buy path. */
+                    float nbal = sp->pubkey_set
+                        ? ledger_balance_by_pubkey(nearby_st, sp->pubkey)
+                        : ledger_balance(nearby_st, sp->session_token);
                     float afford = (price_per > FLOAT_EPSILON) ? floorf(nbal / price_per) : 0.0f;
                     float amount = fminf(fminf(available, 1.0f), afford); /* buy 1 at a time */
                     if (amount > FLOAT_EPSILON) {
                         float cost = amount * price_per;
-                        if (ledger_spend(nearby_st, sp->session_token, cost, &sp->ship)) {
+                        bool spent = sp->pubkey_set
+                            ? ledger_spend_by_pubkey(nearby_st, sp->pubkey, cost, &sp->ship)
+                            : ledger_spend(nearby_st, sp->session_token, cost, &sp->ship);
+                        if (spent) {
                             sp->ship.cargo[c] += amount;
                             nearby_st->_inventory_cache[c] -= amount;
                             /* Phase 1/2.5 manifest-first: if the station

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -2788,7 +2788,27 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
         commodity_t filter = intent->service_sell_only;
         bool deliver_frames = (filter == COMMODITY_COUNT) || (filter == COMMODITY_FRAME);
         if (deliver_frames) step_scaffold_delivery(w, sp);
-        step_module_delivery(w, docked_st, sp->current_station, &sp->ship, filter);
+        float build_payout = step_module_delivery(w, docked_st,
+                                                  sp->current_station,
+                                                  &sp->ship, filter);
+        if (build_payout > 0.01f) {
+            if (sp->pubkey_set) {
+                ledger_earn_by_pubkey(docked_st, sp->pubkey, build_payout);
+            } else {
+                ledger_earn(docked_st, sp->session_token, build_payout);
+            }
+            sp->ship.stat_credits_earned += build_payout;
+            int base_cr = (int)lroundf(build_payout);
+            emit_event(w, (sim_event_t){
+                .type = SIM_EVENT_SELL, .player_id = sp->id,
+                .sell = { .station = sp->current_station,
+                          .grade = (uint8_t)MINING_GRADE_COMMON,
+                          .base_cr = base_cr,
+                          .bonus_cr = 0,
+                          .by_contract = 0 }});
+            SIM_LOG("[sim] player %d delivered build materials for %.0f cr at %s\n",
+                    sp->id, build_payout, docked_st->name);
+        }
         try_sell_station_cargo(w, sp);
     }
     else if (intent->service_repair) try_repair_ship(w, sp);

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -21,6 +21,7 @@
  * slice of #285 in disguise — file it against #285, not as a refactor.
  */
 #include "game_sim.h"
+#include "tractor.h"
 #include "manifest.h"
 #include "ship.h"
 #include "sim_ai.h"
@@ -1809,37 +1810,31 @@ static bool is_already_towed(const ship_t *ship, int asteroid_idx) {
 #define BAND_DAMPING       0.6f   /* light along-band damping — let it bounce */
 #define BAND_TANGENT_DRAG  0.4f   /* just enough to bleed orbit, not lock parallel motion */
 #define BAND_SHIP_MASS     8.0f   /* ship is heavier than a rock; reaction force scaled by 1/MASS */
+/* Player tow band: symmetric spring (push == pull, signed by stretch),
+ * 1D axial damping, separate tangent drag, full reaction on the ship.
+ * Behavior identical to the pre-tractor-primitive hand-rolled version. */
+static const tractor_beam_t PLAYER_TOW_BAND = {
+    .rest_length     = BAND_REST_LEN,
+    .pull_strength   = BAND_SPRING_K,
+    .push_strength   = BAND_SPRING_K,
+    .range           = 0.0f,                       /* 0 = no range gate */
+    .axial_damping   = BAND_DAMPING,
+    .tangent_damping = BAND_TANGENT_DRAG,
+    .speed_cap       = 0.0f,
+    .falloff         = TRACTOR_FALLOFF_CONSTANT,
+};
 static void apply_band_force(server_player_t *sp, asteroid_t *a, float dt) {
-    vec2 to_ship = v2_sub(sp->ship.pos, a->pos);
-    float dist = v2_len(to_ship);
-    if (dist < 0.001f) return;
-    vec2 dir = v2_scale(to_ship, 1.0f / dist);
-
-    /* Spring: pull rock toward ship past the rest length. Push rock
-     * AWAY when below rest (no slamming into hull on rapid approach). */
-    float stretch = dist - BAND_REST_LEN;
-    float spring_mag = BAND_SPRING_K * stretch;     /* signed: + = pull, - = push */
-
-    /* Damping along the band axis: oppose along-band relative velocity. */
-    vec2 rel_vel = v2_sub(sp->ship.vel, a->vel);
-    float vel_along = v2_dot(rel_vel, dir);
-    float damp_mag = BAND_DAMPING * vel_along;
-
-    /* Axial force = spring + axial damping. */
-    vec2 force_axial = v2_scale(dir, spring_mag + damp_mag);
-
-    /* Tangential drag: kill the rock's perpendicular drift relative to
-     * the ship. Without this the band only restores radial distance —
-     * any sideways relative velocity persists and the rock ends up
-     * orbiting rather than trailing behind. */
-    vec2 vel_tangent = v2_sub(rel_vel, v2_scale(dir, vel_along));
-    vec2 force_tangent = v2_scale(vel_tangent, BAND_TANGENT_DRAG);
-
-    vec2 force = v2_add(force_axial, force_tangent);
-
-    /* Apply to rock (full force) + reaction on ship (1/MASS). */
-    a->vel       = v2_add(a->vel, v2_scale(force, dt));
-    sp->ship.vel = v2_sub(sp->ship.vel, v2_scale(force, dt / BAND_SHIP_MASS));
+    tractor_anchor_t src = {
+        .pos      = sp->ship.pos,
+        .vel      = &sp->ship.vel,
+        .inv_mass = 1.0f / BAND_SHIP_MASS,
+    };
+    tractor_anchor_t tgt = {
+        .pos      = a->pos,
+        .vel      = &a->vel,
+        .inv_mass = 1.0f,
+    };
+    (void)tractor_apply(&src, &tgt, &PLAYER_TOW_BAND, dt);
 }
 
 static void step_fragment_collection(world_t *w, server_player_t *sp, float dt) {

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -4509,6 +4509,34 @@ void step_station_jostle(world_t *w, float dt) {
     }
 }
 
+/* Apply one spoke's spring torque to its two endpoint rings. Equal-and-
+ * opposite (Newton's third) so the spoke conserves angular momentum
+ * within the station. Same-ring spokes (rb == ra) net to zero and are
+ * skipped — their torque contribution would cancel anyway, but the
+ * skip also keeps the renderer/physics agreement clean. Out-of-bounds
+ * rings or scaffolded hoppers are no-ops. */
+static void apply_spoke_torque(const station_t *st,
+                               const station_module_t *prod, float wa, int ra,
+                               int hop, float pulse, float net_torque[]) {
+    if (hop < 0) return;
+    const station_module_t *hm = &st->modules[hop];
+    if (hm->scaffold) return;
+    int rb = (int)hm->ring;
+    if (rb < 1 || rb > STATION_NUM_RINGS) return;
+    if (rb == ra) return;
+    int slots_b = STATION_RING_SLOTS[rb];
+    if (slots_b <= 0) return;
+    float alpha_b = TWO_PI_F * (float)hm->slot / (float)slots_b;
+    float wb = st->arm_rotation[rb-1] + alpha_b;
+    float dr = wb - wa;
+    while (dr >  PI_F) dr -= TWO_PI_F;
+    while (dr < -PI_F) dr += TWO_PI_F;
+    float T = pulse * RING_SPOKE_K * sinf(dr);
+    net_torque[ra-1] += T;
+    net_torque[rb-1] -= T;
+    (void)prod; /* reserved for future per-spoke scaling */
+}
+
 void step_station_ring_dynamics(world_t *w, float dt) {
     /* Decay all module activity pulses linearly. Production code
      * sets the pulse to 1.0 each tick a producer actually consumes
@@ -4555,44 +4583,19 @@ void step_station_ring_dynamics(world_t *w, float dt) {
             float alpha_a = TWO_PI_F * (float)prod->slot / (float)slots_a;
             float wa = st->arm_rotation[ra-1] + alpha_a;
 
-            /* Add a spoke contribution from producer `prod` to the
-             * module at index `hop` (must satisfy ring/slot bounds).
-             * Equal-and-opposite torque on the two endpoint rings. */
-            #define ADD_SPOKE(hop) do {                                    \
-                if ((hop) >= 0) {                                          \
-                    const station_module_t *hm = &st->modules[(hop)];      \
-                    if (!hm->scaffold) {                                   \
-                        int rb = (int)hm->ring;                            \
-                        if (rb >= 1 && rb <= STATION_NUM_RINGS && rb != ra) { \
-                            int slots_b = STATION_RING_SLOTS[rb];          \
-                            if (slots_b > 0) {                             \
-                                float alpha_b = TWO_PI_F * (float)hm->slot \
-                                                / (float)slots_b;          \
-                                float wb = st->arm_rotation[rb-1] + alpha_b; \
-                                float dr = wb - wa;                        \
-                                while (dr > PI_F)  dr -= TWO_PI_F;         \
-                                while (dr < -PI_F) dr += TWO_PI_F;         \
-                                float T = pulse * RING_SPOKE_K * sinf(dr); \
-                                net_torque[ra-1] += T;                     \
-                                net_torque[rb-1] -= T;                     \
-                            }                                              \
-                        }                                                  \
-                    }                                                      \
-                }                                                          \
-            } while (0)
-
             /* Input spokes — each declared input commodity. */
             module_inputs_t req = module_required_inputs(prod->type);
             for (int i = 0; i < req.count; i++) {
-                ADD_SPOKE(station_find_hopper_for(st, req.commodities[i]));
+                int hop = station_find_hopper_for(st, req.commodities[i]);
+                apply_spoke_torque(st, prod, wa, ra, hop, pulse, net_torque);
             }
             /* Output spoke (Slice 1 — cargo-in-space schema). SHIPYARD
              * has no commodity output and is naturally skipped: its
              * module_instance_output() returns COMMODITY_COUNT, and
              * station_find_output_hopper_for_module returns -1. */
-            ADD_SPOKE(station_find_output_hopper_for_module(st, prod));
-
-            #undef ADD_SPOKE
+            apply_spoke_torque(st, prod, wa, ra,
+                               station_find_output_hopper_for_module(st, prod),
+                               pulse, net_torque);
         }
 
         /* Per-ring integrate: drift bias + drag, semi-implicit Euler. */
@@ -5025,25 +5028,14 @@ void world_reset(world_t *w) {
     add_furnace_for(&w->stations[0], 1, 2, COMMODITY_FERRITE_INGOT);
     /* Ring 2: ferrite-ore intake at slot 4 (240°, cross-ring opposite
      * the furnace at ring 1 slot 2), ferrite-ingot output at slot 0
-     * (0°, on the dock's radial axis). Slot choice for the new output
-     * hopper is load-bearing — slot 0 is the only ring-2 slot that
-     * doesn't perturb NPC docking pathways. Empirically, adding any
-     * hopper at slots 1/2/3/5 stalls the NPC mining cycle in
-     * test_scenario_npc_economy_30s; slot 0 alone preserves it.
-     * (The A* nav mesh is rebuilt by station_rebuild_all_nav at end
-     * of world_reset, so it's not stale; the stall comes from the
-     * ring's annular-sector corridor geometry between this slot and
-     * the existing slot-4 hopper. Slot 0's corridor sweeps through
-     * empty slot 5 and terminates on the dock radial — a region NPCs
-     * already vacate when undocking.) */
+     * (0°, on the dock's radial axis). */
     add_hopper_for(&w->stations[0], 2, 4, COMMODITY_FERRITE_ORE);
     add_hopper_for(&w->stations[0], 2, 0, COMMODITY_FERRITE_INGOT);
     w->stations[0].arm_count = 2;
-    /* Ring 2 (idx 1) is the driver — ring 2 spins, ring 1 is dragged
-     * along by the cross-ring spoke spring. Prospect has only one
-     * spoke (FURNACE@1:2 ↔ HOPPER@2:4) so coupling is loose; ring 1's
-     * steady-state phase lag is large. ring_offset stays at 0; the
-     * spoke dynamics determine relative phase. */
+    /* Drift bias on ring 2 — under the all-passive Slice 1.5a dynamics
+     * this is the per-ring ambient torque. Ring 1 co-rotates via the
+     * cross-ring spoke spring. Prospect has light spoke load (one
+     * input + one output spoke) so ring 1 lags noticeably behind. */
     w->stations[0].arm_speed[1] = STATION_RING_SPEED;
     rebuild_station_services(&w->stations[0]);
     /* Stations are sovereign currency issuers. Net issuance is derived
@@ -5087,7 +5079,7 @@ void world_reset(world_t *w) {
     add_hopper_for(&w->stations[1], 3, 4, COMMODITY_LASER_MODULE);   /* feeds SHIPYARD    */
     add_hopper_for(&w->stations[1], 3, 6, COMMODITY_TRACTOR_MODULE); /* feeds SHIPYARD    */
     w->stations[1].arm_count = 3;
-    w->stations[1].arm_speed[1] = STATION_RING_SPEED; /* ring 2 drives */
+    w->stations[1].arm_speed[1] = STATION_RING_SPEED; /* ring 2 drift bias */
     rebuild_station_services(&w->stations[1]);
     snprintf(w->stations[1].station_slug, sizeof(w->stations[1].station_slug), "kepler");
     snprintf(w->stations[1].currency_name, sizeof(w->stations[1].currency_name), "kepler bonds");
@@ -5140,7 +5132,7 @@ void world_reset(world_t *w) {
     add_hopper_for(&w->stations[2], 3, 6, COMMODITY_CRYSTAL_ORE);
     add_hopper_for(&w->stations[2], 3, 7, COMMODITY_TRACTOR_MODULE); /* TRACTOR_FAB output */
     w->stations[2].arm_count = 3;
-    w->stations[2].arm_speed[1] = STATION_RING_SPEED; /* ring 2 drives */
+    w->stations[2].arm_speed[1] = STATION_RING_SPEED; /* ring 2 drift bias */
     rebuild_station_services(&w->stations[2]);
     snprintf(w->stations[2].station_slug, sizeof(w->stations[2].station_slug), "helios");
     snprintf(w->stations[2].currency_name, sizeof(w->stations[2].currency_name), "helios credits");

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -4158,12 +4158,33 @@ static void step_scaffolds(world_t *w, float dt) {
                 const float PLAN_PULL_RANGE = 800.0f;
                 if (dist_sq > PLAN_PULL_RANGE * PLAN_PULL_RANGE) continue;
                 float dist = sqrtf(dist_sq);
-                if (dist < 1.0f) dist = 1.0f;
-                vec2 norm = v2_scale(delta, 1.0f / dist);
-                /* Strong direct pull — no orbit, tractor-like */
-                float pull_strength = 25.0f * (1.0f + 2.0f * (1.0f - dist / PLAN_PULL_RANGE));
-                sc->vel = v2_add(sc->vel, v2_scale(norm, pull_strength * dt));
-                sc->vel = v2_scale(sc->vel, 1.0f / (1.0f + 3.0f * dt)); /* heavy damping */
+                /* Constant-pull beam from blueprint center to scaffold.
+                 * Legacy 25*(1 + 2*(1-d/range)) ranged from 25 (at
+                 * d=range) to 75 (at d=0) with average ~50. Modeling
+                 * as a fixed 50 with no falloff matches the average
+                 * impulse the legacy delivered over a typical
+                 * approach trajectory, and means scaffolds at the
+                 * edge of pull range still get engaged at half the
+                 * legacy peak (vs zero with linear falloff). */
+                static const tractor_beam_t PLAN_BLUEPRINT = {
+                    .rest_length     = 0.0f,
+                    .pull_strength   = 0.0f,
+                    .push_strength   = 0.0f,
+                    .pull_constant   = 50.0f,
+                    .push_constant   = 0.0f,
+                    .range           = 800.0f,   /* PLAN_PULL_RANGE */
+                    .axial_damping   = 3.0f,
+                    /* Tangent damping matches axial (= legacy isotropic
+                     * drag 3.0). Lowering breaks placement timing on
+                     * test_outpost_*. Worth revisiting once playtest
+                     * confirms the pull feels right. */
+                    .tangent_damping = 3.0f,
+                    .speed_cap       = 0.0f,
+                    .falloff         = TRACTOR_FALLOFF_CONSTANT,
+                };
+                tractor_anchor_t plan_src = { .pos = st->pos, .vel = NULL,     .inv_mass = 0.0f };
+                tractor_anchor_t plan_tgt = { .pos = sc->pos, .vel = &sc->vel, .inv_mass = 1.0f };
+                (void)tractor_apply(&plan_src, &plan_tgt, &PLAN_BLUEPRINT, dt);
                 /* Materialize on arrival */
                 if (dist < 40.0f) {
                     st->planned = false;
@@ -4235,13 +4256,37 @@ static void step_scaffolds(world_t *w, float dt) {
                 continue; /* scaffold is now deactivated */
             }
 
-            /* Accelerating pull — gets stronger as it gets closer (tendril grip tightens) */
-            float pull_strength = SCAFFOLD_SNAP_PULL * (1.0f + 2.0f * (1.0f - dist / SCAFFOLD_SNAP_RANGE));
-            if (pull_strength < SCAFFOLD_SNAP_PULL) pull_strength = SCAFFOLD_SNAP_PULL;
-            vec2 pull_dir = v2_scale(delta, pull_strength);
-            sc->vel = v2_add(sc->vel, v2_scale(pull_dir, dt));
-            /* Heavy damping so it doesn't overshoot */
-            sc->vel = v2_scale(sc->vel, 1.0f / (1.0f + 5.0f * dt));
+            /* Spring pull toward the rotating target slot. Legacy used
+             * K*d*(1+2*(1-d/range)) which integrates to ~7K total
+             * impulse over the snap range. A constant-K spring with
+             * pull_strength=12 (= 3*SCAFFOLD_SNAP_PULL) and no falloff
+             * delivers slightly stronger total impulse than the legacy,
+             * which keeps the snap fast enough to satisfy the existing
+             * 5-sim-second test windows. */
+            (void)dist;
+            static const tractor_beam_t SCAFFOLD_SNAP = {
+                .rest_length     = 0.0f,
+                .pull_strength   = SCAFFOLD_SNAP_PULL * 3.0f,   /* K = 12 */
+                .push_strength   = 0.0f,
+                .pull_constant   = 0.0f,
+                .push_constant   = 0.0f,
+                /* No range gate — the SNAPPING state itself guarantees
+                 * the scaffold is supposed to be converging. A range
+                 * gate would disable damping past the limit and let an
+                 * overshooting scaffold fly off into the void. */
+                .range           = 0.0f,
+                .axial_damping   = 5.0f,
+                /* Tangent matches axial (= legacy isotropic drag 5.0).
+                 * The target slot rotates with the ring; without strong
+                 * tangent damping the scaffold orbits the rotating slot
+                 * instead of converging on it. */
+                .tangent_damping = 5.0f,
+                .speed_cap       = 0.0f,
+                .falloff         = TRACTOR_FALLOFF_CONSTANT,
+            };
+            tractor_anchor_t snap_src = { .pos = target,  .vel = NULL,     .inv_mass = 0.0f };
+            tractor_anchor_t snap_tgt = { .pos = sc->pos, .vel = &sc->vel, .inv_mass = 1.0f };
+            (void)tractor_apply(&snap_src, &snap_tgt, &SCAFFOLD_SNAP, dt);
             sc->pos = v2_add(sc->pos, v2_scale(sc->vel, dt));
 
             /* Safety: if station was destroyed or slot got taken, release back to LOOSE */

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -592,6 +592,14 @@ bool player_save_rename_legacy_to_pubkey(const char *dir,
 void anchor_ship_in_station(server_player_t *sp, world_t *w);
 asteroid_tier_t max_mineable_tier(int mining_level);
 vec2 station_approach_target(const station_t *st, vec2 from);
+/* Exit target: symmetric departure waypoint for station_approach_target.
+ * Returns a position past the outermost ring along the radial axis of
+ * the dock module nearest `from` (typically the dock the NPC is
+ * undocking from). Drives the NPC_STATE_UNDOCKING phase so a
+ * just-departed ship clears ring corridors before steering to its
+ * real destination. Falls back to a position outside the station's
+ * outer ring along +X if no dock module exists. */
+vec2 station_exit_target(const station_t *st, vec2 from);
 void emit_event(world_t *w, sim_event_t ev);
 /* Station-local ledger economy */
 float ledger_balance(const station_t *st, const uint8_t *token);

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -542,8 +542,12 @@ void begin_module_construction_at(world_t *w, station_t *st, int station_idx, mo
  * be consumed; pass COMMODITY_COUNT to allow any. The filter prevents
  * "deliver ingots only" from also draining frames into a half-built
  * module behind the player's back. */
-void step_module_delivery(world_t *w, station_t *st, int station_idx,
-                          ship_t *ship, commodity_t filter);
+/* Returns the credit owed to the ship for materials it donated to
+ * AWAITING_SUPPLY scaffolds. Caller pays via ledger_earn / equivalent.
+ * Materials drawn from station inventory (NPC-side restock) are NOT
+ * counted — those were already paid for at intake. */
+float step_module_delivery(world_t *w, station_t *st, int station_idx,
+                           ship_t *ship, commodity_t filter);
 
 /* Backfill every active station's manifest from its seeded float
  * inventory (RECIPE_LEGACY_MIGRATE units, deterministic per-station

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -557,6 +557,11 @@ void world_seed_station_manifests(world_t *w);
 int spawn_scaffold(world_t *w, module_type_t type, vec2 pos, int owner);
 bool world_save(const world_t *w, const char *path);
 bool world_load(world_t *w, const char *path);
+/* v51 cargo-in-space schema migration: tag untagged furnaces by
+ * station-furnace-count heuristic and auto-spawn missing output
+ * hoppers in free outer-ring slots. Run automatically by world_load
+ * for v50 saves; exposed so tests can exercise directly. Idempotent. */
+void world_apply_cargo_schema_migration(world_t *w);
 /* Station catalog — per-station identity persistence (sim_catalog.c) */
 int  station_catalog_load_all(station_t *stations, int max, const char *dir);
 bool station_catalog_save_all(const station_t *stations, int count, const char *dir);

--- a/server/main.c
+++ b/server/main.c
@@ -698,15 +698,28 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
                         /* Migrate ledger entries from the old token →
                          * the new connection's session_token across
                          * every station, so balances stay spendable
-                         * after the rebinding. */
-                        uint8_t old_tok[8];
-                        memcpy(old_tok, old->session_token, 8);
+                         * after the rebinding.
+                         *
+                         * Compare and write the FULL 32-byte pseudokey
+                         * form (token bytes + 24 trailing zeros — see
+                         * token_to_pseudo_pubkey). The old version did
+                         * memcmp/memcpy on 8 bytes against a 32-byte
+                         * field, which (a) could partially-match a real
+                         * Ed25519 pubkey by 1/2^64 chance and (b) left
+                         * the trailing 24 bytes of a touched entry
+                         * holding stale data, orphaning the entry from
+                         * future lookups. Both bugs are silent —
+                         * 32-byte compare + 32-byte write fixes them. */
+                        uint8_t old_pseudo[32] = {0};
+                        uint8_t new_pseudo[32] = {0};
+                        memcpy(old_pseudo, old->session_token, 8);
+                        memcpy(new_pseudo, sp->session_token, 8);
                         for (int s = 0; s < MAX_STATIONS; s++) {
                             station_t *st = &world.stations[s];
                             for (int e = 0; e < st->ledger_count; e++) {
-                                if (memcmp(st->ledger[e].player_pubkey, old_tok, 8) == 0) {
+                                if (memcmp(st->ledger[e].player_pubkey, old_pseudo, 32) == 0) {
                                     memcpy(st->ledger[e].player_pubkey,
-                                           sp->session_token, 8);
+                                           new_pseudo, 32);
                                 }
                             }
                         }

--- a/server/main.c
+++ b/server/main.c
@@ -1828,10 +1828,18 @@ static void broadcast_world(void) {
     broadcast(tbuf, 5);
 }
 
-/* Compute station-local balance for a player at their current/nearby station */
+/* Compute station-local balance for a player at their current/nearby
+ * station. Must read the same ledger entry the buy/credit paths use:
+ * pubkey when registered, session-token-pseudokey otherwise. Reading
+ * the wrong entry was the visible-bug-symptom that motivated the
+ * earlier identity-fix series — broadcast balance came from a stale
+ * (often negative) session-token entry while real earnings sat on
+ * the pubkey entry. */
 static float player_station_balance(const server_player_t *sp) {
     int st = sp->docked ? sp->current_station : sp->nearby_station;
     if (st < 0 || st >= MAX_STATIONS) return 0.0f;
+    if (sp->pubkey_set)
+        return ledger_balance_by_pubkey(&world.stations[st], sp->pubkey);
     return ledger_balance(&world.stations[st], sp->session_token);
 }
 

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -744,6 +744,32 @@ static bool resolve_npc_annular_sector(npc_ship_t *npc, vec2 center,
     return true;
 }
 
+/* If the NPC is still inside its home station's outer-ring envelope
+ * AND the target is outside that envelope, override the steering
+ * target with the dock's exit waypoint (past the outer ring along the
+ * dock's current radial axis). This routes a just-undocked ship along
+ * a known-clear angular corridor before it tries to fly straight at a
+ * far destination, which used to pin it against ring-2 modules.
+ *
+ * Returns the unmodified target if either: (a) the ship is already
+ * past the outer ring, or (b) the target itself is inside the home
+ * envelope (e.g. a tow scaffold sitting just outside the dock — the
+ * NPC should steer to it directly, not detour through an exit waypoint).
+ *
+ * The override is a *target swap* only — physics integration and
+ * collision pushback are unchanged, so the per-tick paired-ship
+ * parity invariant (test_npc_ship_physics_in_sync_each_tick) holds. */
+static vec2 npc_target_clear_of_home_rings(const world_t *w, const npc_ship_t *npc,
+                                           vec2 want_target) {
+    if (npc->home_station < 0 || npc->home_station >= MAX_STATIONS) return want_target;
+    const station_t *home = &w->stations[npc->home_station];
+    float exit_r = STATION_RING_RADIUS[STATION_NUM_RINGS] + 80.0f;
+    float exit_r_sq = exit_r * exit_r;
+    if (v2_dist_sq(npc->ship.pos, home->pos) > exit_r_sq) return want_target;
+    if (v2_dist_sq(want_target,    home->pos) <= exit_r_sq) return want_target;
+    return station_exit_target(home, npc->ship.pos);
+}
+
 static void npc_resolve_station_collisions(world_t *w, npc_ship_t *npc) {
     const hull_def_t *hull = npc_hull_def(npc);
     float ship_r = hull->ship_radius;
@@ -1058,6 +1084,7 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
     case NPC_STATE_TRAVEL_TO_DEST: {
         station_t *dest = &w->stations[npc->dest_station];
         vec2 approach = station_approach_target(dest, npc->ship.pos);
+        approach = npc_target_clear_of_home_rings(w, npc, approach);
         npc_steer_with_path(w, n, npc, approach, /*thrust_scale=*/1.0f, dt);
         npc_apply_physics(npc, dt, w);
         float dock_r = dest->dock_radius * 0.7f;
@@ -1361,7 +1388,8 @@ static void step_tow_drone(world_t *w, npc_ship_t *npc, int n, float dt) {
             npc->state_timer = HAULER_DOCK_TIME;
             break;
         }
-        npc_steer_with_path(w, n, npc, sc->pos, /*thrust_scale=*/1.0f, dt);
+        vec2 sc_target = npc_target_clear_of_home_rings(w, npc, sc->pos);
+        npc_steer_with_path(w, n, npc, sc_target, /*thrust_scale=*/1.0f, dt);
         npc_apply_physics(npc, dt, w);
         if (v2_dist_sq(npc->ship.pos, sc->pos) < 80.0f * 80.0f) {
             /* Grab — claim the scaffold and switch to tow mode.
@@ -1574,7 +1602,8 @@ void step_npc_ships(world_t *w, float dt) {
                 }
             }
             asteroid_t *a = &w->asteroids[npc->target_asteroid];
-            npc_steer_with_path(w, n, npc, a->pos, /*thrust_scale=*/1.0f, dt);
+            vec2 ast_target = npc_target_clear_of_home_rings(w, npc, a->pos);
+            npc_steer_with_path(w, n, npc, ast_target, /*thrust_scale=*/1.0f, dt);
             npc_apply_physics(npc, dt, w);
             if (v2_dist_sq(npc->ship.pos, a->pos) < MINING_RANGE * MINING_RANGE)
                 npc->state = NPC_STATE_MINING;

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -564,12 +564,28 @@ static int npc_find_loose_fragment(const world_t *w, const npc_ship_t *self, flo
  * always preferable to fracturing more rock. Returns true iff a
  * fragment was claimed and the caller should transition to
  * NPC_STATE_RETURN_TO_STATION. */
+/* NPC tow tokens start with the literal "NPC" prefix (see spawn_npc).
+ * A player's session_token is 8 random bytes — collision probability
+ * with the "NPC\0" prefix is ~1/16M and the worst case is one fragment
+ * smelt going to the wrong ledger; cheaper than a side-table. Used by
+ * the NPC tow paths to AVOID overwriting a player's stamp on a
+ * fragment they already towed (first-player-tower wins). */
+static bool token_is_npc(const uint8_t token[8]) {
+    return token && token[0] == 'N' && token[1] == 'P' && token[2] == 'C';
+}
+
 static bool npc_try_claim_loose_fragment(world_t *w, npc_ship_t *npc, float range_sq) {
     int frag = npc_find_loose_fragment(w, npc, range_sq);
     if (frag < 0) return false;
     npc->towed_fragment = frag;
     asteroid_t *f = &w->asteroids[frag];
-    memcpy(f->last_towed_token, npc->session_token, sizeof(f->last_towed_token));
+    /* Only stamp when the slot is empty or carries another NPC's
+     * token — never overwrite a player tow stamp. */
+    bool stamped = false;
+    for (int b = 0; b < 8 && !stamped; b++) if (f->last_towed_token[b]) stamped = true;
+    if (!stamped || token_is_npc(f->last_towed_token)) {
+        memcpy(f->last_towed_token, npc->session_token, sizeof(f->last_towed_token));
+    }
     return true;
 }
 
@@ -1721,13 +1737,18 @@ void step_npc_ships(world_t *w, float dt) {
                     npc->towed_fragment = best_frag;
                     npc->state = NPC_STATE_RETURN_TO_STATION;
                     /* Stamp the NPC's token onto the towed fragment so
-                     * the eventual smelt-payout (ledger_credit_supply
-                     * keyed off last_towed_token) credits the NPC's
-                     * ledger at the home station. Same hook the player
-                     * pickup uses — symmetrical economic identity. */
+                     * the eventual smelt-payout credits the NPC's ledger.
+                     * Skip if a non-NPC token is already there — the
+                     * player who first towed this fragment keeps the
+                     * payout claim. */
                     asteroid_t *frag = &w->asteroids[best_frag];
-                    memcpy(frag->last_towed_token, npc->session_token,
-                           sizeof(frag->last_towed_token));
+                    bool stamped = false;
+                    for (int b = 0; b < 8 && !stamped; b++)
+                        if (frag->last_towed_token[b]) stamped = true;
+                    if (!stamped || token_is_npc(frag->last_towed_token)) {
+                        memcpy(frag->last_towed_token, npc->session_token,
+                               sizeof(frag->last_towed_token));
+                    }
                 }
             }
             break;

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -1159,7 +1159,11 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                             activate_outpost(w, npc->dest_station);
                     }
                 }
-                step_module_delivery(w, dest, npc->dest_station, &hauler_ship, COMMODITY_COUNT);
+                /* Hauler is paid via the contract path elsewhere; the
+                 * build-material payout returned here is discarded. NPC
+                 * economic identity tracking happens through
+                 * ledger_credit_supply_amount on contract completion. */
+                (void)step_module_delivery(w, dest, npc->dest_station, &hauler_ship, COMMODITY_COUNT);
                 /* Put remaining back. The float was drained into
                  * module_input by step_module_delivery; we have to drain
                  * the matching manifest entries too or the BUY picker

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -5,6 +5,7 @@
  * step_npc_ships() dispatcher.
  */
 #include "sim_ai.h"
+#include "tractor.h"
 #include "sim_nav.h"
 #include "sim_flight.h"
 #include "sim_ship.h"
@@ -1422,16 +1423,22 @@ static void step_tow_drone(world_t *w, npc_ship_t *npc, int n, float dt) {
         }
         scaffold_t *sc = &w->scaffolds[npc->towed_scaffold];
         station_t *dest = &w->stations[npc->dest_station];
-        /* Drag the scaffold along behind us with simple spring chase. */
-        vec2 to_drone = v2_sub(npc->ship.pos, sc->pos);
-        float td = sqrtf(v2_len_sq(to_drone));
-        float tow_dist = 60.0f;
-        if (td > tow_dist && td > 0.1f) {
-            vec2 dir = v2_scale(to_drone, 1.0f / td);
-            float over = td - tow_dist;
-            sc->vel = v2_add(sc->vel, v2_scale(dir, over * 8.0f * dt));
-        }
-        sc->vel = v2_scale(sc->vel, 1.0f / (1.0f + 0.6f * dt));
+        /* Spring-chase the scaffold behind the drone. Pull-only spring at
+         * rest_length=60; 1D axial damping along the rope; small tangent
+         * drag to bleed orbital drift without locking lateral motion. */
+        static const tractor_beam_t SCAFFOLD_TOW = {
+            .rest_length     = 60.0f,
+            .pull_strength   = 8.0f,
+            .push_strength   = 0.0f,
+            .range           = 0.0f,
+            .axial_damping   = 0.6f,
+            .tangent_damping = 0.15f,   /* ~25% of axial — anti-orbit, tunable */
+            .speed_cap       = 0.0f,
+            .falloff         = TRACTOR_FALLOFF_CONSTANT,
+        };
+        tractor_anchor_t src_drone = { .pos = npc->ship.pos, .vel = NULL,     .inv_mass = 0.0f };
+        tractor_anchor_t tgt_sc    = { .pos = sc->pos,       .vel = &sc->vel, .inv_mass = 1.0f };
+        (void)tractor_apply(&src_drone, &tgt_sc, &SCAFFOLD_TOW, dt);
         sc->pos = v2_add(sc->pos, v2_scale(sc->vel, dt));
 
         vec2 approach = station_approach_target(dest, npc->ship.pos);
@@ -1747,20 +1754,36 @@ void step_npc_ships(world_t *w, float dt) {
                     npc->ship.vel = v2_scale(npc->ship.vel, max_tow_speed / spd);
             }
 
-            /* Tow the fragment — drag it along with spring physics */
+            /* Tow the fragment — constant-pull thruster engages when the
+             * fragment is past the safe distance behind the NPC. 1D
+             * axial damping keeps the rope steady; small tangent drag
+             * bleeds orbital drift. Speed cap prevents runaway. */
             if (npc->towed_fragment >= 0 && npc->towed_fragment < MAX_ASTEROIDS) {
                 asteroid_t *tow = &w->asteroids[npc->towed_fragment];
                 if (tow->active) {
-                    vec2 to_npc = v2_sub(npc->ship.pos, tow->pos);
-                    float td = sqrtf(v2_len_sq(to_npc));
-                    float safe = 40.0f + tow->radius;
-                    if (td > safe && td > 0.1f) {
-                        vec2 pull_dir = v2_scale(to_npc, 1.0f / td);
-                        tow->vel = v2_add(tow->vel, v2_scale(pull_dir, 500.0f * dt));
-                        tow->vel = v2_scale(tow->vel, 1.0f / (1.0f + 3.0f * dt));
-                        float spd = v2_len(tow->vel);
-                        if (spd > 150.0f) tow->vel = v2_scale(tow->vel, 150.0f / spd);
-                    }
+                    /* rest_length depends on the fragment's radius — bigger
+                     * fragments tow farther behind the drone. */
+                    tractor_beam_t npc_tow = {
+                        .rest_length     = 40.0f + tow->radius,
+                        .pull_strength   = 0.0f,
+                        .push_strength   = 0.0f,
+                        .pull_constant   = 500.0f,    /* constant accel toward NPC */
+                        .push_constant   = 0.0f,
+                        .range           = 0.0f,
+                        .axial_damping   = 3.0f,
+                        /* Tangent damping near axial value — fragments
+                         * will orbit the NPC if it's much lower, and
+                         * orbiting fragments never deliver. The legacy
+                         * code used isotropic drag 3.0 for the same
+                         * reason. Bumping below ~2.0 breaks
+                         * test_scenario_npc_economy_30_seconds. */
+                        .tangent_damping = 2.5f,
+                        .speed_cap       = 150.0f,
+                        .falloff         = TRACTOR_FALLOFF_CONSTANT,
+                    };
+                    tractor_anchor_t src = { .pos = npc->ship.pos, .vel = NULL,      .inv_mass = 0.0f };
+                    tractor_anchor_t tgt = { .pos = tow->pos,      .vel = &tow->vel, .inv_mass = 1.0f };
+                    (void)tractor_apply(&src, &tgt, &npc_tow, dt);
                     /* Release when close to the furnace — let the furnace tractor take over */
                     float furnace_d = v2_dist_sq(tow->pos, delivery_target);
                     if (furnace_d < 150.0f * 150.0f) {

--- a/server/sim_construction.c
+++ b/server/sim_construction.c
@@ -93,6 +93,16 @@ void add_hopper_for(station_t *st, uint8_t arm, uint8_t chain_pos, commodity_t c
 }
 
 void add_furnace_for(station_t *st, uint8_t arm, uint8_t chain_pos, commodity_t ingot) {
+    /* The tag must be one of the smeltable ingot commodities. Anything
+     * else (a raw ore, a finished good, COMMODITY_COUNT) would silently
+     * fall back to FERRITE_INGOT via module_instance_output() — easy to
+     * miss in seed code. Guard at the construction site. */
+    if (!(ingot == COMMODITY_FERRITE_INGOT ||
+          ingot == COMMODITY_CUPRITE_INGOT ||
+          ingot == COMMODITY_CRYSTAL_INGOT)) {
+        SIM_LOG("[sim] add_furnace_for: invalid ingot tag %d (defaulting to ferrite)\n", (int)ingot);
+        ingot = COMMODITY_FERRITE_INGOT;
+    }
     add_module_at(st, MODULE_FURNACE, arm, chain_pos);
     if (st->module_count > 0) {
         st->modules[st->module_count - 1].commodity = (uint8_t)ingot;

--- a/server/sim_construction.c
+++ b/server/sim_construction.c
@@ -92,6 +92,13 @@ void add_hopper_for(station_t *st, uint8_t arm, uint8_t chain_pos, commodity_t c
     }
 }
 
+void add_furnace_for(station_t *st, uint8_t arm, uint8_t chain_pos, commodity_t ingot) {
+    add_module_at(st, MODULE_FURNACE, arm, chain_pos);
+    if (st->module_count > 0) {
+        st->modules[st->module_count - 1].commodity = (uint8_t)ingot;
+    }
+}
+
 void activate_outpost(world_t *w, int station_idx) {
     station_t *st = &w->stations[station_idx];
     st->scaffold = false;

--- a/server/sim_construction.c
+++ b/server/sim_construction.c
@@ -122,12 +122,17 @@ void activate_outpost(world_t *w, int station_idx) {
     }
     if (!have_relay) add_module_at(st, MODULE_SIGNAL_RELAY, 1, 0);
     st->arm_count = 1;
-    /* Drive whichever ring is current "center" (ring 2 if it ever
-     * gains modules, ring 1 today for fresh outposts). Setting both
-     * lets station_driver_ring_idx pick correctly as the outpost
-     * grows through tiers without a separate retrigger. */
+    /* Per-ring drift bias under the all-passive Slice 1.5a dynamics —
+     * a perfectly balanced station still rotates at this rate. Set
+     * both inner rings so an outpost growing through ring tiers keeps
+     * a sensible rotation without a separate retrigger event. */
     st->arm_speed[0] = STATION_RING_SPEED;
     st->arm_speed[1] = STATION_RING_SPEED;
+    /* Bootstrap omega to match the bias so the freshly-activated
+     * outpost doesn't show a 1.7s spin-up transient. Mirrors the
+     * post-seed bootstrap loop in world_reset. */
+    st->arm_omega[0] = STATION_RING_SPEED;
+    st->arm_omega[1] = STATION_RING_SPEED;
     rebuild_station_services(st);
     rebuild_signal_chain(w);
     /* Count connected stations for milestone tracking */

--- a/server/sim_construction.h
+++ b/server/sim_construction.h
@@ -18,6 +18,10 @@ void add_module_at(station_t *st, module_type_t type, uint8_t arm, uint8_t chain
  * auto-solver — used by seed code and tests that need deterministic
  * hopper layouts. */
 void add_hopper_for(station_t *st, uint8_t arm, uint8_t chain_pos, commodity_t c);
+/* Place a furnace with an explicit output ingot tag. Pass one of
+ * COMMODITY_FERRITE_INGOT / CUPRITE_INGOT / CRYSTAL_INGOT. The
+ * matching ore is implied by module_instance_input_ore(). */
+void add_furnace_for(station_t *st, uint8_t arm, uint8_t chain_pos, commodity_t ingot);
 void step_module_activation(world_t *w, float dt);
 
 /*

--- a/server/sim_mining.c
+++ b/server/sim_mining.c
@@ -13,6 +13,7 @@
  * and ignoring weak signal — visible as "NPC ship lasering very far".
  */
 #include "sim_mining.h"
+#include "laser.h"
 #include "game_sim.h"      /* MINING_RANGE, max_mineable_tier, fracture_asteroid */
 #include "sim_asteroid.h"  /* asteroid_is_collectible */
 #include <math.h>
@@ -73,13 +74,17 @@ mining_beam_t sim_mining_beam_step(world_t *w, vec2 muzzle, vec2 forward,
         return r;
     }
 
-    /* Damage. Signal efficiency scales output the same way for everyone
-     * so weak-signal mining feels weak whether you're a player or AI. */
-    float mined = mining_rate * dt * signal_eff;
-    mined = fminf(mined, a->hp);
-    a->hp -= mined;
-    a->net_dirty = true;
-    r.fired = true;
+    /* Damage delivered as a negative laser_apply_effect — laser_apply
+     * floors at zero, so we don't need the explicit fminf clamp the
+     * legacy code carried. Signal efficiency scales output the same
+     * way for everyone so weak-signal mining feels weak whether
+     * you're a player or AI. */
+    float pre_hp = a->hp;
+    laser_apply_effect(&a->hp, -mining_rate * signal_eff, 0.0f, dt);
+    if (a->hp < pre_hp) {
+        a->net_dirty = true;
+        r.fired = true;
+    }
 
     if (a->hp <= 0.01f) {
         fracture_asteroid(w, target_idx, normal, fracturer_id);

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -710,6 +710,12 @@ void step_furnace_smelting(world_t *w, float dt) {
              * fallback. */
             int tower = connected_player_by_token(w, a->last_towed_token);
             int fracturer = connected_player_by_token(w, a->last_fractured_token);
+            SIM_LOG("[smelt-attr] tower=%d fracturer=%d tow_tok=%02x%02x%02x%02x frac_tok=%02x%02x%02x%02x\n",
+                    tower, fracturer,
+                    a->last_towed_token[0], a->last_towed_token[1],
+                    a->last_towed_token[2], a->last_towed_token[3],
+                    a->last_fractured_token[0], a->last_fractured_token[1],
+                    a->last_fractured_token[2], a->last_fractured_token[3]);
 
             /* Grade is committed when the fracture claim resolves.
              * Smelt only publishes that cached value — no fresh dice. */
@@ -753,6 +759,9 @@ void step_furnace_smelting(world_t *w, float dt) {
                             ? ledger_credit_supply_amount_by_pubkey(st, pt->pubkey, graded_value)
                             : ledger_credit_supply_amount(st, pt->session_token, graded_value);
                     }
+                    SIM_LOG("[smelt-pay] player %d tower credit: graded=%.2f credited=%.2f pubkey_set=%d session_ready=%d\n",
+                            tower, graded_value, credited, pt->pubkey_set ? 1 : 0,
+                            pt->session_ready ? 1 : 0);
                     pt->ship.stat_credits_earned += credited;
                     emit_event(w, (sim_event_t){
                         .type = SIM_EVENT_SELL, .player_id = tower,

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -3,6 +3,7 @@
  * Extracted from game_sim.c.
  */
 #include "sim_production.h"
+#include "tractor.h"
 #include "sim_asteroid.h"      /* fracture_claim_state_reset */
 #include "sim_construction.h"  /* module_build_material, module_build_cost */
 #include "manifest.h"
@@ -562,19 +563,29 @@ void step_furnace_smelting(world_t *w, float dt) {
                 bool silo_reach = (d_silo_sq <= pull_sq);
                 if (!furnace_reach || !silo_reach) continue;  /* both must reach */
 
-                /* Pull toward midpoint between furnace and silo — strong pull */
+                /* Pull fragment toward the midpoint between furnace and
+                 * silo. World-pinned source (midpoint isn't a single
+                 * body — it's the geometric center of the two-module
+                 * smelt path). Linear-falloff constant-pull beam:
+                 * peak at d=0, decays to zero at pull_range. */
                 vec2 midpoint = v2_scale(v2_add(furnace_pos, silo_pos), 0.5f);
-                vec2 to_mid = v2_sub(midpoint, a->pos);
-                float d_mid = sqrtf(v2_len_sq(to_mid));
-                if (d_mid > 0.5f) {
-                    float strength = HOPPER_PULL_ACCEL * 1.5f * (1.0f - d_mid / pull_range);
-                    vec2 dir = v2_scale(to_mid, 1.0f / d_mid);
-                    a->vel = v2_add(a->vel, v2_scale(dir, strength * dt));
-                    a->vel = v2_scale(a->vel, 1.0f / (1.0f + 8.0f * dt));
-                    float spd = v2_len(a->vel);
-                    if (spd > 100.0f) a->vel = v2_scale(a->vel, 100.0f / spd);
-                }
+                static const tractor_beam_t SMELT_BEAM = {
+                    .rest_length     = 0.0f,
+                    .pull_strength   = 0.0f,
+                    .push_strength   = 0.0f,
+                    .pull_constant   = HOPPER_PULL_ACCEL * 1.5f,
+                    .push_constant   = 0.0f,
+                    .range           = HOPPER_PULL_RANGE,
+                    .axial_damping   = 8.0f,
+                    .tangent_damping = 2.0f,    /* ~25% of axial */
+                    .speed_cap       = 100.0f,
+                    .falloff         = TRACTOR_FALLOFF_LINEAR,
+                };
+                tractor_anchor_t src = { .pos = midpoint, .vel = NULL,    .inv_mass = 0.0f };
+                tractor_anchor_t tgt = { .pos = a->pos,   .vel = &a->vel, .inv_mass = 1.0f };
+                (void)tractor_apply(&src, &tgt, &SMELT_BEAM, dt);
 
+                float d_mid = sqrtf(v2_dist_sq(a->pos, midpoint));
                 /* Smelt when fragment is close to the midpoint */
                 if (d_mid < 80.0f) {
                     smelt_station = s;

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -4,6 +4,7 @@
  */
 #include "sim_production.h"
 #include "tractor.h"
+#include "laser.h"
 #include "sim_asteroid.h"      /* fracture_claim_state_reset */
 #include "sim_construction.h"  /* module_build_material, module_build_cost */
 #include "manifest.h"
@@ -594,24 +595,19 @@ void step_furnace_smelting(world_t *w, float dt) {
             }
         }
 
-        /* If not in any smelt beam this tick, decay progress */
+        /* Smelt-progress laser-effect: in beam → accumulate at 0.5/sec
+         * (~2s to fully smelt); not in beam → decay at 0.5/sec back to 0.
+         * Clamped to [0, 1] so a fragment waiting on a fracture-claim
+         * resolution doesn't grow progress unbounded. */
+        const float SMELT_RATE = 0.5f;
         if (!smelted) {
-            if (a->smelt_progress > 0.0f) {
-                a->smelt_progress -= dt * 0.5f;
-                if (a->smelt_progress < 0.0f) a->smelt_progress = 0.0f;
-            }
+            laser_apply_effect(&a->smelt_progress, -SMELT_RATE, 1.0f, dt);
             continue;
         }
-
-        /* Accumulate smelt progress (~2 seconds to fully smelt) */
-        a->smelt_progress += dt * 0.5f;
+        laser_apply_effect(&a->smelt_progress, +SMELT_RATE, 1.0f, dt);
 
         /* Hold fragment in place while smelting — dampen velocity */
         a->vel = v2_scale(a->vel, 1.0f / (1.0f + 10.0f * dt));
-
-        /* L8: clamp accumulated progress at 1.0 so a fragment waiting on
-         * a fracture-claim resolution doesn't grow smelt_progress unbounded. */
-        if (a->smelt_progress > 1.0f) a->smelt_progress = 1.0f;
 
         if (a->smelt_progress >= 1.0f && smelt_station >= 0) {
             station_t *st = &w->stations[smelt_station];

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -586,6 +586,15 @@ void step_furnace_smelting(world_t *w, float dt) {
                 tractor_anchor_t tgt = { .pos = a->pos,   .vel = &a->vel, .inv_mass = 1.0f };
                 (void)tractor_apply(&src, &tgt, &SMELT_BEAM, dt);
 
+                /* Pulse the furnace module — the existing ring-spoke
+                 * physics in step_station_ring_dynamics looks at
+                 * module_active_pulse[] to scale spoke torque. Without
+                 * this, an active smelt beam wouldn't drive any ring
+                 * rotation. The bulk-ore-from-inventory smelt path
+                 * (line ~323) already pulses; the fragment-tow path
+                 * lacked the equivalent. */
+                st->module_active_pulse[m] = 1.0f;
+
                 float d_mid = sqrtf(v2_dist_sq(a->pos, midpoint));
                 /* Smelt when fragment is close to the midpoint */
                 if (d_mid < 80.0f) {

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -528,7 +528,13 @@ void step_furnace_smelting(world_t *w, float dt) {
                 int ring = st->modules[m].ring;
                 vec2 furnace_pos = module_world_pos_ring(st, ring, st->modules[m].slot);
 
-                /* Find nearest module on an adjacent ring (inner or outer) */
+                /* Find nearest matching ORE-tagged hopper on an adjacent
+                 * ring. Filtering by commodity matters now that stations
+                 * carry both input AND output hoppers (Slice 1) — without
+                 * the filter, a ferrite-furnace's silo could anchor on a
+                 * neighboring FERRITE_INGOT output hopper at certain
+                 * angles, shifting the smelt midpoint and the visible
+                 * beam endpoint to the wrong hopper. */
                 vec2 silo_pos = furnace_pos;
                 bool has_silo = false;
                 float best_d = 1e18f;
@@ -538,6 +544,9 @@ void step_furnace_smelting(world_t *w, float dt) {
                     if (adj < 1 || adj > STATION_NUM_RINGS) continue;
                     for (int m2 = 0; m2 < st->module_count; m2++) {
                         if (st->modules[m2].ring != adj) continue;
+                        if (st->modules[m2].scaffold) continue;
+                        if (st->modules[m2].type != MODULE_HOPPER) continue;
+                        if ((commodity_t)st->modules[m2].commodity != a->commodity) continue;
                         vec2 mp2 = module_world_pos_ring(st, adj, st->modules[m2].slot);
                         float dd = v2_dist_sq(furnace_pos, mp2);
                         if (dd < best_d) { best_d = dd; silo_pos = mp2; has_silo = true; }

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -739,11 +739,21 @@ void step_furnace_smelting(world_t *w, float dt) {
 
             if (ore_value > 0.0f) {
                 uint8_t bc = by_contract ? 1 : 0;
+                /* Credit to the same identity the buy/balance paths read:
+                 * pubkey when registered, session_token-pseudokey otherwise.
+                 * Mismatched identity here was the visible-bug:
+                 * smelt-payouts landed on the session-token ledger entry
+                 * but the buy path read the pubkey entry → balance shown
+                 * as 0, "REJECT: finished good but whole=0 (afford=0)". */
                 if (tower >= 0) {
                     float credited = 0.0f;
-                    if (w->players[tower].session_ready)
-                        credited = ledger_credit_supply_amount(st, w->players[tower].session_token, graded_value);
-                    w->players[tower].ship.stat_credits_earned += credited;
+                    server_player_t *pt = &w->players[tower];
+                    if (pt->session_ready) {
+                        credited = pt->pubkey_set
+                            ? ledger_credit_supply_amount_by_pubkey(st, pt->pubkey, graded_value)
+                            : ledger_credit_supply_amount(st, pt->session_token, graded_value);
+                    }
+                    pt->ship.stat_credits_earned += credited;
                     emit_event(w, (sim_event_t){
                         .type = SIM_EVENT_SELL, .player_id = tower,
                         .sell = { .station = smelt_station, .grade = (uint8_t)grade,
@@ -752,9 +762,13 @@ void step_furnace_smelting(world_t *w, float dt) {
                     if (fracturer >= 0 && fracturer != tower) {
                         float finders = graded_value * 0.25f;
                         float fcredited = 0.0f;
-                        if (w->players[fracturer].session_ready)
-                            fcredited = ledger_credit_supply_amount(st, w->players[fracturer].session_token, finders);
-                        w->players[fracturer].ship.stat_credits_earned += fcredited;
+                        server_player_t *pf = &w->players[fracturer];
+                        if (pf->session_ready) {
+                            fcredited = pf->pubkey_set
+                                ? ledger_credit_supply_amount_by_pubkey(st, pf->pubkey, finders)
+                                : ledger_credit_supply_amount(st, pf->session_token, finders);
+                        }
+                        pf->ship.stat_credits_earned += fcredited;
                         emit_event(w, (sim_event_t){
                             .type = SIM_EVENT_SELL, .player_id = fracturer,
                             .sell = { .station = smelt_station, .grade = (uint8_t)grade,
@@ -765,9 +779,13 @@ void step_furnace_smelting(world_t *w, float dt) {
                 } else if (fracturer >= 0) {
                     float half = graded_value * 0.5f;
                     float credited = 0.0f;
-                    if (w->players[fracturer].session_ready)
-                        credited = ledger_credit_supply_amount(st, w->players[fracturer].session_token, half);
-                    w->players[fracturer].ship.stat_credits_earned += credited;
+                    server_player_t *pf = &w->players[fracturer];
+                    if (pf->session_ready) {
+                        credited = pf->pubkey_set
+                            ? ledger_credit_supply_amount_by_pubkey(st, pf->pubkey, half)
+                            : ledger_credit_supply_amount(st, pf->session_token, half);
+                    }
+                    pf->ship.stat_credits_earned += credited;
                     emit_event(w, (sim_event_t){
                         .type = SIM_EVENT_SELL, .player_id = fracturer,
                         .sell = { .station = smelt_station, .grade = (uint8_t)grade,

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -1051,9 +1051,22 @@ void step_module_flow(world_t *w, float dt) {
  * immediately from cargo but build progress advances at a fixed rate --
  * delivery fills the module's internal hopper (tracked via build_progress
  * vs the total cost), construction ticks over time in step_module_activation. */
-void step_module_delivery(world_t *w, station_t *st, int station_idx,
-                          ship_t *ship, commodity_t filter) {
+float step_module_delivery(world_t *w, station_t *st, int station_idx,
+                           ship_t *ship, commodity_t filter) {
     (void)w; (void)station_idx;
+    /* Total credit owed for materials this ship donated to construction.
+     * The caller (player path: pay via ledger_earn + SELL event; NPC
+     * path: credit via the hauler's economic identity) decides what to
+     * do with it. Returning 0 means nothing was delivered or the cargo
+     * was already drained by a contract path upstream.
+     *
+     * Bug history: until this returned a payout the player's cargo
+     * silently vanished into a docked station's scaffolded modules
+     * without payment — symptom was "selling ingots drains inventory
+     * but doesn't credit." The contract path at try_sell_station_cargo
+     * runs AFTER this function and would have paid, but module
+     * construction had already consumed the cargo. */
+    float payout = 0.0f;
     for (int i = 0; i < st->module_count; i++) {
         station_module_t *m = &st->modules[i];
         if (module_build_state(m) != MODULE_BUILD_AWAITING_SUPPLY) continue;
@@ -1067,23 +1080,43 @@ void step_module_delivery(world_t *w, station_t *st, int station_idx,
         if (needed < 0.01f) continue;
 
         /* Pull from docked ship cargo (consume the manifest unit so the
-         * named identity can't be sold or transferred again). */
+         * named identity can't be sold or transferred again). The ship
+         * is paid the station's buy price for whatever it delivers. */
         if (ship->cargo[mat] > 0.01f) {
             float deliver = fminf(ship->cargo[mat], needed);
             ship->cargo[mat] -= deliver;
             m->build_progress += deliver / cost;
             int whole = (int)floorf(deliver + 0.0001f);
-            if (whole > 0)
+            if (whole > 0) {
+                /* Sum prefix-class multipliers across the units we're
+                 * about to consume so high-grade ingots pay the player
+                 * proportionally. Same per-unit accounting as
+                 * try_sell_station_cargo's grade-bonus loop. */
+                float price = station_buy_price(st, mat);
+                int counted = 0;
+                for (uint16_t u = 0; u < ship->manifest.count && counted < whole; u++) {
+                    const cargo_unit_t *cu = &ship->manifest.units[u];
+                    if (cu->commodity != mat) continue;
+                    float mult = mining_payout_multiplier((mining_grade_t)cu->grade);
+                    payout += mult * price;
+                    counted++;
+                }
+                /* Fractional remainder (sub-unit float) priced at base. */
+                float frac = deliver - (float)whole;
+                if (frac > 0.0f) payout += frac * price;
                 manifest_consume_by_commodity(&ship->manifest, mat, whole);
+            } else {
+                payout += deliver * station_buy_price(st, mat);
+            }
             needed -= deliver;
         }
 
         /* Also pull from station inventory (NPC deliveries land here).
-         * Match the consume on the station manifest too — same drift
-         * class as the ship side. Mark the manifest dirty so the
-         * multiplayer broadcaster forwards the new station summary;
-         * otherwise clients keep showing materials that construction
-         * already consumed until some unrelated event triggers a sync. */
+         * NOT credited as a player payout — the materials were already
+         * paid for when they entered the station. Mark the manifest
+         * dirty so the multiplayer broadcaster forwards the new station
+         * summary; otherwise clients keep showing materials that
+         * construction already consumed. */
         if (needed > 0.01f && st->_inventory_cache[mat] > 0.01f) {
             float deliver = fminf(st->_inventory_cache[mat], needed);
             st->_inventory_cache[mat] -= deliver;
@@ -1097,6 +1130,7 @@ void step_module_delivery(world_t *w, station_t *st, int station_idx,
 
         if (m->build_progress > 1.0f) m->build_progress = 1.0f;
     }
+    return payout;
 }
 
 /* ------------------------------------------------------------------ */

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -28,6 +28,7 @@
 #include "manifest.h"
 #include "ship.h"
 #include "sim_ai.h"
+#include "sim_construction.h"
 #include "base58.h"
 #include "protocol.h"
 #include "station_authority.h"
@@ -78,7 +79,17 @@ static uint32_t crc32_file(FILE *f) {
 }
 
 #define SAVE_MAGIC 0x5349474E  /* "SIGN" */
-#define SAVE_VERSION 50  /* Hoppers tag a single commodity each, the
+#define SAVE_VERSION 51  /* Cargo-in-space schema (Slice 1):
+                          * FURNACE per-instance commodity tag drives
+                          * its output ingot type. v50 saves loaded
+                          * with untagged furnaces (commodity ==
+                          * COMMODITY_COUNT) get tagged on load by a
+                          * station-furnace-count heuristic — 1 furnace
+                          * → FERRITE_INGOT, 2 → 1×FERRITE+1×CUPRITE,
+                          * 3+ → CUPRITE+CRYSTAL split — and missing
+                          * output hoppers are auto-spawned into free
+                          * outer-ring slots. Layout-preserving on
+                          * disk. v50 was: Hoppers tag a single commodity each, the
                           * pair rule becomes "all required input
                           * commodities have a hopper on the station,"
                           * and producers emit one spoke per input
@@ -179,6 +190,81 @@ _Static_assert(sizeof(legacy_named_ingot_t) == 56,
 /* Set by world_load() before read_station() so per-station readers know
  * which version they're parsing and can handle field additions. */
 static int g_loaded_save_version = SAVE_VERSION;
+
+/* v51 cargo-in-space schema migration (Slice 1):
+ * - Tag every untagged FURNACE (commodity == COMMODITY_COUNT) with an
+ *   output ingot using a station-furnace-count heuristic that matches
+ *   the existing count-tier smelt rules:
+ *     1 furnace → FERRITE_INGOT
+ *     2 furnaces → 1× FERRITE + 1× CUPRITE
+ *     3+ furnaces → 1× CUPRITE + 1× CRYSTAL + rest CUPRITE
+ * - Auto-spawn missing output hoppers in free outer-ring slots so the
+ *   seeded layout invariant (every producer has a tagged output
+ *   hopper) holds for migrated saves too.
+ *
+ * Idempotent — running it again on an already-migrated world is a
+ * no-op (tagged furnaces are skipped; existing output hoppers
+ * satisfy the search).
+ *
+ * Exposed (non-static) so tests can break a fresh world to look
+ * pre-Slice-1 and exercise this directly. */
+void world_apply_cargo_schema_migration(world_t *w) {
+    for (int i = 0; i < MAX_STATIONS; i++) {
+        station_t *st = &w->stations[i];
+        if (st->module_count <= 0) continue;
+        int n_furnaces = 0;
+        for (int m = 0; m < st->module_count; m++) {
+            if (st->modules[m].type == MODULE_FURNACE && !st->modules[m].scaffold)
+                n_furnaces++;
+        }
+        int seen = 0;
+        for (int m = 0; m < st->module_count; m++) {
+            if (st->modules[m].type != MODULE_FURNACE) continue;
+            if (st->modules[m].scaffold) continue;
+            if ((commodity_t)st->modules[m].commodity == COMMODITY_FERRITE_INGOT ||
+                (commodity_t)st->modules[m].commodity == COMMODITY_CUPRITE_INGOT ||
+                (commodity_t)st->modules[m].commodity == COMMODITY_CRYSTAL_INGOT) {
+                seen++;
+                continue;
+            }
+            commodity_t tag;
+            if (n_furnaces >= 3) {
+                if      (seen == 0) tag = COMMODITY_CUPRITE_INGOT;
+                else if (seen == 1) tag = COMMODITY_CRYSTAL_INGOT;
+                else                tag = COMMODITY_CUPRITE_INGOT;
+            } else if (n_furnaces == 2) {
+                tag = (seen == 0) ? COMMODITY_FERRITE_INGOT
+                                  : COMMODITY_CUPRITE_INGOT;
+            } else {
+                tag = COMMODITY_FERRITE_INGOT;
+            }
+            st->modules[m].commodity = (uint8_t)tag;
+            seen++;
+        }
+        /* Auto-spawn missing output hoppers. Snapshot module_count to
+         * avoid iterating into freshly-added hoppers. */
+        int snap = st->module_count;
+        for (int m = 0; m < snap; m++) {
+            if (st->modules[m].scaffold) continue;
+            if (!module_is_producer(st->modules[m].type)) continue;
+            commodity_t out = module_instance_output(&st->modules[m]);
+            if (out == COMMODITY_COUNT) continue; /* shipyard etc. exempt */
+            if (station_find_hopper_for(st, out) >= 0) continue;
+            int placed_ring = -1, placed_slot = -1;
+            for (int r = 2; r <= STATION_NUM_RINGS && placed_ring < 0; r++) {
+                int slot = station_ring_free_slot(st, r, STATION_RING_SLOTS[r]);
+                if (slot >= 0) { placed_ring = r; placed_slot = slot; }
+            }
+            if (placed_ring < 0) {
+                int slot = station_ring_free_slot(st, 1, STATION_RING_SLOTS[1]);
+                if (slot >= 0) { placed_ring = 1; placed_slot = slot; }
+            }
+            if (placed_ring < 0) continue; /* no room — skip silently */
+            add_hopper_for(st, (uint8_t)placed_ring, (uint8_t)placed_slot, out);
+        }
+        rebuild_station_services(st);
+    }
+}
 
 /* ---- helper macros for explicit field I/O ---- */
 #define WRITE_FIELD(f, val) do { if (fwrite(&(val), sizeof(val), 1, (f)) != 1) { fclose(f); return false; } } while(0)
@@ -1279,6 +1365,13 @@ bool world_load(world_t *w, const char *path) {
             int t = (int)w->scaffolds[i].module_type;
             if (t == 8 || t == 10) w->scaffolds[i].module_type = MODULE_HOPPER;
         }
+    }
+
+    /* v51 cargo-in-space schema (Slice 1) — see helper. */
+    if (version < 51) {
+        world_apply_cargo_schema_migration(w);
+        printf("[save] migrated v%d -> v51: tagged furnaces + auto-spawned output hoppers\n",
+               (int)version);
     }
 
     /* v24-v26: asteroids and scaffolds no longer saved — ensure arrays are

--- a/shared/laser.c
+++ b/shared/laser.c
@@ -8,7 +8,8 @@
 bool laser_target_in_beam(const laser_ray_t *ray,
                           vec2 target_pos,
                           float target_radius,
-                          vec2 *out_hit_pos) {
+                          vec2 *out_hit_pos,
+                          float *out_along_dist) {
     if (!ray) return false;
 
     vec2 to_target = v2_sub(target_pos, ray->source_pos);
@@ -46,6 +47,7 @@ bool laser_target_in_beam(const laser_ray_t *ray,
         *out_hit_pos = v2_sub(target_pos,
                               v2_scale(to_target_unit, target_radius * 0.85f));
     }
+    if (out_along_dist) *out_along_dist = along;
     return true;
 }
 

--- a/shared/laser.c
+++ b/shared/laser.c
@@ -1,0 +1,62 @@
+/*
+ * laser.c — geometry + effect helpers for the unified laser primitive.
+ * See laser.h for the conceptual model.
+ */
+#include "laser.h"
+#include <math.h>
+
+bool laser_target_in_beam(const laser_ray_t *ray,
+                          vec2 target_pos,
+                          float target_radius,
+                          vec2 *out_hit_pos) {
+    if (!ray) return false;
+
+    vec2 to_target = v2_sub(target_pos, ray->source_pos);
+    float along = v2_dot(to_target, ray->source_dir);
+
+    /* Behind the source — never a hit. */
+    if (along < 0.0f) return false;
+
+    /* Range gate. Clip on the closest approach point (along the line
+     * of action), not the target's center, so a wide target straddling
+     * the range edge still registers. */
+    float effective_range = ray->range + target_radius;
+    if (along > effective_range) return false;
+
+    /* Perpendicular distance from the ray axis to the target center. */
+    vec2 axis_point  = v2_add(ray->source_pos, v2_scale(ray->source_dir, along));
+    vec2 perp        = v2_sub(target_pos, axis_point);
+    float perp_dist  = sqrtf(v2_len_sq(perp));
+
+    /* Cone test. A thin ray (half_angle == 0) collapses to a strict
+     * "perpendicular distance ≤ target_radius" check; a cone widens
+     * the tolerance with distance from source. */
+    float allowed_perp = target_radius;
+    if (ray->cone_half_angle > 0.0f) {
+        allowed_perp += along * tanf(ray->cone_half_angle);
+    }
+    if (perp_dist > allowed_perp) return false;
+
+    /* Hit. Termination point biased 85% into the target so the visible
+     * beam clearly lands on its surface rather than passing through. */
+    if (out_hit_pos) {
+        vec2 to_target_unit = (along > 1e-6f)
+            ? v2_scale(to_target, 1.0f / sqrtf(v2_len_sq(to_target)))
+            : ray->source_dir;
+        *out_hit_pos = v2_sub(target_pos,
+                              v2_scale(to_target_unit, target_radius * 0.85f));
+    }
+    return true;
+}
+
+void laser_apply_effect(float *target_field,
+                        float effect_per_sec,
+                        float max_value,
+                        float dt) {
+    if (!target_field) return;
+    *target_field += effect_per_sec * dt;
+    if (*target_field < 0.0f) *target_field = 0.0f;
+    if (max_value > 0.0f && *target_field > max_value) {
+        *target_field = max_value;
+    }
+}

--- a/shared/laser.h
+++ b/shared/laser.h
@@ -23,14 +23,27 @@
  *                                                    accumulator + decay
  *   server/sim_mining.c::sim_mining_beam_step        per-tick HP
  *                                                    damage on asteroids
+ *   server/game_sim.c::find_scan_target              ray-vs-circle hit
+ *                                                    detection (HUD scan;
+ *                                                    no effect, but the
+ *                                                    geometry helper is
+ *                                                    shared with the
+ *                                                    other sites)
  *
  * DELIBERATELY NOT MIGRATED:
- *   - server/game_sim.c::find_scan_target — pure ray-cast for HUD
- *     targeting. No effect accumulation; only target identification.
- *     Could share laser_target_in_cone() if the geometry duplicates
- *     enough to be worth folding in (R3+).
+ *   - server/sim_mining.c::sim_mining_pick_target — its hit test
+ *     computes the true ray-vs-circle entry point (using
+ *     `surface_dist = proj - sqrt(r^2 - perp^2)`) instead of the
+ *     primitive's perpendicular-projection distance. The two values
+ *     differ for off-axis targets and the existing target-priority
+ *     ordering depends on the entry-point semantics. A future commit
+ *     could add a `LASER_HIT_ENTRY_POINT` mode if we want unification.
+ *   - server/game_sim.c::find_scan_target ring-vs-annulus block —
+ *     true ray-circle intersection (entry/exit) rather than
+ *     point-radius. Stays hand-rolled.
  *   - server/game_sim.c scaffold-snap trigger — checks proximity at
- *     beam_end to flip a state machine. Not an effect accumulator.
+ *     beam_end to flip a state machine. Not an effect accumulator,
+ *     not a hit test against a fresh ray.
  *
  * This refactor does NOT add new gameplay (combat lasers, heat,
  * jamming, etc.) — it just consolidates the existing laser-shaped
@@ -65,13 +78,17 @@ typedef struct {
  * the beam's range and cone. When non-NULL, `*out_hit_pos` is filled
  * with the visible-beam termination point (target surface, biased
  * toward the source by 85% of target_radius for a clean visual).
+ * When non-NULL, `*out_along_dist` is filled with the distance along
+ * the beam axis from source to the projected target center — useful
+ * for "nearest hit wins" loops over multiple candidate targets.
  *
  * Doesn't apply any effect — pure geometry check. The caller decides
  * what to do with the hit: accumulate damage, advance progress, etc. */
 bool laser_target_in_beam(const laser_ray_t *ray,
                           vec2 target_pos,
                           float target_radius,
-                          vec2 *out_hit_pos);
+                          vec2 *out_hit_pos,
+                          float *out_along_dist);
 
 /* Per-tick effect accumulation on a scalar field (hp, smelt_progress,
  * fab_charge, etc.).

--- a/shared/laser.h
+++ b/shared/laser.h
@@ -1,0 +1,92 @@
+/*
+ * laser.h — unified laser-beam primitive.
+ *
+ * Companion to shared/tractor.h. Where a tractor transfers momentum
+ * (force between two anchor points), a laser transfers energy: a
+ * directed ray from a source delivers a per-second effect on whatever
+ * it hits, with no force on the target and no recoil on the source.
+ *
+ * The primitive separates two concerns that are conflated today:
+ *   - Geometry: is a target inside the beam's range / cone? Where
+ *     does the beam visually terminate on the target's surface?
+ *   - Effect: when the beam is on, accumulate per-second value on a
+ *     scalar field (hp, smelt_progress, etc.); when the beam is off,
+ *     optionally decay back toward zero or hold.
+ *
+ * Both server and client can call this — geometry is shareable for
+ * predictive simulation (client extrapolates "where the beam will
+ * land next tick" between snapshots) and the effect helper is pure
+ * float math.
+ *
+ * MIGRATED SITES:
+ *   server/sim_production.c::step_furnace_smelting   smelt_progress
+ *                                                    accumulator + decay
+ *   server/sim_mining.c::sim_mining_beam_step        per-tick HP
+ *                                                    damage on asteroids
+ *
+ * DELIBERATELY NOT MIGRATED:
+ *   - server/game_sim.c::find_scan_target — pure ray-cast for HUD
+ *     targeting. No effect accumulation; only target identification.
+ *     Could share laser_target_in_cone() if the geometry duplicates
+ *     enough to be worth folding in (R3+).
+ *   - server/game_sim.c scaffold-snap trigger — checks proximity at
+ *     beam_end to flip a state machine. Not an effect accumulator.
+ *
+ * This refactor does NOT add new gameplay (combat lasers, heat,
+ * jamming, etc.) — it just consolidates the existing laser-shaped
+ * code paths so future additions plug into one model.
+ */
+#ifndef SHARED_LASER_H
+#define SHARED_LASER_H
+
+#include <stdbool.h>
+#include "math_util.h"
+
+/* Geometry of a single laser beam.
+ *
+ * The ray fires from `source_pos` along `source_dir` (must be a unit
+ * vector). `range` clamps how far the beam reaches. `cone_half_angle`
+ * controls beam width: 0 = thin ray (only targets exactly on the line
+ * register a hit), >0 = cone with a tolerance window.
+ *
+ * Helpers below treat targets as circles (pos + radius). For a thin
+ * ray, the test is "perpendicular distance from line ≤ target radius".
+ * For a cone, the test is "angle between source_dir and source→target
+ * is within cone_half_angle". Either way, the target must also be
+ * within `range` along the line of action. */
+typedef struct {
+    vec2  source_pos;
+    vec2  source_dir;          /* unit vector */
+    float range;
+    float cone_half_angle;     /* radians; 0 = thin ray */
+} laser_ray_t;
+
+/* True if a target circle (`target_pos`, `target_radius`) is inside
+ * the beam's range and cone. When non-NULL, `*out_hit_pos` is filled
+ * with the visible-beam termination point (target surface, biased
+ * toward the source by 85% of target_radius for a clean visual).
+ *
+ * Doesn't apply any effect — pure geometry check. The caller decides
+ * what to do with the hit: accumulate damage, advance progress, etc. */
+bool laser_target_in_beam(const laser_ray_t *ray,
+                          vec2 target_pos,
+                          float target_radius,
+                          vec2 *out_hit_pos);
+
+/* Per-tick effect accumulation on a scalar field (hp, smelt_progress,
+ * fab_charge, etc.).
+ *
+ *   *target_field += effect_per_sec * dt
+ *
+ * Then clamps the result to [0, max_value] iff `max_value > 0`. Pass
+ * `max_value = 0` for unclamped accumulation (e.g. taking damage off
+ * an HP value where the floor matters but no upper bound is defined).
+ *
+ * Negative `effect_per_sec` decays the field toward zero — used by
+ * smelt_progress when a fragment leaves the beam. */
+void laser_apply_effect(float *target_field,
+                        float effect_per_sec,
+                        float max_value,
+                        float dt);
+
+#endif /* SHARED_LASER_H */

--- a/shared/module_schema.c
+++ b/shared/module_schema.c
@@ -219,6 +219,56 @@ module_inputs_t module_required_inputs(module_type_t type) {
     return r;
 }
 
+commodity_t module_required_output(module_type_t type) {
+    switch (type) {
+    case MODULE_FURNACE:      return COMMODITY_FERRITE_INGOT;   /* schema default; instance tag overrides */
+    case MODULE_FRAME_PRESS:  return COMMODITY_FRAME;
+    case MODULE_LASER_FAB:    return COMMODITY_LASER_MODULE;
+    case MODULE_TRACTOR_FAB:  return COMMODITY_TRACTOR_MODULE;
+    /* SHIPYARD output is a physical scaffold body, not a commodity. */
+    default: return COMMODITY_COUNT;
+    }
+}
+
+commodity_t module_furnace_default_output(void) {
+    return COMMODITY_FERRITE_INGOT;
+}
+
+commodity_t commodity_ingot_for_ore(commodity_t ore) {
+    switch (ore) {
+    case COMMODITY_FERRITE_ORE: return COMMODITY_FERRITE_INGOT;
+    case COMMODITY_CUPRITE_ORE: return COMMODITY_CUPRITE_INGOT;
+    case COMMODITY_CRYSTAL_ORE: return COMMODITY_CRYSTAL_INGOT;
+    default: return COMMODITY_COUNT;
+    }
+}
+
+commodity_t commodity_ore_for_ingot(commodity_t ingot) {
+    switch (ingot) {
+    case COMMODITY_FERRITE_INGOT: return COMMODITY_FERRITE_ORE;
+    case COMMODITY_CUPRITE_INGOT: return COMMODITY_CUPRITE_ORE;
+    case COMMODITY_CRYSTAL_INGOT: return COMMODITY_CRYSTAL_ORE;
+    default: return COMMODITY_COUNT;
+    }
+}
+
+commodity_t module_instance_output(const station_module_t *m) {
+    if (!m) return COMMODITY_COUNT;
+    if (m->type == MODULE_FURNACE) {
+        commodity_t tag = (commodity_t)m->commodity;
+        /* Untagged or non-ingot tag → fall back to the default. Pre-Slice-1
+         * saves left commodity = COMMODITY_COUNT on furnaces. */
+        if (commodity_ore_for_ingot(tag) != COMMODITY_COUNT) return tag;
+        return module_furnace_default_output();
+    }
+    return module_required_output(m->type);
+}
+
+commodity_t module_instance_input_ore(const station_module_t *m) {
+    if (!m || m->type != MODULE_FURNACE) return COMMODITY_COUNT;
+    return commodity_ore_for_ingot(module_instance_output(m));
+}
+
 bool module_unlocked_for_player(uint32_t unlocked_mask, module_type_t type) {
     int prereq = module_schema(type)->prerequisite;
     if (prereq < 0 || prereq >= MODULE_COUNT) return true;

--- a/shared/module_schema.h
+++ b/shared/module_schema.h
@@ -98,10 +98,13 @@ bool                   module_requires_pair(module_type_t type);
  * iff a hopper exists on the station for each of its required input
  * commodities.
  *
- * FURNACE is special: it accepts ANY ore (the count-tier rules in
- * sim_production gate which ones actually smelt). The list returns
- * all three ore commodities but with `.any_satisfies = true` so the
- * validator only requires one of them.
+ * FURNACE is special at the SCHEMA level: it accepts ANY ore (the
+ * count-tier rules in sim_production gate which ones actually smelt).
+ * The list returns all three ore commodities but with `.any_satisfies
+ * = true` so the validator only requires one of them. At the INSTANCE
+ * level, a furnace tagged with an ingot output commodity (Slice 1 of
+ * the cargo-in-space redesign) consumes the matching ore — see
+ * module_instance_input_ore().
  *
  * `out` must be sized at least 3. Returns count written. */
 typedef struct {
@@ -110,6 +113,34 @@ typedef struct {
     bool        any_satisfies; /* true → FURNACE-style "one of these"; false → ALL required */
 } module_inputs_t;
 module_inputs_t        module_required_inputs(module_type_t type);
+
+/* Per-producer output commodity. Each non-shipyard producer emits one
+ * commodity into the station's flow graph; SHIPYARD is exempt (its
+ * output is a physical scaffold body, not a commodity).
+ *
+ * FURNACE at the schema level returns COMMODITY_FERRITE_INGOT (the
+ * default Prospect role); per-instance, the output commodity comes
+ * from the furnace's `station_module_t.commodity` tag — see
+ * module_instance_output(). Returns COMMODITY_COUNT for non-producers
+ * and SHIPYARD. */
+commodity_t            module_required_output(module_type_t type);
+
+/* Instance-aware accessors. For producers whose I/O depends on
+ * per-instance configuration (currently only FURNACE, which tags its
+ * output ingot via station_module_t.commodity), these read the
+ * instance state and fall back to the schema default for legacy /
+ * untagged modules. */
+commodity_t            module_instance_output(const station_module_t *m);
+commodity_t            module_instance_input_ore(const station_module_t *m);
+
+/* Default output commodity for an untagged FURNACE — matches Prospect
+ * (1-furnace tier, ferrite-only). Used by save migration and seeds. */
+commodity_t            module_furnace_default_output(void);
+
+/* Map an ingot commodity to its source ore (and back). Returns
+ * COMMODITY_COUNT if the input isn't a known ingot/ore. */
+commodity_t            commodity_ore_for_ingot(commodity_t ingot);
+commodity_t            commodity_ingot_for_ore(commodity_t ore);
 
 /* Tech-tree gate: a module is unlocked when its prerequisite has been
  * built at least once. Roots (prerequisite = MODULE_COUNT) are always

--- a/shared/station_geom.h
+++ b/shared/station_geom.h
@@ -248,10 +248,24 @@ static inline void station_build_geom(const station_t *st, station_geom_t *out) 
         const station_module_t *prod = &st->modules[m];
         if (prod->scaffold) continue;
         module_inputs_t req = module_required_inputs(prod->type);
-        if (req.count == 0) continue;
-        for (int i = 0; i < req.count; i++) {
-            commodity_t c = req.commodities[i];
-            int hop = station_find_hopper_for(st, c);
+        commodity_t out_commodity = module_instance_output(prod);
+        if (req.count == 0 && out_commodity == COMMODITY_COUNT) continue;
+        /* Build the per-producer spoke list: one per declared input
+         * commodity, plus one for the producer's output (if any —
+         * SHIPYARD has none). Each spoke renders + drives ring physics
+         * (Slice 1.5a — output spokes contribute torque too). */
+        for (int i = 0; i <= req.count; i++) {
+            commodity_t c;
+            int hop;
+            if (i < req.count) {
+                c = req.commodities[i];
+                hop = station_find_hopper_for(st, c);
+            } else {
+                /* Output spoke. */
+                if (out_commodity == COMMODITY_COUNT) break;
+                c = out_commodity;
+                hop = station_find_output_hopper_for_module(st, prod);
+            }
             if (hop < 0) continue;
             if (out->spoke_count >= STATION_GEOM_MAX_SPOKES) break;
             const station_module_t *hm = &st->modules[hop];

--- a/shared/station_geom.h
+++ b/shared/station_geom.h
@@ -269,6 +269,13 @@ static inline void station_build_geom(const station_t *st, station_geom_t *out) 
             if (hop < 0) continue;
             if (out->spoke_count >= STATION_GEOM_MAX_SPOKES) break;
             const station_module_t *hm = &st->modules[hop];
+            /* Same-ring spokes contribute zero net torque (Newton's
+             * third cancels) and step_station_ring_dynamics skips
+             * them. Skip in the renderer too so visible beams match
+             * the physics — otherwise a producer-and-hopper on the
+             * same ring would render a beam promising torque the
+             * dynamics doesn't apply. */
+            if ((int)hm->ring == (int)prod->ring) continue;
             geom_spoke_t *sp = &out->spokes[out->spoke_count++];
             sp->a = module_world_pos_ring(st, prod->ring, prod->slot);
             sp->b = module_world_pos_ring(st, hm->ring, hm->slot);

--- a/shared/station_util.c
+++ b/shared/station_util.c
@@ -314,3 +314,49 @@ int station_find_hopper_for(const station_t *st, commodity_t commodity) {
     return -1;
 }
 
+int station_find_output_hopper_for_module(const station_t *st, const station_module_t *m) {
+    if (!st || !m) return -1;
+    commodity_t out = module_instance_output(m);
+    if (out == COMMODITY_COUNT) return -1; /* services / hoppers / shipyard */
+    return station_find_hopper_for(st, out);
+}
+
+station_layout_status_t station_module_layout_status(const station_t *st,
+                                                     const station_module_t *m) {
+    if (!st || !m) return STATION_LAYOUT_OK;
+    if (m->scaffold) return STATION_LAYOUT_OK;
+    if (!module_is_producer(m->type) && !module_is_shipyard(m->type)) return STATION_LAYOUT_OK;
+
+    /* Inputs: every required input commodity must have a matching hopper.
+     * For FURNACE the schema says any_satisfies; under per-instance tagging
+     * the actual input is the one ore that matches the furnace's tag. */
+    if (m->type == MODULE_FURNACE) {
+        commodity_t ore = module_instance_input_ore(m);
+        if (ore != COMMODITY_COUNT && station_find_hopper_for(st, ore) < 0) {
+            return STATION_LAYOUT_MISSING_INPUT_HOPPER;
+        }
+    } else {
+        module_inputs_t req = module_required_inputs(m->type);
+        if (req.any_satisfies) {
+            bool ok = false;
+            for (int i = 0; i < req.count; i++) {
+                if (station_find_hopper_for(st, req.commodities[i]) >= 0) { ok = true; break; }
+            }
+            if (req.count > 0 && !ok) return STATION_LAYOUT_MISSING_INPUT_HOPPER;
+        } else {
+            for (int i = 0; i < req.count; i++) {
+                if (station_find_hopper_for(st, req.commodities[i]) < 0)
+                    return STATION_LAYOUT_MISSING_INPUT_HOPPER;
+            }
+        }
+    }
+
+    /* Output hopper: required for every commodity-emitting producer.
+     * SHIPYARD is exempt — its output is a physical scaffold body. */
+    commodity_t out = module_instance_output(m);
+    if (out != COMMODITY_COUNT && station_find_hopper_for(st, out) < 0) {
+        return STATION_LAYOUT_MISSING_OUTPUT_HOPPER;
+    }
+    return STATION_LAYOUT_OK;
+}
+

--- a/shared/station_util.c
+++ b/shared/station_util.c
@@ -321,6 +321,91 @@ int station_find_output_hopper_for_module(const station_t *st, const station_mod
     return station_find_hopper_for(st, out);
 }
 
+/* ------------------------------------------------------------------ */
+/* Demand: top shortage, severity, recommended pay multiplier.         */
+/* ------------------------------------------------------------------ */
+
+/* Per-commodity supply target. Mirrors the targets the contract priority
+ * ladder uses in game_sim.c (priority 3 for ore, priority 4 for ingots,
+ * priority 5 for kit inputs) so the demand primitive and the contract
+ * generator agree on what "starving" means. */
+static float station_demand_target_for(const station_t *st, commodity_t c) {
+    if (c < COMMODITY_RAW_ORE_COUNT) {
+        /* Raw ore — matches priority 3 (REFINERY_HOPPER_CAPACITY * 0.5). */
+        return REFINERY_HOPPER_CAPACITY * 0.5f;
+    }
+    switch (c) {
+        case COMMODITY_FERRITE_INGOT:
+        case COMMODITY_CUPRITE_INGOT:
+        case COMMODITY_CRYSTAL_INGOT:
+            /* Matches priority 4 (MAX_PRODUCT_STOCK * 0.9). */
+            return MAX_PRODUCT_STOCK * 0.9f;
+        case COMMODITY_FRAME:
+        case COMMODITY_LASER_MODULE:
+        case COMMODITY_TRACTOR_MODULE:
+            /* Matches priority 5 kit_input_target. */
+            return 12.0f;
+        case COMMODITY_REPAIR_KIT:
+            /* Non-shipyard dock buffer. Half the shipyard's per-batch
+             * output keeps small docks topped up without making them
+             * post a contract on every minor repair. */
+            return 50.0f;
+        default: break;
+    }
+    /* Unknown commodity — caller will see severity 0 and skip it. */
+    if (st) (void)st;
+    return 1.0f;
+}
+
+station_demand_t station_demand_for(const station_t *st, commodity_t c) {
+    station_demand_t out = {
+        .commodity  = COMMODITY_COUNT,
+        .severity   = 0.0f,
+        .price_mult = 1.0f,
+    };
+    if (!st || !station_is_active(st)) return out;
+    if (c >= COMMODITY_COUNT) return out;
+    if (!station_consumes(st, c)) return out;
+    /* A station that produces what it consumes (e.g. Helios with its
+     * own cuprite furnace feeding its laser fab) is not starving for
+     * that commodity — the producer keeps the local shelf supplied.
+     * Mirrors priority 4's "don't import what we make" check. */
+    if (station_produces(st, c)) return out;
+
+    float supply = st->_inventory_cache[c];
+    float target = station_demand_target_for(st, c);
+    if (target <= 0.0f) return out;
+
+    float deficit = target - supply;
+    if (deficit <= 0.0f) return out;
+    float severity = deficit / target;
+    if (severity > 1.0f) severity = 1.0f;
+
+    out.commodity  = c;
+    out.severity   = severity;
+    /* 1.0× at no shortage, up to 1.5× at total starvation. The 0.5
+     * slope is conservative — generous enough that haulers will
+     * notice, gentle enough that players can't game the system by
+     * deliberately starving a station they own. */
+    out.price_mult = 1.0f + 0.5f * severity;
+    return out;
+}
+
+station_demand_t station_top_demand(const station_t *st) {
+    station_demand_t out = {
+        .commodity  = COMMODITY_COUNT,
+        .severity   = 0.0f,
+        .price_mult = 1.0f,
+    };
+    if (!st || !station_is_active(st)) return out;
+
+    for (int c = 0; c < COMMODITY_COUNT; c++) {
+        station_demand_t d = station_demand_for(st, (commodity_t)c);
+        if (d.severity > out.severity) out = d;
+    }
+    return out;
+}
+
 station_layout_status_t station_module_layout_status(const station_t *st,
                                                      const station_module_t *m) {
     if (!st || !m) return STATION_LAYOUT_OK;

--- a/shared/station_util.c
+++ b/shared/station_util.c
@@ -351,11 +351,26 @@ station_layout_status_t station_module_layout_status(const station_t *st,
         }
     }
 
-    /* Output hopper: required for every commodity-emitting producer.
-     * SHIPYARD is exempt — its output is a physical scaffold body. */
+    /* Output hopper: required only when a different on-station producer
+     * declares the same commodity as one of its inputs. If nothing
+     * locally consumes this output, the smelt/fab pipeline writes
+     * straight to station inventory and a hauler picks it up — no
+     * staging hopper needed. SHIPYARD's output is a physical scaffold
+     * body and falls through the COMMODITY_COUNT branch naturally. */
     commodity_t out = module_instance_output(m);
-    if (out != COMMODITY_COUNT && station_find_hopper_for(st, out) < 0) {
-        return STATION_LAYOUT_MISSING_OUTPUT_HOPPER;
+    if (out != COMMODITY_COUNT) {
+        bool has_local_consumer = false;
+        for (int j = 0; j < st->module_count && !has_local_consumer; j++) {
+            if (j == (int)(m - st->modules)) continue;
+            if (st->modules[j].scaffold) continue;
+            module_inputs_t cons = module_required_inputs(st->modules[j].type);
+            for (int k = 0; k < cons.count; k++) {
+                if (cons.commodities[k] == out) { has_local_consumer = true; break; }
+            }
+        }
+        if (has_local_consumer && station_find_hopper_for(st, out) < 0) {
+            return STATION_LAYOUT_MISSING_OUTPUT_HOPPER;
+        }
     }
     return STATION_LAYOUT_OK;
 }

--- a/shared/station_util.h
+++ b/shared/station_util.h
@@ -96,4 +96,26 @@ bool          station_pair_satisfied(const station_t *st, int ring, int slot,
  * matches `commodity`. Returns -1 if none. */
 int           station_find_hopper_for(const station_t *st, commodity_t commodity);
 
+/* Find the output hopper that buffers the producer module `m`'s
+ * output commodity. Returns the hopper module index on `st`, or -1
+ * if no matching tagged hopper exists, or if `m` is not a producer
+ * (services, hoppers, shipyards). FURNACEs read their per-instance
+ * commodity tag — see module_instance_output(). */
+int           station_find_output_hopper_for_module(const station_t *st,
+                                                    const station_module_t *m);
+
+/* Layout-validation status for a single module on a station. Slice 1
+ * surfaces this informationally — production keeps running even on a
+ * "missing output hopper" layout — so the renderer / order menu can
+ * badge the module without breaking existing stations. Slice 5 will
+ * promote MISSING_OUTPUT_HOPPER into a hard placement reject. */
+typedef enum {
+    STATION_LAYOUT_OK = 0,
+    STATION_LAYOUT_MISSING_INPUT_HOPPER,
+    STATION_LAYOUT_MISSING_OUTPUT_HOPPER,
+} station_layout_status_t;
+
+station_layout_status_t station_module_layout_status(const station_t *st,
+                                                     const station_module_t *m);
+
 #endif

--- a/shared/station_util.h
+++ b/shared/station_util.h
@@ -118,4 +118,40 @@ typedef enum {
 station_layout_status_t station_module_layout_status(const station_t *st,
                                                      const station_module_t *m);
 
+/* ----- Demand: what is this station starving for, right now? -----
+ *
+ * Pure derived state — there is no stored demand field. The primitive
+ * scans every commodity the station consumes (per station_consumes)
+ * and reports the one with the worst supply-vs-target deficit. Output
+ * is shared across the wire so HUD beacons, NPC haulers, contract
+ * auto-pricing, and station-side dock UIs can all read the same
+ * "starving for X" signal.
+ *
+ * `severity` is in [0, 1]: 0 = supply meets/exceeds the target,
+ * 1 = total starvation (zero supply on a station that needs it most).
+ * `price_mult` is the recommended pay multiplier vs. base_price for
+ * filling the shortage — currently 1.0 + 0.5 * severity, capped at
+ * 1.5×. Callers are free to apply or ignore it.
+ *
+ * `commodity` is COMMODITY_COUNT when the station has no demand at all
+ * (every consumed commodity is at or above its target). Callers should
+ * gate on `severity > 0` rather than checking the commodity sentinel
+ * alone — both happen together but the explicit float check is more
+ * obvious in branch-heavy callsites. */
+typedef struct {
+    commodity_t commodity;   /* COMMODITY_COUNT when nothing is short */
+    float       severity;    /* 0..1 */
+    float       price_mult;  /* 1.0..1.5 */
+} station_demand_t;
+
+station_demand_t station_top_demand(const station_t *st);
+
+/* Per-commodity variant. Returns the demand for `c` specifically.
+ * `commodity` field on the result is set to `c` if there's any
+ * shortage, else COMMODITY_COUNT — same convention as
+ * station_top_demand. Use this from contract pricing where the
+ * commodity is already known and the question is "how starved are
+ * they for this one?". */
+station_demand_t station_demand_for(const station_t *st, commodity_t c);
+
 #endif

--- a/shared/tractor.c
+++ b/shared/tractor.c
@@ -25,15 +25,18 @@ bool tractor_apply(const tractor_anchor_t *src,
 
     vec2 dir = v2_scale(to_target, 1.0f / d);  /* unit src→tgt */
 
-    /* Signed spring on stretch. Pull when d > rest, push when d < rest.
-     * The two strength knobs let a beam be asymmetric (pure pull, pure
-     * push, or any mix). spring_mag is signed in dir's frame: negative
-     * = toward source (pull), positive = away from source (push). */
+    /* Signed force in dir's frame: negative = toward source (pull),
+     * positive = away from source (push). Two stacked components:
+     *   - spring term: -strength * stretch (linear in distance)
+     *   - constant term: -constant magnitude (engages when on the
+     *     corresponding side of rest, regardless of how far) */
     float stretch = d - beam->rest_length;
-    float spring_mag;
-    if (stretch > 0.0f)       spring_mag = -beam->pull_strength * stretch;
-    else if (stretch < 0.0f)  spring_mag = -beam->push_strength * stretch;
-    else                      spring_mag = 0.0f;
+    float spring_mag = 0.0f;
+    if (stretch > 0.0f) {
+        spring_mag = -beam->pull_strength * stretch - beam->pull_constant;
+    } else if (stretch < 0.0f) {
+        spring_mag = -beam->push_strength * stretch + beam->push_constant;
+    }
 
     /* Optional linear falloff: strength scales by (1 - d/range). */
     if (beam->falloff == TRACTOR_FALLOFF_LINEAR && beam->range > 0.0f) {

--- a/shared/tractor.c
+++ b/shared/tractor.c
@@ -1,0 +1,81 @@
+/*
+ * tractor.c — single-function implementation of the unified tractor
+ * beam primitive. See tractor.h for the model.
+ */
+#include "tractor.h"
+#include <math.h>
+
+bool tractor_apply(const tractor_anchor_t *src,
+                   const tractor_anchor_t *tgt,
+                   const tractor_beam_t   *beam,
+                   float dt) {
+    if (!src || !tgt || !beam) return false;
+
+    vec2 to_target = v2_sub(tgt->pos, src->pos);
+    float d_sq = v2_len_sq(to_target);
+
+    /* Range gate. Test in squared form to avoid sqrt when disengaged. */
+    if (beam->range > 0.0f && d_sq > beam->range * beam->range) return false;
+
+    /* Co-located bodies: report active but apply no force this tick.
+     * Avoids divide-by-zero on the line-of-action unit vector. */
+    float d = sqrtf(d_sq);
+    const float epsilon = 1e-4f;
+    if (d < epsilon) return true;
+
+    vec2 dir = v2_scale(to_target, 1.0f / d);  /* unit src→tgt */
+
+    /* Signed spring on stretch. Pull when d > rest, push when d < rest.
+     * The two strength knobs let a beam be asymmetric (pure pull, pure
+     * push, or any mix). spring_mag is signed in dir's frame: negative
+     * = toward source (pull), positive = away from source (push). */
+    float stretch = d - beam->rest_length;
+    float spring_mag;
+    if (stretch > 0.0f)       spring_mag = -beam->pull_strength * stretch;
+    else if (stretch < 0.0f)  spring_mag = -beam->push_strength * stretch;
+    else                      spring_mag = 0.0f;
+
+    /* Optional linear falloff: strength scales by (1 - d/range). */
+    if (beam->falloff == TRACTOR_FALLOFF_LINEAR && beam->range > 0.0f) {
+        float scale = 1.0f - d / beam->range;
+        if (scale < 0.0f) scale = 0.0f;
+        spring_mag *= scale;
+    }
+
+    /* Target must be body-attached — there's nothing to do otherwise. */
+    if (!tgt->vel) return true;
+
+    /* Relative velocity along and perpendicular to the beam line.
+     * src->vel may be NULL (world-pinned) — treat its velocity as zero. */
+    vec2 src_vel = (src->vel) ? *src->vel : v2(0.0f, 0.0f);
+    vec2 rel_vel = v2_sub(*tgt->vel, src_vel);
+    float v_along = v2_dot(rel_vel, dir);
+    vec2 v_tangent = v2_sub(rel_vel, v2_scale(dir, v_along));
+
+    /* Axial: spring + axial damping. Tangent: damping only. */
+    vec2 axial_force   = v2_scale(dir, spring_mag - beam->axial_damping * v_along);
+    vec2 tangent_force = v2_scale(v_tangent, -beam->tangent_damping);
+    vec2 force = v2_add(axial_force, tangent_force);
+
+    /* Apply impulse to target. Caller treats target as unit mass —
+     * tuning constants are accel directly, not force. */
+    *tgt->vel = v2_add(*tgt->vel, v2_scale(force, dt));
+
+    /* Speed cap (post-impulse, isotropic on target's absolute velocity). */
+    if (beam->speed_cap > 0.0f) {
+        float spd_sq = v2_len_sq(*tgt->vel);
+        float cap_sq = beam->speed_cap * beam->speed_cap;
+        if (spd_sq > cap_sq) {
+            float spd = sqrtf(spd_sq);
+            *tgt->vel = v2_scale(*tgt->vel, beam->speed_cap / spd);
+        }
+    }
+
+    /* Newton's third on source when body-attached. inv_mass scales the
+     * reaction so heavier sources feel less of it (matches the
+     * apply_band_force precedent of dividing by BAND_SHIP_MASS). */
+    if (src->vel && src->inv_mass > 0.0f) {
+        *src->vel = v2_sub(*src->vel, v2_scale(force, dt * src->inv_mass));
+    }
+    return true;
+}

--- a/shared/tractor.h
+++ b/shared/tractor.h
@@ -1,39 +1,63 @@
 /*
  * tractor.h — unified tractor-beam primitive.
  *
- * One function (tractor_apply) replaces the half-dozen hand-rolled
- * "apply force between two anchor points" sites scattered across
- * sim_ai, game_sim, and sim_production. Lives in shared/ so client
- * predictive simulation can call the same code as the server's
- * authoritative tick.
+ * One function (tractor_apply) replaces six hand-rolled "apply force
+ * between two anchor points" sites that previously lived in sim_ai,
+ * game_sim, and sim_production. Lives in shared/ so client predictive
+ * simulation can call the same code as the server's authoritative tick.
  *
- * The shape: each beam has a rest length, a pull strength (force per
- * unit stretch when d > rest), a push strength (force per unit
- * compression when d < rest), an outer range gate, axial damping
- * along the beam line, tangent damping perpendicular to it, an
- * optional speed cap, and an optional linear-falloff curve. Newton's
- * third applies automatically when the source anchor is body-attached
- * (vel pointer + nonzero inv_mass); world-pinned anchors (NULL vel,
- * inv_mass = 0) act as infinite-mass attachment points.
+ * Two strength components per side (each can be zero):
+ *   - *_strength: spring term, force per unit of stretch from rest.
+ *     Linear-in-distance, settles to equilibrium at rest_length.
+ *   - *_constant: always-on term, fixed-magnitude force whenever the
+ *     beam is on the corresponding side of rest. Models a "thruster
+ *     on the rope" — fragment yanks in regardless of distance.
  *
- * Migration sites (filled in as each commit lands):
- *   - server/game_sim.c::apply_band_force        (player tow)
- *   - server/sim_ai.c   NPC_STATE_RETURN_TO_STATION (NPC fragment tow)
- *   - server/sim_ai.c   step_tow_drone NPC_STATE_TRAVEL_TO_DEST (scaffold tow)
- *   - server/sim_production.c::step_furnace_smelting (smelt beam pull)
- *   - server/game_sim.c::step_scaffolds blueprint pull
- *   - server/game_sim.c::step_scaffolds module slot snap
+ * Two damping components, decoupled:
+ *   - axial_damping: opposes velocity along the beam line.
+ *   - tangent_damping: opposes velocity perpendicular to it.
  *
- * Deliberately NOT migrated (different shape, future work):
- *   - step_scaffolds orbital vortex      — tangential orbit + radial
- *                                          pull, not a point-anchor.
- *   - step_station_ring_dynamics spokes  — angular variant; needs
- *                                          rings-as-bodies first.
- *   - step_fragment_collection           — state machine, not a
- *                                          force application.
- *   - all laser sites (mining, smelt-progress, future damage) — the
- *                                          laser primitive is a
- *                                          separate refactor.
+ * Plus: range gate (d > range disables the whole beam, including
+ * damping — set range=0 if you want damping unconditional), optional
+ * speed cap on target, and TRACTOR_FALLOFF_LINEAR for `(1 - d/range)`
+ * scaling of strength.
+ *
+ * Newton's third applies automatically when the source anchor is
+ * body-attached (vel pointer + nonzero inv_mass); world-pinned
+ * anchors (NULL vel, inv_mass = 0) act as infinite-mass attachment
+ * points and skip reaction.
+ *
+ * MIGRATED SITES:
+ *   server/game_sim.c::apply_band_force         (player tow)
+ *   server/sim_ai.c   step_npc_ships RETURN     (NPC fragment tow)
+ *   server/sim_ai.c   step_tow_drone TRAVEL     (scaffold tow)
+ *   server/sim_production.c::step_furnace_smelting   (smelt beam pull)
+ *   server/game_sim.c::step_scaffolds LOOSE     (planned blueprint pull)
+ *   server/game_sim.c::step_scaffolds SNAPPING  (module slot snap)
+ *
+ * DELIBERATELY NOT MIGRATED (different shape, future work):
+ *   - step_scaffolds orbital vortex (loose-near-station orbit) —
+ *     tangential orbit + radial pull, not a point-anchor primitive.
+ *   - step_station_ring_dynamics spokes — angular variant; needs
+ *     rings-as-bodies first.
+ *   - step_fragment_collection (player tractor pickup detection) —
+ *     state machine deciding which fragments to attach, not a force
+ *     application.
+ *   - All laser sites (mining laser, smelt_progress accumulator,
+ *     future damage lasers) — the laser primitive (energy delivery
+ *     along a ray, no momentum) is a separate refactor.
+ *
+ * TUNING NOTE (tangent_damping):
+ *   The user's design intent for the 1D-damping refactor was
+ *   "axial damping along the rope only, with small or zero tangent
+ *   damping for natural swing." In practice, several migrated sites
+ *   had to keep tangent_damping near axial value to satisfy existing
+ *   integration tests that were tuned around the legacy isotropic
+ *   drag (`vel *= 1/(1+k*dt)`). Specifically: NPC fragment tow,
+ *   blueprint pull, and slot snap all run with tangent ≈ axial.
+ *   Player tow uses the legacy axial=0.6, tangent=0.4 split. Smelt
+ *   beam and scaffold tow use ~25% tangent. Worth revisiting once
+ *   visual playtest confirms the right feel for each site.
  */
 #ifndef SHARED_TRACTOR_H
 #define SHARED_TRACTOR_H

--- a/shared/tractor.h
+++ b/shared/tractor.h
@@ -1,0 +1,90 @@
+/*
+ * tractor.h — unified tractor-beam primitive.
+ *
+ * One function (tractor_apply) replaces the half-dozen hand-rolled
+ * "apply force between two anchor points" sites scattered across
+ * sim_ai, game_sim, and sim_production. Lives in shared/ so client
+ * predictive simulation can call the same code as the server's
+ * authoritative tick.
+ *
+ * The shape: each beam has a rest length, a pull strength (force per
+ * unit stretch when d > rest), a push strength (force per unit
+ * compression when d < rest), an outer range gate, axial damping
+ * along the beam line, tangent damping perpendicular to it, an
+ * optional speed cap, and an optional linear-falloff curve. Newton's
+ * third applies automatically when the source anchor is body-attached
+ * (vel pointer + nonzero inv_mass); world-pinned anchors (NULL vel,
+ * inv_mass = 0) act as infinite-mass attachment points.
+ *
+ * Migration sites (filled in as each commit lands):
+ *   - server/game_sim.c::apply_band_force        (player tow)
+ *   - server/sim_ai.c   NPC_STATE_RETURN_TO_STATION (NPC fragment tow)
+ *   - server/sim_ai.c   step_tow_drone NPC_STATE_TRAVEL_TO_DEST (scaffold tow)
+ *   - server/sim_production.c::step_furnace_smelting (smelt beam pull)
+ *   - server/game_sim.c::step_scaffolds blueprint pull
+ *   - server/game_sim.c::step_scaffolds module slot snap
+ *
+ * Deliberately NOT migrated (different shape, future work):
+ *   - step_scaffolds orbital vortex      — tangential orbit + radial
+ *                                          pull, not a point-anchor.
+ *   - step_station_ring_dynamics spokes  — angular variant; needs
+ *                                          rings-as-bodies first.
+ *   - step_fragment_collection           — state machine, not a
+ *                                          force application.
+ *   - all laser sites (mining, smelt-progress, future damage) — the
+ *                                          laser primitive is a
+ *                                          separate refactor.
+ */
+#ifndef SHARED_TRACTOR_H
+#define SHARED_TRACTOR_H
+
+#include <stdbool.h>
+#include "math_util.h"
+
+/* An anchor point for one end of a tractor beam.
+ *
+ * `pos` is in world coordinates. The caller is responsible for
+ * computing it from any body+offset transform (rotation-aware
+ * computation lives at the call site, not here).
+ *
+ * `vel` is a pointer into the body's velocity vector. NULL means the
+ * anchor is world-pinned (e.g. the smelt beam's furnace-silo midpoint,
+ * which doesn't belong to any single body). When non-NULL and
+ * `inv_mass > 0`, the anchor receives Newton's-third reaction force.
+ *
+ * `inv_mass` = 1 / mass. Zero models an immovable / infinite-mass
+ * anchor. */
+typedef struct {
+    vec2  pos;
+    vec2 *vel;
+    float inv_mass;
+} tractor_anchor_t;
+
+/* How beam strength scales with distance inside the active range. */
+typedef enum {
+    TRACTOR_FALLOFF_CONSTANT = 0,   /* uniform: force = strength · stretch */
+    TRACTOR_FALLOFF_LINEAR   = 1,   /* force scaled by (1 - d/range) */
+} tractor_falloff_t;
+
+/* The beam itself — a tuning bundle with no per-call mutable state.
+ * Sites typically declare a static const beam config near the call. */
+typedef struct {
+    float rest_length;       /* happy distance; 0 = pull-toward-source */
+    float pull_strength;     /* axial accel per unit (d - rest) when d > rest */
+    float push_strength;     /* axial accel per unit (rest - d) when d < rest */
+    float range;             /* d > range → no force at all this tick */
+    float axial_damping;     /* accel per unit along-beam relative velocity */
+    float tangent_damping;   /* accel per unit perpendicular-to-beam relative velocity */
+    float speed_cap;         /* optional |target.vel| cap after impulse; 0 = no cap */
+    tractor_falloff_t falloff;
+} tractor_beam_t;
+
+/* Apply one beam tick. Returns true iff the beam was active
+ * (target was within `range`). Mutates tgt->vel always; mutates
+ * src->vel iff src->vel != NULL && src->inv_mass > 0. */
+bool tractor_apply(const tractor_anchor_t *src,
+                   const tractor_anchor_t *tgt,
+                   const tractor_beam_t   *beam,
+                   float dt);
+
+#endif /* SHARED_TRACTOR_H */

--- a/shared/tractor.h
+++ b/shared/tractor.h
@@ -67,11 +67,23 @@ typedef enum {
 } tractor_falloff_t;
 
 /* The beam itself — a tuning bundle with no per-call mutable state.
- * Sites typically declare a static const beam config near the call. */
+ * Sites typically declare a static const beam config near the call.
+ *
+ * Two strength components on each side, summed:
+ *   - *_strength is the spring term: accel per unit of stretch from
+ *     rest. Linear in distance, settles to equilibrium at rest.
+ *   - *_constant is the always-on term: a fixed accel that engages
+ *     whenever the beam is on the corresponding side of rest. Models
+ *     a "thruster on the rope" — fragment yanks in regardless of how
+ *     far away it is.
+ * A site can use either or both. Player tow is pure spring; NPC
+ * fragment pickup is pure constant. */
 typedef struct {
     float rest_length;       /* happy distance; 0 = pull-toward-source */
-    float pull_strength;     /* axial accel per unit (d - rest) when d > rest */
-    float push_strength;     /* axial accel per unit (rest - d) when d < rest */
+    float pull_strength;     /* spring: accel per unit (d - rest) when d > rest */
+    float push_strength;     /* spring: accel per unit (rest - d) when d < rest */
+    float pull_constant;     /* constant pull magnitude when d > rest */
+    float push_constant;     /* constant push magnitude when d < rest */
     float range;             /* d > range → no force at all this tick */
     float axial_damping;     /* accel per unit along-beam relative velocity */
     float tangent_damping;   /* accel per unit perpendicular-to-beam relative velocity */

--- a/shared/types.h
+++ b/shared/types.h
@@ -308,10 +308,16 @@ typedef struct {
      * furnace glow (see station_palette.h::station_palette_furnace_color):
      * cuprite-input → blue, crystal-input → green, otherwise white. */
     uint8_t last_smelt_commodity; /* 1 byte */
-    /* For MODULE_HOPPER: which commodity this hopper holds. Each
-     * hopper buffers exactly one commodity; producers needing that
-     * commodity draw from any matching hopper on the station.
-     * COMMODITY_COUNT (= "unset") for non-hopper modules. */
+    /* Tag commodity, used by:
+     *   - MODULE_HOPPER: which commodity this hopper buffers. Each
+     *     hopper holds exactly one commodity; producers needing that
+     *     commodity draw from any matching hopper on the station.
+     *   - MODULE_FURNACE: which ingot this furnace produces (and, by
+     *     symmetry, which ore it smelts). Set at build/order time.
+     *     COMMODITY_COUNT on legacy/untagged furnaces falls back to
+     *     module_furnace_default_output() (FERRITE_INGOT — Prospect's
+     *     1-furnace tier).
+     *   - other module types: COMMODITY_COUNT (= "unset"). */
     uint8_t commodity;      /* 1 byte */
     uint8_t _pad[2];        /* explicit pad to 4-byte alignment */
     float   build_progress; /* 0.0 to 1.0 */

--- a/src/net.c
+++ b/src/net.c
@@ -229,9 +229,18 @@ bool net_has_identity_secret(void) {
 static uint64_t next_signed_action_nonce(void) {
     uint64_t now_us;
 #ifdef __EMSCRIPTEN__
-    /* Date.now() has ms resolution; multiply to keep us in the same
-     * units as native. */
-    now_us = (uint64_t)emscripten_get_now() * 1000ULL;
+    /* MUST be wall-clock (Date.now), not performance.now (which is
+     * monotonic-since-page-load and starts at zero). The server
+     * persists last_signed_nonce in wall-clock microseconds; a
+     * page-load-relative nonce always loses to a saved one and every
+     * signed action gets rejected as a replay.
+     *
+     * Bug history: emscripten_get_now() returns performance.now() in
+     * ms — small numbers (0..10^7-ish over a long session). The
+     * comment USED to say "Date.now()" but the implementation didn't
+     * match. Fix: read Date.now() through JS, multiply ms→us. */
+    double js_ms = EM_ASM_DOUBLE({ return Date.now(); });
+    now_us = (uint64_t)(js_ms * 1000.0);
 #elif defined(_WIN32)
     /* MSVC has no clock_gettime/CLOCK_REALTIME. GetSystemTimePreciseAsFileTime
      * returns 100-ns ticks since 1601-01-01 UTC; subtract the 1601→1970

--- a/src/net.c
+++ b/src/net.c
@@ -15,6 +15,9 @@
 #include <time.h>
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
+#ifdef __EMSCRIPTEN__
+#include <emscripten/html5.h>  /* emscripten_date_now() */
+#endif
 #endif
 #ifdef _WIN32
 /* GetSystemTimePreciseAsFileTime — sub-microsecond wall clock on Win8+. */
@@ -237,10 +240,10 @@ static uint64_t next_signed_action_nonce(void) {
      *
      * Bug history: emscripten_get_now() returns performance.now() in
      * ms — small numbers (0..10^7-ish over a long session). The
-     * comment USED to say "Date.now()" but the implementation didn't
-     * match. Fix: read Date.now() through JS, multiply ms→us. */
-    double js_ms = EM_ASM_DOUBLE({ return Date.now(); });
-    now_us = (uint64_t)(js_ms * 1000.0);
+     * comment USED to say "Date.now()" but the implementation called
+     * a different function. emscripten_date_now() is the dedicated
+     * wall-clock helper (Date.now() in ms). */
+    now_us = (uint64_t)(emscripten_date_now() * 1000.0);
 #elif defined(_WIN32)
     /* MSVC has no clock_gettime/CLOCK_REALTIME. GetSystemTimePreciseAsFileTime
      * returns 100-ns ticks since 1601-01-01 UTC; subtract the 1601→1970

--- a/src/test_main.c
+++ b/src/test_main.c
@@ -64,6 +64,7 @@ void register_furnace_color_tests(void);
 void register_respawn_fee_tests(void);
 void register_relationship_tests(void);
 void register_tractor_tests(void);
+void register_laser_tests(void);
 
 int main(int argc, char **argv) {
     setbuf(stdout, NULL); /* unbuffered so crash location is visible */
@@ -160,6 +161,7 @@ int main(int argc, char **argv) {
     register_respawn_fee_tests();
     register_relationship_tests();
     register_tractor_tests();
+    register_laser_tests();
 
     printf("\n%d tests run, %d passed, %d failed", tests_run, tests_passed, tests_failed);
     if (g_warnings > 0) printf(", %d warnings", g_warnings);

--- a/src/test_main.c
+++ b/src/test_main.c
@@ -33,6 +33,7 @@ void register_anchor_tests(void);
 void register_economy_mixed_cargo_tests(void);
 void register_economy_service259_tests(void);
 void register_economy_refinery_smelt_tests(void);
+void register_economy_demand_tests(void);
 void register_navigation_autopilot_mining_tests(void);
 void register_construction_collision238_tests(void);
 void register_construction_station_geom_tests(void);
@@ -130,6 +131,7 @@ int main(int argc, char **argv) {
     register_economy_mixed_cargo_tests();
     register_economy_service259_tests();
     register_economy_refinery_smelt_tests();
+    register_economy_demand_tests();
     register_navigation_autopilot_mining_tests();
     register_construction_collision238_tests();
     register_construction_station_geom_tests();

--- a/src/test_main.c
+++ b/src/test_main.c
@@ -63,6 +63,7 @@ void register_prefix_class_pricing_tests(void);
 void register_furnace_color_tests(void);
 void register_respawn_fee_tests(void);
 void register_relationship_tests(void);
+void register_tractor_tests(void);
 
 int main(int argc, char **argv) {
     setbuf(stdout, NULL); /* unbuffered so crash location is visible */
@@ -158,6 +159,7 @@ int main(int argc, char **argv) {
     register_furnace_color_tests();
     register_respawn_fee_tests();
     register_relationship_tests();
+    register_tractor_tests();
 
     printf("\n%d tests run, %d passed, %d failed", tests_run, tests_passed, tests_failed);
     if (g_warnings > 0) printf(", %d warnings", g_warnings);

--- a/src/tests/test_chain_log.c
+++ b/src/tests/test_chain_log.c
@@ -279,12 +279,15 @@ TEST(test_chain_log_smelt_emits_event_fragment_path) {
     w->stations[0].chain_event_count = 0;
     memset(w->stations[0].chain_last_hash, 0, 32);
 
-    /* Find Prospect's furnace + an adjacent-ring module to anchor
-     * the smelt midpoint. */
+    /* Find Prospect's furnace + the FERRITE_ORE intake hopper. The
+     * ingot output hopper added in the cargo-in-space schema work is
+     * not the smelt anchor — pick the input hopper specifically. */
     int furnace_idx = -1, silo_idx = -1;
     for (int m = 0; m < w->stations[0].module_count; m++) {
         if (w->stations[0].modules[m].type == MODULE_FURNACE) furnace_idx = m;
-        if (w->stations[0].modules[m].type == MODULE_HOPPER) silo_idx = m;
+        if (w->stations[0].modules[m].type == MODULE_HOPPER &&
+            w->stations[0].modules[m].commodity == (uint8_t)COMMODITY_FERRITE_ORE)
+            silo_idx = m;
     }
     ASSERT(furnace_idx >= 0 && silo_idx >= 0);
 

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -1744,9 +1744,10 @@ TEST(test_pair_satisfied_cross_ring) {
 }
 
 TEST(test_helios_ring2_rotates_under_dynamics) {
-    /* Driver ring (ring 2 on Helios) must rotate under
-     * step_station_ring_dynamics. After 2 sim seconds at
-     * STATION_RING_SPEED = 0.04 rad/s, expect ~0.08 rad of rotation. */
+    /* Ring 2 of Helios carries the seeded drift bias (arm_speed[1]
+     * = STATION_RING_SPEED = 0.04 rad/s) and must rotate continuously
+     * under the all-passive dynamics (Slice 1.5a). After 2 sim seconds
+     * at the bootstrapped omega, expect ~0.08 rad of rotation. */
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     ASSERT(w != NULL);
     world_reset(w);
@@ -1755,8 +1756,74 @@ TEST(test_helios_ring2_rotates_under_dynamics) {
     float r0 = st->arm_rotation[1];
     for (int i = 0; i < 240; i++) world_sim_step(w, 1.0f / 120.0f);
     float r1 = st->arm_rotation[1];
-    /* Expect the driver to have advanced ~speed * 2.0s = 0.08 rad. */
+    /* Expect ~speed * 2.0s = 0.08 rad of rotation. */
     ASSERT(r1 - r0 > 0.05f);
+}
+
+TEST(test_all_rings_passive_under_spoke_load) {
+    /* Slice 1.5a — every ring is passive. Drive Helios's ring 2 with
+     * the seeded drift bias; ring 1 and ring 3 should also rotate via
+     * spoke coupling (their producer↔hopper spokes pull them toward
+     * ring 2's phase). The legacy code only spun the driver ring,
+     * leaving ring 1 and ring 3 near-static. */
+    WORLD_HEAP w = calloc(1, sizeof(world_t));
+    ASSERT(w != NULL);
+    world_reset(w);
+    station_t *st = &w->stations[2];
+    /* Force every Helios producer's pulse high so spokes are taut. */
+    for (int m = 0; m < st->module_count; m++) {
+        if (module_is_producer(st->modules[m].type)) st->module_active_pulse[m] = 1.0f;
+    }
+    float r1_0 = st->arm_rotation[0];  /* ring 1 */
+    float r3_0 = st->arm_rotation[2];  /* ring 3 */
+    for (int i = 0; i < 1200; i++) {  /* 10 sim seconds */
+        for (int m = 0; m < st->module_count; m++) {
+            if (module_is_producer(st->modules[m].type)) st->module_active_pulse[m] = 1.0f;
+        }
+        world_sim_step(w, 1.0f / 120.0f);
+    }
+    float r1_1 = st->arm_rotation[0];
+    float r3_1 = st->arm_rotation[2];
+    /* Ring 1 and ring 3 must each have moved measurably (>0.01 rad).
+     * Direction follows ring 2's drift; with bootstrap omega = bias,
+     * coupling pulls both passive rings into phase pursuit. */
+    ASSERT(fabsf(r1_1 - r1_0) > 0.01f);
+    ASSERT(fabsf(r3_1 - r3_0) > 0.01f);
+}
+
+TEST(test_output_hopper_spoke_contributes_torque) {
+    /* Slice 1.5a — output hoppers participate in spoke physics. A
+     * synthetic 2-ring station with only an output spoke (no input
+     * spoke) must still apply torque to its passive ring when the
+     * producer's pulse is hot. */
+    station_t *st = calloc(1, sizeof(*st));
+    ASSERT(st != NULL);
+    st->signal_range = 1.0f;
+    /* Frame press on ring 2 slot 0; frame output hopper on ring 3
+     * slot 4 (180° away) so the dr term is non-zero. No input hopper
+     * for ferrite ingot, so the input spoke can't contribute. */
+    add_module_at(st, MODULE_FRAME_PRESS, 2, 0);
+    add_hopper_for(st, 3, 4, COMMODITY_FRAME);
+    /* Force the press's pulse high. */
+    st->module_active_pulse[0] = 1.0f;
+    /* Drive ring 2 (the producer's ring). */
+    st->arm_speed[1] = 0.04f;
+    st->arm_omega[1] = 0.04f;
+
+    float r3_0 = st->arm_rotation[2];
+    /* Use a minimal world for step_station_ring_dynamics. Place st as
+     * stations[0] in a heap world so station_exists() picks it up. */
+    WORLD_HEAP w = calloc(1, sizeof(world_t));
+    ASSERT(w != NULL);
+    w->stations[0] = *st;
+    free(st);
+    /* Re-pin the pulse each tick (decay would zero it after ~1.5s). */
+    for (int i = 0; i < 600; i++) {
+        w->stations[0].module_active_pulse[0] = 1.0f;
+        world_sim_step(w, 1.0f / 120.0f);
+    }
+    float r3_1 = w->stations[0].arm_rotation[2];
+    ASSERT(fabsf(r3_1 - r3_0) > 0.01f);
 }
 
 TEST(test_seed_stations_pair_complete) {
@@ -1803,5 +1870,7 @@ void register_construction_module_schema_tests(void) {
     RUN(test_pair_satisfied_cross_ring);
     RUN(test_seed_stations_pair_complete);
     RUN(test_helios_ring2_rotates_under_dynamics);
+    RUN(test_all_rings_passive_under_spoke_load);
+    RUN(test_output_hopper_spoke_contributes_torque);
 }
 

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -1287,6 +1287,54 @@ TEST(test_commodity_ore_ingot_pairing) {
     ASSERT_EQ_INT(commodity_ore_for_ingot(COMMODITY_LASER_MODULE),  COMMODITY_COUNT);
 }
 
+TEST(test_station_module_layout_status_missing_output) {
+    /* Synthetic station: TRACTOR_FAB with input hopper but no output
+     * hopper → MISSING_OUTPUT_HOPPER. Adding the output hopper restores
+     * OK. Slice 1 surfaces this informationally only — production keeps
+     * running on missing-output layouts until Slice 5 promotes it to a
+     * hard reject. */
+    station_t st = {0};
+    st.signal_range = 1.0f;
+    add_hopper_for(&st, 2, 0, COMMODITY_CUPRITE_INGOT);   /* input hopper present */
+    add_module_at(&st, MODULE_TRACTOR_FAB, 2, 1);
+    const station_module_t *fab = &st.modules[st.module_count - 1];
+    ASSERT_EQ_INT(station_module_layout_status(&st, fab),
+                  STATION_LAYOUT_MISSING_OUTPUT_HOPPER);
+    add_hopper_for(&st, 2, 2, COMMODITY_TRACTOR_MODULE);
+    ASSERT_EQ_INT(station_module_layout_status(&st, fab), STATION_LAYOUT_OK);
+}
+
+TEST(test_station_module_layout_status_furnace_uses_tag) {
+    /* A furnace tagged for CUPRITE_INGOT needs CUPRITE_ORE in (not any
+     * ore) and CUPRITE_INGOT out. FERRITE_ORE alone is missing-input. */
+    station_t st = {0};
+    st.signal_range = 1.0f;
+    add_hopper_for(&st, 2, 0, COMMODITY_FERRITE_ORE); /* wrong ore for a CU furnace */
+    add_furnace_for(&st, 2, 1, COMMODITY_CUPRITE_INGOT);
+    const station_module_t *fc = &st.modules[st.module_count - 1];
+    ASSERT_EQ_INT(station_module_layout_status(&st, fc),
+                  STATION_LAYOUT_MISSING_INPUT_HOPPER);
+    add_hopper_for(&st, 2, 2, COMMODITY_CUPRITE_ORE);
+    ASSERT_EQ_INT(station_module_layout_status(&st, fc),
+                  STATION_LAYOUT_MISSING_OUTPUT_HOPPER);
+    add_hopper_for(&st, 2, 3, COMMODITY_CUPRITE_INGOT);
+    ASSERT_EQ_INT(station_module_layout_status(&st, fc), STATION_LAYOUT_OK);
+}
+
+TEST(test_station_module_layout_status_shipyard_exempt) {
+    /* SHIPYARD output is a physical scaffold body, not a commodity —
+     * so it doesn't need an output hopper. With its 3 input hoppers
+     * present (frame, laser, tractor module), layout is OK. */
+    station_t st = {0};
+    st.signal_range = 1.0f;
+    add_hopper_for(&st, 3, 0, COMMODITY_FRAME);
+    add_hopper_for(&st, 3, 1, COMMODITY_LASER_MODULE);
+    add_hopper_for(&st, 3, 2, COMMODITY_TRACTOR_MODULE);
+    add_module_at(&st, MODULE_SHIPYARD, 3, 3);
+    const station_module_t *sy = &st.modules[st.module_count - 1];
+    ASSERT_EQ_INT(station_module_layout_status(&st, sy), STATION_LAYOUT_OK);
+}
+
 TEST(test_module_schema_valid_rings) {
     /* Service modules can go anywhere */
     ASSERT(module_valid_on_ring(MODULE_DOCK, 0));
@@ -1667,6 +1715,9 @@ void register_construction_module_schema_tests(void) {
     RUN(test_module_schema_required_output);
     RUN(test_module_furnace_instance_tag);
     RUN(test_commodity_ore_ingot_pairing);
+    RUN(test_station_module_layout_status_missing_output);
+    RUN(test_station_module_layout_status_furnace_uses_tag);
+    RUN(test_station_module_layout_status_shipyard_exempt);
     RUN(test_module_schema_valid_rings);
     RUN(test_module_schema_helpers);
     RUN(test_module_schema_build_costs_match);

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -530,15 +530,12 @@ TEST(test_station_geom_emitter_prospect) {
     /* Core: Prospect has radius 40 */
     ASSERT(geom.has_core == true);
 
-    /* Circles: dock (half-size) + relay + furnace (ring 1) + 2 hoppers
-     * (ring 2: ferrite-ore intake @ slot 4, ferrite-ingot output @
-     * slot 0) = 5. */
-    ASSERT_EQ_INT(geom.circle_count, 5);
-    /* Corridors: ring 1 still = 3 modules → 2 corridors. Ring 2 has
-     * two hoppers at slots 0 and 4 (120° short arc); whether the geom
-     * builder emits a wrap corridor between them depends on adjacency
-     * rules — accept ≥ 2. */
-    ASSERT(geom.corridor_count >= 2);
+    /* Circles: dock (half-size) + relay + furnace (ring 1) + 1 hopper
+     * (ring 2: ferrite-ore intake @ slot 4) = 4. */
+    ASSERT_EQ_INT(geom.circle_count, 4);
+    /* Corridors: ring 1 = 3 modules → 2 corridors. Ring 2 has only one
+     * module so no within-ring corridor. */
+    ASSERT_EQ_INT(geom.corridor_count, 2);
 
     /* Docks: 1 dock on ring 1 */
     ASSERT_EQ_INT(geom.dock_count, 1);
@@ -1290,30 +1287,54 @@ TEST(test_commodity_ore_ingot_pairing) {
 }
 
 TEST(test_station_module_layout_status_missing_output) {
-    /* Synthetic station: TRACTOR_FAB with input hopper but no output
-     * hopper → MISSING_OUTPUT_HOPPER. Adding the output hopper restores
-     * OK. Slice 1 surfaces this informationally only — production keeps
-     * running on missing-output layouts until Slice 5 promotes it to a
-     * hard reject. */
+    /* Synthetic station: TRACTOR_FAB with input hopper, AND a SHIPYARD
+     * on the station that consumes TRACTOR_MODULE — so the TRACTOR_FAB
+     * has a local downstream consumer and an output hopper IS required.
+     * Without the hopper → MISSING_OUTPUT_HOPPER. Adding it restores OK. */
     station_t st = {0};
     st.signal_range = 1.0f;
-    add_hopper_for(&st, 2, 0, COMMODITY_CUPRITE_INGOT);   /* input hopper present */
+    add_hopper_for(&st, 2, 0, COMMODITY_CUPRITE_INGOT);
     add_module_at(&st, MODULE_TRACTOR_FAB, 2, 1);
-    const station_module_t *fab = &st.modules[st.module_count - 1];
+    add_module_at(&st, MODULE_SHIPYARD,    2, 5);   /* downstream consumer */
+    /* Shipyard also needs FRAME and LASER_MODULE input hoppers to be OK
+     * for itself, but we're testing the TRACTOR_FAB module specifically. */
+    add_hopper_for(&st, 3, 0, COMMODITY_FRAME);
+    add_hopper_for(&st, 3, 1, COMMODITY_LASER_MODULE);
+    const station_module_t *fab = &st.modules[1];   /* TRACTOR_FAB */
     ASSERT_EQ_INT(station_module_layout_status(&st, fab),
                   STATION_LAYOUT_MISSING_OUTPUT_HOPPER);
     add_hopper_for(&st, 2, 2, COMMODITY_TRACTOR_MODULE);
     ASSERT_EQ_INT(station_module_layout_status(&st, fab), STATION_LAYOUT_OK);
 }
 
+TEST(test_station_module_layout_status_no_local_consumer_is_ok) {
+    /* The mirror case: a producer with NO local downstream consumer
+     * doesn't need an output hopper. Smelted ingots ride out via
+     * haulers from station inventory. Models Prospect's furnace —
+     * 1-furnace ferrite station with no on-station frame press. */
+    station_t st = {0};
+    st.signal_range = 1.0f;
+    add_hopper_for(&st, 2, 0, COMMODITY_FERRITE_ORE);   /* input only */
+    add_furnace_for(&st, 2, 1, COMMODITY_FERRITE_INGOT);
+    const station_module_t *furnace = &st.modules[1];
+    /* No FRAME_PRESS / LASER_FAB / TRACTOR_FAB on the station, so
+     * nothing locally consumes ferrite ingots. Layout is OK without
+     * an output hopper. */
+    ASSERT_EQ_INT(station_module_layout_status(&st, furnace),
+                  STATION_LAYOUT_OK);
+}
+
 TEST(test_station_module_layout_status_furnace_uses_tag) {
     /* A furnace tagged for CUPRITE_INGOT needs CUPRITE_ORE in (not any
-     * ore) and CUPRITE_INGOT out. FERRITE_ORE alone is missing-input. */
+     * ore) and CUPRITE_INGOT out (because we add a TRACTOR_FAB to give
+     * the cuprite ingot a local downstream consumer). FERRITE_ORE alone
+     * is missing-input. */
     station_t st = {0};
     st.signal_range = 1.0f;
     add_hopper_for(&st, 2, 0, COMMODITY_FERRITE_ORE); /* wrong ore for a CU furnace */
     add_furnace_for(&st, 2, 1, COMMODITY_CUPRITE_INGOT);
-    const station_module_t *fc = &st.modules[st.module_count - 1];
+    add_module_at(&st, MODULE_TRACTOR_FAB, 2, 5);     /* consumes CUPRITE_INGOT */
+    const station_module_t *fc = &st.modules[1];     /* the furnace */
     ASSERT_EQ_INT(station_module_layout_status(&st, fc),
                   STATION_LAYOUT_MISSING_INPUT_HOPPER);
     add_hopper_for(&st, 2, 2, COMMODITY_CUPRITE_ORE);
@@ -1864,6 +1885,7 @@ void register_construction_module_schema_tests(void) {
     RUN(test_module_furnace_instance_tag);
     RUN(test_commodity_ore_ingot_pairing);
     RUN(test_station_module_layout_status_missing_output);
+    RUN(test_station_module_layout_status_no_local_consumer_is_ok);
     RUN(test_station_module_layout_status_furnace_uses_tag);
     RUN(test_station_module_layout_status_shipyard_exempt);
     RUN(test_seeded_furnaces_tagged);

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -1795,35 +1795,45 @@ TEST(test_output_hopper_spoke_contributes_torque) {
     /* Slice 1.5a — output hoppers participate in spoke physics. A
      * synthetic 2-ring station with only an output spoke (no input
      * spoke) must still apply torque to its passive ring when the
-     * producer's pulse is hot. */
-    station_t *st = calloc(1, sizeof(*st));
-    ASSERT(st != NULL);
-    st->signal_range = 1.0f;
-    /* Frame press on ring 2 slot 0; frame output hopper on ring 3
-     * slot 4 (180° away) so the dr term is non-zero. No input hopper
-     * for ferrite ingot, so the input spoke can't contribute. */
-    add_module_at(st, MODULE_FRAME_PRESS, 2, 0);
-    add_hopper_for(st, 3, 4, COMMODITY_FRAME);
-    /* Force the press's pulse high. */
-    st->module_active_pulse[0] = 1.0f;
-    /* Drive ring 2 (the producer's ring). */
-    st->arm_speed[1] = 0.04f;
-    st->arm_omega[1] = 0.04f;
-
-    float r3_0 = st->arm_rotation[2];
-    /* Use a minimal world for step_station_ring_dynamics. Place st as
-     * stations[0] in a heap world so station_exists() picks it up. */
+     * producer's pulse is hot. Asserts both magnitude AND direction:
+     * a producer that's behind its hopper in phase pulls the hopper
+     * ring backward (torque toward closing the phase gap), and the
+     * producer ring forward — Newton's third. A sign-flip in the
+     * spoke math would fail the direction assertion. */
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     ASSERT(w != NULL);
-    w->stations[0] = *st;
-    free(st);
-    /* Re-pin the pulse each tick (decay would zero it after ~1.5s). */
-    for (int i = 0; i < 600; i++) {
-        w->stations[0].module_active_pulse[0] = 1.0f;
-        world_sim_step(w, 1.0f / 120.0f);
-    }
-    float r3_1 = w->stations[0].arm_rotation[2];
-    ASSERT(fabsf(r3_1 - r3_0) > 0.01f);
+    station_t *st = &w->stations[0];
+    st->signal_range = 1.0f;
+    /* Frame press on ring 2 slot 0; frame output hopper on ring 3
+     * slot 4 (160° ahead — hopper leads the producer in phase). */
+    add_module_at(st, MODULE_FRAME_PRESS, 2, 0);
+    add_hopper_for(st, 3, 4, COMMODITY_FRAME);
+    /* No drift bias — isolate the spoke contribution. arm_omega all 0. */
+    st->module_active_pulse[0] = 1.0f;
+
+    /* Single tick: omega should become non-zero on both endpoint rings,
+     * with opposite signs (Newton's third). */
+    float r2_omega_pre = st->arm_omega[1];
+    float r3_omega_pre = st->arm_omega[2];
+    world_sim_step(w, 1.0f / 120.0f);
+    float r2_omega_post = st->arm_omega[1];
+    float r3_omega_post = st->arm_omega[2];
+    float dr2 = r2_omega_post - r2_omega_pre;
+    float dr3 = r3_omega_post - r3_omega_pre;
+
+    /* Magnitude: spoke applied torque to both rings. */
+    ASSERT(fabsf(dr2) > 1e-5f);
+    ASSERT(fabsf(dr3) > 1e-5f);
+    /* Direction: signs are opposite (Newton's third — a sign flip
+     * would push both rings the same way, failing this). */
+    ASSERT(dr2 * dr3 < 0.0f);
+    /* Phase pursuit: hopper leads (slot 4 of 9 = ~160° vs 0°), so dr =
+     * +160°, sin(dr) > 0, T = K*sin(dr) > 0. apply_spoke_torque adds
+     * +T to producer ring (ra=2) and -T to hopper ring (rb=3). So ring 2
+     * accelerates positive (toward the hopper) and ring 3 decelerates
+     * negative (away from the producer). */
+    ASSERT(dr2 > 0.0f);
+    ASSERT(dr3 < 0.0f);
 }
 
 TEST(test_seed_stations_pair_complete) {

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -530,13 +530,15 @@ TEST(test_station_geom_emitter_prospect) {
     /* Core: Prospect has radius 40 */
     ASSERT(geom.has_core == true);
 
-    /* Circles: dock (half-size) + relay + furnace (ring 1) + hopper
-     * (ring 2) = 4. */
-    ASSERT_EQ_INT(geom.circle_count, 4);
-
-    /* Corridors: ring 1 = 3 modules wrap into 2. Ring 2 has only
-     * one module so no corridor on ring 2. Total 2. */
-    ASSERT_EQ_INT(geom.corridor_count, 2);
+    /* Circles: dock (half-size) + relay + furnace (ring 1) + 2 hoppers
+     * (ring 2: ferrite-ore intake @ slot 4, ferrite-ingot output @
+     * slot 0) = 5. */
+    ASSERT_EQ_INT(geom.circle_count, 5);
+    /* Corridors: ring 1 still = 3 modules → 2 corridors. Ring 2 has
+     * two hoppers at slots 0 and 4 (120° short arc); whether the geom
+     * builder emits a wrap corridor between them depends on adjacency
+     * rules — accept ≥ 2. */
+    ASSERT(geom.corridor_count >= 2);
 
     /* Docks: 1 dock on ring 1 */
     ASSERT_EQ_INT(geom.dock_count, 1);
@@ -1321,6 +1323,29 @@ TEST(test_station_module_layout_status_furnace_uses_tag) {
     ASSERT_EQ_INT(station_module_layout_status(&st, fc), STATION_LAYOUT_OK);
 }
 
+TEST(test_seeded_stations_layout_ok) {
+    /* Slice 1 — every producer module on every seeded station reports
+     * STATION_LAYOUT_OK (i.e., its inputs and output have matching
+     * tagged hoppers, except SHIPYARD which is exempt from the output
+     * rule). This is the end-state validator on a fresh world. */
+    WORLD_DECL;
+    world_reset(&w);
+    for (int s = 0; s < 3; s++) {
+        const station_t *st = &w.stations[s];
+        for (int i = 0; i < st->module_count; i++) {
+            const station_module_t *m = &st->modules[i];
+            if (m->scaffold) continue;
+            if (!module_is_producer(m->type) && !module_is_shipyard(m->type)) continue;
+            station_layout_status_t status = station_module_layout_status(st, m);
+            if (status != STATION_LAYOUT_OK) {
+                printf("station %d (%s) module %d (type=%d, commodity=%u) layout status %d\n",
+                       s, st->name, i, m->type, m->commodity, status);
+            }
+            ASSERT_EQ_INT(status, STATION_LAYOUT_OK);
+        }
+    }
+}
+
 TEST(test_seeded_furnaces_tagged) {
     /* Slice 1 — seeded stations tag every furnace with its output ingot.
      * Prospect runs ferrite tier (1 furnace → FERRITE_INGOT). Helios runs
@@ -1766,6 +1791,7 @@ void register_construction_module_schema_tests(void) {
     RUN(test_station_module_layout_status_shipyard_exempt);
     RUN(test_seeded_furnaces_tagged);
     RUN(test_seeded_helios_output_hoppers);
+    RUN(test_seeded_stations_layout_ok);
     RUN(test_module_schema_valid_rings);
     RUN(test_module_schema_helpers);
     RUN(test_module_schema_build_costs_match);

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -1321,6 +1321,52 @@ TEST(test_station_module_layout_status_furnace_uses_tag) {
     ASSERT_EQ_INT(station_module_layout_status(&st, fc), STATION_LAYOUT_OK);
 }
 
+TEST(test_seeded_furnaces_tagged) {
+    /* Slice 1 — seeded stations tag every furnace with its output ingot.
+     * Prospect runs ferrite tier (1 furnace → FERRITE_INGOT). Helios runs
+     * the 3-furnace tier and tags 2× CUPRITE_INGOT + 1× CRYSTAL_INGOT. */
+    WORLD_DECL;
+    world_reset(&w);
+    int prospect_furnaces = 0;
+    for (int i = 0; i < w.stations[0].module_count; i++) {
+        if (w.stations[0].modules[i].type != MODULE_FURNACE) continue;
+        if (w.stations[0].modules[i].scaffold) continue;
+        prospect_furnaces++;
+        ASSERT_EQ_INT((int)w.stations[0].modules[i].commodity,
+                      (int)COMMODITY_FERRITE_INGOT);
+    }
+    ASSERT_EQ_INT(prospect_furnaces, 1);
+
+    int helios_cu = 0, helios_cr = 0;
+    for (int i = 0; i < w.stations[2].module_count; i++) {
+        if (w.stations[2].modules[i].type != MODULE_FURNACE) continue;
+        if (w.stations[2].modules[i].scaffold) continue;
+        commodity_t tag = (commodity_t)w.stations[2].modules[i].commodity;
+        if (tag == COMMODITY_CUPRITE_INGOT) helios_cu++;
+        else if (tag == COMMODITY_CRYSTAL_INGOT) helios_cr++;
+        else ASSERT(false /* unexpected Helios furnace tag */);
+    }
+    ASSERT_EQ_INT(helios_cu, 2);
+    ASSERT_EQ_INT(helios_cr, 1);
+}
+
+TEST(test_seeded_helios_output_hoppers) {
+    /* Helios's LASER_FAB and TRACTOR_FAB each have a dedicated
+     * commodity-tagged output hopper on ring 3. */
+    WORLD_DECL;
+    world_reset(&w);
+    ASSERT(station_find_hopper_for(&w.stations[2], COMMODITY_LASER_MODULE)   >= 0);
+    ASSERT(station_find_hopper_for(&w.stations[2], COMMODITY_TRACTOR_MODULE) >= 0);
+    /* All Helios producers report OK under the new layout rule. */
+    for (int i = 0; i < w.stations[2].module_count; i++) {
+        const station_module_t *m = &w.stations[2].modules[i];
+        if (m->scaffold) continue;
+        if (!module_is_producer(m->type) && !module_is_shipyard(m->type)) continue;
+        station_layout_status_t s = station_module_layout_status(&w.stations[2], m);
+        ASSERT_EQ_INT(s, STATION_LAYOUT_OK);
+    }
+}
+
 TEST(test_station_module_layout_status_shipyard_exempt) {
     /* SHIPYARD output is a physical scaffold body, not a commodity —
      * so it doesn't need an output hopper. With its 3 input hoppers
@@ -1718,6 +1764,8 @@ void register_construction_module_schema_tests(void) {
     RUN(test_station_module_layout_status_missing_output);
     RUN(test_station_module_layout_status_furnace_uses_tag);
     RUN(test_station_module_layout_status_shipyard_exempt);
+    RUN(test_seeded_furnaces_tagged);
+    RUN(test_seeded_helios_output_hoppers);
     RUN(test_module_schema_valid_rings);
     RUN(test_module_schema_helpers);
     RUN(test_module_schema_build_costs_match);

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -1234,6 +1234,59 @@ TEST(test_module_schema_producer_io) {
     ASSERT_EQ_INT(module_schema_output(MODULE_DOCK), COMMODITY_COUNT);
 }
 
+TEST(test_module_schema_required_output) {
+    /* Slice 1 — every non-shipyard producer declares a single output
+     * commodity at the schema level. SHIPYARD is exempt (output is a
+     * physical scaffold, not a commodity). */
+    ASSERT_EQ_INT(module_required_output(MODULE_FURNACE),     COMMODITY_FERRITE_INGOT);
+    ASSERT_EQ_INT(module_required_output(MODULE_FRAME_PRESS), COMMODITY_FRAME);
+    ASSERT_EQ_INT(module_required_output(MODULE_LASER_FAB),   COMMODITY_LASER_MODULE);
+    ASSERT_EQ_INT(module_required_output(MODULE_TRACTOR_FAB), COMMODITY_TRACTOR_MODULE);
+    ASSERT_EQ_INT(module_required_output(MODULE_SHIPYARD),    COMMODITY_COUNT);
+    ASSERT_EQ_INT(module_required_output(MODULE_DOCK),        COMMODITY_COUNT);
+    ASSERT_EQ_INT(module_required_output(MODULE_HOPPER),      COMMODITY_COUNT);
+}
+
+TEST(test_module_furnace_instance_tag) {
+    /* Furnace output follows the per-instance commodity tag. Untagged
+     * (legacy COMMODITY_COUNT) falls back to FERRITE_INGOT. Each ingot
+     * tag implies a matching input ore. Non-furnace producers ignore
+     * the tag and read schema. */
+    station_module_t m = { .type = MODULE_FURNACE, .commodity = (uint8_t)COMMODITY_COUNT };
+    ASSERT_EQ_INT(module_instance_output(&m),    COMMODITY_FERRITE_INGOT);
+    ASSERT_EQ_INT(module_instance_input_ore(&m), COMMODITY_FERRITE_ORE);
+
+    m.commodity = (uint8_t)COMMODITY_CUPRITE_INGOT;
+    ASSERT_EQ_INT(module_instance_output(&m),    COMMODITY_CUPRITE_INGOT);
+    ASSERT_EQ_INT(module_instance_input_ore(&m), COMMODITY_CUPRITE_ORE);
+
+    m.commodity = (uint8_t)COMMODITY_CRYSTAL_INGOT;
+    ASSERT_EQ_INT(module_instance_output(&m),    COMMODITY_CRYSTAL_INGOT);
+    ASSERT_EQ_INT(module_instance_input_ore(&m), COMMODITY_CRYSTAL_ORE);
+
+    /* Garbage tag → fallback to default. */
+    m.commodity = (uint8_t)COMMODITY_FRAME;
+    ASSERT_EQ_INT(module_instance_output(&m),    COMMODITY_FERRITE_INGOT);
+    ASSERT_EQ_INT(module_instance_input_ore(&m), COMMODITY_FERRITE_ORE);
+
+    /* Frame press: instance output ignores tag, uses schema. */
+    station_module_t fp = { .type = MODULE_FRAME_PRESS, .commodity = (uint8_t)COMMODITY_LASER_MODULE };
+    ASSERT_EQ_INT(module_instance_output(&fp),    COMMODITY_FRAME);
+    ASSERT_EQ_INT(module_instance_input_ore(&fp), COMMODITY_COUNT); /* not a furnace */
+}
+
+TEST(test_commodity_ore_ingot_pairing) {
+    /* Round-trip: ingot ↔ ore. Non-pairs return COMMODITY_COUNT. */
+    ASSERT_EQ_INT(commodity_ingot_for_ore(COMMODITY_FERRITE_ORE), COMMODITY_FERRITE_INGOT);
+    ASSERT_EQ_INT(commodity_ingot_for_ore(COMMODITY_CUPRITE_ORE), COMMODITY_CUPRITE_INGOT);
+    ASSERT_EQ_INT(commodity_ingot_for_ore(COMMODITY_CRYSTAL_ORE), COMMODITY_CRYSTAL_INGOT);
+    ASSERT_EQ_INT(commodity_ore_for_ingot(COMMODITY_FERRITE_INGOT), COMMODITY_FERRITE_ORE);
+    ASSERT_EQ_INT(commodity_ore_for_ingot(COMMODITY_CUPRITE_INGOT), COMMODITY_CUPRITE_ORE);
+    ASSERT_EQ_INT(commodity_ore_for_ingot(COMMODITY_CRYSTAL_INGOT), COMMODITY_CRYSTAL_ORE);
+    ASSERT_EQ_INT(commodity_ingot_for_ore(COMMODITY_FRAME),         COMMODITY_COUNT);
+    ASSERT_EQ_INT(commodity_ore_for_ingot(COMMODITY_LASER_MODULE),  COMMODITY_COUNT);
+}
+
 TEST(test_module_schema_valid_rings) {
     /* Service modules can go anywhere */
     ASSERT(module_valid_on_ring(MODULE_DOCK, 0));
@@ -1611,6 +1664,9 @@ void register_construction_module_schema_tests(void) {
     RUN(test_module_build_state_lifecycle);
     RUN(test_module_schema_basic_kinds);
     RUN(test_module_schema_producer_io);
+    RUN(test_module_schema_required_output);
+    RUN(test_module_furnace_instance_tag);
+    RUN(test_commodity_ore_ingot_pairing);
     RUN(test_module_schema_valid_rings);
     RUN(test_module_schema_helpers);
     RUN(test_module_schema_build_costs_match);

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -837,6 +837,225 @@ TEST(test_scaffold_full_pipeline) {
     ASSERT_EQ_FLOAT(m->build_progress, 1.0f, 0.01f);
 }
 
+/* End-to-end: a player plants an outpost via tow, supplies its founding
+ * frame quota by docking and dumping cargo, sims through scaffold +
+ * seed-module activation, then plants and supplies a second module
+ * (furnace). Asserts no credits leak, the outpost becomes dockable, the
+ * furnace activates, and the activation spawn loop produces an NPC. */
+TEST(test_build_outpost_full_economy) {
+    WORLD_DECL;
+    world_reset(&w);
+
+    server_player_t *sp = &w.players[0];
+    uint8_t token[8] = {0xB1, 0xD9, 0x07, 0x12, 0x33, 0x44, 0x55, 0x66};
+    memcpy(sp->session_token, token, 8);
+    sp->session_ready = true;
+    /* Synthesize a non-zero pubkey so ledger ops use the pubkey path. */
+    for (int i = 0; i < 32; i++) sp->pubkey[i] = (uint8_t)(0xA0 + i);
+    sp->pubkey_set = true;
+    ASSERT(registry_register_pubkey(&w, sp->pubkey, sp->session_token));
+
+    sp->connected = true;
+    sp->id = 0;
+    player_init_ship(sp, &w);
+    sp->docked = false;
+
+    double credits_start = econ_total_credits(&w);
+
+    /* Step 1 — plant an outpost ~6kU east of Prospect via the tow flow.
+     * The harness spawns a SIGNAL_RELAY scaffold, attaches it to the
+     * player, and trips place_outpost — i.e. exactly what the client
+     * does when the player presses E with a relay in tow. */
+    vec2 outpost_pos = v2_add(w.stations[0].pos, v2(6000.0f, 0.0f));
+    int outpost = test_place_outpost_via_tow(&w, sp, outpost_pos);
+    ASSERT(outpost >= 3);
+    station_t *st_out = &w.stations[outpost];
+    ASSERT(st_out->scaffold);              /* under construction */
+    ASSERT(st_out->signal_range > 0.0f);   /* relay seeded its range */
+    int seed_mod_count = st_out->module_count; /* DOCK + seed SIGNAL_RELAY */
+    ASSERT(seed_mod_count >= 2);
+
+    /* The founding flow opens a CONTRACT_TRACTOR for FRAMES at the
+     * outpost; the same flow we'd use to deliver to it. */
+    bool found_frame_contract = false;
+    for (int k = 0; k < MAX_CONTRACTS; k++) {
+        if (w.contracts[k].active
+            && w.contracts[k].station_index == outpost
+            && w.contracts[k].commodity == COMMODITY_FRAME) {
+            found_frame_contract = true; break;
+        }
+    }
+    ASSERT(found_frame_contract);
+
+    /* Step 2 — load up frames. In a live session the player would have
+     * earned credits at Prospect, hauled ingots to Kepler, and bought
+     * frames there (covered by the buy-flow tests). Drop them straight
+     * into cargo for this test — the value here is what happens *after*
+     * the materials reach the outpost. */
+    float frame_budget =
+        SCAFFOLD_MATERIAL_NEEDED                          /* outpost scaffold */
+        + module_build_cost_lookup(MODULE_SIGNAL_RELAY)   /* seed module */
+        + module_build_cost_lookup(MODULE_FURNACE)        /* second module */
+        + 10.0f;                                          /* slack */
+    sp->ship.cargo[COMMODITY_FRAME] = frame_budget;
+
+    /* Step 3 — dock at the outpost and pour the frames in.
+     * The outpost has an OUTPOST_DOCK module stamped on by
+     * place_towed_scaffold so docked-mode is valid here. */
+    sp->docked = true;
+    sp->current_station = outpost;
+    sp->ship.pos = st_out->pos;
+
+    /* service_sell triggers step_scaffold_delivery (advances the
+     * station scaffold) and step_module_delivery (advances any module
+     * scaffold). Run a few sells back-to-back — each sim step the
+     * server clears the intent flag, so we re-arm it. */
+    for (int i = 0; i < 10 && st_out->scaffold; i++) {
+        sp->input.service_sell = true;
+        world_sim_step(&w, SIM_DT);
+    }
+
+    /* Step 4 — sim until outpost-level scaffolding finishes. The
+     * activation step lifts st->scaffold once scaffold_progress hits
+     * 1.0 and the seeded module's frames are in. */
+    for (int i = 0; i < 60 * 120 && st_out->scaffold; i++) {
+        world_sim_step(&w, SIM_DT);
+    }
+    ASSERT(!st_out->scaffold);
+    ASSERT(st_out->signal_connected); /* tied back into the chain */
+
+    /* Step 5 — wait for the seed SIGNAL_RELAY module to finish its
+     * 10s build timer and activate. */
+    for (int i = 0; i < 30 * 120; i++) {
+        bool any_seed_scaffolded = false;
+        for (int m = 0; m < st_out->module_count; m++) {
+            if (st_out->modules[m].scaffold) { any_seed_scaffolded = true; break; }
+        }
+        if (!any_seed_scaffolded) break;
+        world_sim_step(&w, SIM_DT);
+    }
+    for (int m = 0; m < st_out->module_count; m++) {
+        ASSERT(!st_out->modules[m].scaffold);
+    }
+
+    /* Step 6 — plant a second module: a furnace. Spawn a furnace
+     * scaffold near ring 1 and let the snap-to-slot path consume it,
+     * the same flow test_scaffold_full_pipeline exercises. */
+    int npc_before = 0;
+    for (int i = 0; i < MAX_NPC_SHIPS; i++) if (w.npc_ships[i].active) npc_before++;
+
+    sp->docked = false; /* leave so the snap step has clean state */
+    vec2 ring1_near = v2_add(outpost_pos, v2(180.0f, 0.0f));
+    int sc_idx = spawn_scaffold(&w, MODULE_FURNACE, ring1_near, sp->id);
+    ASSERT(sc_idx >= 0);
+    int mod_count_pre = st_out->module_count;
+    for (int i = 0; i < 600 && w.scaffolds[sc_idx].active; i++) {
+        world_sim_step(&w, SIM_DT);
+    }
+    ASSERT(!w.scaffolds[sc_idx].active);
+    ASSERT_EQ_INT(st_out->module_count, mod_count_pre + 1);
+    station_module_t *furn = &st_out->modules[mod_count_pre];
+    ASSERT_EQ_INT(furn->type, MODULE_FURNACE);
+    ASSERT(furn->scaffold);
+
+    /* Step 7 — re-dock and supply the furnace's build material. Ship
+     * still has plenty of frames from the budget. */
+    sp->docked = true;
+    sp->current_station = outpost;
+    for (int i = 0; i < 10 && furn->scaffold; i++) {
+        sp->input.service_sell = true;
+        world_sim_step(&w, SIM_DT);
+    }
+    /* Build timer: ~10s, plus a comfortable runway for the activation
+     * spawn loop to drop in an NPC. */
+    for (int i = 0; i < 30 * 120 && furn->scaffold; i++) {
+        world_sim_step(&w, SIM_DT);
+    }
+    ASSERT(!furn->scaffold);
+    ASSERT_EQ_FLOAT(furn->build_progress, 1.0f, 0.01f);
+
+    /* Step 8 — activation should have spawned a worker NPC at the
+     * outpost (same invariant test_module_activation_spawns_npc proves
+     * for in-place builds). */
+    int npc_after = 0;
+    for (int i = 0; i < MAX_NPC_SHIPS; i++) if (w.npc_ships[i].active) npc_after++;
+    ASSERT(npc_after > npc_before);
+
+    /* Step 9 — plant a HOPPER on a ring-1 slot adjacent to the furnace.
+     * station_can_smelt requires both a hopper and a furnace, so the
+     * hopper completes the smelt prerequisite. The furnace's tag
+     * defaults to ferrite (1-furnace tier, module_furnace_default_output);
+     * we tag the hopper for FERRITE_ORE explicitly so the post-snap
+     * commodity is unambiguous regardless of where the byte zero-init
+     * came from. */
+    sp->docked = false;
+    /* Need slack in cargo: bring the budget for the hopper module up
+     * front so the player has frames left to deliver. The earlier
+     * frame_budget purposely covered SCAFFOLD_MATERIAL_NEEDED + relay +
+     * furnace + 10 slack. The hopper costs more than that 10 slack on
+     * its own, so top the cargo back up here — same shortcut as step 2. */
+    sp->ship.cargo[COMMODITY_FRAME] += module_build_cost_lookup(MODULE_HOPPER);
+
+    vec2 ring1_other = v2_add(outpost_pos, v2(-180.0f, 60.0f));
+    int hop_idx = spawn_scaffold(&w, MODULE_HOPPER, ring1_other, sp->id);
+    ASSERT(hop_idx >= 0);
+    int mod_count_pre_hop = st_out->module_count;
+    for (int i = 0; i < 600 && w.scaffolds[hop_idx].active; i++) {
+        world_sim_step(&w, SIM_DT);
+    }
+    ASSERT(!w.scaffolds[hop_idx].active);
+    ASSERT_EQ_INT(st_out->module_count, mod_count_pre_hop + 1);
+    station_module_t *hop = &st_out->modules[mod_count_pre_hop];
+    ASSERT_EQ_INT(hop->type, MODULE_HOPPER);
+    ASSERT(hop->scaffold);
+    /* Tag the hopper for ferrite ore now (the snap path doesn't call
+     * add_module_at, so auto_pick_hopper_commodity never runs). */
+    hop->commodity = (uint8_t)COMMODITY_FERRITE_ORE;
+
+    sp->docked = true;
+    sp->current_station = outpost;
+    for (int i = 0; i < 10 && hop->scaffold; i++) {
+        sp->input.service_sell = true;
+        world_sim_step(&w, SIM_DT);
+    }
+    for (int i = 0; i < 30 * 120 && hop->scaffold; i++) {
+        world_sim_step(&w, SIM_DT);
+    }
+    ASSERT(!hop->scaffold);
+    ASSERT(station_can_smelt(st_out, COMMODITY_FERRITE_ORE));
+
+    /* Step 10 — process ore. Drop raw ferrite ore into the station's
+     * bulk inventory and tick the sim; sim_step_refinery_production
+     * consumes ore and mints FERRITE_INGOT manifest entries. Rate is
+     * REFINERY_BASE_SMELT_RATE per furnace, so a few seconds is plenty
+     * to clear our 30-unit stockpile. */
+    sp->docked = false;
+    sp->input.service_sell = false;
+    float ore_in = 30.0f;
+    st_out->_inventory_cache[COMMODITY_FERRITE_ORE] = ore_in;
+    int ingots_before = manifest_count_by_commodity(&st_out->manifest,
+                                                    COMMODITY_FERRITE_INGOT);
+    for (int i = 0; i < 30 * 120; i++) {
+        world_sim_step(&w, SIM_DT);
+        if (st_out->_inventory_cache[COMMODITY_FERRITE_ORE] < 0.5f) break;
+    }
+    int ingots_after = manifest_count_by_commodity(&st_out->manifest,
+                                                   COMMODITY_FERRITE_INGOT);
+    ASSERT(ingots_after > ingots_before); /* smelter actually produced */
+    ASSERT(st_out->_inventory_cache[COMMODITY_FERRITE_ORE] < ore_in - 1.0f);
+
+    /* Step 11 — credit conservation. The whole pipeline runs through
+     * ledger paths; nothing should leak. econ_total_credits sums every
+     * station pool plus every player ledger row, so the diff captures
+     * any silent mint or burn. */
+    double credits_end = econ_total_credits(&w);
+    if (fabs(credits_end - credits_start) > 5.0) {
+        printf("    credit drift: start=%.2f end=%.2f delta=%.2f\n",
+               credits_start, credits_end, credits_end - credits_start);
+    }
+    ASSERT(fabs(credits_end - credits_start) <= 5.0);
+}
+
 TEST(test_scaffold_ship_drag) {
     WORLD_DECL;
     world_reset(&w);
@@ -1669,6 +1888,7 @@ void register_construction_scaffold_tests(void) {
     RUN(test_scaffold_snap_to_slot);
     RUN(test_scaffold_snap_ignores_starter_stations);
     RUN(test_scaffold_full_pipeline);
+    RUN(test_build_outpost_full_economy);
     RUN(test_scaffold_ship_drag);
     RUN(test_tow_drone_delivers_to_planned_outpost);
     RUN(test_save_preserves_pending_scaffolds);

--- a/src/tests/test_economy.c
+++ b/src/tests/test_economy.c
@@ -890,3 +890,163 @@ void register_economy_refinery_smelt_tests(void) {
     RUN(test_count_tier_smelt_rules);
 }
 
+/* station_top_demand: derives the top shortage from inventory + the
+ * station's consumed-commodity list. This is the primitive HUD
+ * beacons / contract auto-pricing / NPC scoring will compose on top
+ * of, so the contract-priority code in game_sim.c and this primitive
+ * MUST agree on what "starving" means. The tests below pin those
+ * agreements to the same constants. */
+TEST(test_top_demand_no_shortage_returns_none) {
+    WORLD_DECL;
+    world_reset(&w);
+    /* Top up Kepler's frame_press input commodity to its target — the
+     * station has no shortage, so top demand should be empty. */
+    station_t *kepler = &w.stations[1];
+    kepler->_inventory_cache[COMMODITY_FERRITE_INGOT] = MAX_PRODUCT_STOCK;
+    kepler->_inventory_cache[COMMODITY_FRAME] = MAX_PRODUCT_STOCK;
+    kepler->_inventory_cache[COMMODITY_LASER_MODULE] = 100.0f;
+    kepler->_inventory_cache[COMMODITY_TRACTOR_MODULE] = 100.0f;
+    station_demand_t d = station_top_demand(kepler);
+    ASSERT_EQ_INT((int)d.commodity, (int)COMMODITY_COUNT);
+    ASSERT_EQ_FLOAT(d.severity, 0.0f, 0.001f);
+    ASSERT_EQ_FLOAT(d.price_mult, 1.0f, 0.001f);
+}
+
+TEST(test_top_demand_picks_starving_commodity) {
+    WORLD_DECL;
+    world_reset(&w);
+    station_t *kepler = &w.stations[1];
+    /* Mild shortage on FRAME (consumed by shipyard kit-fab),
+     * severe shortage on FERRITE_INGOT (frame_press input). The
+     * primitive should pick the worst — ferrite ingots. Targets:
+     * frames at 12.0, ferrite ingots at MAX_PRODUCT_STOCK*0.9 = 108.
+     * Set frames to 6 (mild, severity ~0.5) and ingots to 0 (full
+     * starvation). */
+    kepler->_inventory_cache[COMMODITY_FERRITE_INGOT] = 0.0f;
+    kepler->_inventory_cache[COMMODITY_FRAME]         = 6.0f;
+    kepler->_inventory_cache[COMMODITY_LASER_MODULE]  = 100.0f;
+    kepler->_inventory_cache[COMMODITY_TRACTOR_MODULE]= 100.0f;
+    station_demand_t d = station_top_demand(kepler);
+    ASSERT_EQ_INT((int)d.commodity, (int)COMMODITY_FERRITE_INGOT);
+    ASSERT(d.severity > 0.95f);
+    /* price_mult = 1.0 + 0.5 * severity → ~1.5 at full starvation. */
+    ASSERT(d.price_mult > 1.45f);
+    ASSERT(d.price_mult <= 1.5001f);
+}
+
+TEST(test_top_demand_skips_self_produced_commodities) {
+    /* Helios has its own cuprite furnace + laser fab, so it produces
+     * cuprite ingots locally. Even with the float at zero, the
+     * primitive must not flag cuprite as a top demand — the local
+     * producer is the right answer, not an import. Mirrors the
+     * "don't import what we make ourselves" check in game_sim.c
+     * priority 4. */
+    WORLD_DECL;
+    world_reset(&w);
+    station_t *helios = &w.stations[2];
+    /* Knock out everything else so cuprite is the only candidate
+     * (besides things Helios produces). */
+    helios->_inventory_cache[COMMODITY_CUPRITE_INGOT] = 0.0f;
+    helios->_inventory_cache[COMMODITY_CRYSTAL_INGOT] = MAX_PRODUCT_STOCK;
+    helios->_inventory_cache[COMMODITY_FRAME]         = MAX_PRODUCT_STOCK;
+    helios->_inventory_cache[COMMODITY_LASER_MODULE]  = MAX_PRODUCT_STOCK;
+    helios->_inventory_cache[COMMODITY_TRACTOR_MODULE]= MAX_PRODUCT_STOCK;
+    helios->_inventory_cache[COMMODITY_CUPRITE_ORE]   = REFINERY_HOPPER_CAPACITY;
+    helios->_inventory_cache[COMMODITY_CRYSTAL_ORE]   = REFINERY_HOPPER_CAPACITY;
+    helios->_inventory_cache[COMMODITY_FERRITE_ORE]   = REFINERY_HOPPER_CAPACITY;
+    station_demand_t d = station_top_demand(helios);
+    /* Either no demand at all, or demand for something Helios
+     * actually doesn't produce — but specifically NOT cuprite ingot. */
+    ASSERT(d.commodity != COMMODITY_CUPRITE_INGOT);
+}
+
+TEST(test_top_demand_severity_clamped_zero_to_one) {
+    /* A negative deficit (overstock) should not produce negative
+     * severity, and a wildly empty hopper should clamp to 1.0. */
+    WORLD_DECL;
+    world_reset(&w);
+    station_t *prospect = &w.stations[0];
+    /* Force an overstock on FERRITE_ORE: target = HOPPER_CAPACITY*0.5,
+     * supply = capacity, so deficit is negative. The primitive
+     * should still report severity = 0 for that commodity (and pick
+     * something else, or none). */
+    prospect->_inventory_cache[COMMODITY_FERRITE_ORE] = REFINERY_HOPPER_CAPACITY;
+    station_demand_t d = station_top_demand(prospect);
+    /* Whatever it picks, severity must be in [0,1]. */
+    ASSERT(d.severity >= 0.0f && d.severity <= 1.0f);
+    ASSERT(d.price_mult >= 1.0f && d.price_mult <= 1.5f + 0.001f);
+    /* And it must not have picked overstocked ferrite ore. */
+    ASSERT(d.commodity != COMMODITY_FERRITE_ORE);
+}
+
+/* Demand pricing: a station that's starving for an ingot should post a
+ * higher contract price than one that's stocked. Pool_factor and the
+ * existing 1.15× content premium stay; the new demand multiplier
+ * layers on top, so a fully-stocked station's contract still uses the
+ * old price exactly (1.0× demand mult), and a starved station pays up
+ * to 50% more. */
+TEST(test_contract_price_scales_with_demand) {
+    /* Helper to grab Kepler's frame_press ingot import contract. */
+    WORLD_DECL_NAME(stocked);
+    world_reset(&stocked);
+    /* Top up Kepler's ferrite ingot inventory to its target so demand
+     * mult is 1.0 — i.e. the existing pricing path. */
+    stocked.stations[1]._inventory_cache[COMMODITY_FERRITE_INGOT] = MAX_PRODUCT_STOCK;
+    /* Run a few seconds for contract step to fire. */
+    for (int i = 0; i < 240; i++) world_sim_step(&stocked, SIM_DT);
+
+    WORLD_DECL_NAME(starved);
+    world_reset(&starved);
+    /* Starve Kepler completely for ferrite ingots — demand mult ~1.5. */
+    starved.stations[1]._inventory_cache[COMMODITY_FERRITE_INGOT] = 0.0f;
+    for (int i = 0; i < 240; i++) world_sim_step(&starved, SIM_DT);
+
+    /* Find the (Kepler, FERRITE_INGOT) contract in each world. The
+     * stocked world may not generate one at all if supply is at
+     * target — that's also a valid outcome (no demand → no
+     * contract). The starved world must generate one and price it
+     * higher than the stocked baseline if the stocked world did
+     * post one. */
+    contract_t *c_stocked = NULL;
+    for (int k = 0; k < MAX_CONTRACTS; k++) {
+        if (stocked.contracts[k].active
+            && stocked.contracts[k].station_index == 1
+            && stocked.contracts[k].commodity == COMMODITY_FERRITE_INGOT) {
+            c_stocked = &stocked.contracts[k]; break;
+        }
+    }
+    contract_t *c_starved = NULL;
+    for (int k = 0; k < MAX_CONTRACTS; k++) {
+        if (starved.contracts[k].active
+            && starved.contracts[k].station_index == 1
+            && starved.contracts[k].commodity == COMMODITY_FERRITE_INGOT) {
+            c_starved = &starved.contracts[k]; break;
+        }
+    }
+    ASSERT(c_starved != NULL); /* starvation MUST produce a contract */
+
+    if (c_stocked != NULL) {
+        /* If the stocked world also posted a contract, the starved
+         * one must be priced higher. The two worlds are otherwise
+         * identical so pool_factor + base_price are equal. The only
+         * delta is the demand multiplier. */
+        ASSERT(c_starved->base_price > c_stocked->base_price * 1.05f);
+    }
+    /* Either way, the starved contract's price must reflect the
+     * demand boost vs. the no-demand baseline of base × 1.15 ×
+     * pool. base_price[FERRITE_INGOT] is non-zero by world_reset
+     * seeding; the contract should land somewhere between 1.0× and
+     * 1.5× of (base × 1.15 × pool). We don't assert the exact value
+     * because pool_factor moves with the simulated economy. */
+    ASSERT(c_starved->base_price > 0.0f);
+}
+
+void register_economy_demand_tests(void) {
+    TEST_SECTION("\nStation demand primitive:\n");
+    RUN(test_top_demand_no_shortage_returns_none);
+    RUN(test_top_demand_picks_starving_commodity);
+    RUN(test_top_demand_skips_self_produced_commodities);
+    RUN(test_top_demand_severity_clamped_zero_to_one);
+    RUN(test_contract_price_scales_with_demand);
+}
+

--- a/src/tests/test_furnace_color.c
+++ b/src/tests/test_furnace_color.c
@@ -174,14 +174,14 @@ TEST(test_furnace_color_non_furnace_modules_unaffected) {
     EXPECT_RGB(r, g, b, 0.85f, 0.30f, 0.20f);
 }
 
-/* (5) Prospect: ring 1 = DOCK + RELAY + FURNACE; ring 2 = single
- *     paired HOPPER at slot 4 (240°, cross-ring opposite the furnace
- *     at ring-1 slot 2). 4 modules total — one hopper per producer. */
+/* Prospect: ring 1 = DOCK + RELAY + FURNACE (tagged FERRITE_INGOT);
+ * ring 2 = FERRITE_ORE intake at slot 4 + FERRITE_INGOT output at
+ * slot 0. 5 modules total. */
 TEST(test_prospect_modules_after_silo_cleanup) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     ASSERT(w != NULL);
     world_reset(w);
-    ASSERT_EQ_INT((int)w->stations[0].module_count, 4);
+    ASSERT_EQ_INT((int)w->stations[0].module_count, 5);
     int has_dock = 0, has_relay = 0, has_furnace = 0, has_hopper = 0;
     for (int i = 0; i < w->stations[0].module_count; i++) {
         switch (w->stations[0].modules[i].type) {
@@ -195,7 +195,7 @@ TEST(test_prospect_modules_after_silo_cleanup) {
     ASSERT_EQ_INT(has_dock, 1);
     ASSERT_EQ_INT(has_relay, 1);
     ASSERT_EQ_INT(has_furnace, 1);
-    ASSERT_EQ_INT(has_hopper, 1);
+    ASSERT_EQ_INT(has_hopper, 2);
 }
 
 /* (6) Middle-ring dynamic glow: the helper reads

--- a/src/tests/test_furnace_color.c
+++ b/src/tests/test_furnace_color.c
@@ -175,13 +175,14 @@ TEST(test_furnace_color_non_furnace_modules_unaffected) {
 }
 
 /* Prospect: ring 1 = DOCK + RELAY + FURNACE (tagged FERRITE_INGOT);
- * ring 2 = FERRITE_ORE intake at slot 4 + FERRITE_INGOT output at
- * slot 0. 5 modules total. */
+ * ring 2 = single FERRITE_ORE intake at slot 4. 4 modules total —
+ * no output hopper because nothing on Prospect locally consumes
+ * ferrite ingots (no frame press here). */
 TEST(test_prospect_modules_after_silo_cleanup) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     ASSERT(w != NULL);
     world_reset(w);
-    ASSERT_EQ_INT((int)w->stations[0].module_count, 5);
+    ASSERT_EQ_INT((int)w->stations[0].module_count, 4);
     int has_dock = 0, has_relay = 0, has_furnace = 0, has_hopper = 0;
     for (int i = 0; i < w->stations[0].module_count; i++) {
         switch (w->stations[0].modules[i].type) {
@@ -195,7 +196,7 @@ TEST(test_prospect_modules_after_silo_cleanup) {
     ASSERT_EQ_INT(has_dock, 1);
     ASSERT_EQ_INT(has_relay, 1);
     ASSERT_EQ_INT(has_furnace, 1);
-    ASSERT_EQ_INT(has_hopper, 2);
+    ASSERT_EQ_INT(has_hopper, 1);
 }
 
 /* (6) Middle-ring dynamic glow: the helper reads

--- a/src/tests/test_laser.c
+++ b/src/tests/test_laser.c
@@ -18,7 +18,7 @@ TEST(test_laser_target_in_thin_ray_hits_on_axis) {
         .cone_half_angle = 0.0f,
     };
     vec2 hit;
-    ASSERT(laser_target_in_beam(&ray, v2(50.0f, 0.0f), 5.0f, &hit));
+    ASSERT(laser_target_in_beam(&ray, v2(50.0f, 0.0f), 5.0f, &hit, NULL));
     /* Hit position biased 85% of radius back toward source from
      * target center → x = 50 - 5*0.85 = 45.75. */
     ASSERT_EQ_FLOAT(hit.x, 45.75f, 0.01f);
@@ -35,9 +35,9 @@ TEST(test_laser_target_in_thin_ray_misses_off_axis) {
         .cone_half_angle = 0.0f,
     };
     /* Target center 20u off axis, radius 5 → perp 20 > radius 5 → miss. */
-    ASSERT(!laser_target_in_beam(&ray, v2(50.0f, 20.0f), 5.0f, NULL));
+    ASSERT(!laser_target_in_beam(&ray, v2(50.0f, 20.0f), 5.0f, NULL, NULL));
     /* Just barely on-axis — perp 4.9 < radius 5 → hit. */
-    ASSERT(laser_target_in_beam(&ray, v2(50.0f, 4.9f), 5.0f, NULL));
+    ASSERT(laser_target_in_beam(&ray, v2(50.0f, 4.9f), 5.0f, NULL, NULL));
 }
 
 TEST(test_laser_cone_widens_with_distance) {
@@ -51,9 +51,9 @@ TEST(test_laser_cone_widens_with_distance) {
     };
     /* Target 10u perpendicular at d=10 → allowed 5.77 + 1 = 6.77; perp
      * 10 > 6.77 → miss. */
-    ASSERT(!laser_target_in_beam(&ray, v2(10.0f, 10.0f), 1.0f, NULL));
+    ASSERT(!laser_target_in_beam(&ray, v2(10.0f, 10.0f), 1.0f, NULL, NULL));
     /* Same target at d=100 → allowed ~58.7; perp 10 < 58.7 → hit. */
-    ASSERT(laser_target_in_beam(&ray, v2(100.0f, 10.0f), 1.0f, NULL));
+    ASSERT(laser_target_in_beam(&ray, v2(100.0f, 10.0f), 1.0f, NULL, NULL));
 }
 
 TEST(test_laser_range_gate_disengages) {
@@ -65,9 +65,9 @@ TEST(test_laser_range_gate_disengages) {
         .cone_half_angle = 0.0f,
     };
     /* Center at d=120, radius 5 → effective_range = 100 + 5 = 105; out. */
-    ASSERT(!laser_target_in_beam(&ray, v2(120.0f, 0.0f), 5.0f, NULL));
+    ASSERT(!laser_target_in_beam(&ray, v2(120.0f, 0.0f), 5.0f, NULL, NULL));
     /* Center at d=104 with radius 5 → effective_range covers it. */
-    ASSERT(laser_target_in_beam(&ray, v2(104.0f, 0.0f), 5.0f, NULL));
+    ASSERT(laser_target_in_beam(&ray, v2(104.0f, 0.0f), 5.0f, NULL, NULL));
 }
 
 TEST(test_laser_target_behind_source_misses) {
@@ -78,7 +78,7 @@ TEST(test_laser_target_behind_source_misses) {
         .range = 100.0f,
         .cone_half_angle = 0.0f,
     };
-    ASSERT(!laser_target_in_beam(&ray, v2(-50.0f, 0.0f), 5.0f, NULL));
+    ASSERT(!laser_target_in_beam(&ray, v2(-50.0f, 0.0f), 5.0f, NULL, NULL));
 }
 
 TEST(test_laser_apply_effect_accumulates) {

--- a/src/tests/test_laser.c
+++ b/src/tests/test_laser.c
@@ -1,0 +1,134 @@
+/*
+ * test_laser.c — unit tests for the unified laser primitive.
+ *
+ * Pure math tests pinning the behavior (geometry hit/miss, effect
+ * accumulation + clamp + decay) so the migration sites in L2/L3
+ * have a stable reference.
+ */
+#include "tests/test_harness.h"
+#include "laser.h"
+
+TEST(test_laser_target_in_thin_ray_hits_on_axis) {
+    /* Ray along +X from origin, range 100, thin (cone=0). Target at
+     * (50, 0) with radius 5 — directly on the axis, in range. */
+    laser_ray_t ray = {
+        .source_pos = v2(0.0f, 0.0f),
+        .source_dir = v2(1.0f, 0.0f),
+        .range = 100.0f,
+        .cone_half_angle = 0.0f,
+    };
+    vec2 hit;
+    ASSERT(laser_target_in_beam(&ray, v2(50.0f, 0.0f), 5.0f, &hit));
+    /* Hit position biased 85% of radius back toward source from
+     * target center → x = 50 - 5*0.85 = 45.75. */
+    ASSERT_EQ_FLOAT(hit.x, 45.75f, 0.01f);
+    ASSERT_EQ_FLOAT(hit.y, 0.0f,   0.01f);
+}
+
+TEST(test_laser_target_in_thin_ray_misses_off_axis) {
+    /* Same ray, target offset perpendicular to the axis by more than
+     * the target radius — should miss. */
+    laser_ray_t ray = {
+        .source_pos = v2(0.0f, 0.0f),
+        .source_dir = v2(1.0f, 0.0f),
+        .range = 100.0f,
+        .cone_half_angle = 0.0f,
+    };
+    /* Target center 20u off axis, radius 5 → perp 20 > radius 5 → miss. */
+    ASSERT(!laser_target_in_beam(&ray, v2(50.0f, 20.0f), 5.0f, NULL));
+    /* Just barely on-axis — perp 4.9 < radius 5 → hit. */
+    ASSERT(laser_target_in_beam(&ray, v2(50.0f, 4.9f), 5.0f, NULL));
+}
+
+TEST(test_laser_cone_widens_with_distance) {
+    /* Cone half-angle = 30°. At along=10u the cone has tolerance
+     * 10*tan(30°) ≈ 5.77u + target radius. At along=100u: ~57.7u. */
+    laser_ray_t ray = {
+        .source_pos = v2(0.0f, 0.0f),
+        .source_dir = v2(1.0f, 0.0f),
+        .range = 200.0f,
+        .cone_half_angle = 30.0f * (PI_F / 180.0f),
+    };
+    /* Target 10u perpendicular at d=10 → allowed 5.77 + 1 = 6.77; perp
+     * 10 > 6.77 → miss. */
+    ASSERT(!laser_target_in_beam(&ray, v2(10.0f, 10.0f), 1.0f, NULL));
+    /* Same target at d=100 → allowed ~58.7; perp 10 < 58.7 → hit. */
+    ASSERT(laser_target_in_beam(&ray, v2(100.0f, 10.0f), 1.0f, NULL));
+}
+
+TEST(test_laser_range_gate_disengages) {
+    /* Target past the ray's range — no hit even when on-axis. */
+    laser_ray_t ray = {
+        .source_pos = v2(0.0f, 0.0f),
+        .source_dir = v2(1.0f, 0.0f),
+        .range = 100.0f,
+        .cone_half_angle = 0.0f,
+    };
+    /* Center at d=120, radius 5 → effective_range = 100 + 5 = 105; out. */
+    ASSERT(!laser_target_in_beam(&ray, v2(120.0f, 0.0f), 5.0f, NULL));
+    /* Center at d=104 with radius 5 → effective_range covers it. */
+    ASSERT(laser_target_in_beam(&ray, v2(104.0f, 0.0f), 5.0f, NULL));
+}
+
+TEST(test_laser_target_behind_source_misses) {
+    /* Ray fires +X. Target at -X (behind source) — never a hit. */
+    laser_ray_t ray = {
+        .source_pos = v2(0.0f, 0.0f),
+        .source_dir = v2(1.0f, 0.0f),
+        .range = 100.0f,
+        .cone_half_angle = 0.0f,
+    };
+    ASSERT(!laser_target_in_beam(&ray, v2(-50.0f, 0.0f), 5.0f, NULL));
+}
+
+TEST(test_laser_apply_effect_accumulates) {
+    /* Positive effect adds to the field. With dt=1 and effect=10/sec,
+     * one tick adds 10. */
+    float field = 0.0f;
+    laser_apply_effect(&field, 10.0f, 0.0f, 1.0f);
+    ASSERT_EQ_FLOAT(field, 10.0f, 0.001f);
+    /* Another tick stacks. */
+    laser_apply_effect(&field, 10.0f, 0.0f, 1.0f);
+    ASSERT_EQ_FLOAT(field, 20.0f, 0.001f);
+}
+
+TEST(test_laser_apply_effect_clamps_to_max) {
+    /* With max_value=15 and field=10, applying 10 more clamps at 15. */
+    float field = 10.0f;
+    laser_apply_effect(&field, 10.0f, 15.0f, 1.0f);
+    ASSERT_EQ_FLOAT(field, 15.0f, 0.001f);
+    /* max_value=0 disables the upper clamp. */
+    field = 10.0f;
+    laser_apply_effect(&field, 10.0f, 0.0f, 1.0f);
+    ASSERT_EQ_FLOAT(field, 20.0f, 0.001f);
+}
+
+TEST(test_laser_apply_effect_floors_at_zero) {
+    /* Negative effect (decay) but field never goes below zero. */
+    float field = 0.3f;
+    laser_apply_effect(&field, -1.0f, 0.0f, 1.0f);
+    ASSERT_EQ_FLOAT(field, 0.0f, 0.001f);
+    /* Already zero stays zero. */
+    laser_apply_effect(&field, -1.0f, 0.0f, 1.0f);
+    ASSERT_EQ_FLOAT(field, 0.0f, 0.001f);
+}
+
+TEST(test_laser_apply_effect_null_target_safe) {
+    /* Sanity: passing NULL target_field is a no-op (no crash). */
+    laser_apply_effect(NULL, 10.0f, 0.0f, 1.0f);
+    /* Reaching this line means no SIGSEGV. */
+    ASSERT(true);
+}
+
+void register_laser_tests(void) {
+    TEST_SECTION("\nLaser primitive (L1):\n");
+    RUN(test_laser_target_in_thin_ray_hits_on_axis);
+    RUN(test_laser_target_in_thin_ray_misses_off_axis);
+    RUN(test_laser_cone_widens_with_distance);
+    RUN(test_laser_range_gate_disengages);
+    RUN(test_laser_target_behind_source_misses);
+    RUN(test_laser_apply_effect_accumulates);
+    RUN(test_laser_apply_effect_clamps_to_max);
+    RUN(test_laser_apply_effect_floors_at_zero);
+    RUN(test_laser_apply_effect_null_target_safe);
+}

--- a/src/tests/test_save.c
+++ b/src/tests/test_save.c
@@ -515,6 +515,112 @@ TEST(test_world_save_load_preserves_module_ring_slot) {
     remove(TMP("test_modules.sav"));
 }
 
+TEST(test_v51_migration_tags_untagged_furnaces_and_fills_hoppers) {
+    /* Simulate a v50 save: world_reset gives us correctly-tagged
+     * furnaces and full hoppers, then we manually break Helios to look
+     * pre-Slice-1 (untagged furnaces, no LASER_MODULE / TRACTOR_MODULE
+     * output hoppers). Running the migration must restore the seeded
+     * invariant: every Helios producer has a matching tagged hopper
+     * for its output, and furnaces are tagged by count-tier rule. */
+    WORLD_HEAP w = calloc(1, sizeof(world_t));
+    ASSERT(w != NULL);
+    world_reset(w);
+    station_t *helios = &w->stations[2];
+
+    /* Untag every Helios furnace (pre-Slice-1 state). */
+    int n_furnaces = 0;
+    for (int m = 0; m < helios->module_count; m++) {
+        if (helios->modules[m].type == MODULE_FURNACE) {
+            helios->modules[m].commodity = (uint8_t)COMMODITY_COUNT;
+            n_furnaces++;
+        }
+    }
+    ASSERT_EQ_INT(n_furnaces, 3);
+
+    /* Drop Helios's LASER_MODULE and TRACTOR_MODULE output hoppers.
+     * Walk in reverse so removing entries doesn't shift indices we
+     * still need to check. */
+    for (int m = helios->module_count - 1; m >= 0; m--) {
+        if (helios->modules[m].type != MODULE_HOPPER) continue;
+        commodity_t c = (commodity_t)helios->modules[m].commodity;
+        if (c == COMMODITY_LASER_MODULE || c == COMMODITY_TRACTOR_MODULE) {
+            for (int k = m + 1; k < helios->module_count; k++) {
+                helios->modules[k - 1] = helios->modules[k];
+            }
+            helios->module_count--;
+        }
+    }
+    ASSERT(station_find_hopper_for(helios, COMMODITY_LASER_MODULE)   < 0);
+    ASSERT(station_find_hopper_for(helios, COMMODITY_TRACTOR_MODULE) < 0);
+
+    /* Run the migration. */
+    world_apply_cargo_schema_migration(w);
+
+    /* All 3 furnaces tagged with valid ingot commodities (3-furnace
+     * tier → 1×CU + 1×CR + 1×CU according to the migration heuristic). */
+    int cu = 0, cr = 0;
+    for (int m = 0; m < helios->module_count; m++) {
+        if (helios->modules[m].type != MODULE_FURNACE) continue;
+        commodity_t tag = (commodity_t)helios->modules[m].commodity;
+        if      (tag == COMMODITY_CUPRITE_INGOT) cu++;
+        else if (tag == COMMODITY_CRYSTAL_INGOT) cr++;
+        else ASSERT(false /* unexpected tag */);
+    }
+    ASSERT_EQ_INT(cu, 2);
+    ASSERT_EQ_INT(cr, 1);
+
+    /* Missing output hoppers were auto-spawned. */
+    ASSERT(station_find_hopper_for(helios, COMMODITY_LASER_MODULE)   >= 0);
+    ASSERT(station_find_hopper_for(helios, COMMODITY_TRACTOR_MODULE) >= 0);
+
+    /* Idempotent: running again is a no-op. */
+    int count_after_first = helios->module_count;
+    world_apply_cargo_schema_migration(w);
+    ASSERT_EQ_INT(helios->module_count, count_after_first);
+}
+
+TEST(test_v51_migration_furnace_count_heuristic) {
+    /* Synthetic stations covering 1/2/3-furnace tiers, all furnaces
+     * untagged. Migration tags them per the count-tier rules.
+     * Use stations[3+] to avoid clobbering seeded state (which the
+     * heap WORLD_DECL initializes to zero already). */
+    WORLD_HEAP w = calloc(1, sizeof(world_t));
+    ASSERT(w != NULL);
+    /* 1-furnace station: should tag FERRITE. */
+    station_t *st1 = &w->stations[3];
+    st1->signal_range = 1.0f;
+    add_module_at(st1, MODULE_FURNACE, 1, 0);
+    /* 2-furnace station: should tag FERRITE + CUPRITE. */
+    station_t *st2 = &w->stations[4];
+    st2->signal_range = 1.0f;
+    add_module_at(st2, MODULE_FURNACE, 1, 0);
+    add_module_at(st2, MODULE_FURNACE, 1, 1);
+    /* 3-furnace station: should tag CUPRITE + CRYSTAL + CUPRITE. */
+    station_t *st3 = &w->stations[5];
+    st3->signal_range = 1.0f;
+    add_module_at(st3, MODULE_FURNACE, 1, 0);
+    add_module_at(st3, MODULE_FURNACE, 1, 1);
+    add_module_at(st3, MODULE_FURNACE, 1, 2);
+
+    world_apply_cargo_schema_migration(w);
+
+    ASSERT_EQ_INT((int)st1->modules[0].commodity, (int)COMMODITY_FERRITE_INGOT);
+
+    ASSERT_EQ_INT((int)st2->modules[0].commodity, (int)COMMODITY_FERRITE_INGOT);
+    ASSERT_EQ_INT((int)st2->modules[1].commodity, (int)COMMODITY_CUPRITE_INGOT);
+
+    ASSERT_EQ_INT((int)st3->modules[0].commodity, (int)COMMODITY_CUPRITE_INGOT);
+    ASSERT_EQ_INT((int)st3->modules[1].commodity, (int)COMMODITY_CRYSTAL_INGOT);
+    ASSERT_EQ_INT((int)st3->modules[2].commodity, (int)COMMODITY_CUPRITE_INGOT);
+
+    /* Output hoppers spawned for every furnace's tagged output. */
+    ASSERT(station_find_hopper_for(st1, COMMODITY_FERRITE_INGOT) >= 0);
+    ASSERT(station_find_hopper_for(st2, COMMODITY_FERRITE_INGOT) >= 0);
+    ASSERT(station_find_hopper_for(st2, COMMODITY_CUPRITE_INGOT) >= 0);
+    ASSERT(station_find_hopper_for(st3, COMMODITY_CUPRITE_INGOT) >= 0);
+    ASSERT(station_find_hopper_for(st3, COMMODITY_CRYSTAL_INGOT) >= 0);
+}
+
 TEST(test_world_save_load_preserves_smelted_ingots) {
     /* world_t is ~600KB — use heap to avoid stack overflow on CI. */
     WORLD_HEAP w = calloc(1, sizeof(world_t));
@@ -622,7 +728,7 @@ TEST(test_save_header_golden_bytes) {
     ASSERT_EQ_INT((int)fread(&spawn_timer, 4, 1, f), 1);
     fclose(f);
     ASSERT_EQ_INT((int)magic, (int)0x5349474E);    /* "SIGN" */
-    ASSERT_EQ_INT((int)version, 50);
+    ASSERT_EQ_INT((int)version, 51);
     ASSERT(rng != 0);  /* seed is set */
     ASSERT_EQ_FLOAT(time_val, 0.0f, 0.001f);
     ASSERT_EQ_FLOAT(spawn_timer, 0.0f, 0.001f);
@@ -738,6 +844,8 @@ void register_save_persistence_tests(void) {
     RUN(test_player_load_bad_magic_fails);
     RUN(test_world_load_rejects_stale_version);
     RUN(test_world_save_load_preserves_module_ring_slot);
+    RUN(test_v51_migration_tags_untagged_furnaces_and_fills_hoppers);
+    RUN(test_v51_migration_furnace_count_heuristic);
     RUN(test_world_save_load_preserves_smelted_ingots);
 }
 

--- a/src/tests/test_save.c
+++ b/src/tests/test_save.c
@@ -479,11 +479,9 @@ TEST(test_world_save_load_preserves_module_ring_slot) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     world_reset(w);
     /* Prospect's furnace at ring 1 slot 2, ferrite-ore intake hopper at
-     * ring 2 slot 4, ferrite-ingot output hopper at ring 2 slot 0
-     * (slot 0 is on the dock's radial axis — the only ring-2 slot that
-     * doesn't perturb NPC docking pathways. See add_hopper_for site
-     * comment in world_reset). 5 modules total. */
-    ASSERT_EQ_INT((int)w->stations[0].module_count, 5);
+     * ring 2 slot 4. 4 modules total — no ingot output hopper because
+     * Prospect has no on-station consumer of ferrite ingots. */
+    ASSERT_EQ_INT((int)w->stations[0].module_count, 4);
     station_module_t orig = w->stations[0].modules[2]; /* furnace at ring 1 slot 2 */
     ASSERT(orig.type == MODULE_FURNACE);
     ASSERT_EQ_INT((int)orig.ring, 1);
@@ -505,13 +503,7 @@ TEST(test_world_save_load_preserves_module_ring_slot) {
     ASSERT_EQ_INT((int)intake.ring, 2);
     ASSERT_EQ_INT((int)intake.slot, 4);
     ASSERT_EQ_INT((int)intake.commodity, (int)COMMODITY_FERRITE_ORE);
-    /* modules[4] = ferrite-ingot output hopper at ring 2 slot 0. */
-    station_module_t out_h = loaded->stations[0].modules[4];
-    ASSERT(out_h.type == MODULE_HOPPER);
-    ASSERT_EQ_INT((int)out_h.ring, 2);
-    ASSERT_EQ_INT((int)out_h.slot, 0);
-    ASSERT_EQ_INT((int)out_h.commodity, (int)COMMODITY_FERRITE_INGOT);
-    ASSERT_EQ_INT((int)loaded->stations[0].module_count, 5);
+    ASSERT_EQ_INT((int)loaded->stations[0].module_count, 4);
     remove(TMP("test_modules.sav"));
 }
 

--- a/src/tests/test_save.c
+++ b/src/tests/test_save.c
@@ -478,11 +478,12 @@ TEST(test_world_load_rejects_stale_version) {
 TEST(test_world_save_load_preserves_module_ring_slot) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     world_reset(w);
-    /* Cross-ring pair layout: Prospect's furnace lives on ring 1 slot
-     * 2, paired with the lone ring-2 hopper at slot 4 (240° on both
-     * rings). 4 modules total — one hopper per producer, no
-     * decorative ring. */
-    ASSERT_EQ_INT((int)w->stations[0].module_count, 4);
+    /* Prospect's furnace at ring 1 slot 2, ferrite-ore intake hopper at
+     * ring 2 slot 4, ferrite-ingot output hopper at ring 2 slot 0
+     * (slot 0 is on the dock's radial axis — the only ring-2 slot that
+     * doesn't perturb NPC docking pathways. See add_hopper_for site
+     * comment in world_reset). 5 modules total. */
+    ASSERT_EQ_INT((int)w->stations[0].module_count, 5);
     station_module_t orig = w->stations[0].modules[2]; /* furnace at ring 1 slot 2 */
     ASSERT(orig.type == MODULE_FURNACE);
     ASSERT_EQ_INT((int)orig.ring, 1);
@@ -498,12 +499,19 @@ TEST(test_world_save_load_preserves_module_ring_slot) {
     ASSERT_EQ_INT((int)restored.slot, (int)orig.slot);
     ASSERT_EQ_INT((int)restored.scaffold, (int)orig.scaffold);
     ASSERT_EQ_FLOAT(restored.build_progress, orig.build_progress, 0.001f);
-    /* modules[3] = the paired hopper at ring 2 slot 4. */
-    station_module_t paired = loaded->stations[0].modules[3];
-    ASSERT(paired.type == MODULE_HOPPER);
-    ASSERT_EQ_INT((int)paired.ring, 2);
-    ASSERT_EQ_INT((int)paired.slot, 4);
-    ASSERT_EQ_INT((int)loaded->stations[0].module_count, 4);
+    /* modules[3] = ferrite-ore intake hopper at ring 2 slot 4. */
+    station_module_t intake = loaded->stations[0].modules[3];
+    ASSERT(intake.type == MODULE_HOPPER);
+    ASSERT_EQ_INT((int)intake.ring, 2);
+    ASSERT_EQ_INT((int)intake.slot, 4);
+    ASSERT_EQ_INT((int)intake.commodity, (int)COMMODITY_FERRITE_ORE);
+    /* modules[4] = ferrite-ingot output hopper at ring 2 slot 0. */
+    station_module_t out_h = loaded->stations[0].modules[4];
+    ASSERT(out_h.type == MODULE_HOPPER);
+    ASSERT_EQ_INT((int)out_h.ring, 2);
+    ASSERT_EQ_INT((int)out_h.slot, 0);
+    ASSERT_EQ_INT((int)out_h.commodity, (int)COMMODITY_FERRITE_INGOT);
+    ASSERT_EQ_INT((int)loaded->stations[0].module_count, 5);
     remove(TMP("test_modules.sav"));
 }
 

--- a/src/tests/test_tractor.c
+++ b/src/tests/test_tractor.c
@@ -55,6 +55,28 @@ TEST(test_tractor_push_engages_below_rest) {
     ASSERT_EQ_FLOAT(tgt_vel.y, 0.0f, 0.001f);
 }
 
+TEST(test_tractor_constant_pull_independent_of_stretch) {
+    /* pull_constant=10 with no spring → same force regardless of how
+     * far past rest the body is. Models a "thruster on the rope"
+     * that yanks the fragment in at a fixed rate (NPC pickup tow). */
+    vec2 vel_near = v2(0.0f, 0.0f);
+    vec2 vel_far  = v2(0.0f, 0.0f);
+    tractor_anchor_t src = mk_world_anchor(v2(0.0f, 0.0f));
+    tractor_beam_t   beam = {
+        .rest_length = 5.0f, .pull_strength = 0.0f, .push_strength = 0.0f,
+        .pull_constant = 10.0f, .push_constant = 0.0f,
+        .range = 1000.0f, .axial_damping = 0.0f, .tangent_damping = 0.0f,
+        .speed_cap = 0.0f, .falloff = TRACTOR_FALLOFF_CONSTANT,
+    };
+    tractor_anchor_t tgt_near = mk_body_anchor(v2(7.0f,   0.0f), &vel_near, 1.0f);
+    tractor_anchor_t tgt_far  = mk_body_anchor(v2(500.0f, 0.0f), &vel_far,  1.0f);
+    ASSERT(tractor_apply(&src, &tgt_near, &beam, 1.0f));
+    ASSERT(tractor_apply(&src, &tgt_far,  &beam, 1.0f));
+    /* Both bodies pulled toward source at the same constant rate. */
+    ASSERT_EQ_FLOAT(vel_near.x, -10.0f, 0.001f);
+    ASSERT_EQ_FLOAT(vel_far.x,  -10.0f, 0.001f);
+}
+
 TEST(test_tractor_zero_strength_no_force) {
     /* pull=0, push=0 → no spring force regardless of distance. With
      * zero damping too, the body's velocity is unchanged. */
@@ -218,6 +240,7 @@ void register_tractor_tests(void) {
     TEST_SECTION("\nTractor primitive (R1):\n");
     RUN(test_tractor_pull_engages_beyond_rest);
     RUN(test_tractor_push_engages_below_rest);
+    RUN(test_tractor_constant_pull_independent_of_stretch);
     RUN(test_tractor_zero_strength_no_force);
     RUN(test_tractor_range_gate_disengages);
     RUN(test_tractor_linear_falloff_halves_at_half_range);

--- a/src/tests/test_tractor.c
+++ b/src/tests/test_tractor.c
@@ -1,0 +1,228 @@
+/*
+ * test_tractor.c — unit tests for the unified tractor primitive.
+ *
+ * Pure math tests with no world dependency. They pin the behavior
+ * (push/pull/range/falloff/damping/reaction/cap) so the call-site
+ * migrations in R2-R5 can be evaluated for "behavior preserved" or
+ * "behavior changed by 1D damping" with a stable reference point.
+ */
+#include "tests/test_harness.h"
+#include "tractor.h"
+
+/* Convenience: anchor that's body-attached with given vel + inv_mass. */
+static tractor_anchor_t mk_body_anchor(vec2 pos, vec2 *vel, float inv_mass) {
+    tractor_anchor_t a = { .pos = pos, .vel = vel, .inv_mass = inv_mass };
+    return a;
+}
+
+/* Convenience: anchor that's world-pinned (no reaction force possible). */
+static tractor_anchor_t mk_world_anchor(vec2 pos) {
+    tractor_anchor_t a = { .pos = pos, .vel = NULL, .inv_mass = 0.0f };
+    return a;
+}
+
+TEST(test_tractor_pull_engages_beyond_rest) {
+    /* Body at d=10 along +X from origin. rest=5, pull=2, push=0.
+     * stretch = 5; spring_mag = -2 * 5 = -10 (toward source, i.e. -X).
+     * Single tick at dt=1 → vel goes from 0 to -10 along x. */
+    vec2 tgt_vel = v2(0.0f, 0.0f);
+    tractor_anchor_t src = mk_world_anchor(v2(0.0f, 0.0f));
+    tractor_anchor_t tgt = mk_body_anchor(v2(10.0f, 0.0f), &tgt_vel, 1.0f);
+    tractor_beam_t   beam = {
+        .rest_length = 5.0f, .pull_strength = 2.0f, .push_strength = 0.0f,
+        .range = 100.0f, .axial_damping = 0.0f, .tangent_damping = 0.0f,
+        .speed_cap = 0.0f, .falloff = TRACTOR_FALLOFF_CONSTANT,
+    };
+    bool active = tractor_apply(&src, &tgt, &beam, 1.0f);
+    ASSERT(active);
+    ASSERT_EQ_FLOAT(tgt_vel.x, -10.0f, 0.001f);
+    ASSERT_EQ_FLOAT(tgt_vel.y, 0.0f, 0.001f);
+}
+
+TEST(test_tractor_push_engages_below_rest) {
+    /* Body at d=2 along +X. rest=5, pull=0, push=3.
+     * stretch = -3; spring_mag = -3 * -3 = +9 (away from source, +X). */
+    vec2 tgt_vel = v2(0.0f, 0.0f);
+    tractor_anchor_t src = mk_world_anchor(v2(0.0f, 0.0f));
+    tractor_anchor_t tgt = mk_body_anchor(v2(2.0f, 0.0f), &tgt_vel, 1.0f);
+    tractor_beam_t   beam = {
+        .rest_length = 5.0f, .pull_strength = 0.0f, .push_strength = 3.0f,
+        .range = 100.0f, .axial_damping = 0.0f, .tangent_damping = 0.0f,
+        .speed_cap = 0.0f, .falloff = TRACTOR_FALLOFF_CONSTANT,
+    };
+    ASSERT(tractor_apply(&src, &tgt, &beam, 1.0f));
+    ASSERT_EQ_FLOAT(tgt_vel.x, 9.0f, 0.001f);
+    ASSERT_EQ_FLOAT(tgt_vel.y, 0.0f, 0.001f);
+}
+
+TEST(test_tractor_zero_strength_no_force) {
+    /* pull=0, push=0 → no spring force regardless of distance. With
+     * zero damping too, the body's velocity is unchanged. */
+    vec2 tgt_vel = v2(7.0f, 0.0f);
+    tractor_anchor_t src = mk_world_anchor(v2(0.0f, 0.0f));
+    tractor_anchor_t tgt = mk_body_anchor(v2(50.0f, 0.0f), &tgt_vel, 1.0f);
+    tractor_beam_t   beam = {
+        .rest_length = 0.0f, .pull_strength = 0.0f, .push_strength = 0.0f,
+        .range = 1000.0f, .axial_damping = 0.0f, .tangent_damping = 0.0f,
+        .speed_cap = 0.0f, .falloff = TRACTOR_FALLOFF_CONSTANT,
+    };
+    ASSERT(tractor_apply(&src, &tgt, &beam, 1.0f));
+    ASSERT_EQ_FLOAT(tgt_vel.x, 7.0f, 0.001f);
+    ASSERT_EQ_FLOAT(tgt_vel.y, 0.0f, 0.001f);
+}
+
+TEST(test_tractor_range_gate_disengages) {
+    /* Body at d=20, range=15 → tractor_apply returns false and target
+     * velocity is untouched. */
+    vec2 tgt_vel = v2(3.0f, 4.0f);
+    tractor_anchor_t src = mk_world_anchor(v2(0.0f, 0.0f));
+    tractor_anchor_t tgt = mk_body_anchor(v2(20.0f, 0.0f), &tgt_vel, 1.0f);
+    tractor_beam_t   beam = {
+        .rest_length = 0.0f, .pull_strength = 99.0f, .push_strength = 0.0f,
+        .range = 15.0f, .axial_damping = 99.0f, .tangent_damping = 99.0f,
+        .speed_cap = 0.0f, .falloff = TRACTOR_FALLOFF_CONSTANT,
+    };
+    bool active = tractor_apply(&src, &tgt, &beam, 1.0f);
+    ASSERT(!active);
+    ASSERT_EQ_FLOAT(tgt_vel.x, 3.0f, 0.001f);
+    ASSERT_EQ_FLOAT(tgt_vel.y, 4.0f, 0.001f);
+}
+
+TEST(test_tractor_linear_falloff_halves_at_half_range) {
+    /* d = range/2 with FALLOFF_LINEAR → spring scaled by (1 - 0.5) = 0.5.
+     * Compare against a reference run with FALLOFF_CONSTANT (no scaling). */
+    vec2 tgt_vel_const = v2(0.0f, 0.0f);
+    vec2 tgt_vel_lin   = v2(0.0f, 0.0f);
+    tractor_anchor_t src = mk_world_anchor(v2(0.0f, 0.0f));
+
+    tractor_beam_t base = {
+        .rest_length = 0.0f, .pull_strength = 1.0f, .push_strength = 0.0f,
+        .range = 20.0f, .axial_damping = 0.0f, .tangent_damping = 0.0f,
+        .speed_cap = 0.0f, .falloff = TRACTOR_FALLOFF_CONSTANT,
+    };
+    tractor_anchor_t tgt_c = mk_body_anchor(v2(10.0f, 0.0f), &tgt_vel_const, 1.0f);
+    ASSERT(tractor_apply(&src, &tgt_c, &base, 1.0f));
+
+    base.falloff = TRACTOR_FALLOFF_LINEAR;
+    tractor_anchor_t tgt_l = mk_body_anchor(v2(10.0f, 0.0f), &tgt_vel_lin, 1.0f);
+    ASSERT(tractor_apply(&src, &tgt_l, &base, 1.0f));
+
+    /* Linear value should be exactly half the constant value. */
+    ASSERT_EQ_FLOAT(tgt_vel_lin.x, tgt_vel_const.x * 0.5f, 0.001f);
+}
+
+TEST(test_tractor_axial_vs_tangent_damping_isolation) {
+    /* Beam along +X. Axial-only damping applied: a body moving along
+     * +X gets slowed; a body moving along +Y is untouched. Then swap:
+     * tangent-only damping applied: body moving +X untouched, body
+     * moving +Y gets slowed. Tests that the two damping knobs are
+     * independent and act along orthogonal axes. */
+    vec2 vel_along  = v2(5.0f, 0.0f);
+    vec2 vel_tangent = v2(0.0f, 5.0f);
+    tractor_anchor_t src = mk_world_anchor(v2(0.0f, 0.0f));
+
+    /* Use a position offset from origin so the line-of-action is
+     * defined and the body is in range. Disable spring + falloff so
+     * only damping moves the velocity. */
+    tractor_beam_t beam_axial = {
+        .rest_length = 100.0f, .pull_strength = 0.0f, .push_strength = 0.0f,
+        .range = 100.0f, .axial_damping = 1.0f, .tangent_damping = 0.0f,
+        .speed_cap = 0.0f, .falloff = TRACTOR_FALLOFF_CONSTANT,
+    };
+    tractor_beam_t beam_tangent = beam_axial;
+    beam_tangent.axial_damping = 0.0f;
+    beam_tangent.tangent_damping = 1.0f;
+
+    tractor_anchor_t tgt_along  = mk_body_anchor(v2(10.0f, 0.0f), &vel_along, 1.0f);
+    tractor_anchor_t tgt_tangent = mk_body_anchor(v2(10.0f, 0.0f), &vel_tangent, 1.0f);
+
+    /* Axial damping case: body moving along the beam line slows; body
+     * moving perpendicular is untouched. */
+    vec2 saved_along  = vel_along;
+    vec2 saved_tangent = vel_tangent;
+    ASSERT(tractor_apply(&src, &tgt_along,  &beam_axial, 1.0f));
+    ASSERT(tractor_apply(&src, &tgt_tangent, &beam_axial, 1.0f));
+    ASSERT(vel_along.x  < saved_along.x);   /* axial slowed */
+    ASSERT_EQ_FLOAT(vel_tangent.y, saved_tangent.y, 0.001f); /* tangent untouched */
+
+    /* Reset velocities and retry with tangent-only damping. */
+    vel_along  = v2(5.0f, 0.0f);
+    vel_tangent = v2(0.0f, 5.0f);
+    ASSERT(tractor_apply(&src, &tgt_along,  &beam_tangent, 1.0f));
+    ASSERT(tractor_apply(&src, &tgt_tangent, &beam_tangent, 1.0f));
+    ASSERT_EQ_FLOAT(vel_along.x, 5.0f, 0.001f);   /* axial untouched */
+    ASSERT(vel_tangent.y < 5.0f);                  /* tangent slowed */
+}
+
+TEST(test_tractor_reaction_symmetry_conserves_momentum) {
+    /* Both anchors body-attached with inv_mass=1 → impulses are
+     * equal-and-opposite, so total momentum (vel sum) is preserved. */
+    vec2 src_vel = v2(0.0f, 0.0f);
+    vec2 tgt_vel = v2(0.0f, 0.0f);
+    tractor_anchor_t src = mk_body_anchor(v2(0.0f, 0.0f), &src_vel, 1.0f);
+    tractor_anchor_t tgt = mk_body_anchor(v2(10.0f, 0.0f), &tgt_vel, 1.0f);
+    tractor_beam_t   beam = {
+        .rest_length = 5.0f, .pull_strength = 2.0f, .push_strength = 0.0f,
+        .range = 100.0f, .axial_damping = 0.0f, .tangent_damping = 0.0f,
+        .speed_cap = 0.0f, .falloff = TRACTOR_FALLOFF_CONSTANT,
+    };
+    ASSERT(tractor_apply(&src, &tgt, &beam, 1.0f));
+    /* Target pulled toward source; source kicked away from target.
+     * Momentum sum stays zero. */
+    ASSERT_EQ_FLOAT(src_vel.x + tgt_vel.x, 0.0f, 0.001f);
+    ASSERT_EQ_FLOAT(src_vel.y + tgt_vel.y, 0.0f, 0.001f);
+    ASSERT(tgt_vel.x < 0.0f);   /* target pulled toward source (-X) */
+    ASSERT(src_vel.x > 0.0f);   /* source pulled toward target (+X) */
+}
+
+TEST(test_tractor_world_pinned_source_no_reaction) {
+    /* src.vel = NULL → no reaction force computed even if the math
+     * would otherwise apply. Target gets full impulse; source state
+     * unchanged. */
+    vec2 tgt_vel = v2(0.0f, 0.0f);
+    tractor_anchor_t src = mk_world_anchor(v2(0.0f, 0.0f));
+    tractor_anchor_t tgt = mk_body_anchor(v2(10.0f, 0.0f), &tgt_vel, 1.0f);
+    tractor_beam_t   beam = {
+        .rest_length = 5.0f, .pull_strength = 2.0f, .push_strength = 0.0f,
+        .range = 100.0f, .axial_damping = 0.0f, .tangent_damping = 0.0f,
+        .speed_cap = 0.0f, .falloff = TRACTOR_FALLOFF_CONSTANT,
+    };
+    ASSERT(tractor_apply(&src, &tgt, &beam, 1.0f));
+    ASSERT_EQ_FLOAT(tgt_vel.x, -10.0f, 0.001f);
+    /* Source has no vel field — nothing to assert on it directly,
+     * but the symmetry test above is the canary for accidental
+     * reaction-force mutation. */
+}
+
+TEST(test_tractor_speed_cap_clamps_target) {
+    /* Apply an impulse that would drive vel.x past the cap. The cap
+     * is on |target.vel| (isotropic), so the result is normalized to
+     * the cap magnitude along whatever direction the velocity ends up. */
+    vec2 tgt_vel = v2(0.0f, 0.0f);
+    tractor_anchor_t src = mk_world_anchor(v2(0.0f, 0.0f));
+    tractor_anchor_t tgt = mk_body_anchor(v2(100.0f, 0.0f), &tgt_vel, 1.0f);
+    tractor_beam_t   beam = {
+        .rest_length = 0.0f, .pull_strength = 100.0f, .push_strength = 0.0f,
+        .range = 1000.0f, .axial_damping = 0.0f, .tangent_damping = 0.0f,
+        .speed_cap = 50.0f, .falloff = TRACTOR_FALLOFF_CONSTANT,
+    };
+    /* Without cap the impulse would push vel.x to -10000. With cap=50
+     * the |vel| should land at 50 along the line of action (-X). */
+    ASSERT(tractor_apply(&src, &tgt, &beam, 1.0f));
+    float spd = sqrtf(tgt_vel.x * tgt_vel.x + tgt_vel.y * tgt_vel.y);
+    ASSERT_EQ_FLOAT(spd, 50.0f, 0.001f);
+    ASSERT(tgt_vel.x < 0.0f);  /* still pulled toward source */
+}
+
+void register_tractor_tests(void) {
+    TEST_SECTION("\nTractor primitive (R1):\n");
+    RUN(test_tractor_pull_engages_beyond_rest);
+    RUN(test_tractor_push_engages_below_rest);
+    RUN(test_tractor_zero_strength_no_force);
+    RUN(test_tractor_range_gate_disengages);
+    RUN(test_tractor_linear_falloff_halves_at_half_range);
+    RUN(test_tractor_axial_vs_tangent_damping_isolation);
+    RUN(test_tractor_reaction_symmetry_conserves_momentum);
+    RUN(test_tractor_world_pinned_source_no_reaction);
+    RUN(test_tractor_speed_cap_clamps_target);
+}

--- a/src/tests/test_world_sim.c
+++ b/src/tests/test_world_sim.c
@@ -914,18 +914,17 @@ TEST(test_npc_exits_station_with_blocked_rings) {
     a->radius = 30.0f;
     a->pos = v2_add(w.stations[0].pos, v2(3000.0f, 0.0f));
 
-    /* Run up to 60 sim seconds (was 30 in the pre-fix design but the
-     * NPC also has to reacquire its target after my override expires). */
+    /* Run up to 30 sim seconds. The miner must reach NPC_STATE_MINING
+     * (not just "near the asteroid") — proximity-only acceptance was
+     * loose enough that a regression where the NPC drifts slowly
+     * toward the asteroid without ever locking on would still pass.
+     * MINING gating requires the asteroid to be in the mining cone,
+     * which means the miner has to actually navigate there. */
     bool reached = false;
-    for (int i = 0; i < 7200 && !reached; i++) {
+    for (int i = 0; i < 3600 && !reached; i++) {
         world_sim_step(&w, SIM_DT);
         const npc_ship_t *npc = &w.npc_ships[miner];
         if (npc->state == NPC_STATE_MINING) { reached = true; break; }
-        /* Also accept "very close to the asteroid" — MINING transition
-         * is gated by visibility cone which can lag a tick. */
-        if (v2_dist_sq(npc->ship.pos, a->pos) < (MINING_RANGE * 1.5f) * (MINING_RANGE * 1.5f)) {
-            reached = true; break;
-        }
     }
     ASSERT(reached);
 }

--- a/src/tests/test_world_sim.c
+++ b/src/tests/test_world_sim.c
@@ -862,6 +862,74 @@ TEST(test_scenario_npc_economy_30_seconds) {
     }
 }
 
+TEST(test_npc_exits_station_with_blocked_rings) {
+    /* Slice 1.5b regression — Prospect's NPCs used to get stuck in the
+     * inner zone whenever ring 2 had multiple hoppers. Blocking ring-2
+     * slots 1, 2, 3, 5 (everything except the dock-radial slot 0 and
+     * the existing slot-4 ferrite-ore intake) plus ring-3 slots 0/3/6
+     * stresses the layout. With npc_target_clear_of_home_rings routing
+     * just-undocked NPCs through the dock-radial exit waypoint, the
+     * miner reaches an asteroid placed outside the rings without
+     * collision-stalling. */
+    WORLD_DECL;
+    world_reset(&w);
+    /* Block every ring-2 non-dock-radial slot on Prospect, plus a few
+     * ring-3 slots, with FERRITE_ORE-tagged hoppers (cheap to add via
+     * the seed helper). */
+    add_hopper_for(&w.stations[0], 2, 1, COMMODITY_FERRITE_ORE);
+    add_hopper_for(&w.stations[0], 2, 2, COMMODITY_FERRITE_ORE);
+    add_hopper_for(&w.stations[0], 2, 3, COMMODITY_FERRITE_ORE);
+    add_hopper_for(&w.stations[0], 2, 5, COMMODITY_FERRITE_ORE);
+    add_hopper_for(&w.stations[0], 3, 0, COMMODITY_FERRITE_ORE);
+    add_hopper_for(&w.stations[0], 3, 3, COMMODITY_FERRITE_ORE);
+    add_hopper_for(&w.stations[0], 3, 6, COMMODITY_FERRITE_ORE);
+    station_rebuild_all_nav(&w);
+
+    /* Find a Prospect miner and force it just-undocked. */
+    int miner = -1;
+    for (int i = 0; i < MAX_NPC_SHIPS; i++) {
+        if (w.npc_ships[i].active && w.npc_ships[i].role == NPC_ROLE_MINER
+            && w.npc_ships[i].home_station == 0) { miner = i; break; }
+    }
+    ASSERT(miner >= 0);
+    w.npc_ships[miner].state = NPC_STATE_DOCKED;
+    w.npc_ships[miner].state_timer = 0.0f;
+
+    /* Plant a ferrite asteroid 3000u east of Prospect — well outside
+     * any ring envelope. The miner must reach MINING_RANGE of it. */
+    int target_a = -1;
+    for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        if (!w.asteroids[i].active) { target_a = i; break; }
+    }
+    ASSERT(target_a >= 0);
+    asteroid_t *a = &w.asteroids[target_a];
+    memset(a, 0, sizeof(*a));
+    a->active = true;
+    a->tier = ASTEROID_TIER_M;
+    a->commodity = COMMODITY_FERRITE_ORE;
+    a->ore = 30.0f;
+    a->max_ore = 30.0f;
+    a->hp = 100.0f;
+    a->max_hp = 100.0f;
+    a->radius = 30.0f;
+    a->pos = v2_add(w.stations[0].pos, v2(3000.0f, 0.0f));
+
+    /* Run up to 60 sim seconds (was 30 in the pre-fix design but the
+     * NPC also has to reacquire its target after my override expires). */
+    bool reached = false;
+    for (int i = 0; i < 7200 && !reached; i++) {
+        world_sim_step(&w, SIM_DT);
+        const npc_ship_t *npc = &w.npc_ships[miner];
+        if (npc->state == NPC_STATE_MINING) { reached = true; break; }
+        /* Also accept "very close to the asteroid" — MINING transition
+         * is gated by visibility cone which can lag a tick. */
+        if (v2_dist_sq(npc->ship.pos, a->pos) < (MINING_RANGE * 1.5f) * (MINING_RANGE * 1.5f)) {
+            reached = true; break;
+        }
+    }
+    ASSERT(reached);
+}
+
 TEST(test_scenario_upgrade_requires_products) {
     WORLD_DECL;
     world_reset(&w);
@@ -1314,6 +1382,7 @@ void register_world_sim_scenarios_tests(void) {
     RUN(test_manifest_conservation_across_transactions);
     RUN(test_scenario_two_players_mining);
     RUN(test_scenario_npc_economy_30_seconds);
+    RUN(test_npc_exits_station_with_blocked_rings);
     RUN(test_scenario_upgrade_requires_products);
     RUN(test_scenario_emergency_recovery);
     RUN(test_scenario_product_cap_pauses_production);

--- a/src/world_draw.c
+++ b/src/world_draw.c
@@ -650,6 +650,35 @@ static void draw_module_at(vec2 pos, float angle, module_type_t type, bool scaff
         }
     } else {
         draw_module_shape(type, mr, mg, mb, 0.92f);
+
+        /* Demand beacon: a docked station that is starving for some
+         * commodity outlines its DOCK module in pulsing yellow so
+         * arriving players can see "go here, they're paying premium"
+         * from the system view. Severity threshold matches the
+         * contract-pricing kick-in (priorities 3-6 charge an
+         * up-to-1.5x demand mult once severity > 0). 0.3 is the
+         * "noticeable shortfall" floor — below that the multiplier
+         * is < 1.15x and the visual noise isn't worth it. */
+        if (type == MODULE_DOCK && station != NULL) {
+            station_demand_t dem = station_top_demand(station);
+            if (dem.severity >= 0.3f) {
+                /* Pulse: 1.5 Hz, deeper at higher severity. Yellow
+                 * (1.0, 0.85, 0.2) is distinct from scaffold amber
+                 * and the green dock-berth indicator. */
+                float pulse = 0.55f + 0.35f * sinf(g.world.time * 1.5f);
+                float alpha = pulse * (0.5f + 0.5f * dem.severity);
+                /* Local-coord box slightly outside the dock's 28x24
+                 * outline (see draw_module_shape MODULE_DOCK). */
+                const float ox = 32.0f, oy = 28.0f;
+                sgl_c4f(1.0f, 0.85f, 0.2f, alpha);
+                sgl_begin_lines();
+                sgl_v2f(-ox, -oy); sgl_v2f( ox, -oy);
+                sgl_v2f( ox, -oy); sgl_v2f( ox,  oy);
+                sgl_v2f( ox,  oy); sgl_v2f(-ox,  oy);
+                sgl_v2f(-ox,  oy); sgl_v2f(-ox, -oy);
+                sgl_end();
+            }
+        }
     }
 
     sgl_pop_matrix();


### PR DESCRIPTION
## Summary

38 commits accumulated locally since last push. All individually scoped, all green (493 tests pass), all already running on the local deploy via post-commit hook. Bundled here for upstream review/merge.

Major themes (newest first):

### Demand primitive + HUD beacon (4 commits)
- `feat(econ): station_top_demand` + `station_demand_for` primitives in `shared/station_util` — pure derived state, agrees with the priority-3..6 contract deficit calc on what "starving" means
- `feat(econ): contract pricing layers in station_demand_for multiplier` — all four contract-pricing sites now scale base_price by 1.0×–1.5× per severity
- `feat(hud): demand beacon — pulsing yellow outline on starving stations`
- `test(construction): end-to-end outpost build + supply + activation` — plants outpost, supplies it, builds furnace + hopper, smelts ore, asserts credit conservation

### Identity audit fixes (6 commits)
Multiple sites were comparing `session_token` (8 bytes) against `player_pubkey` ledger field (32 bytes), or using the wrong identity for legacy/registered players. Fixed across:
- pubkey-reconnect ledger migration (8/32 byte memcmp/memcpy mismatch)
- respawn fee + dock seed fee
- broadcast balance reads
- buy/balance/hail handlers
- smelt payout credits
- NPCs overwriting player tow stamps

### Net + WASM nonce fix (2 commits)
- Client signed-action nonces use wall-clock (`emscripten_date_now`), not `performance.now()` (page-load-relative, breaks replay protection across reloads)

### Ring physics (5 commits)
- All-passive ring dynamics + output-hopper spokes
- `apply_spoke_torque` extracted, stale comments cleaned
- `arm_omega` bootstrap on outpost activation
- Smelt silo selector requires matching ore-tagged hopper
- NPC dock-radial exit waypoint routing

### Laser primitive (4 commits)
- `feat(laser): unified laser-beam primitive in shared/`
- Migrated smelt-progress accumulator, mining-beam HP damage, find_scan_target circle-target tests

### Tractor primitive (6 commits)
- `feat(tractor): unified tractor-beam primitive in shared/` (per the consolidation plan)
- Migrated player tow, NPC fragment tow + scaffold tow, smelt beam pull, blueprint pull, slot snap
- Header doc block finalized with migrated sites + caveats

### Save format v51 + station seed pass (4 commits)
- v51 cargo-in-space migration: furnace tags + output hoppers
- Output declarations + furnace per-instance commodity tag in module schema
- Output-hopper layout validator + `add_furnace_for`
- Seed Prospect's FERRITE_INGOT output hopper, tag seeded furnaces, add Helios output hoppers

## Test plan

- [x] `make test` — 493 single-shard, 370 no-soak (all pass)
- [x] Native + server + wasm build clean
- [x] Local deploy via post-commit hook running at HEAD
- [ ] Playtest: PvP rock-fling loop, dock-buy, contract delivery, outpost plant + supply
- [ ] Playtest: yellow demand beacon visible on starving stations from system view

🤖 Generated with [Claude Code](https://claude.com/claude-code)