### PR TITLE
test(smoke): cover client core loop in browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-web build-server build-test test test-serial test-fast test-soak test-all crap dev dev-logs dev-clean stop deploy clean install-hooks
+.PHONY: all build build-web build-server build-test test test-serial test-fast test-soak test-all smoke crap dev dev-logs dev-clean stop deploy clean install-hooks
 
 all: build build-web build-server
 
@@ -118,6 +118,11 @@ test-all: build-test
 
 test-serial: build-test
 	./build/signal_test --no-soak $(TEST_QUIET)
+
+# Browser smoke: builds the WASM client, serves build-web locally, and
+# drives the canvas through the same Playwright smoke used after deploy.
+smoke: build-web
+	npm run smoke
 
 # --- CRAP (Change Risk Anti-Patterns): complexity * (1 - coverage) ---
 # Rebuilds signal_test with --coverage, runs it, then joins gcovr line

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "private": true,
+  "scripts": {
+    "smoke": "playwright test",
+    "smoke:headed": "playwright test --headed"
+  },
   "devDependencies": {
     "@playwright/test": "^1.52.0"
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,22 +1,27 @@
 import { defineConfig } from '@playwright/test';
 
 const liveUrl = process.env.SMOKE_URL;
+const port = Number(process.env.SMOKE_PORT || 3000);
 
 export default defineConfig({
   testDir: './tests',
-  timeout: 30_000,
+  timeout: 45_000,
   use: {
     headless: true,
-    baseURL: liveUrl || 'http://localhost:3000',
+    baseURL: liveUrl || `http://127.0.0.1:${port}`,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
   },
   projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],
-  // Only start local server if not testing live URL
+  // Only start a local static server if not testing the deployed URL.
+  // `make smoke` builds build-web first; the smoke spec adds
+  // ?singleplayer=1 so local runs do not require docker/ws://:9091.
   ...(liveUrl
     ? {}
     : {
         webServer: {
-          command: 'npx serve build-web -l 3000 --no-clipboard',
-          port: 3000,
+          command: `python3 -m http.server ${port} --directory build-web`,
+          port,
           reuseExistingServer: !process.env.CI,
         },
       }),

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -1,91 +1,290 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page, type Locator } from '@playwright/test';
+import { inflateSync } from 'node:zlib';
+
+const fatalPattern =
+  /abort|unreachable|RuntimeError|LinkError|compile failed|Cannot enlarge memory|exception thrown/i;
+
+type FatalCollectors = {
+  pageErrors: string[];
+  consoleErrors: string[];
+};
+
+type CanvasStats = {
+  pixels: number;
+  nonBlackRatio: number;
+  uniqueBuckets: number;
+  avgLuma: number;
+};
+
+function smokeUrl(): string {
+  return process.env.SMOKE_URL || '/signal.html?singleplayer=1';
+}
+
+function installFatalCollectors(page: Page): FatalCollectors {
+  const logs: FatalCollectors = { pageErrors: [], consoleErrors: [] };
+  page.on('pageerror', (err) => logs.pageErrors.push(err.message));
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') logs.consoleErrors.push(msg.text());
+  });
+  return logs;
+}
+
+function expectNoFatalErrors(logs: FatalCollectors): void {
+  expect(logs.pageErrors.filter((e) => fatalPattern.test(e))).toEqual([]);
+  expect(logs.consoleErrors.filter((e) => fatalPattern.test(e))).toEqual([]);
+}
+
+function paethPredictor(a: number, b: number, c: number): number {
+  const p = a + b - c;
+  const pa = Math.abs(p - a);
+  const pb = Math.abs(p - b);
+  const pc = Math.abs(p - c);
+  if (pa <= pb && pa <= pc) return a;
+  if (pb <= pc) return b;
+  return c;
+}
+
+function pngStats(png: Buffer): CanvasStats {
+  const signature = '89504e470d0a1a0a';
+  expect(png.subarray(0, 8).toString('hex')).toBe(signature);
+
+  let width = 0;
+  let height = 0;
+  let bitDepth = 0;
+  let colorType = 0;
+  let interlace = 0;
+  const idat: Buffer[] = [];
+
+  for (let off = 8; off < png.length;) {
+    const len = png.readUInt32BE(off);
+    const type = png.subarray(off + 4, off + 8).toString('ascii');
+    const data = png.subarray(off + 8, off + 8 + len);
+    off += 12 + len;
+
+    if (type === 'IHDR') {
+      width = data.readUInt32BE(0);
+      height = data.readUInt32BE(4);
+      bitDepth = data[8];
+      colorType = data[9];
+      interlace = data[12];
+    } else if (type === 'IDAT') {
+      idat.push(Buffer.from(data));
+    } else if (type === 'IEND') {
+      break;
+    }
+  }
+
+  expect(width).toBeGreaterThan(0);
+  expect(height).toBeGreaterThan(0);
+  expect(bitDepth).toBe(8);
+  expect(interlace).toBe(0);
+
+  const channels = colorType === 6 ? 4 : colorType === 2 ? 3 : 0;
+  expect(channels).toBeGreaterThan(0);
+
+  const stride = width * channels;
+  const inflated = inflateSync(Buffer.concat(idat));
+  const pixels = new Uint8Array(height * stride);
+  let src = 0;
+
+  for (let y = 0; y < height; y++) {
+    const filter = inflated[src++];
+    const row = pixels.subarray(y * stride, (y + 1) * stride);
+    const prev = y > 0 ? pixels.subarray((y - 1) * stride, y * stride) : undefined;
+
+    for (let x = 0; x < stride; x++) {
+      const raw = inflated[src++];
+      const left = x >= channels ? row[x - channels] : 0;
+      const up = prev ? prev[x] : 0;
+      const upLeft = prev && x >= channels ? prev[x - channels] : 0;
+      let value: number;
+
+      if (filter === 0) value = raw;
+      else if (filter === 1) value = raw + left;
+      else if (filter === 2) value = raw + up;
+      else if (filter === 3) value = raw + Math.floor((left + up) / 2);
+      else if (filter === 4) value = raw + paethPredictor(left, up, upLeft);
+      else throw new Error(`unsupported PNG filter ${filter}`);
+
+      row[x] = value & 0xff;
+    }
+  }
+
+  let nonBlack = 0;
+  let lumaSum = 0;
+  const buckets = new Set<string>();
+
+  for (let i = 0; i < pixels.length; i += channels) {
+    const r = pixels[i];
+    const g = pixels[i + 1];
+    const b = pixels[i + 2];
+    const a = channels === 4 ? pixels[i + 3] : 255;
+    const luma = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    lumaSum += luma;
+    if (a > 0 && luma > 6) nonBlack++;
+    buckets.add(`${r >> 4}:${g >> 4}:${b >> 4}:${a >> 6}`);
+  }
+
+  const count = width * height;
+  return {
+    pixels: count,
+    nonBlackRatio: count ? nonBlack / count : 0,
+    uniqueBuckets: buckets.size,
+    avgLuma: count ? lumaSum / count : 0,
+  };
+}
+
+async function readCanvasStats(canvas: Locator): Promise<CanvasStats> {
+  return pngStats(await canvas.screenshot());
+}
+
+async function waitForRuntime(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const mod = (window as unknown as { Module?: { ccall?: unknown } }).Module;
+      return !!mod && typeof mod.ccall === 'function';
+    },
+    undefined,
+    { timeout: 20_000 },
+  );
+}
+
+async function signalStrength(page: Page): Promise<number | null> {
+  return page.evaluate(() => {
+    const mod = (window as unknown as {
+      Module?: { ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => number };
+    }).Module;
+    if (!mod || typeof mod.ccall !== 'function') return null;
+    const value = mod.ccall('get_signal_strength', 'number', [], []);
+    return Number.isFinite(value) ? value : null;
+  });
+}
+
+async function waitForRenderedGame(page: Page, canvas: Locator): Promise<void> {
+  await expect(canvas).toBeVisible({ timeout: 20_000 });
+  await waitForRuntime(page);
+
+  const box = await canvas.boundingBox();
+  expect(box).toBeTruthy();
+  expect(box!.width).toBeGreaterThan(100);
+  expect(box!.height).toBeGreaterThan(100);
+
+  await expect
+    .poll(async () => (await readCanvasStats(canvas)).nonBlackRatio, {
+      timeout: 12_000,
+      message: 'canvas should contain rendered pixels',
+    })
+    .toBeGreaterThan(0.05);
+
+  await expect
+    .poll(async () => (await readCanvasStats(canvas)).uniqueBuckets, {
+      timeout: 12_000,
+      message: 'canvas should contain varied game pixels',
+    })
+    .toBeGreaterThan(8);
+
+  const signal = await signalStrength(page);
+  expect(signal).not.toBeNull();
+  expect(signal!).toBeGreaterThanOrEqual(0);
+}
+
+async function loadGame(page: Page): Promise<Locator> {
+  await page.goto(smokeUrl());
+  const canvas = page.locator('canvas');
+  await waitForRenderedGame(page, canvas);
+  return canvas;
+}
+
+async function tap(page: Page, key: string, pauseMs = 80): Promise<void> {
+  await page.keyboard.press(key);
+  await page.waitForTimeout(pauseMs);
+}
+
+async function hold(page: Page, key: string, ms: number): Promise<void> {
+  await page.keyboard.down(key);
+  await page.waitForTimeout(ms);
+  await page.keyboard.up(key);
+  await page.waitForTimeout(80);
+}
+
+async function driveCoreControls(page: Page, canvas: Locator): Promise<void> {
+  await canvas.click();
+
+  await tap(page, 'Escape');
+  await tap(page, 'e');        // launch if docked, interact if already undocked
+  await hold(page, 'w', 450);
+  await hold(page, 'a', 220);
+  await hold(page, 'd', 220);
+  await hold(page, 'Shift', 300);
+  await tap(page, 'h');        // hail / collect credits
+  await hold(page, 'm', 500);  // mining beam
+  await hold(page, 'Space', 550);
+  await tap(page, 'Space');    // release tow tap path
+  await tap(page, 'b');        // plan mode
+  await tap(page, 'r');        // cycle planned module / tow control
+  await tap(page, 'e');        // place / interact
+  await tap(page, 'Escape');   // leave plan mode
+  await tap(page, 'Tab');      // docked tab cycling if docked
+  await tap(page, 'f');        // docked buy primary product if docked
+  await tap(page, 's');        // docked sell-all if docked
+  await tap(page, '1');        // first visible row action
+  await tap(page, '2');        // second visible row action / repair
+  await tap(page, 'o');        // autopilot toggle
+}
 
 test.describe('Browser smoke tests', () => {
-  test('WASM module loads and canvas appears', async ({ page }) => {
-    const errors: string[] = [];
-    const consoleErrors: string[] = [];
-    page.on('pageerror', (err) => errors.push(err.message));
-    page.on('console', (msg) => {
-      if (msg.type() === 'error') consoleErrors.push(msg.text());
-    });
+  test('boots, renders, and persists browser identity across reload', async ({ page }) => {
+    const logs = installFatalCollectors(page);
 
-    // Go to SMOKE_URL directly (not '/'), because Playwright's baseURL
-    // contributes its origin only — page.goto('/') against
-    // baseURL=https://signal.ratimics.com/play/ would land on the
-    // marketing root, which has no canvas.
-    const url = process.env.SMOKE_URL || '/signal.html';
-    await page.goto(url);
+    await loadGame(page);
+    const firstIdentity = await page.evaluate(() => window.localStorage.getItem('signal:identity'));
+    expect(firstIdentity).toMatch(/^[A-Za-z0-9+/]{86}==$/);
 
-    // Wait for the Emscripten canvas to appear
-    const canvas = page.locator('canvas');
-    await expect(canvas).toBeVisible({ timeout: 15_000 });
+    await page.reload();
+    await waitForRenderedGame(page, page.locator('canvas'));
+    const secondIdentity = await page.evaluate(() => window.localStorage.getItem('signal:identity'));
+    expect(secondIdentity).toBe(firstIdentity);
 
-    // Give WASM a moment to fully initialize (link errors can be deferred)
-    await page.waitForTimeout(2_000);
+    expectNoFatalErrors(logs);
+  });
 
-    // Canvas should have real dimensions
+  test('desktop core controls stay alive through the golden path keys', async ({ page }) => {
+    const logs = installFatalCollectors(page);
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const canvas = await loadGame(page);
+
+    await driveCoreControls(page, canvas);
+    await expect
+      .poll(async () => (await readCanvasStats(canvas)).uniqueBuckets, { timeout: 5_000 })
+      .toBeGreaterThan(8);
+
+    expectNoFatalErrors(logs);
+  });
+
+  test('narrow viewport renders and accepts dock/trade/build hotkeys', async ({ page }) => {
+    const logs = installFatalCollectors(page);
+    await page.setViewportSize({ width: 390, height: 760 });
+    const canvas = await loadGame(page);
+
+    await canvas.click();
+    await tap(page, 'Escape');
+    await tap(page, 'Tab');
+    await tap(page, 'Tab');
+    await tap(page, 'f');
+    await tap(page, 's');
+    await tap(page, '1');
+    await tap(page, '2');
+    await tap(page, 'e');
+    await hold(page, 'w', 300);
+
     const box = await canvas.boundingBox();
     expect(box).toBeTruthy();
-    expect(box!.width).toBeGreaterThan(100);
-    expect(box!.height).toBeGreaterThan(100);
+    expect(box!.width).toBeGreaterThan(300);
+    expect(box!.height).toBeGreaterThan(500);
+    await expect
+      .poll(async () => (await readCanvasStats(canvas)).nonBlackRatio, { timeout: 5_000 })
+      .toBeGreaterThan(0.05);
 
-    // No fatal JS errors during startup
-    const fatalPattern = /abort|unreachable|RuntimeError|LinkError|compile failed/i;
-    expect(errors.filter((e) => fatalPattern.test(e))).toHaveLength(0);
-    // No fatal console.error messages (catches WASM link failures logged via printErr)
-    expect(consoleErrors.filter((e) => fatalPattern.test(e))).toHaveLength(0);
-  });
-
-  test('keyboard input does not crash', async ({ page }) => {
-    const errors: string[] = [];
-    page.on('pageerror', (err) => errors.push(err.message));
-
-    // Go to SMOKE_URL directly (not '/'), because Playwright's baseURL
-    // contributes its origin only — page.goto('/') against
-    // baseURL=https://signal.ratimics.com/play/ would land on the
-    // marketing root, which has no canvas.
-    const url = process.env.SMOKE_URL || '/signal.html';
-    await page.goto(url);
-    const canvas = page.locator('canvas');
-    await expect(canvas).toBeVisible({ timeout: 15_000 });
-
-    // Focus the canvas and send key presses
-    await canvas.click();
-    await page.keyboard.press('w');
-    await page.keyboard.press('a');
-    await page.keyboard.press('Space');
-    await page.keyboard.press('Escape');
-
-    // Wait a beat for any deferred crashes
-    await page.waitForTimeout(500);
-
-    expect(errors.filter((e) => /abort|unreachable|RuntimeError/i.test(e))).toHaveLength(0);
-  });
-
-  test('focus loss does not crash', async ({ page }) => {
-    const errors: string[] = [];
-    page.on('pageerror', (err) => errors.push(err.message));
-
-    // Go to SMOKE_URL directly (not '/'), because Playwright's baseURL
-    // contributes its origin only — page.goto('/') against
-    // baseURL=https://signal.ratimics.com/play/ would land on the
-    // marketing root, which has no canvas.
-    const url = process.env.SMOKE_URL || '/signal.html';
-    await page.goto(url);
-    const canvas = page.locator('canvas');
-    await expect(canvas).toBeVisible({ timeout: 15_000 });
-
-    // Focus then blur
-    await canvas.click();
-    await page.keyboard.press('w');
-    await page.evaluate(() => document.activeElement instanceof HTMLElement && document.activeElement.blur());
-    await page.waitForTimeout(300);
-
-    // Re-focus
-    await canvas.click();
-    await page.keyboard.press('w');
-    await page.waitForTimeout(300);
-
-    expect(errors.filter((e) => /abort|unreachable|RuntimeError/i.test(e))).toHaveLength(0);
+    expectNoFatalErrors(logs);
   });
 });

--- a/web/play.html
+++ b/web/play.html
@@ -79,14 +79,17 @@
         printErr: function(text) { console.error(text); }
       };
 
-      /* Default SIGNAL_SERVER to the local docker websocket when this
+      /* ?singleplayer=1 forces the in-process server for local smoke
+       * tests and client-only iteration. Otherwise, default
+       * SIGNAL_SERVER to the local docker websocket when this
        * page is served from localhost / 127.0.0.1 / a private LAN IP.
        * Without this, opening http://localhost:8080/signal.html stays in
        * singleplayer and the docker signal_server on :9091 is unused —
        * which means no global highscores, no other players, no chain.
        * Production CDN sets window.SIGNAL_SERVER explicitly before this
        * script runs, so this default never fires there. */
-      if (!window.SIGNAL_SERVER) {
+      var signalParams = new URLSearchParams(window.location.search);
+      if (!signalParams.has('singleplayer') && !window.SIGNAL_SERVER) {
         var h = window.location.hostname;
         var isLocal = (h === 'localhost' || h === '127.0.0.1' || h === '0.0.0.0'
                     || /^192\.168\./.test(h) || /^10\./.test(h)

--- a/web/shell.html
+++ b/web/shell.html
@@ -103,14 +103,17 @@
         }
       };
 
-      /* Default SIGNAL_SERVER to the local docker websocket when this
+      /* ?singleplayer=1 forces the in-process server for local smoke
+       * tests and client-only iteration. Otherwise, default
+       * SIGNAL_SERVER to the local docker websocket when this
        * page is served from a localhost / private-LAN host. Without
        * this, opening http://localhost:8080/signal.html stays in
        * singleplayer and the docker signal_server on :9091 is unused —
        * which means no global highscore broadcast reaches the client.
        * Production sets window.SIGNAL_SERVER explicitly before this
        * script runs, so this default never fires there. */
-      if (!window.SIGNAL_SERVER) {
+      var signalParams = new URLSearchParams(window.location.search);
+      if (!signalParams.has('singleplayer') && !window.SIGNAL_SERVER) {
         var h = window.location.hostname;
         var isLocal = (h === 'localhost' || h === '127.0.0.1' || h === '0.0.0.0'
                     || /^192\.168\./.test(h) || /^10\./.test(h)


### PR DESCRIPTION
Adds a local browser smoke target for the WASM client, expands the Playwright smoke suite to cover rendered pixels, runtime sanity, identity persistence, desktop core controls, and narrow dock/trade/build hotkeys, and adds ?singleplayer=1 so local smoke runs do not require the docker WebSocket server.\n\nValidation:\n- make smoke\n- make test\n- pre-push: 505 tests passed