### PR TITLE
[codex] Render remote tractor beams in multiplayer

### DIFF
--- a/shared/protocol.h
+++ b/shared/protocol.h
@@ -355,7 +355,7 @@ _Static_assert(NET_ACTION_DELIVER_COMMODITY + COMMODITY_COUNT <= 256,
  * [beam_start_x:f32][beam_start_y:f32][beam_end_x:f32][beam_end_y:f32]
  * towed_frags: 10 × uint16_t asteroid index, 0xFFFF = unused. Widened
  * from uint8_t in #285 Phase 3 so slots 255-2047 survive the wire.
- * flags bits: 1=thrust 2=beam_active+hit 4=docked 8=scan 16=tractor 32=beam_ineffective
+ * flags bits: 1=thrust 2=beam_active 4=docked 8=scan 16=tractor 32=beam_ineffective 64=beam_hit
  * Beam coords are server-authoritative — fixes autopilot mining visuals
  * and (eventually) combat hit prediction. */
 #define PLAYER_RECORD_SIZE 67  /* 51 + 16 bytes beam coords */

--- a/src/tests/test_protocol.c
+++ b/src/tests/test_protocol.c
@@ -50,6 +50,11 @@ TEST(test_roundtrip_batched_player_states) {
     players[3].ship.vel = v2(0.0f, 2.0f);
     players[3].ship.angle = 3.14f;
     players[3].docked = true;
+    players[3].ship.tractor_active = true;
+    players[3].ship.tractor_level = 2;
+    players[3].ship.towed_count = 2;
+    players[3].ship.towed_fragments[0] = 301;
+    players[3].ship.towed_fragments[1] = 1024;
 
     uint8_t buf[2 + MAX_PLAYERS * PLAYER_RECORD_SIZE];
     int len = serialize_all_player_states(buf, players);
@@ -72,6 +77,11 @@ TEST(test_roundtrip_batched_player_states) {
     ASSERT_EQ_INT(p1[0], 3);
     ASSERT_EQ_FLOAT(read_f32_le(&p1[1]), -50.0f, 0.01f);
     ASSERT(p1[21] & 4); /* docked */
+    ASSERT(p1[21] & 16); /* tractor active */
+    ASSERT_EQ_INT(p1[22], 2);
+    ASSERT_EQ_INT(p1[23], 2);
+    ASSERT_EQ_INT((int)((uint16_t)p1[24] | ((uint16_t)p1[25] << 8)), 301);
+    ASSERT_EQ_INT((int)((uint16_t)p1[26] | ((uint16_t)p1[27] << 8)), 1024);
 }
 
 TEST(test_roundtrip_asteroids) {
@@ -408,4 +418,3 @@ void register_protocol_main_tests(void) {
     RUN(test_parse_input_no_action);
     RUN(test_parse_input_action_accumulates);
 }
-

--- a/src/world_draw.c
+++ b/src/world_draw.c
@@ -2083,11 +2083,20 @@ void draw_remote_players(void) {
             float dy = players[i].y - LOCAL_PLAYER.ship.pos.y;
             if (dx * dx + dy * dy < 4.0f) continue; /* within 2u = us */
         }
-        if (!on_screen(players[i].x, players[i].y, 50.0f)) continue;
         int ci = i % 6;
         float cr = colors[ci][0], cg = colors[ci][1], cb = colors[ci][2];
         bool thrusting = (players[i].flags & 1) != 0;
         bool mining = (players[i].flags & 2) != 0;
+        bool tractor_on = (players[i].flags & 16) != 0;
+        /* Compute tractor range from level (mirrors ship_tractor_range).
+         * Remote snapshots don't carry hull class yet; multiplayer player
+         * ships are currently the default miner hull. */
+        float base_range = 150.0f;
+        float tr = base_range + (float)players[i].tractor_level * SHIP_TRACTOR_UPGRADE_STEP;
+        float render_radius = tractor_on ? tr : 50.0f;
+        if (players[i].towed_count > 0 && render_radius < tr * 1.5f)
+            render_radius = tr * 1.5f;
+        if (!on_screen(players[i].x, players[i].y, render_radius)) continue;
 
         sgl_push_matrix();
         sgl_translate(players[i].x, players[i].y, 0.0f);
@@ -2141,15 +2150,15 @@ void draw_remote_players(void) {
             }
         }
 
-        /* Tractor field circle + towed tethers */
-        bool tractor_on = (players[i].flags & 16) != 0;
-        if (tractor_on && players[i].towed_count > 0) {
+        /* Tractor field circle + towed tethers. Mirror local rendering:
+         * active tractor shows the field even before pickup, and leashed
+         * fragments keep visible tethers after the player releases R. */
+        if (tractor_on || players[i].towed_count > 0) {
             vec2 pos = v2(players[i].x, players[i].y);
-            /* Compute tractor range from level (mirrors ship_tractor_range) */
-            float base_range = 150.0f; /* default hull tractor_range */
-            float tr = base_range + (float)players[i].tractor_level * SHIP_TRACTOR_UPGRADE_STEP;
-            float pulse = 0.28f + (sinf(g.world.time * 7.0f + (float)i * 2.0f) * 0.08f);
-            draw_circle_outline(pos, tr, 40, cr * 0.4f, cg * 0.8f, cb * 0.9f, pulse);
+            if (tractor_on) {
+                float pulse = 0.28f + (sinf(g.world.time * 7.0f + (float)i * 2.0f) * 0.08f);
+                draw_circle_outline(pos, tr, 40, cr * 0.4f, cg * 0.8f, cb * 0.9f, pulse);
+            }
 
             /* Tether lines to towed fragments */
             for (int t = 0; t < players[i].towed_count && t < 10; t++) {
@@ -2157,8 +2166,11 @@ void draw_remote_players(void) {
                 if (raw == 0xFFFFu || raw >= MAX_ASTEROIDS) continue;
                 const asteroid_t *a = &g.world.asteroids[raw];
                 if (!a->active) continue;
+                float rr, rg, rb;
+                grade_tint(a->grade, &rr, &rg, &rb);
                 float tp = 0.4f + 0.15f * sinf(g.world.time * 3.0f + (float)t * 1.5f);
-                draw_segment(pos, a->pos, cr * 0.4f, cg * 0.8f, cb * 0.7f, tp);
+                if (a->grade >= 2) tp += 0.12f * sinf(g.world.time * 7.0f + (float)t);
+                draw_segment(pos, a->pos, rr, rg, rb, tp);
             }
         }
     }


### PR DESCRIPTION
## Summary
- render remote tractor fields whenever the remote tractor flag is active, even before pickup
- keep remote towed-fragment tethers visible while fragments are leashed after R is released
- expand remote-player culling to include tractor/tether radius and assert tractor/towed fields in player-state protocol tests

## Root Cause
The server was already serializing the tractor-active flag, tractor level, towed count, and 16-bit towed fragment ids in NET_MSG_WORLD_PLAYERS. The client render path incorrectly gated remote tractor visuals on tractor_active && towed_count > 0, hiding active tractor fields before pickup and hiding leashed tethers when the tractor button was released.

## Validation
- make test
- make build-web (rerun with escalated permissions because Emscripten needed to write its compiler cache)
- pre-push hook reran tests for 28f3f0c: 507 passed