### PR TITLE
test(smoke): assert HUD hint copy from browser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,7 @@ if(EMSCRIPTEN)
         "SHELL:-sMIN_WEBGL_VERSION=2"
         "SHELL:-sMAX_WEBGL_VERSION=2"
         "SHELL:-sNO_EXIT_RUNTIME=1"
-        "SHELL:-sEXPORTED_FUNCTIONS=['_main','__saudio_emsc_pull','_get_signal_strength']"
+        "SHELL:-sEXPORTED_FUNCTIONS=['_main','__saudio_emsc_pull','_get_signal_strength','_get_hud_hint_text']"
         "SHELL:-sEXPORTED_RUNTIME_METHODS=['ccall','cwrap']"
         "SHELL:--shell-file ${CMAKE_CURRENT_SOURCE_DIR}/web/shell.html"
         "SHELL:-lwebsocket.js"

--- a/src/hud.c
+++ b/src/hud.c
@@ -13,6 +13,9 @@
 #include "mining.h"  /* mining_alphanumeric_callsign — pubkey-derived */
 #include "signal_model.h"
 #include "palette.h"
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 
 /* ------------------------------------------------------------------ */
 /* Station-local balance helper                                        */
@@ -940,6 +943,28 @@ static bool build_hud_message(char* label, size_t label_size, char* message, siz
     /* Nothing to say. Panel is empty. */
     return false;
 }
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+const char *get_hud_hint_text(void) {
+    static char out[384];
+    char label[64];
+    char message[256];
+    uint8_t r = 0, g0 = 0, b = 0;
+
+    out[0] = '\0';
+    label[0] = '\0';
+    message[0] = '\0';
+    if (!build_hud_message(label, sizeof(label), message, sizeof(message), &r, &g0, &b))
+        return out;
+
+    if (label[0] != '\0')
+        snprintf(out, sizeof(out), "%s: %s", label, message);
+    else
+        snprintf(out, sizeof(out), "%s", message);
+    return out;
+}
+#endif
 
 /* ------------------------------------------------------------------ */
 /* draw_hud_panels -- background panel geometry for the flight HUD     */

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -160,6 +160,16 @@ async function signalStrength(page: Page): Promise<number | null> {
   });
 }
 
+async function hudHintText(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const mod = (window as unknown as {
+      Module?: { ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => string };
+    }).Module;
+    if (!mod || typeof mod.ccall !== 'function') return '';
+    return mod.ccall('get_hud_hint_text', 'string', [], []) || '';
+  });
+}
+
 async function waitForRenderedGame(page: Page, canvas: Locator): Promise<void> {
   await expect(canvas).toBeVisible({ timeout: 20_000 });
   await waitForRuntime(page);
@@ -211,25 +221,25 @@ async function driveCoreControls(page: Page, canvas: Locator): Promise<void> {
   await canvas.click();
 
   await tap(page, 'Escape');
-  await tap(page, 'e');        // launch if docked, interact if already undocked
-  await hold(page, 'w', 450);
-  await hold(page, 'a', 220);
-  await hold(page, 'd', 220);
+  await tap(page, 'E');        // launch if docked, interact if already undocked
+  await hold(page, 'W', 450);
+  await hold(page, 'A', 220);
+  await hold(page, 'D', 220);
   await hold(page, 'Shift', 300);
-  await tap(page, 'h');        // hail / collect credits
-  await hold(page, 'm', 500);  // mining beam
+  await tap(page, 'H');        // hail / collect credits
+  await hold(page, 'M', 500);  // mining beam
   await hold(page, 'Space', 550);
   await tap(page, 'Space');    // release tow tap path
-  await tap(page, 'b');        // plan mode
-  await tap(page, 'r');        // cycle planned module / tow control
-  await tap(page, 'e');        // place / interact
+  await tap(page, 'B');        // plan mode
+  await tap(page, 'R');        // cycle planned module / tow control
+  await tap(page, 'E');        // place / interact
   await tap(page, 'Escape');   // leave plan mode
   await tap(page, 'Tab');      // docked tab cycling if docked
-  await tap(page, 'f');        // docked buy primary product if docked
-  await tap(page, 's');        // docked sell-all if docked
+  await tap(page, 'F');        // docked buy primary product if docked
+  await tap(page, 'S');        // docked sell-all if docked
   await tap(page, '1');        // first visible row action
   await tap(page, '2');        // second visible row action / repair
-  await tap(page, 'o');        // autopilot toggle
+  await tap(page, 'O');        // autopilot toggle
 }
 
 test.describe('Browser smoke tests', () => {
@@ -237,8 +247,18 @@ test.describe('Browser smoke tests', () => {
     const logs = installFatalCollectors(page);
 
     await loadGame(page);
+    await expect
+      .poll(async () => hudHintText(page), { timeout: 5_000 })
+      .toContain('Press E to launch.');
+
     const firstIdentity = await page.evaluate(() => window.localStorage.getItem('signal:identity'));
     expect(firstIdentity).toMatch(/^[A-Za-z0-9+/]{86}==$/);
+
+    await page.locator('canvas').click();
+    await tap(page, 'E');
+    await expect
+      .poll(async () => hudHintText(page), { timeout: 8_000 })
+      .toContain('Fly with W A S D.');
 
     await page.reload();
     await waitForRenderedGame(page, page.locator('canvas'));
@@ -252,6 +272,10 @@ test.describe('Browser smoke tests', () => {
     const logs = installFatalCollectors(page);
     await page.setViewportSize({ width: 1280, height: 720 });
     const canvas = await loadGame(page);
+
+    await expect
+      .poll(async () => hudHintText(page), { timeout: 5_000 })
+      .toContain('Press E to launch.');
 
     await driveCoreControls(page, canvas);
     await expect
@@ -270,12 +294,12 @@ test.describe('Browser smoke tests', () => {
     await tap(page, 'Escape');
     await tap(page, 'Tab');
     await tap(page, 'Tab');
-    await tap(page, 'f');
-    await tap(page, 's');
+    await tap(page, 'F');
+    await tap(page, 'S');
     await tap(page, '1');
     await tap(page, '2');
-    await tap(page, 'e');
-    await hold(page, 'w', 300);
+    await tap(page, 'E');
+    await hold(page, 'W', 300);
 
     const box = await canvas.boundingBox();
     expect(box).toBeTruthy();


### PR DESCRIPTION
Exports the current HUD hint text to the WASM runtime and teaches the browser smoke test to assert the actual first-run UX copy.\n\nChanges:\n- add get_hud_hint_text() for Emscripten smoke assertions\n- export the function from the WASM build\n- assert the launch hint and launch-to-flight hint in Playwright\n- keep the broader desktop/narrow control smoke checks as render/no-crash coverage\n\nValidation:\n- make test\n- make smoke\n- pre-push: 505 tests passed