### PR TITLE
fix(msvc): unbreak Windows + Linux native builds (rename shadowing locals + #define SCAFFOLD_SNAP_PULL)

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -2427,27 +2427,27 @@ static bool find_scan_target(world_t *w, server_player_t *sp, vec2 muzzle, vec2 
             if (t_hit < 0.0f || t_hit >= best_dist) continue;
             /* Verify the hit is on the ring band, not just crossing the
              * inner empty space (annulus check via distance from station). */
-            vec2 hit = v2_add(muzzle, v2_scale(forward, t_hit));
-            float hit_dist = v2_len(v2_sub(hit, st->pos));
+            vec2 ring_hit = v2_add(muzzle, v2_scale(forward, t_hit));
+            float hit_dist = v2_len(v2_sub(ring_hit, st->pos));
             if (fabsf(hit_dist - rr) > ring_thickness) continue;
             best_dist = t_hit;
             sp->scan_target_type = 1;
             sp->scan_target_index = si;
             sp->scan_module_index = -1;
-            sp->beam_end = hit;
+            sp->beam_end = ring_hit;
         }
         /* Check individual modules */
         for (int mi = 0; mi < st->module_count; mi++) {
             if (st->modules[mi].scaffold) continue;
             vec2 mp = module_world_pos_ring(st, st->modules[mi].ring, st->modules[mi].slot);
-            vec2 hit; float along;
-            if (laser_target_in_beam(&ray, mp, STATION_MODULE_COL_RADIUS, &hit, &along)
-                && along < best_dist) {
-                best_dist = along;
+            vec2 mod_hit; float mod_along;
+            if (laser_target_in_beam(&ray, mp, STATION_MODULE_COL_RADIUS, &mod_hit, &mod_along)
+                && mod_along < best_dist) {
+                best_dist = mod_along;
                 sp->scan_target_type = 1;
                 sp->scan_target_index = si;
                 sp->scan_module_index = mi;
-                sp->beam_end = hit;
+                sp->beam_end = mod_hit;
             }
         }
     }
@@ -4059,11 +4059,15 @@ int spawn_scaffold(world_t *w, module_type_t type, vec2 pos, int owner) {
 
 /* Snap range: how close a LOOSE scaffold must be to a ring slot for the
  * station to reach out and grab it. */
-static const float SCAFFOLD_SNAP_RANGE = 200.0f;
-/* How fast the station's tendrils pull a scaffold into position. */
-static const float SCAFFOLD_SNAP_PULL = 4.0f;
+#define SCAFFOLD_SNAP_RANGE 200.0f
+/* How fast the station's tendrils pull a scaffold into position.
+ * #define instead of static const float so MSVC accepts SCAFFOLD_SNAP_PULL
+ * * 3.0f as a constant initializer for the static SCAFFOLD_SNAP tractor
+ * beam below — clang/gcc treat const float as a constant expression but
+ * MSVC does not. */
+#define SCAFFOLD_SNAP_PULL  4.0f
 /* Distance threshold to finalize placement. */
-static const float SCAFFOLD_SNAP_ARRIVE = 8.0f;
+#define SCAFFOLD_SNAP_ARRIVE 8.0f
 
 /* Find the open ring slot on a station that best matches a scaffold's
  * approach. The RING is chosen by the scaffold's distance from the station

--- a/server/main.c
+++ b/server/main.c
@@ -1169,9 +1169,9 @@ static void handle_station_state(struct mg_connection *c, int sid, struct mg_htt
     for (int i = 0; i < rel_count - 1; i++) {
         for (int j = 0; j < rel_count - 1 - i; j++) {
             if (st->ledger[rel_indices[j]].last_dock_tick < st->ledger[rel_indices[j+1]].last_dock_tick) {
-                int tmp = rel_indices[j];
+                int swap = rel_indices[j];
                 rel_indices[j] = rel_indices[j+1];
-                rel_indices[j+1] = tmp;
+                rel_indices[j+1] = swap;
             }
         }
     }


### PR DESCRIPTION
## Summary

Restores native CI builds. PR #539 was merged from `251281e`, one commit before the MSVC fix landed on the source branch, so `main` shipped without it. This PR cherry-picks the fix directly onto `main` plus a follow-up shadow fix that the same Windows log surfaced.

Three errors fixed:
- `server/game_sim.c` — `vec2 hit; float along;` blocks at lines 2400/2443/2460 trip MSVC `C4456` (warning-as-error). Renamed inner per-target locals to `ring_hit` / `mod_hit` / `mod_along`.
- `server/game_sim.c:4342` — `static const tractor_beam_t SCAFFOLD_SNAP = { .pull_strength = SCAFFOLD_SNAP_PULL * 3.0f, ... }` failed MSVC `C2099` ("initializer is not a constant") because `SCAFFOLD_SNAP_PULL` was a `static const float`. Promoted to `#define`.
- `server/main.c:1172` — `int tmp` swap variable in `get_station_relationships` bubble-sort shadowed the outer `char tmp[32]` query-param scratch buffer. Renamed to `swap`.

## Test plan
- [x] Linux native rebuild green locally (`signal`, `signal_server`, `signal_test`)
- [ ] CI: `native (windows-latest)`, `native (ubuntu-latest)`, `native (macos-latest)` all green
- [ ] Auto-issue #329 stops re-firing on next deploy