### PR TITLE
feat(mining): scale fracture burst cap with distance

### DIFF
--- a/server/sim_asteroid.c
+++ b/server/sim_asteroid.c
@@ -137,6 +137,28 @@ static int fracture_find_by_id(const world_t *w, uint32_t fracture_id) {
     return -1;
 }
 
+/* Distance-graded burst cap: rocks near the spawn cluster (origin)
+ * fracture with the baseline FRACTURE_CHALLENGE_BURST_CAP attempts;
+ * rocks further out get more attempts, which raises the probability
+ * tail on rare prefix classes (RATi etc.). The driver: pushing the
+ * frontier outward — planting outposts, hauling deeper — should pay
+ * better-graded ore, not just more of the same. The scaling is gentle
+ * (50 → 200 over 30 kU) so the existing prefix distribution stays
+ * dominant near the seed cluster and the dial only matters as players
+ * actually expand. Wire byte 41 already carries burst_cap, so clients
+ * search the matching range with no protocol change. */
+uint16_t mining_burst_cap_for_position(vec2 pos) {
+    const float SCALE_START = 5000.0f;     /* below this — baseline */
+    const float SCALE_FULL  = 30000.0f;    /* above this — clamped at max */
+    const uint16_t CAP_MIN  = FRACTURE_CHALLENGE_BURST_CAP;     /* 50 */
+    const uint16_t CAP_MAX  = FRACTURE_CHALLENGE_BURST_CAP * 4; /* 200 */
+    float dist = sqrtf(pos.x * pos.x + pos.y * pos.y);
+    if (dist <= SCALE_START) return CAP_MIN;
+    if (dist >= SCALE_FULL)  return CAP_MAX;
+    float t = (dist - SCALE_START) / (SCALE_FULL - SCALE_START);
+    return (uint16_t)(CAP_MIN + t * (float)(CAP_MAX - CAP_MIN));
+}
+
 static void fracture_begin_claim_window(world_t *w, int asteroid_idx) {
     fracture_claim_state_t *state;
     asteroid_t *a;
@@ -149,7 +171,7 @@ static void fracture_begin_claim_window(world_t *w, int asteroid_idx) {
     state->challenge_dirty = true;
     state->fracture_id = w->next_fracture_id;
     state->deadline_ms = (uint32_t)(w->time * 1000.0f) + 500u;
-    state->burst_cap = FRACTURE_CHALLENGE_BURST_CAP;
+    state->burst_cap = mining_burst_cap_for_position(a->pos);
     a->grade = MINING_GRADE_COMMON;
     memset(a->fragment_pub, 0, sizeof(a->fragment_pub));
     a->net_dirty = true;

--- a/server/sim_asteroid.h
+++ b/server/sim_asteroid.h
@@ -37,6 +37,12 @@ int  seed_asteroid_clump(world_t *w, int first_slot);
 void seed_field_asteroid_of_tier(world_t *w, asteroid_t *a, asteroid_tier_t tier);
 void seed_random_field_asteroid(world_t *w, asteroid_t *a);
 
+/* Distance-graded fracture burst cap — exposed for tests. Production
+ * callers never invoke this directly; they pick it up through
+ * fracture_begin_claim_window which now reads it off the asteroid's
+ * world position. */
+uint16_t mining_burst_cap_for_position(vec2 pos);
+
 /*
  * Already declared in game_sim.h:
  *   fracture_asteroid

--- a/src/tests/test_asteroid.c
+++ b/src/tests/test_asteroid.c
@@ -98,6 +98,52 @@ TEST(test_clear_asteroid_marks_net_dirty_when_was_active) {
     ASSERT(!b.net_dirty);
 }
 
+/* Distance-graded mining: rocks near the spawn cluster keep the
+ * baseline burst cap (50), rocks at the frontier fracture with up to
+ * 200 attempts, raising the probability tail on rare prefix classes.
+ * This is the lever that makes pushing outward pay off — players who
+ * plant outposts deeper find better-graded ore, not just more of the
+ * same. */
+TEST(test_burst_cap_baseline_at_origin) {
+    vec2 origin = v2(0.0f, 0.0f);
+    ASSERT_EQ_INT((int)mining_burst_cap_for_position(origin),
+                  (int)FRACTURE_CHALLENGE_BURST_CAP);
+    /* Anywhere within the seed cluster radius (5 kU) stays at baseline. */
+    ASSERT_EQ_INT((int)mining_burst_cap_for_position(v2(3000.0f, 4000.0f)),
+                  (int)FRACTURE_CHALLENGE_BURST_CAP);
+}
+
+TEST(test_burst_cap_clamps_at_far_frontier) {
+    /* Past 30 kU the cap is at maximum — 4× the baseline. */
+    uint16_t cap = mining_burst_cap_for_position(v2(50000.0f, 0.0f));
+    ASSERT_EQ_INT((int)cap, (int)(FRACTURE_CHALLENGE_BURST_CAP * 4));
+}
+
+TEST(test_burst_cap_scales_monotonically_with_distance) {
+    /* Strict monotonicity in the linear range so every kU outward is
+     * a real (not just notional) bump. */
+    uint16_t near    = mining_burst_cap_for_position(v2( 6000.0f, 0.0f));
+    uint16_t mid     = mining_burst_cap_for_position(v2(15000.0f, 0.0f));
+    uint16_t farish  = mining_burst_cap_for_position(v2(25000.0f, 0.0f));
+    ASSERT(near < mid);
+    ASSERT(mid  < farish);
+    ASSERT(near >= FRACTURE_CHALLENGE_BURST_CAP);
+    ASSERT(farish <= FRACTURE_CHALLENGE_BURST_CAP * 4);
+}
+
+TEST(test_burst_cap_isotropic) {
+    /* Distance-only (not direction): the gradient must be radially
+     * symmetric, otherwise frontier outposts on one axis would pay
+     * differently than on another. */
+    float r = 18000.0f;
+    uint16_t east  = mining_burst_cap_for_position(v2( r,  0.0f));
+    uint16_t north = mining_burst_cap_for_position(v2( 0.0f,  r));
+    uint16_t sw    = mining_burst_cap_for_position(v2(-r * 0.7071f, -r * 0.7071f));
+    ASSERT_EQ_INT((int)east, (int)north);
+    /* sqrt(2)/2 ≈ 0.7071 keeps |sw| == r exactly so the cap matches too. */
+    ASSERT(abs((int)east - (int)sw) <= 1);
+}
+
 void register_asteroid_tests(void) {
     TEST_SECTION("Asteroid helper tests:\n");
     RUN(test_asteroid_tier_name_all);
@@ -107,6 +153,10 @@ void register_asteroid_tests(void) {
     RUN(test_asteroid_progress_ratio_tier_s_uses_ore);
     RUN(test_asteroid_progress_ratio_falls_back_to_hp);
     RUN(test_asteroid_progress_ratio_zero_when_uninitialized);
+    RUN(test_burst_cap_baseline_at_origin);
+    RUN(test_burst_cap_clamps_at_far_frontier);
+    RUN(test_burst_cap_scales_monotonically_with_distance);
+    RUN(test_burst_cap_isotropic);
     RUN(test_asteroid_geom_ladder_strictly_decreases);
     RUN(test_clear_asteroid_marks_net_dirty_when_was_active);
 }


### PR DESCRIPTION
## Summary

Scales asteroid fracture burst cap with distance from the origin so far-field asteroid breaks can emit enough child fragments while keeping near-origin behavior constrained.

## Changes

- Adds a distance-aware fracture burst cap helper.
- Applies it to asteroid fracture emission.
- Adds regression coverage for origin, mid-field, and far-field cap behavior.

## Test plan

- [x] pre-push hook: 505 tests passed for 9a0df2f