### PR TITLE
[codex] Make server repair paths manifest-backed

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -533,18 +533,16 @@ static void step_scaffold_delivery(world_t *w, server_player_t *sp) {
     if (!sp->docked) return;
     station_t *st = &w->stations[sp->current_station];
     if (!st->scaffold) return;
-    if (sp->ship.cargo[COMMODITY_FRAME] < 0.01f) return;
-    float deliver = sp->ship.cargo[COMMODITY_FRAME];
-    float needed = SCAFFOLD_MATERIAL_NEEDED * (1.0f - st->scaffold_progress);
-    float accepted = fminf(deliver, needed);
-    sp->ship.cargo[COMMODITY_FRAME] -= accepted;
-    st->scaffold_progress += accepted / SCAFFOLD_MATERIAL_NEEDED;
-    /* Consume the matching manifest units so the named identity can't
-     * be sold or transferred again from the same hold. */
-    int whole = (int)floorf(accepted + 0.0001f);
-    if (whole > 0)
-        manifest_consume_by_commodity(&sp->ship.manifest, COMMODITY_FRAME, whole);
-    SIM_LOG("[sim] player %d delivered %.1f frames to scaffold %d (progress %.0f%%)\n",
+    int held = ship_finished_count(&sp->ship, COMMODITY_FRAME);
+    if (held <= 0) return;
+    float needed_f = SCAFFOLD_MATERIAL_NEEDED * (1.0f - st->scaffold_progress);
+    int needed = (int)ceilf(needed_f - 0.0001f);
+    if (needed <= 0) return;
+    int request = held < needed ? held : needed;
+    int accepted = ship_finished_drain(&sp->ship, COMMODITY_FRAME, request);
+    if (accepted <= 0) return;
+    st->scaffold_progress += (float)accepted / SCAFFOLD_MATERIAL_NEEDED;
+    SIM_LOG("[sim] player %d delivered %d frames to scaffold %d (progress %.0f%%)\n",
             sp->id, accepted, sp->current_station, st->scaffold_progress * 100.0f);
     if (st->scaffold_progress >= 1.0f) {
         activate_outpost(w, sp->current_station);
@@ -1411,8 +1409,8 @@ static void try_repair_ship(world_t *w, server_player_t *sp) {
      * retail already if buying here); any other dock charges
      * LABOR_FEE_PER_HP for the install. Partial repair is allowed if
      * neither source has enough kits. */
-    int kits_in_cargo  = (int)floorf(sp->ship.cargo[COMMODITY_REPAIR_KIT] + 0.0001f);
-    int kits_at_station = (int)floorf(st->_inventory_cache[COMMODITY_REPAIR_KIT] + 0.0001f);
+    int kits_in_cargo  = ship_finished_count(&sp->ship, COMMODITY_REPAIR_KIT);
+    int kits_at_station = station_finished_count(st, COMMODITY_REPAIR_KIT);
     int hp_needed       = (int)ceilf(missing);
     int hp_apply        = hp_needed;
     if (hp_apply > kits_in_cargo + kits_at_station)
@@ -1422,30 +1420,16 @@ static void try_repair_ship(world_t *w, server_player_t *sp) {
     int from_cargo   = (hp_apply < kits_in_cargo) ? hp_apply : kits_in_cargo;
     int from_station = hp_apply - from_cargo;
 
-    /* Drain ship cargo + ship manifest. */
-    if (from_cargo > 0) {
-        sp->ship.cargo[COMMODITY_REPAIR_KIT] -= (float)from_cargo;
-        if (sp->ship.cargo[COMMODITY_REPAIR_KIT] < 0.0f)
-            sp->ship.cargo[COMMODITY_REPAIR_KIT] = 0.0f;
-        manifest_consume_by_commodity(&sp->ship.manifest,
-                                      COMMODITY_REPAIR_KIT, from_cargo);
-    }
-
-    /* Drain station inventory + station manifest for the fallback. */
-    if (from_station > 0) {
-        st->_inventory_cache[COMMODITY_REPAIR_KIT] -= (float)from_station;
-        if (st->_inventory_cache[COMMODITY_REPAIR_KIT] < 0.0f)
-            st->_inventory_cache[COMMODITY_REPAIR_KIT] = 0.0f;
-        manifest_consume_by_commodity(&st->manifest,
-                                      COMMODITY_REPAIR_KIT, from_station);
-        st->manifest_dirty = true;
-    }
+    int drained_cargo = ship_finished_drain(&sp->ship, COMMODITY_REPAIR_KIT, from_cargo);
+    int drained_station = station_finished_drain(st, COMMODITY_REPAIR_KIT, from_station);
+    int actual_apply = drained_cargo + drained_station;
+    if (actual_apply <= 0) return;
 
     /* Cost = station retail on station-sourced kits + labor at non-shipyard. */
-    float station_kit_cost = (float)from_station
+    float station_kit_cost = (float)drained_station
                            * station_sell_price(st, COMMODITY_REPAIR_KIT);
     bool is_shipyard = station_has_module(st, MODULE_SHIPYARD);
-    float labor_cost = is_shipyard ? 0.0f : (float)hp_apply * LABOR_FEE_PER_HP;
+    float labor_cost = is_shipyard ? 0.0f : (float)actual_apply * LABOR_FEE_PER_HP;
     float cost = ceilf(station_kit_cost + labor_cost);
     if (cost > 0.0f) {
         if (sp->pubkey_set) {
@@ -1455,9 +1439,9 @@ static void try_repair_ship(world_t *w, server_player_t *sp) {
         }
     }
 
-    sp->ship.hull = fminf(max_hull, sp->ship.hull + (float)hp_apply);
+    sp->ship.hull = fminf(max_hull, sp->ship.hull + (float)actual_apply);
     SIM_LOG("[sim] player %d repaired %d HP (%d cargo + %d station kits, %.0f cr)\n",
-            sp->id, hp_apply, from_cargo, from_station, cost);
+            sp->id, actual_apply, drained_cargo, drained_station, cost);
     emit_event(w, (sim_event_t){.type = SIM_EVENT_REPAIR, .player_id = sp->id});
 }
 
@@ -1478,8 +1462,8 @@ static void try_apply_ship_upgrade(world_t *w, server_player_t *sp, ship_upgrade
     product_t required = upgrade_required_product(upgrade);
     commodity_t comm = (commodity_t)(COMMODITY_FRAME + required);
     int units_needed = (int)ceilf(upgrade_product_cost(&sp->ship, upgrade));
-    int in_cargo  = (int)floorf(sp->ship.cargo[comm] + 0.0001f);
-    int at_station = (int)floorf(st->_inventory_cache[comm] + 0.0001f);
+    int in_cargo  = ship_finished_count(&sp->ship, comm);
+    int at_station = station_finished_count(st, comm);
     if (in_cargo + at_station < units_needed) return;
 
     int from_cargo   = (units_needed < in_cargo) ? units_needed : in_cargo;
@@ -1493,17 +1477,9 @@ static void try_apply_ship_upgrade(world_t *w, server_player_t *sp, ship_upgrade
         if (!can_afford) return;
     }
 
-    if (from_cargo > 0) {
-        sp->ship.cargo[comm] -= (float)from_cargo;
-        if (sp->ship.cargo[comm] < 0.0f) sp->ship.cargo[comm] = 0.0f;
-        manifest_consume_by_commodity(&sp->ship.manifest, comm, from_cargo);
-    }
-    if (from_station > 0) {
-        st->_inventory_cache[comm] -= (float)from_station;
-        if (st->_inventory_cache[comm] < 0.0f) st->_inventory_cache[comm] = 0.0f;
-        manifest_consume_by_commodity(&st->manifest, comm, from_station);
-        st->manifest_dirty = true;
-    }
+    int drained_cargo = ship_finished_drain(&sp->ship, comm, from_cargo);
+    int drained_station = station_finished_drain(st, comm, from_station);
+    if (drained_cargo + drained_station < units_needed) return;
 
     switch (upgrade) {
     case SHIP_UPGRADE_MINING:  sp->ship.mining_level++;  break;
@@ -1512,8 +1488,8 @@ static void try_apply_ship_upgrade(world_t *w, server_player_t *sp, ship_upgrade
     default: break;
     }
     SIM_LOG("[sim] player %d upgraded %d to level %d (%d cargo + %d dock kits, %.0f cr)\n",
-           sp->id, (int)upgrade, ship_upgrade_level(&sp->ship, upgrade),
-           from_cargo, from_station, credit_cost);
+            sp->id, (int)upgrade, ship_upgrade_level(&sp->ship, upgrade),
+            drained_cargo, drained_station, credit_cost);
     emit_event(w, (sim_event_t){.type = SIM_EVENT_UPGRADE, .player_id = sp->id, .upgrade.upgrade = upgrade});
 }
 
@@ -3944,8 +3920,9 @@ static void step_contracts(world_t *w, float dt) {
             && station_has_module(st, MODULE_DOCK)
             && !station_has_module(st, MODULE_SHIPYARD)) {
             const float kit_import_threshold = REPAIR_KIT_STOCK_CAP * 0.25f;
-            if (st->_inventory_cache[COMMODITY_REPAIR_KIT] < kit_import_threshold) {
-                float deficit = REPAIR_KIT_STOCK_CAP - st->_inventory_cache[COMMODITY_REPAIR_KIT];
+            float kits_on_hand = (float)station_finished_count(st, COMMODITY_REPAIR_KIT);
+            if (kits_on_hand < kit_import_threshold) {
+                float deficit = REPAIR_KIT_STOCK_CAP - kits_on_hand;
                 float seed = st->base_price[COMMODITY_REPAIR_KIT] > 0.0f
                              ? st->base_price[COMMODITY_REPAIR_KIT]
                              : 6.0f;

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -1161,20 +1161,23 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
             }
             /* Hauler also delivers ingots to scaffold station and modules */
             if (dest->scaffold || dest->module_count > 0) {
-                /* Feed from station inventory into scaffolds */
-                ship_t hauler_ship = {0};
-                for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++)
-                    hauler_ship.cargo[c] = dest->_inventory_cache[c];
                 if (dest->scaffold) {
-                    float needed = SCAFFOLD_MATERIAL_NEEDED * (1.0f - dest->scaffold_progress);
-                    float deliver = fminf(hauler_ship.cargo[COMMODITY_FRAME], needed);
-                    if (deliver > 0.01f) {
-                        hauler_ship.cargo[COMMODITY_FRAME] -= deliver;
-                        dest->scaffold_progress += deliver / SCAFFOLD_MATERIAL_NEEDED;
+                    float needed_f = SCAFFOLD_MATERIAL_NEEDED * (1.0f - dest->scaffold_progress);
+                    int held = station_finished_count(dest, COMMODITY_FRAME);
+                    int needed = (int)ceilf(needed_f - 0.0001f);
+                    if (needed < 0) needed = 0;
+                    int request = held < needed ? held : needed;
+                    int delivered = station_finished_drain(dest, COMMODITY_FRAME, request);
+                    if (delivered > 0) {
+                        dest->scaffold_progress += (float)delivered / SCAFFOLD_MATERIAL_NEEDED;
                         if (dest->scaffold_progress >= 1.0f)
                             activate_outpost(w, npc->dest_station);
                     }
                 }
+                /* Feed remaining station inventory into scaffolded modules. */
+                ship_t hauler_ship = {0};
+                for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++)
+                    hauler_ship.cargo[c] = dest->_inventory_cache[c];
                 /* Hauler is paid via the contract path elsewhere; the
                  * build-material payout returned here is discarded. NPC
                  * economic identity tracking happens through
@@ -1233,32 +1236,30 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
             float cur_hull = ship ? ship->hull : npc->hull;
             if (cur_hull < max_h - 0.5f
                 && station_has_module(home, MODULE_DOCK)) {
-                int kits = (int)floorf(home->_inventory_cache[COMMODITY_REPAIR_KIT] + 0.0001f);
+                int kits = station_finished_count(home, COMMODITY_REPAIR_KIT);
                 int missing = (int)ceilf(max_h - cur_hull);
                 int apply = kits < missing ? kits : missing;
                 if (apply > 0) {
-                    float kit_price = home->base_price[COMMODITY_REPAIR_KIT];
-                    if (kit_price < 0.01f) kit_price = 6.0f;
-                    float cost = (float)apply * kit_price;
-                    /* Force-debit -> balance can go negative, station
-                     * still gets credited. Hauler pays it back over
-                     * subsequent deliveries. */
-                    ledger_force_debit(home, npc->session_token, cost, ship);
-                    home->_inventory_cache[COMMODITY_REPAIR_KIT] -= (float)apply;
-                    if (home->_inventory_cache[COMMODITY_REPAIR_KIT] < 0.0f)
-                        home->_inventory_cache[COMMODITY_REPAIR_KIT] = 0.0f;
-                    if (manifest_consume_by_commodity(&home->manifest,
-                                                     COMMODITY_REPAIR_KIT, apply) > 0)
-                        home->manifest_dirty = true;
-                    /* Write through ship layer; reverse-mirror at
-                     * end of the NPC tick pushes the value back to
-                     * npc->hull. */
-                    if (ship) {
-                        ship->hull += (float)apply;
-                        if (ship->hull > max_h) ship->hull = max_h;
-                    } else {
-                        npc->hull += (float)apply;
-                        if (npc->hull > max_h) npc->hull = max_h;
+                    int drained = station_finished_drain(home, COMMODITY_REPAIR_KIT, apply);
+                    if (drained > 0) {
+                        apply = drained;
+                        float kit_price = home->base_price[COMMODITY_REPAIR_KIT];
+                        if (kit_price < 0.01f) kit_price = 6.0f;
+                        float cost = (float)apply * kit_price;
+                        /* Force-debit -> balance can go negative, station
+                         * still gets credited. Hauler pays it back over
+                         * subsequent deliveries. */
+                        ledger_force_debit(home, npc->session_token, cost, ship);
+                        /* Write through ship layer; reverse-mirror at
+                         * end of the NPC tick pushes the value back to
+                         * npc->hull. */
+                        if (ship) {
+                            ship->hull += (float)apply;
+                            if (ship->hull > max_h) ship->hull = max_h;
+                        } else {
+                            npc->hull += (float)apply;
+                            if (npc->hull > max_h) npc->hull = max_h;
+                        }
                     }
                 }
             }
@@ -1270,14 +1271,12 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
              * trip, and the inter-station chain stalls. Force-debit so
              * the hauler is on the hook for upkeep just like a repair. */
             if (station_has_module(home, MODULE_DOCK)
-                && home->_inventory_cache[COMMODITY_REPAIR_KIT] >= 1.0f) {
+                && station_finished_count(home, COMMODITY_REPAIR_KIT) >= 1) {
+                if (station_finished_drain(home, COMMODITY_REPAIR_KIT, 1) <= 0)
+                    break;
                 float kit_price = home->base_price[COMMODITY_REPAIR_KIT];
                 if (kit_price < 0.01f) kit_price = 6.0f;
                 ledger_force_debit(home, npc->session_token, kit_price, ship);
-                home->_inventory_cache[COMMODITY_REPAIR_KIT] -= 1.0f;
-                if (manifest_consume_by_commodity(&home->manifest,
-                                                  COMMODITY_REPAIR_KIT, 1) > 0)
-                    home->manifest_dirty = true;
             }
         }
         break;

--- a/server/sim_autopilot.c
+++ b/server/sim_autopilot.c
@@ -9,6 +9,7 @@
 #include "sim_nav.h"
 #include "sim_flight.h"
 #include "signal_model.h"
+#include "manifest.h"
 
 /* ================================================================== */
 /* Player autopilot — server-side AI driving the player's own ship    */
@@ -578,9 +579,9 @@ void step_autopilot(world_t *w, server_player_t *sp, float dt) {
          * delivered kits to this dock and the player isn't carrying
          * any — better to launch with damage than to idle forever. */
         const station_t *st = &w->stations[sp->current_station];
-        float ship_kits = sp->ship.cargo[COMMODITY_REPAIR_KIT];
-        float station_kits = st->_inventory_cache[COMMODITY_REPAIR_KIT];
-        bool any_kits = (ship_kits + station_kits) > 0.5f;
+        int ship_kits = ship_finished_count(&sp->ship, COMMODITY_REPAIR_KIT);
+        int station_kits = station_finished_count(st, COMMODITY_REPAIR_KIT);
+        bool any_kits = (ship_kits + station_kits) > 0;
         if (!autopilot_hull_full(&sp->ship) && any_kits) {
             /* Stay docked; repair will keep ticking from cargo first
              * then station inventory. */

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -72,23 +72,29 @@ static bool station_manifest_push_finished(station_t *st, const cargo_unit_t *un
     if (st->manifest.cap == 0 || st->manifest.units == NULL) {
         if (!station_manifest_bootstrap(st)) return false;
     }
-    if (st->manifest.count >= st->manifest.cap) return false;
-    return manifest_push(&st->manifest, unit);
+    if (manifest_push(&st->manifest, unit)) {
+        st->manifest_dirty = true;
+        return true;
+    }
+    return false;
 }
 
 static bool manifest_unit_matches_recipe_input(const cargo_unit_t *unit,
                                                commodity_t commodity) {
+    cargo_kind_t kind;
+    if (!cargo_kind_for_commodity(commodity, &kind)) return false;
     return unit != NULL &&
-           (cargo_kind_t)unit->kind == CARGO_KIND_INGOT &&
+           (cargo_kind_t)unit->kind == kind &&
            (commodity_t)unit->commodity == commodity;
 }
 
 static bool station_manifest_select_recipe_inputs(const station_t *st,
                                                   const recipe_def_t *recipe,
-                                                  uint16_t out_indices[2],
-                                                  cargo_unit_t out_inputs[2]) {
+                                                  uint16_t out_indices[RECIPE_INPUT_MAX],
+                                                  cargo_unit_t out_inputs[RECIPE_INPUT_MAX]) {
     if (!st || !recipe || !out_indices || !out_inputs ||
-        !st->manifest.units || recipe->input_count == 0 || recipe->input_count > 2) {
+        !st->manifest.units || recipe->input_count == 0 ||
+        recipe->input_count > RECIPE_INPUT_MAX) {
         return false;
     }
 
@@ -121,26 +127,36 @@ static bool station_manifest_select_recipe_inputs(const station_t *st,
 static bool station_manifest_consume_selected_inputs(station_t *st,
                                                      const uint16_t *indices,
                                                      size_t count) {
-    if (!st || !indices || count == 0 || count > 2) return false;
+    uint16_t sorted[RECIPE_INPUT_MAX] = {0};
+    if (!st || !indices || count == 0 || count > RECIPE_INPUT_MAX) return false;
     if (!st->manifest.units) return false;
 
-    if (count == 2) {
-        uint16_t hi = indices[0] > indices[1] ? indices[0] : indices[1];
-        uint16_t lo = indices[0] > indices[1] ? indices[1] : indices[0];
-        return manifest_remove(&st->manifest, hi, NULL) &&
-               manifest_remove(&st->manifest, lo, NULL);
+    for (size_t i = 0; i < count; i++) sorted[i] = indices[i];
+    for (size_t i = 0; i < count; i++) {
+        for (size_t j = i + 1; j < count; j++) {
+            if (sorted[j] > sorted[i]) {
+                uint16_t tmp = sorted[i];
+                sorted[i] = sorted[j];
+                sorted[j] = tmp;
+            }
+        }
     }
-
-    return manifest_remove(&st->manifest, indices[0], NULL);
+    for (size_t i = 0; i < count; i++) {
+        if (!manifest_remove(&st->manifest, sorted[i], NULL)) return false;
+    }
+    return true;
 }
 
 static bool station_manifest_craft_product(world_t *w, station_t *st,
                                            recipe_id_t recipe_id) {
     const recipe_def_t *recipe = recipe_get(recipe_id);
-    uint16_t indices[2] = {0, 0};
-    cargo_unit_t inputs[2] = {{0}};
+    uint16_t indices[RECIPE_INPUT_MAX] = {0};
+    cargo_unit_t inputs[RECIPE_INPUT_MAX] = {{0}};
     cargo_unit_t product = {0};
 
+    /* The signed craft payload currently records two input pubs. Keep the
+     * generic craft path to two-input producer recipes; the repair-kit fab
+     * handles its three-input recipe directly below. */
     if (!st || !recipe || recipe->input_count == 0 || recipe->input_count > 2) return false;
     if (st->manifest.cap == 0 || st->manifest.units == NULL) {
         if (!station_manifest_bootstrap(st)) return false;
@@ -1179,7 +1195,7 @@ void step_dock_repair_kit_fab(world_t *w, float dt) {
         station_t *st = &w->stations[s];
         if (!station_exists(st)) continue;
         if (!station_has_module(st, MODULE_SHIPYARD)) continue;
-        if (st->_inventory_cache[COMMODITY_REPAIR_KIT] >= REPAIR_KIT_STOCK_CAP) continue;
+        if ((float)station_finished_count(st, COMMODITY_REPAIR_KIT) >= REPAIR_KIT_STOCK_CAP) continue;
 
         st->repair_kit_fab_timer += dt;
         if (st->repair_kit_fab_timer < REPAIR_KIT_FAB_PERIOD) continue;
@@ -1187,18 +1203,32 @@ void step_dock_repair_kit_fab(world_t *w, float dt) {
         /* All three inputs required. If any are missing, hold the timer
          * at the period (don't keep accumulating) so the next batch
          * fires the moment supply arrives. */
-        if (st->_inventory_cache[COMMODITY_FRAME] < 1.0f ||
-            st->_inventory_cache[COMMODITY_LASER_MODULE] < 1.0f ||
-            st->_inventory_cache[COMMODITY_TRACTOR_MODULE] < 1.0f) {
+        const recipe_def_t *recipe = recipe_get(RECIPE_REPAIR_KIT_FAB);
+        uint16_t indices[RECIPE_INPUT_MAX] = {0};
+        cargo_unit_t inputs[RECIPE_INPUT_MAX] = {{0}};
+        if (st->manifest.cap == 0 && !station_manifest_bootstrap(st)) {
+            st->repair_kit_fab_timer = REPAIR_KIT_FAB_PERIOD;
+            continue;
+        }
+        if (!recipe || !station_manifest_select_recipe_inputs(st, recipe, indices, inputs)) {
             st->repair_kit_fab_timer = REPAIR_KIT_FAB_PERIOD;
             continue;
         }
 
-        /* Consume one of each from the float + manifest, in lockstep
-         * with the manifest-truth invariant. */
-        st->_inventory_cache[COMMODITY_FRAME]          -= 1.0f;
-        st->_inventory_cache[COMMODITY_LASER_MODULE]   -= 1.0f;
-        st->_inventory_cache[COMMODITY_TRACTOR_MODULE] -= 1.0f;
+        int room = (int)floorf(REPAIR_KIT_STOCK_CAP + 0.0001f) -
+                   station_finished_count(st, COMMODITY_REPAIR_KIT);
+        int batch = (int)floorf(REPAIR_KIT_PER_BATCH + 0.0001f);
+        int int_minted = room < batch ? room : batch;
+        if (int_minted <= 0) continue;
+
+        if (!station_manifest_consume_selected_inputs(st, indices, recipe->input_count)) {
+            st->repair_kit_fab_timer = REPAIR_KIT_FAB_PERIOD;
+            continue;
+        }
+        station_finished_sync(st, COMMODITY_FRAME);
+        station_finished_sync(st, COMMODITY_LASER_MODULE);
+        station_finished_sync(st, COMMODITY_TRACTOR_MODULE);
+
         /* Light the SHIPYARD's tractor beam. The kit-fab path doesn't
          * go through the producer-recipe pipeline that already pulses
          * other producers, so set it here. */
@@ -1208,36 +1238,23 @@ void step_dock_repair_kit_fab(world_t *w, float dt) {
                 st->module_active_pulse[m] = 1.0f;
             }
         }
-        manifest_consume_by_commodity(&st->manifest, COMMODITY_FRAME, 1);
-        manifest_consume_by_commodity(&st->manifest, COMMODITY_LASER_MODULE, 1);
-        manifest_consume_by_commodity(&st->manifest, COMMODITY_TRACTOR_MODULE, 1);
-
-        /* Mint kits — clamp at the cap. Each minted unit gets a
-         * legacy-migrate manifest entry so the TRADE picker can see
-         * them and the per-station origin stays traceable. */
-        float room = REPAIR_KIT_STOCK_CAP - st->_inventory_cache[COMMODITY_REPAIR_KIT];
-        float minted = fminf(REPAIR_KIT_PER_BATCH, room);
-        st->_inventory_cache[COMMODITY_REPAIR_KIT] += minted;
-        int int_minted = (int)floorf(minted + 0.0001f);
-        if (int_minted > 0) {
-            uint8_t origin[8] = { 'D','O','C','K','F','A','B','0' };
-            origin[7] = (uint8_t)('0' + (s % 10));
-            for (int k = 0; k < int_minted; k++) {
-                if (st->manifest.cap == 0 && !station_manifest_bootstrap(st)) break;
-                if (st->manifest.count >= st->manifest.cap) break;
-                cargo_unit_t unit = {0};
-                if (!hash_legacy_migrate_unit(origin, COMMODITY_REPAIR_KIT,
-                                              (uint16_t)k, &unit))
-                    continue;
-                /* Stamp the recipe so future inspectors can see this is a
-                 * dock-fab kit rather than a save-migration leftover. */
-                unit.recipe_id = (uint16_t)RECIPE_REPAIR_KIT_FAB;
-                if (!manifest_push(&st->manifest, &unit)) break;
-            }
-            st->manifest_dirty = true;
+        /* Mint kits as real recipe products. The output multiplier lives
+         * in this production loop; each kit's pub key binds back to the
+         * same frame/laser/tractor input set through hash_product. */
+        int actual_minted = 0;
+        for (int k = 0; k < int_minted; k++) {
+            cargo_unit_t unit = {0};
+            if (!hash_product(RECIPE_REPAIR_KIT_FAB, inputs, recipe->input_count,
+                              (uint16_t)k, &unit))
+                break;
+            unit.origin_station = (uint8_t)s;
+            if (!station_manifest_push_finished(st, &unit)) break;
+            actual_minted++;
         }
+        if (actual_minted > 0)
+            station_finished_sync(st, COMMODITY_REPAIR_KIT);
         st->repair_kit_fab_timer = 0.0f;
         SIM_LOG("[shipyard-fab] station %d minted %d kits (1 frame + 1 laser + 1 tractor consumed)\n",
-                s, int_minted);
+                s, actual_minted);
     }
 }

--- a/shared/manifest.h
+++ b/shared/manifest.h
@@ -45,6 +45,12 @@ int manifest_count_by_commodity(const manifest_t *manifest,
 int manifest_consume_by_commodity(manifest_t *manifest,
                                   commodity_t commodity, int n);
 
+/* Ship-side finished-good helpers. Finished goods live in the manifest;
+ * ship.cargo[c] is a derived compatibility count. */
+int ship_finished_count(const ship_t *ship, commodity_t c);
+void ship_finished_sync(ship_t *ship, commodity_t c);
+int ship_finished_drain(ship_t *ship, commodity_t c, int n);
+
 void ship_cleanup(ship_t *ship);
 bool ship_manifest_bootstrap(ship_t *ship);
 bool ship_copy(ship_t *dst, const ship_t *src);
@@ -121,6 +127,11 @@ void manifest_migrate_quantity(manifest_t *manifest);
  * actually minted (may be < n if manifest cap is hit). */
 int station_finished_mint(station_t *st, commodity_t c, int n,
                           const uint8_t origin[8]);
+
+/* Count/sync helpers for callers that need manifest-authoritative reads
+ * or that consumed specific manifest entries themselves. */
+int station_finished_count(const station_t *st, commodity_t c);
+void station_finished_sync(station_t *st, commodity_t c);
 
 /* Drain up to `n` units of finished `c` from the manifest (FIFO) and
  * decrement the float cache by the same number. Returns units drained. */

--- a/src/economy.c
+++ b/src/economy.c
@@ -113,13 +113,13 @@ bool can_afford_upgrade(const station_t* station, const ship_t* ship, ship_upgra
      * the repair-kit "any dock" model from #373. */
     if (!station) return false;
     if (ship_upgrade_maxed(ship, upgrade)) return false;
-    /* Cargo first, dock fallback at retail. Mirror the server logic so
-     * the UI's "can afford?" matches what try_apply_ship_upgrade will
-     * actually accept. */
+    /* Manifest-backed cargo first, dock fallback at retail. Mirror the
+     * server logic so the UI's "can afford?" matches what
+     * try_apply_ship_upgrade will actually accept. */
     commodity_t comm = (commodity_t)(COMMODITY_FRAME + upgrade_required_product(upgrade));
     int units_needed = (int)ceilf(upgrade_product_cost(ship, upgrade));
-    int in_cargo  = (int)floorf(ship->cargo[comm] + 0.0001f);
-    int at_station = (int)floorf(station->_inventory_cache[comm] + 0.0001f);
+    int in_cargo  = ship_finished_count(ship, comm);
+    int at_station = station_finished_count(station, comm);
     if (in_cargo + at_station < units_needed) return false;
     int from_station = units_needed - (units_needed < in_cargo ? units_needed : in_cargo);
     float credit_cost = (float)from_station * station_sell_price(station, comm);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -123,18 +123,29 @@ static mining_grade_t min_input_grade(const cargo_unit_t *inputs, size_t count) 
     return grade;
 }
 
+static bool finished_good_commodity(commodity_t c) {
+    return (int)c >= (int)COMMODITY_RAW_ORE_COUNT &&
+           (int)c < (int)COMMODITY_COUNT;
+}
+
 static bool recipe_inputs_match(const recipe_def_t *recipe,
                                 const cargo_unit_t *inputs,
                                 size_t input_count) {
-    bool matched[2] = { false, false };
+    bool matched[RECIPE_INPUT_MAX] = { false };
 
-    if (!recipe || input_count != recipe->input_count || input_count > 2) return false;
+    if (!recipe || !inputs ||
+        input_count != recipe->input_count ||
+        input_count > RECIPE_INPUT_MAX) {
+        return false;
+    }
     for (size_t i = 0; i < input_count; i++) {
-        if ((cargo_kind_t)inputs[i].kind != CARGO_KIND_INGOT) return false;
+        cargo_kind_t input_kind = (cargo_kind_t)inputs[i].kind;
+        commodity_t input_commodity = (commodity_t)inputs[i].commodity;
+        if (!cargo_kind_matches_commodity(input_kind, input_commodity)) return false;
         bool found = false;
         for (size_t j = 0; j < input_count; j++) {
             if (matched[j]) continue;
-            if ((commodity_t)inputs[i].commodity != recipe->input_commodities[j]) continue;
+            if (input_commodity != recipe->input_commodities[j]) continue;
             matched[j] = true;
             found = true;
             break;
@@ -620,8 +631,7 @@ static const uint8_t kStationDefaultOrigin[8] = { 'S','T','A','T','I','O','N',' 
 int station_finished_mint(station_t *st, commodity_t c, int n,
                           const uint8_t origin[8]) {
     if (!st || n <= 0) return 0;
-    if ((int)c < (int)COMMODITY_RAW_ORE_COUNT) return 0;
-    if ((int)c >= (int)COMMODITY_COUNT) return 0;
+    if (!finished_good_commodity(c)) return 0;
     cargo_kind_t kind;
     if (!cargo_kind_for_commodity(c, &kind)) return 0;
     if (st->manifest.cap == 0 && !station_manifest_bootstrap(st)) return 0;
@@ -633,7 +643,6 @@ int station_finished_mint(station_t *st, commodity_t c, int n,
      * units. */
     uint16_t base_idx = st->manifest.count;
     for (int i = 0; i < n; i++) {
-        if (st->manifest.count >= st->manifest.cap) break;
         cargo_unit_t unit = {0};
         if (!hash_legacy_migrate_unit(use_origin, c,
                                       (uint16_t)(base_idx + i), &unit)) continue;
@@ -660,17 +669,45 @@ int station_finished_mint(station_t *st, commodity_t c, int n,
     return minted;
 }
 
+int ship_finished_count(const ship_t *ship, commodity_t c) {
+    if (!ship || !finished_good_commodity(c)) return 0;
+    return manifest_count_by_commodity(&ship->manifest, c);
+}
+
+void ship_finished_sync(ship_t *ship, commodity_t c) {
+    if (!ship || !finished_good_commodity(c)) return;
+    ship->cargo[c] = (float)manifest_count_by_commodity(&ship->manifest, c);
+}
+
+int ship_finished_drain(ship_t *ship, commodity_t c, int n) {
+    if (!ship || n <= 0 || !finished_good_commodity(c)) return 0;
+    int drained = manifest_consume_by_commodity(&ship->manifest, c, n);
+    if (drained > 0) ship_finished_sync(ship, c);
+    return drained;
+}
+
+int station_finished_count(const station_t *st, commodity_t c) {
+    if (!st || !finished_good_commodity(c)) return 0;
+    return manifest_count_by_commodity(&st->manifest, c);
+}
+
+void station_finished_sync(station_t *st, commodity_t c) {
+    if (!st || !finished_good_commodity(c)) return;
+    float v = st->_inventory_cache[c];
+    float floor_v = floorf(v + 0.0001f);
+    float frac = v - floor_v;
+    if (frac < 0.0f) frac = 0.0f;
+    if (frac >= 1.0f) frac = 0.0f;
+    st->_inventory_cache[c] = (float)manifest_count_by_commodity(&st->manifest, c) + frac;
+    st->manifest_dirty = true;
+    assert_finished_invariant(st, c);
+}
+
 int station_finished_drain(station_t *st, commodity_t c, int n) {
     if (!st || n <= 0) return 0;
-    if ((int)c < (int)COMMODITY_RAW_ORE_COUNT) return 0;
-    if ((int)c >= (int)COMMODITY_COUNT) return 0;
+    if (!finished_good_commodity(c)) return 0;
     int drained = manifest_consume_by_commodity(&st->manifest, c, n);
-    if (drained > 0) {
-        float frac = st->_inventory_cache[c] - floorf(st->_inventory_cache[c]);
-        st->_inventory_cache[c] = (float)manifest_count_by_commodity(&st->manifest, c) + frac;
-        if (st->_inventory_cache[c] < 0.0f) st->_inventory_cache[c] = 0.0f;
-        st->manifest_dirty = true;
-    }
+    if (drained > 0) station_finished_sync(st, c);
     assert_finished_invariant(st, c);
     return drained;
 }
@@ -678,8 +715,7 @@ int station_finished_drain(station_t *st, commodity_t c, int n) {
 int station_finished_accumulate(station_t *st, commodity_t c, float amount,
                                 const uint8_t origin[8]) {
     if (!st || amount <= 0.0f) return 0;
-    if ((int)c < (int)COMMODITY_RAW_ORE_COUNT) return 0;
-    if ((int)c >= (int)COMMODITY_COUNT) return 0;
+    if (!finished_good_commodity(c)) return 0;
 
     /* Compute how many integer crossings this addition triggers. The
      * float currently holds: (manifest count) + (fractional residue).

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -897,7 +897,9 @@ TEST(test_build_outpost_full_economy) {
         + module_build_cost_lookup(MODULE_SIGNAL_RELAY)   /* seed module */
         + module_build_cost_lookup(MODULE_FURNACE)        /* second module */
         + 10.0f;                                          /* slack */
-    sp->ship.cargo[COMMODITY_FRAME] = frame_budget;
+    ASSERT(test_set_ship_finished_units(&sp->ship, COMMODITY_FRAME,
+                                        (int)ceilf(frame_budget),
+                                        MINING_GRADE_COMMON));
 
     /* Step 3 — dock at the outpost and pour the frames in.
      * The outpost has an OUTPOST_DOCK module stamped on by
@@ -994,7 +996,11 @@ TEST(test_build_outpost_full_economy) {
      * frame_budget purposely covered SCAFFOLD_MATERIAL_NEEDED + relay +
      * furnace + 10 slack. The hopper costs more than that 10 slack on
      * its own, so top the cargo back up here — same shortcut as step 2. */
-    sp->ship.cargo[COMMODITY_FRAME] += module_build_cost_lookup(MODULE_HOPPER);
+    ASSERT(test_set_ship_finished_units(
+        &sp->ship, COMMODITY_FRAME,
+        ship_finished_count(&sp->ship, COMMODITY_FRAME) +
+            (int)ceilf(module_build_cost_lookup(MODULE_HOPPER)),
+        MINING_GRADE_COMMON));
 
     vec2 ring1_other = v2_add(outpost_pos, v2(-180.0f, 60.0f));
     int hop_idx = spawn_scaffold(&w, MODULE_HOPPER, ring1_other, sp->id);
@@ -2125,4 +2131,3 @@ void register_construction_module_schema_tests(void) {
     RUN(test_all_rings_passive_under_spoke_load);
     RUN(test_output_hopper_spoke_contributes_torque);
 }
-

--- a/src/tests/test_econ_sim.c
+++ b/src/tests/test_econ_sim.c
@@ -628,10 +628,10 @@ TEST(test_e2e_kit_chain_converges) {
     }
     ASSERT(shipyard >= 0);
     /* Big buffer of inputs so fab never starves. */
-    w->stations[shipyard]._inventory_cache[COMMODITY_FRAME]          = 50.0f;
-    w->stations[shipyard]._inventory_cache[COMMODITY_LASER_MODULE]   = 50.0f;
-    w->stations[shipyard]._inventory_cache[COMMODITY_TRACTOR_MODULE] = 50.0f;
-    w->stations[shipyard]._inventory_cache[COMMODITY_REPAIR_KIT]     = 0.0f;
+    ASSERT(test_set_station_finished_units(&w->stations[shipyard], COMMODITY_FRAME, 50));
+    ASSERT(test_set_station_finished_units(&w->stations[shipyard], COMMODITY_LASER_MODULE, 50));
+    ASSERT(test_set_station_finished_units(&w->stations[shipyard], COMMODITY_TRACTOR_MODULE, 50));
+    ASSERT(test_set_station_finished_units(&w->stations[shipyard], COMMODITY_REPAIR_KIT, 0));
     w->stations[shipyard].repair_kit_fab_timer = 0.0f;
 
     int ticks = (int)(300.0f / SIM_DT);
@@ -669,7 +669,8 @@ TEST(test_e2e_npc_dock_auto_repair_drains_kits) {
     }
     ASSERT(shipyard >= 0);
     /* Stock the dock with kits so the auto-repair has something to drain. */
-    w->stations[shipyard]._inventory_cache[COMMODITY_REPAIR_KIT] = 100.0f;
+    ASSERT(test_set_station_finished_units(&w->stations[shipyard],
+                                           COMMODITY_REPAIR_KIT, 100));
 
     /* Pick the first hauler that's currently homed at the shipyard,
      * wound it, and drop it just outside the dock approach radius. */
@@ -739,7 +740,8 @@ TEST(test_e2e_kit_import_contract_lifecycle) {
     ASSERT(prospect >= 0);
 
     /* Phase 1: drain kits and run until a kit import contract is issued. */
-    w->stations[prospect]._inventory_cache[COMMODITY_REPAIR_KIT] = 0.0f;
+    ASSERT(test_set_station_finished_units(&w->stations[prospect],
+                                           COMMODITY_REPAIR_KIT, 0));
     bool found_open = false;
     for (int i = 0; i < (int)(120.0f / SIM_DT); i++) {
         world_sim_step(w, SIM_DT);
@@ -762,7 +764,9 @@ TEST(test_e2e_kit_import_contract_lifecycle) {
      * higher bound is the only stable closed state. The fact that
      * those two thresholds don't agree is a real bug worth a separate
      * PR; this test pins current behaviour for now. */
-    w->stations[prospect]._inventory_cache[COMMODITY_REPAIR_KIT] = REPAIR_KIT_STOCK_CAP * 0.5f;
+    ASSERT(test_set_station_finished_units(&w->stations[prospect],
+                                           COMMODITY_REPAIR_KIT,
+                                           (int)(REPAIR_KIT_STOCK_CAP * 0.5f)));
     bool found_after_fill = true;
     for (int i = 0; i < (int)(60.0f / SIM_DT); i++) {
         world_sim_step(w, SIM_DT);

--- a/src/tests/test_economy.c
+++ b/src/tests/test_economy.c
@@ -49,7 +49,7 @@ TEST(test_can_afford_upgrade_dock_fallback) {
     ship.hull_class = HULL_CLASS_MINER;
     station_t station = {0};
     station.services = STATION_SERVICE_UPGRADE_HOLD;
-    station._inventory_cache[COMMODITY_FRAME] = 100.0f;
+    ASSERT(test_set_station_finished_units(&station, COMMODITY_FRAME, 100));
     station.base_price[COMMODITY_FRAME] = 22.0f;
     ASSERT(can_afford_upgrade(&station, &ship, SHIP_UPGRADE_HOLD,10000.0f));
 }
@@ -61,7 +61,7 @@ TEST(test_can_afford_upgrade_no_credits_for_dock_fallback) {
     ship.hull_class = HULL_CLASS_MINER;
     station_t station = {0};
     station.services = STATION_SERVICE_UPGRADE_HOLD;
-    station._inventory_cache[COMMODITY_FRAME] = 100.0f;
+    ASSERT(test_set_station_finished_units(&station, COMMODITY_FRAME, 100));
     station.base_price[COMMODITY_FRAME] = 22.0f;
     ASSERT(!can_afford_upgrade(&station, &ship, SHIP_UPGRADE_HOLD,0.0f));
 }
@@ -85,7 +85,8 @@ TEST(test_can_afford_upgrade_cargo_only_no_credits_needed) {
     station.services = STATION_SERVICE_UPGRADE_HOLD;
     /* Empty dock inventory; ship carries enough frames itself. */
     int need = (int)ceilf(upgrade_product_cost(&ship, SHIP_UPGRADE_HOLD));
-    ship.cargo[COMMODITY_FRAME] = (float)need;
+    ASSERT(test_set_ship_finished_units(&ship, COMMODITY_FRAME, need,
+                                        MINING_GRADE_COMMON));
     ASSERT(can_afford_upgrade(&station, &ship, SHIP_UPGRADE_HOLD,0.0f));
 }
 
@@ -504,10 +505,10 @@ TEST(test_kit_fab_requires_shipyard) {
     ASSERT(!station_has_module(&w.stations[0], MODULE_SHIPYARD));
     ASSERT(station_has_module(&w.stations[1], MODULE_SHIPYARD));
     for (int s = 0; s < 2; s++) {
-        w.stations[s]._inventory_cache[COMMODITY_FRAME]          = 5.0f;
-        w.stations[s]._inventory_cache[COMMODITY_LASER_MODULE]   = 5.0f;
-        w.stations[s]._inventory_cache[COMMODITY_TRACTOR_MODULE] = 5.0f;
-        w.stations[s]._inventory_cache[COMMODITY_REPAIR_KIT]     = 0.0f;
+        ASSERT(test_set_station_finished_units(&w.stations[s], COMMODITY_FRAME, 5));
+        ASSERT(test_set_station_finished_units(&w.stations[s], COMMODITY_LASER_MODULE, 5));
+        ASSERT(test_set_station_finished_units(&w.stations[s], COMMODITY_TRACTOR_MODULE, 5));
+        ASSERT(test_set_station_finished_units(&w.stations[s], COMMODITY_REPAIR_KIT, 0));
         w.stations[s].repair_kit_fab_timer = 0.0f;
     }
     /* Run long enough for at least one fab cycle (REPAIR_KIT_FAB_PERIOD = 30s). */
@@ -581,8 +582,9 @@ TEST(test_repair_drains_ship_cargo_first) {
 
     /* Force the repair service (default Prospect lacks REPAIR_BAY). */
     w.stations[0].services |= STATION_SERVICE_REPAIR;
-    w.stations[0]._inventory_cache[COMMODITY_REPAIR_KIT] = 100.0f;
-    w.players[0].ship.cargo[COMMODITY_REPAIR_KIT] = 50.0f;
+    ASSERT(test_set_station_finished_units(&w.stations[0], COMMODITY_REPAIR_KIT, 100));
+    ASSERT(test_set_ship_finished_units(&w.players[0].ship, COMMODITY_REPAIR_KIT,
+                                        50, MINING_GRADE_COMMON));
     float max_hull = ship_max_hull(&w.players[0].ship);
     w.players[0].ship.hull = max_hull - 30.0f; /* 30 HP missing */
 
@@ -617,8 +619,10 @@ TEST(test_repair_falls_back_to_station_inventory) {
 
     w.stations[0].services |= STATION_SERVICE_REPAIR;
     w.stations[0].base_price[COMMODITY_REPAIR_KIT] = 6.0f;
-    w.stations[0]._inventory_cache[COMMODITY_REPAIR_KIT]  = MAX_PRODUCT_STOCK; /* full → 1× */
-    w.players[0].ship.cargo[COMMODITY_REPAIR_KIT]  = 0.0f;
+    ASSERT(test_set_station_finished_units(&w.stations[0], COMMODITY_REPAIR_KIT,
+                                           (int)MAX_PRODUCT_STOCK)); /* full → 1× */
+    ASSERT(test_set_ship_finished_units(&w.players[0].ship, COMMODITY_REPAIR_KIT,
+                                        0, MINING_GRADE_COMMON));
     float max_hull = ship_max_hull(&w.players[0].ship);
     w.players[0].ship.hull = max_hull - 10.0f;
 
@@ -651,8 +655,10 @@ TEST(test_repair_at_shipyard_no_labor_fee) {
 
     w.stations[1].services |= STATION_SERVICE_REPAIR;
     w.stations[1].base_price[COMMODITY_REPAIR_KIT] = 6.0f;
-    w.stations[1]._inventory_cache[COMMODITY_REPAIR_KIT]  = MAX_PRODUCT_STOCK;
-    w.players[0].ship.cargo[COMMODITY_REPAIR_KIT]  = 0.0f;
+    ASSERT(test_set_station_finished_units(&w.stations[1], COMMODITY_REPAIR_KIT,
+                                           (int)MAX_PRODUCT_STOCK));
+    ASSERT(test_set_ship_finished_units(&w.players[0].ship, COMMODITY_REPAIR_KIT,
+                                        0, MINING_GRADE_COMMON));
     float max_hull = ship_max_hull(&w.players[0].ship);
     w.players[0].ship.hull = max_hull - 10.0f;
 

--- a/src/tests/test_manifest.c
+++ b/src/tests/test_manifest.c
@@ -306,6 +306,33 @@ TEST(test_hash_product_matches_known_vector_and_min_grade) {
     ASSERT_HEX32_EQ(frame.pub, "afd71562654d3d5a973927c68df0b3187fc3651a2296cd4b48b52e74925bf2d2");
 }
 
+TEST(test_hash_product_accepts_repair_kit_three_finished_inputs) {
+    cargo_unit_t inputs[RECIPE_INPUT_MAX] = {0};
+    cargo_unit_t kit = {0};
+
+    inputs[0].kind = (uint8_t)CARGO_KIND_FRAME;
+    inputs[0].commodity = (uint8_t)COMMODITY_FRAME;
+    inputs[0].grade = (uint8_t)MINING_GRADE_FINE;
+    for (int i = 0; i < 32; i++) inputs[0].pub[i] = (uint8_t)(0x10 + i);
+
+    inputs[1].kind = (uint8_t)CARGO_KIND_LASER;
+    inputs[1].commodity = (uint8_t)COMMODITY_LASER_MODULE;
+    inputs[1].grade = (uint8_t)MINING_GRADE_RARE;
+    for (int i = 0; i < 32; i++) inputs[1].pub[i] = (uint8_t)(0x40 + i);
+
+    inputs[2].kind = (uint8_t)CARGO_KIND_TRACTOR;
+    inputs[2].commodity = (uint8_t)COMMODITY_TRACTOR_MODULE;
+    inputs[2].grade = (uint8_t)MINING_GRADE_COMMON;
+    for (int i = 0; i < 32; i++) inputs[2].pub[i] = (uint8_t)(0x70 + i);
+
+    ASSERT(hash_product(RECIPE_REPAIR_KIT_FAB, inputs, 3, 17, &kit));
+    ASSERT_EQ_INT(kit.kind, CARGO_KIND_REPAIR_KIT);
+    ASSERT_EQ_INT(kit.commodity, COMMODITY_REPAIR_KIT);
+    ASSERT_EQ_INT(kit.grade, MINING_GRADE_COMMON);
+    ASSERT_EQ_INT(kit.recipe_id, RECIPE_REPAIR_KIT_FAB);
+    ASSERT(!hash_product(RECIPE_REPAIR_KIT_FAB, inputs, 2, 0, &kit));
+}
+
 TEST(test_fracture_claim_resolves_best_verified_grade) {
     WORLD_DECL;
     asteroid_t *a = &w.asteroids[0];
@@ -865,6 +892,7 @@ void register_manifest_tests(void) {
     RUN(test_hash_merkle_root_sorts_and_duplicates_odd_leaf);
     RUN(test_hash_ingot_matches_known_vector);
     RUN(test_hash_product_matches_known_vector_and_min_grade);
+    RUN(test_hash_product_accepts_repair_kit_three_finished_inputs);
     RUN(test_fracture_claim_resolves_best_verified_grade);
     RUN(test_fracture_claim_fallback_resolves_without_claims);
     RUN(test_fracture_claim_rejects_past_deadline);


### PR DESCRIPTION
## Summary
- make repair, upgrade, scaffold delivery, autopilot, and NPC repair paths read and drain finished goods through manifests
- make repair-kit fabrication consume frame/laser/tractor manifest inputs and mint recipe-hashed kit products
- add manifest helpers and update tests to seed finished goods through manifests

## Validation
- make test
- make test-soak
- pre-push hook reran tests for 881d6d7: 507 passed