### PR TITLE
[codex] Repair Helios shipyard seed

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -5224,7 +5224,8 @@ void world_reset(world_t *w) {
     w->stations[0].base_price[COMMODITY_CUPRITE_INGOT] = 32.0f;
     w->stations[0].base_price[COMMODITY_CRYSTAL_INGOT] = 40.0f;
     w->stations[0].base_price[COMMODITY_REPAIR_KIT] = 6.0f;
-    /* Prospect doesn't make these but its dock buys them in for kit fab. */
+    /* Finished-good price baselines if Prospect receives stock; its dock
+     * imports repair kits rather than shipyard kit-fab inputs. */
     w->stations[0].base_price[COMMODITY_FRAME]          = 22.0f;
     w->stations[0].base_price[COMMODITY_LASER_MODULE]   = 30.0f;
     w->stations[0].base_price[COMMODITY_TRACTOR_MODULE] = 38.0f;
@@ -5268,7 +5269,7 @@ void world_reset(world_t *w) {
     w->stations[1].base_price[COMMODITY_FERRITE_INGOT] = 24.0f;
     w->stations[1].base_price[COMMODITY_FRAME] = 20.0f;
     w->stations[1].base_price[COMMODITY_REPAIR_KIT] = 6.0f;
-    /* Kepler imports laser/tractor modules for its dock kit fab. */
+    /* Kepler imports laser/tractor modules for its shipyard kit fab. */
     w->stations[1].base_price[COMMODITY_LASER_MODULE]   = 30.0f;
     w->stations[1].base_price[COMMODITY_TRACTOR_MODULE] = 38.0f;
     /* Ring 1: dock + relay only. Ring-1 slot 2 stays empty. */
@@ -5309,7 +5310,7 @@ void world_reset(world_t *w) {
     w->stations[2].base_price[COMMODITY_LASER_MODULE] = 28.0f;
     w->stations[2].base_price[COMMODITY_TRACTOR_MODULE] = 36.0f;
     w->stations[2].base_price[COMMODITY_REPAIR_KIT] = 6.0f;
-    /* Helios imports frames for its dock kit fab. */
+    /* Helios imports frames for its shipyard kit fab. */
     w->stations[2].base_price[COMMODITY_FRAME]          = 22.0f;
     /* No ferrite ingots produced or imported here — Helios runs at the
      * 3-furnace tier, which the new count rules deliberately gate
@@ -5321,24 +5322,26 @@ void world_reset(world_t *w) {
     add_module_at(&w->stations[2], MODULE_DOCK,         1, 0);
     add_module_at(&w->stations[2], MODULE_SIGNAL_RELAY, 1, 1);
     add_furnace_for(&w->stations[2], 1, 2, COMMODITY_CUPRITE_INGOT);
-    /* Ring 2: fabs + paired ingot hoppers. LASER_FAB needs both
+    /* Ring 2: fabs + paired ingot hoppers + shipyard. LASER_FAB needs both
      * cuprite and crystal ingots → 2 spokes from it. TRACTOR_FAB
-     * just cuprite → 1 spoke. */
+     * just cuprite → 1 spoke. The shipyard consumes frames plus the
+     * locally-produced laser/tractor modules for repair-kit fabrication. */
     add_module_at(&w->stations[2], MODULE_LASER_FAB,    2, 0);
     add_hopper_for(&w->stations[2], 2, 1, COMMODITY_CUPRITE_INGOT);
+    add_module_at(&w->stations[2], MODULE_SHIPYARD,     2, 2); /* needs FRAME, LASER, TRACTOR */
     add_hopper_for(&w->stations[2], 2, 3, COMMODITY_CRYSTAL_INGOT);
     add_module_at(&w->stations[2], MODULE_TRACTOR_FAB,  2, 5);
     /* Ring 3: 2 more furnaces (cuprite + crystal output) + cuprite /
-     * crystal ore intake hoppers + laser/tractor module output hoppers
-     * for the ring-2 fabs. All 5 slots used here are well clear of the
-     * dock approach axis (slot 0 = 0° aligns with the dock; we sit
-     * elsewhere on the 9-slot ring). */
+     * crystal ore intake hoppers + frame / laser / tractor module hoppers
+     * for the ring-2 fabs and shipyard. Slots stay clear of the dock
+     * approach axis except the ore intake at slot 0. */
     add_hopper_for(&w->stations[2], 3, 0, COMMODITY_CUPRITE_ORE);
     add_furnace_for(&w->stations[2],   3, 1, COMMODITY_CUPRITE_INGOT);
-    add_hopper_for(&w->stations[2], 3, 2, COMMODITY_LASER_MODULE);   /* LASER_FAB output */
+    add_hopper_for(&w->stations[2], 3, 2, COMMODITY_LASER_MODULE);   /* LASER_FAB output + shipyard input */
+    add_hopper_for(&w->stations[2], 3, 3, COMMODITY_FRAME);          /* feeds SHIPYARD */
     add_furnace_for(&w->stations[2],   3, 4, COMMODITY_CRYSTAL_INGOT);
     add_hopper_for(&w->stations[2], 3, 6, COMMODITY_CRYSTAL_ORE);
-    add_hopper_for(&w->stations[2], 3, 7, COMMODITY_TRACTOR_MODULE); /* TRACTOR_FAB output */
+    add_hopper_for(&w->stations[2], 3, 7, COMMODITY_TRACTOR_MODULE); /* TRACTOR_FAB output + shipyard input */
     w->stations[2].arm_count = 3;
     w->stations[2].arm_speed[1] = STATION_RING_SPEED; /* ring 2 drift bias */
     rebuild_station_services(&w->stations[2]);
@@ -5401,7 +5404,8 @@ void world_reset(world_t *w) {
     spawn_npc(w, 0, NPC_ROLE_HAULER);
     spawn_npc(w, 1, NPC_ROLE_HAULER);   /* Kepler -> Helios frames */
     spawn_npc(w, 2, NPC_ROLE_HAULER);   /* Helios -> Prospect repair kits */
-    spawn_npc(w, 1, NPC_ROLE_TOW);      /* Kepler shipyard (only shipyard) */
+    spawn_npc(w, 1, NPC_ROLE_TOW);      /* Kepler shipyard */
+    spawn_npc(w, 2, NPC_ROLE_TOW);      /* Helios shipyard */
 
     /* Bootstrap each station's per-ring angular velocity to its drift
      * bias. Under the all-passive Slice 1.5a dynamics, omega ramps to

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -5322,25 +5322,24 @@ void world_reset(world_t *w) {
     add_module_at(&w->stations[2], MODULE_DOCK,         1, 0);
     add_module_at(&w->stations[2], MODULE_SIGNAL_RELAY, 1, 1);
     add_furnace_for(&w->stations[2], 1, 2, COMMODITY_CUPRITE_INGOT);
-    /* Ring 2: fabs + paired ingot hoppers + shipyard. LASER_FAB needs both
-     * cuprite and crystal ingots → 2 spokes from it. TRACTOR_FAB
-     * just cuprite → 1 spoke. The shipyard consumes frames plus the
-     * locally-produced laser/tractor modules for repair-kit fabrication. */
+    /* Ring 2: fabs + paired ingot / ore hoppers + shipyard. Smelter beams
+     * require the ore hopper on an adjacent ring, so cuprite/crystal ore
+     * intakes live between the ring-1/ring-3 furnaces they feed. */
     add_module_at(&w->stations[2], MODULE_LASER_FAB,    2, 0);
     add_hopper_for(&w->stations[2], 2, 1, COMMODITY_CUPRITE_INGOT);
     add_module_at(&w->stations[2], MODULE_SHIPYARD,     2, 2); /* needs FRAME, LASER, TRACTOR */
-    add_hopper_for(&w->stations[2], 2, 3, COMMODITY_CRYSTAL_INGOT);
+    add_hopper_for(&w->stations[2], 2, 3, COMMODITY_CRYSTAL_ORE);
+    add_hopper_for(&w->stations[2], 2, 4, COMMODITY_CUPRITE_ORE);
     add_module_at(&w->stations[2], MODULE_TRACTOR_FAB,  2, 5);
-    /* Ring 3: 2 more furnaces (cuprite + crystal output) + cuprite /
-     * crystal ore intake hoppers + frame / laser / tractor module hoppers
-     * for the ring-2 fabs and shipyard. Slots stay clear of the dock
-     * approach axis except the ore intake at slot 0. */
-    add_hopper_for(&w->stations[2], 3, 0, COMMODITY_CUPRITE_ORE);
-    add_furnace_for(&w->stations[2],   3, 1, COMMODITY_CUPRITE_INGOT);
+    /* Ring 3: 2 more furnaces (crystal + cuprite output) plus frame /
+     * crystal-ingot / laser / tractor module hoppers for the ring-2 fabs
+     * and shipyard. The ring-3 cuprite furnace shares the ring-2 cuprite
+     * ore intake with the inner cuprite furnace. */
     add_hopper_for(&w->stations[2], 3, 2, COMMODITY_LASER_MODULE);   /* LASER_FAB output + shipyard input */
     add_hopper_for(&w->stations[2], 3, 3, COMMODITY_FRAME);          /* feeds SHIPYARD */
     add_furnace_for(&w->stations[2],   3, 4, COMMODITY_CRYSTAL_INGOT);
-    add_hopper_for(&w->stations[2], 3, 6, COMMODITY_CRYSTAL_ORE);
+    add_hopper_for(&w->stations[2], 3, 5, COMMODITY_CRYSTAL_INGOT);
+    add_furnace_for(&w->stations[2],   3, 6, COMMODITY_CUPRITE_INGOT);
     add_hopper_for(&w->stations[2], 3, 7, COMMODITY_TRACTOR_MODULE); /* TRACTOR_FAB output + shipyard input */
     w->stations[2].arm_count = 3;
     w->stations[2].arm_speed[1] = STATION_RING_SPEED; /* ring 2 drift bias */

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -56,6 +56,42 @@ static int station_manifest_seed_from_npc(station_t *st, commodity_t c, int n,
     return pushed;
 }
 
+static bool station_smelt_pair_for_ore(const station_t *st, commodity_t ore,
+                                       vec2 *drop_point) {
+    if (!st || !drop_point || ore == COMMODITY_COUNT) return false;
+    bool found = false;
+    float best_d = 1e18f;
+    for (int fm = 0; fm < st->module_count; fm++) {
+        const station_module_t *f = &st->modules[fm];
+        if (f->type != MODULE_FURNACE) continue;
+        if (f->scaffold) continue;
+        if (module_instance_input_ore(f) != ore) continue;
+
+        int ring = (int)f->ring;
+        vec2 furnace_pos = module_world_pos_ring(st, ring, f->slot);
+        int adj_rings[2] = { ring + 1, ring - 1 };
+        for (int ri = 0; ri < 2; ri++) {
+            int adj = adj_rings[ri];
+            if (adj < 1 || adj > STATION_NUM_RINGS) continue;
+            for (int hm = 0; hm < st->module_count; hm++) {
+                const station_module_t *h = &st->modules[hm];
+                if (h->ring != adj) continue;
+                if (h->scaffold) continue;
+                if (h->type != MODULE_HOPPER) continue;
+                if ((commodity_t)h->commodity != ore) continue;
+                vec2 hopper_pos = module_world_pos_ring(st, adj, h->slot);
+                float d = v2_dist_sq(furnace_pos, hopper_pos);
+                if (d < best_d) {
+                    best_d = d;
+                    *drop_point = v2_scale(v2_add(furnace_pos, hopper_pos), 0.5f);
+                    found = true;
+                }
+            }
+        }
+    }
+    return found;
+}
+
 /* ================================================================== */
 /* NPC ships                                                          */
 /* ================================================================== */
@@ -1774,14 +1810,25 @@ void step_npc_ships(world_t *w, float dt) {
         case NPC_STATE_RETURN_TO_STATION: {
             station_t *home = &w->stations[npc->home_station];
 
-            /* Find the nearest furnace on this station to deliver to */
+            /* Deliver to the same furnace+ore-hopper midpoint the smelter
+             * beam uses. Picking the first furnace strands crystal at
+             * Helios when the first furnace is cuprite-tagged. */
             vec2 delivery_target = home->pos;
-            for (int fm = 0; fm < home->module_count; fm++) {
-                module_type_t fmt = home->modules[fm].type;
-                if (fmt != MODULE_FURNACE) continue;
-                if (home->modules[fm].scaffold) continue;
-                delivery_target = module_world_pos_ring(home, home->modules[fm].ring, home->modules[fm].slot);
-                break;
+            bool have_delivery_target = false;
+            if (npc->towed_fragment >= 0 && npc->towed_fragment < MAX_ASTEROIDS) {
+                asteroid_t *tow = &w->asteroids[npc->towed_fragment];
+                if (tow->active) {
+                    have_delivery_target = station_smelt_pair_for_ore(home, tow->commodity, &delivery_target);
+                }
+            }
+            if (!have_delivery_target) {
+                for (int fm = 0; fm < home->module_count; fm++) {
+                    module_type_t fmt = home->modules[fm].type;
+                    if (fmt != MODULE_FURNACE) continue;
+                    if (home->modules[fm].scaffold) continue;
+                    delivery_target = module_world_pos_ring(home, home->modules[fm].ring, home->modules[fm].slot);
+                    break;
+                }
             }
 
             /* Slow down when towing so the fragment can keep up */

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -317,14 +317,23 @@ static void mirror_npc_to_character(world_t *w, int npc_slot) {
  * built and don't get auto-replenished here; they can scaffold their
  * own NPCs via gameplay later. */
 static void station_target_npc_counts(int station_idx, const station_t *st,
-                                      int *miners, int *haulers) {
+                                      int *miners, int *haulers, int *tows) {
     *miners = 0;
     *haulers = 0;
+    *tows = 0;
     if (!st || !station_is_active(st)) return;
     switch (station_idx) {
     case 0: *miners = 2; *haulers = 2; return;  /* Prospect */
-    case 1: *miners = 0; *haulers = 1; return;  /* Kepler   */
-    case 2: *miners = 1; *haulers = 1; return;  /* Helios   */
+    case 1: /* Kepler */
+        *miners = 0;
+        *haulers = 1;
+        *tows = station_has_module(st, MODULE_SHIPYARD) ? 1 : 0;
+        return;
+    case 2: /* Helios */
+        *miners = 1;
+        *haulers = 1;
+        *tows = station_has_module(st, MODULE_SHIPYARD) ? 1 : 0;
+        return;
     default: return;                            /* outposts: no auto */
     }
 }
@@ -334,14 +343,20 @@ static void station_target_npc_counts(int station_idx, const station_t *st,
  * (station, role) pair. */
 static void count_npc_roster(const world_t *w,
                              int miners[MAX_STATIONS],
-                             int haulers[MAX_STATIONS]) {
-    for (int s = 0; s < MAX_STATIONS; s++) { miners[s] = 0; haulers[s] = 0; }
+                             int haulers[MAX_STATIONS],
+                             int tows[MAX_STATIONS]) {
+    for (int s = 0; s < MAX_STATIONS; s++) {
+        miners[s] = 0;
+        haulers[s] = 0;
+        tows[s] = 0;
+    }
     for (int n = 0; n < MAX_NPC_SHIPS; n++) {
         const npc_ship_t *npc = &w->npc_ships[n];
         if (!npc->active) continue;
         if (npc->home_station < 0 || npc->home_station >= MAX_STATIONS) continue;
         if (npc->role == NPC_ROLE_MINER)  miners[npc->home_station]++;
         if (npc->role == NPC_ROLE_HAULER) haulers[npc->home_station]++;
+        if (npc->role == NPC_ROLE_TOW)    tows[npc->home_station]++;
     }
 }
 
@@ -351,8 +366,8 @@ static void count_npc_roster(const world_t *w,
  * is informational, so spawning is no longer gated on solvency.
  * Returns true if a spawn fired. */
 static bool replenish_npc_roster(world_t *w) {
-    int miners[MAX_STATIONS], haulers[MAX_STATIONS];
-    count_npc_roster(w, miners, haulers);
+    int miners[MAX_STATIONS], haulers[MAX_STATIONS], tows[MAX_STATIONS];
+    count_npc_roster(w, miners, haulers, tows);
 
     /* Find the largest shortfall across all (station, role) pairs.
      * Tie-broken by station index (lower wins). */
@@ -360,16 +375,20 @@ static bool replenish_npc_roster(world_t *w) {
     npc_role_t best_role = NPC_ROLE_MINER;
     int best_shortfall = 0;
     for (int s = 0; s < MAX_STATIONS; s++) {
-        int target_m = 0, target_h = 0;
-        station_target_npc_counts(s, &w->stations[s], &target_m, &target_h);
+        int target_m = 0, target_h = 0, target_t = 0;
+        station_target_npc_counts(s, &w->stations[s], &target_m, &target_h, &target_t);
         /* Sovereign station can run negative; pool is informational. */
         int short_m = target_m - miners[s];
         int short_h = target_h - haulers[s];
+        int short_t = target_t - tows[s];
         if (short_m > best_shortfall) {
             best_shortfall = short_m; best_station = s; best_role = NPC_ROLE_MINER;
         }
         if (short_h > best_shortfall) {
             best_shortfall = short_h; best_station = s; best_role = NPC_ROLE_HAULER;
+        }
+        if (short_t > best_shortfall) {
+            best_shortfall = short_t; best_station = s; best_role = NPC_ROLE_TOW;
         }
     }
     if (best_station < 0) return false;

--- a/server/sim_autopilot.c
+++ b/server/sim_autopilot.c
@@ -41,21 +41,19 @@ static bool station_can_smelt_ore_for_autopilot(const station_t *st, commodity_t
 }
 
 /* Compute the smelt-beam drop point for `ore` at `st`: the midpoint of a
- * matching furnace and its nearest adjacent-ring module. Mirrors the
+ * matching furnace and its nearest adjacent-ring ore hopper. Mirrors the
  * pairing logic in step_furnace_smelting so the autopilot parks where
  * fragments will actually be pulled in. Falls back to the station center
  * when no furnace+silo pair exists. */
 static vec2 station_smelt_drop_point(const station_t *st, commodity_t ore) {
-    /* All furnaces are equivalent for parking purposes; the count tier
-     * still has to permit smelting of `ore` for the beam to fire, but
-     * any furnace anchors the geometry. */
-    (void)ore;
     vec2 best_mid = st->pos;
     float best_silo_d = 1e18f;
     bool found = false;
     for (int m = 0; m < st->module_count; m++) {
         if (st->modules[m].scaffold) continue;
         if (st->modules[m].type != MODULE_FURNACE) continue;
+        commodity_t furnace_ore = module_instance_input_ore(&st->modules[m]);
+        if (ore != COMMODITY_COUNT && furnace_ore != ore) continue;
         int ring = st->modules[m].ring;
         vec2 furnace_pos = module_world_pos_ring(st, ring, st->modules[m].slot);
         int adj_rings[2] = { ring + 1, ring - 1 };
@@ -65,6 +63,8 @@ static vec2 station_smelt_drop_point(const station_t *st, commodity_t ore) {
             for (int m2 = 0; m2 < st->module_count; m2++) {
                 if (st->modules[m2].ring != adj) continue;
                 if (st->modules[m2].scaffold) continue;
+                if (st->modules[m2].type != MODULE_HOPPER) continue;
+                if ((commodity_t)st->modules[m2].commodity != furnace_ore) continue;
                 vec2 mp2 = module_world_pos_ring(st, adj, st->modules[m2].slot);
                 float d = v2_dist_sq(furnace_pos, mp2);
                 if (d < best_silo_d) {

--- a/server/sim_catalog.c
+++ b/server/sim_catalog.c
@@ -12,6 +12,8 @@
  */
 #include "sim_catalog.h"
 #include "manifest.h"
+#include "sim_construction.h"
+#include "station_util.h"
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -45,7 +47,8 @@ static uint32_t crc32_file(FILE *f) {
 }
 
 #define CATALOG_MAGIC   0x53544E43  /* "STNC" */
-#define CATALOG_VERSION 3  /* v3: per-module commodity tag (hopper specialization) */
+#define CATALOG_VERSION 4  /* v4: repair Helios seed to include shipyard + frame hopper.
+                            * v3: per-module commodity tag (hopper specialization). */
 
 /* ---- helper macros (same pattern as sim_save.c) ---- */
 #define WRITE_FIELD(f, val) do { if (fwrite(&(val), sizeof(val), 1, (f)) != 1) { fclose(f); return false; } } while(0)
@@ -58,6 +61,70 @@ static void ensure_dir(const char *dir) {
 #else
     mkdir(dir, 0755);
 #endif
+}
+
+static bool catalog_slot_free(const station_t *st, int ring, int slot) {
+    if (!st || ring < 1 || ring > STATION_NUM_RINGS) return false;
+    if (slot < 0 || slot >= STATION_RING_SLOTS[ring]) return false;
+    for (int i = 0; i < st->module_count; i++) {
+        if (st->modules[i].ring == ring && st->modules[i].slot == slot)
+            return false;
+    }
+    return true;
+}
+
+static bool catalog_add_module_prefer(station_t *st, module_type_t type,
+                                      int preferred_ring, int preferred_slot) {
+    if (!st || st->module_count >= MAX_MODULES_PER_STATION) return false;
+    if (catalog_slot_free(st, preferred_ring, preferred_slot)) {
+        add_module_at(st, type, (uint8_t)preferred_ring, (uint8_t)preferred_slot);
+        return true;
+    }
+    for (int r = 2; r <= STATION_NUM_RINGS; r++) {
+        int slot = station_ring_free_slot(st, r, STATION_RING_SLOTS[r]);
+        if (slot >= 0) {
+            add_module_at(st, type, (uint8_t)r, (uint8_t)slot);
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool catalog_add_hopper_prefer(station_t *st, commodity_t c,
+                                      int preferred_ring, int preferred_slot) {
+    if (!st || st->module_count >= MAX_MODULES_PER_STATION) return false;
+    if (catalog_slot_free(st, preferred_ring, preferred_slot)) {
+        add_hopper_for(st, (uint8_t)preferred_ring, (uint8_t)preferred_slot, c);
+        return true;
+    }
+    for (int r = 2; r <= STATION_NUM_RINGS; r++) {
+        int slot = station_ring_free_slot(st, r, STATION_RING_SLOTS[r]);
+        if (slot >= 0) {
+            add_hopper_for(st, (uint8_t)r, (uint8_t)slot, c);
+            return true;
+        }
+    }
+    for (int r = 1; r <= STATION_NUM_RINGS; r++) {
+        int slot = station_ring_free_slot(st, r, STATION_RING_SLOTS[r]);
+        if (slot >= 0) {
+            add_hopper_for(st, (uint8_t)r, (uint8_t)slot, c);
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool station_catalog_migrate_v4_helios(station_t *st, int index, uint32_t ver) {
+    if (!st || index != 2 || ver >= 4) return false;
+    bool changed = false;
+    if (!station_has_module(st, MODULE_SHIPYARD)) {
+        changed |= catalog_add_module_prefer(st, MODULE_SHIPYARD, 2, 2);
+    }
+    if (station_find_hopper_for(st, COMMODITY_FRAME) < 0) {
+        changed |= catalog_add_hopper_prefer(st, COMMODITY_FRAME, 3, 3);
+    }
+    if (changed) rebuild_station_services(st);
+    return changed;
 }
 
 /* ================================================================== */
@@ -229,6 +296,10 @@ static bool station_catalog_load_one(station_t *st, int index, const char *dir) 
         memset(st, 0, sizeof(*st));
         (void)station_manifest_bootstrap(st);
         return false;
+    }
+
+    if (station_catalog_migrate_v4_helios(st, index, ver)) {
+        printf("[catalog] migrated station %d to v4 Helios shipyard layout\n", index);
     }
 
     /* Rebuild service flags from module list */

--- a/server/sim_catalog.c
+++ b/server/sim_catalog.c
@@ -47,7 +47,8 @@ static uint32_t crc32_file(FILE *f) {
 }
 
 #define CATALOG_MAGIC   0x53544E43  /* "STNC" */
-#define CATALOG_VERSION 4  /* v4: repair Helios seed to include shipyard + frame hopper.
+#define CATALOG_VERSION 5  /* v5: repair Helios smelter ore/furnace adjacency.
+                            * v4: repair Helios seed to include shipyard + frame hopper.
                             * v3: per-module commodity tag (hopper specialization). */
 
 /* ---- helper macros (same pattern as sim_save.c) ---- */
@@ -63,66 +64,106 @@ static void ensure_dir(const char *dir) {
 #endif
 }
 
-static bool catalog_slot_free(const station_t *st, int ring, int slot) {
-    if (!st || ring < 1 || ring > STATION_NUM_RINGS) return false;
-    if (slot < 0 || slot >= STATION_RING_SLOTS[ring]) return false;
-    for (int i = 0; i < st->module_count; i++) {
-        if (st->modules[i].ring == ring && st->modules[i].slot == slot)
-            return false;
-    }
-    return true;
-}
-
-static bool catalog_add_module_prefer(station_t *st, module_type_t type,
-                                      int preferred_ring, int preferred_slot) {
-    if (!st || st->module_count >= MAX_MODULES_PER_STATION) return false;
-    if (catalog_slot_free(st, preferred_ring, preferred_slot)) {
-        add_module_at(st, type, (uint8_t)preferred_ring, (uint8_t)preferred_slot);
-        return true;
-    }
-    for (int r = 2; r <= STATION_NUM_RINGS; r++) {
-        int slot = station_ring_free_slot(st, r, STATION_RING_SLOTS[r]);
-        if (slot >= 0) {
-            add_module_at(st, type, (uint8_t)r, (uint8_t)slot);
-            return true;
-        }
-    }
-    return false;
-}
-
-static bool catalog_add_hopper_prefer(station_t *st, commodity_t c,
-                                      int preferred_ring, int preferred_slot) {
-    if (!st || st->module_count >= MAX_MODULES_PER_STATION) return false;
-    if (catalog_slot_free(st, preferred_ring, preferred_slot)) {
-        add_hopper_for(st, (uint8_t)preferred_ring, (uint8_t)preferred_slot, c);
-        return true;
-    }
-    for (int r = 2; r <= STATION_NUM_RINGS; r++) {
-        int slot = station_ring_free_slot(st, r, STATION_RING_SLOTS[r]);
-        if (slot >= 0) {
-            add_hopper_for(st, (uint8_t)r, (uint8_t)slot, c);
-            return true;
-        }
-    }
-    for (int r = 1; r <= STATION_NUM_RINGS; r++) {
-        int slot = station_ring_free_slot(st, r, STATION_RING_SLOTS[r]);
-        if (slot >= 0) {
-            add_hopper_for(st, (uint8_t)r, (uint8_t)slot, c);
-            return true;
-        }
-    }
-    return false;
-}
-
-static bool station_catalog_migrate_v4_helios(station_t *st, int index, uint32_t ver) {
-    if (!st || index != 2 || ver >= 4) return false;
+static bool catalog_move_module(station_module_t *m, int ring, int slot) {
     bool changed = false;
-    if (!station_has_module(st, MODULE_SHIPYARD)) {
-        changed |= catalog_add_module_prefer(st, MODULE_SHIPYARD, 2, 2);
+    if ((int)m->ring != ring) { m->ring = (uint8_t)ring; changed = true; }
+    if ((int)m->slot != slot) { m->slot = (uint8_t)slot; changed = true; }
+    return changed;
+}
+
+static int catalog_find_module(const station_t *st, module_type_t type) {
+    if (!st) return -1;
+    for (int i = 0; i < st->module_count; i++) {
+        if (st->modules[i].type == type) return i;
     }
-    if (station_find_hopper_for(st, COMMODITY_FRAME) < 0) {
-        changed |= catalog_add_hopper_prefer(st, COMMODITY_FRAME, 3, 3);
+    return -1;
+}
+
+static int catalog_find_hopper_for(const station_t *st, commodity_t commodity) {
+    if (!st) return -1;
+    for (int i = 0; i < st->module_count; i++) {
+        if (st->modules[i].type != MODULE_HOPPER) continue;
+        if ((commodity_t)st->modules[i].commodity == commodity) return i;
     }
+    return -1;
+}
+
+static int catalog_find_furnace_for(const station_t *st, commodity_t ingot, int ordinal) {
+    if (!st) return -1;
+    int seen = 0;
+    for (int i = 0; i < st->module_count; i++) {
+        const station_module_t *m = &st->modules[i];
+        if (m->type != MODULE_FURNACE) continue;
+        if (module_instance_output(m) != ingot) continue;
+        if (seen == ordinal) return i;
+        seen++;
+    }
+    return -1;
+}
+
+static bool catalog_place_module(station_t *st, module_type_t type, int ring, int slot) {
+    if (!st) return false;
+    int idx = catalog_find_module(st, type);
+    if (idx < 0) {
+        if (st->module_count >= MAX_MODULES_PER_STATION) return false;
+        add_module_at(st, type, (uint8_t)ring, (uint8_t)slot);
+        return true;
+    }
+    return catalog_move_module(&st->modules[idx], ring, slot);
+}
+
+static bool catalog_place_hopper(station_t *st, commodity_t commodity, int ring, int slot) {
+    if (!st) return false;
+    int idx = catalog_find_hopper_for(st, commodity);
+    if (idx < 0) {
+        if (st->module_count >= MAX_MODULES_PER_STATION) return false;
+        add_hopper_for(st, (uint8_t)ring, (uint8_t)slot, commodity);
+        return true;
+    }
+    bool changed = catalog_move_module(&st->modules[idx], ring, slot);
+    if ((commodity_t)st->modules[idx].commodity != commodity) {
+        st->modules[idx].commodity = (uint8_t)commodity;
+        changed = true;
+    }
+    return changed;
+}
+
+static bool catalog_place_furnace(station_t *st, commodity_t ingot, int ordinal,
+                                  int ring, int slot) {
+    if (!st) return false;
+    int idx = catalog_find_furnace_for(st, ingot, ordinal);
+    if (idx < 0) {
+        if (st->module_count >= MAX_MODULES_PER_STATION) return false;
+        add_furnace_for(st, (uint8_t)ring, (uint8_t)slot, ingot);
+        return true;
+    }
+    bool changed = catalog_move_module(&st->modules[idx], ring, slot);
+    if ((commodity_t)st->modules[idx].commodity != ingot) {
+        st->modules[idx].commodity = (uint8_t)ingot;
+        changed = true;
+    }
+    return changed;
+}
+
+static bool station_catalog_migrate_v5_helios(station_t *st, int index, uint32_t ver) {
+    if (!st || index != 2 || ver >= 5) return false;
+    bool changed = false;
+
+    changed |= catalog_place_module(st, MODULE_LASER_FAB, 2, 0);
+    changed |= catalog_place_hopper(st, COMMODITY_CUPRITE_INGOT, 2, 1);
+    changed |= catalog_place_module(st, MODULE_SHIPYARD, 2, 2);
+    changed |= catalog_place_hopper(st, COMMODITY_CRYSTAL_ORE, 2, 3);
+    changed |= catalog_place_hopper(st, COMMODITY_CUPRITE_ORE, 2, 4);
+    changed |= catalog_place_module(st, MODULE_TRACTOR_FAB, 2, 5);
+
+    changed |= catalog_place_hopper(st, COMMODITY_LASER_MODULE, 3, 2);
+    changed |= catalog_place_hopper(st, COMMODITY_FRAME, 3, 3);
+    changed |= catalog_place_furnace(st, COMMODITY_CRYSTAL_INGOT, 0, 3, 4);
+    changed |= catalog_place_hopper(st, COMMODITY_CRYSTAL_INGOT, 3, 5);
+    changed |= catalog_place_furnace(st, COMMODITY_CUPRITE_INGOT, 0, 1, 2);
+    changed |= catalog_place_furnace(st, COMMODITY_CUPRITE_INGOT, 1, 3, 6);
+    changed |= catalog_place_hopper(st, COMMODITY_TRACTOR_MODULE, 3, 7);
+
     if (changed) rebuild_station_services(st);
     return changed;
 }
@@ -298,8 +339,8 @@ static bool station_catalog_load_one(station_t *st, int index, const char *dir) 
         return false;
     }
 
-    if (station_catalog_migrate_v4_helios(st, index, ver)) {
-        printf("[catalog] migrated station %d to v4 Helios shipyard layout\n", index);
+    if (station_catalog_migrate_v5_helios(st, index, ver)) {
+        printf("[catalog] migrated station %d to v5 Helios smelter layout\n", index);
     }
 
     /* Rebuild service flags from module list */

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -523,12 +523,13 @@ void step_furnace_smelting(world_t *w, float dt) {
              * fragments" failure mode under the new rules. */
             if (!sim_can_smelt_ore(st, a->commodity)) continue;
 
-            /* Find furnace+target pairs: any furnace on the station can
-             * anchor the beam, paired with the nearest module on an
-             * adjacent ring. */
+            /* Find furnace+target pairs: only a furnace tagged for this ore
+             * can anchor the beam, paired with the nearest matching hopper
+             * on an adjacent ring. */
             for (int m = 0; m < st->module_count && !smelted; m++) {
                 if (st->modules[m].scaffold) continue;
                 if (st->modules[m].type != MODULE_FURNACE) continue;
+                if (module_instance_input_ore(&st->modules[m]) != a->commodity) continue;
 
                 /* Output cap: refuse to engage the beam if the station's
                  * ingot stockpile is already full. Without this, smelts

--- a/server/sim_production.h
+++ b/server/sim_production.h
@@ -14,7 +14,7 @@ void sim_step_refinery_production(world_t *w, float dt);
 void sim_step_station_production(world_t *w, float dt);
 void step_module_flow(world_t *w, float dt);
 
-/* Dock repair-kit fabrication: every station with a MODULE_DOCK turns
+/* Shipyard repair-kit fabrication: every station with a MODULE_SHIPYARD turns
  * 1 frame + 1 laser + 1 tractor module into 100 repair kits, slowly,
  * up to a per-station cap. Provides the end-of-chain demand sink that
  * pulls finished goods out of Kepler/Helios. */

--- a/shared/station_util.c
+++ b/shared/station_util.c
@@ -407,6 +407,21 @@ station_demand_t station_top_demand(const station_t *st) {
     return out;
 }
 
+static bool station_has_adjacent_hopper_for(const station_t *st,
+                                            const station_module_t *m,
+                                            commodity_t commodity) {
+    if (!st || !m || commodity == COMMODITY_COUNT) return false;
+    for (int i = 0; i < st->module_count; i++) {
+        const station_module_t *h = &st->modules[i];
+        if (h->scaffold) continue;
+        if (h->type != MODULE_HOPPER) continue;
+        if ((commodity_t)h->commodity != commodity) continue;
+        int dr = (int)h->ring - (int)m->ring;
+        if (dr == 1 || dr == -1) return true;
+    }
+    return false;
+}
+
 station_layout_status_t station_module_layout_status(const station_t *st,
                                                      const station_module_t *m) {
     if (!st || !m) return STATION_LAYOUT_OK;
@@ -418,7 +433,7 @@ station_layout_status_t station_module_layout_status(const station_t *st,
      * the actual input is the one ore that matches the furnace's tag. */
     if (m->type == MODULE_FURNACE) {
         commodity_t ore = module_instance_input_ore(m);
-        if (ore != COMMODITY_COUNT && station_find_hopper_for(st, ore) < 0) {
+        if (ore != COMMODITY_COUNT && !station_has_adjacent_hopper_for(st, m, ore)) {
             return STATION_LAYOUT_MISSING_INPUT_HOPPER;
         }
     } else {
@@ -482,4 +497,3 @@ const char *station_short_name(int station_idx) {
         return outpost_buf;
     }
 }
-

--- a/shared/types.h
+++ b/shared/types.h
@@ -174,13 +174,13 @@ typedef enum {
     RECIPE_FRAME_BASIC,
     RECIPE_LASER_BASIC,
     RECIPE_TRACTOR_COIL,
-    RECIPE_REPAIR_KIT_FAB,    /* 1 frame + 1 laser → 100 repair kits, at any dock */
+    RECIPE_REPAIR_KIT_FAB,    /* 1 frame + 1 laser + 1 tractor -> 100 repair kits at shipyards */
     RECIPE_LEGACY_MIGRATE,
     RECIPE_COUNT
 } recipe_id_t;
 
-/* RECIPE_INPUT_MAX bumped from 2 → 3 so the dock repair-kit recipe
- * (frame + laser + tractor → 100 kits) can fit. All recipes still
+/* RECIPE_INPUT_MAX bumped from 2 -> 3 so the shipyard repair-kit recipe
+ * (frame + laser + tractor -> 100 kits) can fit. All recipes still
  * declare their actual input_count; the array slot is just sized
  * to the largest recipe in the table. */
 #define RECIPE_INPUT_MAX 3
@@ -440,10 +440,10 @@ typedef struct {
      * wire-push (server-only). */
     manifest_t    manifest;
     bool          manifest_dirty;
-    /* Dock repair-kit fab cadence: server-only countdown. When it
-     * reaches zero and the station has 1 frame + 1 laser + 1 tractor
-     * in inventory, consume them, mint REPAIR_KIT_PER_BATCH kits, and
-     * reset the timer to REPAIR_KIT_FAB_PERIOD. */
+    /* Shipyard repair-kit fab cadence: server-only countdown. When it
+     * reaches the period and the station has 1 frame + 1 laser + 1
+     * tractor in its manifest, consume them, mint REPAIR_KIT_PER_BATCH
+     * kits, and reset the timer. */
     float         repair_kit_fab_timer;
     /* Layer B of #479 — per-station Ed25519 identity.
      *

--- a/src/commodity.c
+++ b/src/commodity.c
@@ -87,28 +87,30 @@ const char* commodity_code(commodity_t commodity) {
 }
 
 void commodity_color_u8(commodity_t commodity, uint8_t *r, uint8_t *g, uint8_t *b) {
-    /* Warm-to-cool ladder for the three ores (matches the color dot on
-     * the asteroid and the tow tether so the TRADE row reads the same).
-     * Fabricated goods get their own signature so the market scans
-     * quickly: frame = slate, laser = nav-blue, tractor = mint. */
+    /* Resource-family ladder: ore is full resource color; ingots are that
+     * resource blended with gray metal; products are mostly metal with a
+     * source-resource accent. Keep this in sync with src/palette.h. */
     switch (commodity) {
     case COMMODITY_FERRITE_ORE:
-    case COMMODITY_FERRITE_INGOT:
-        *r = 217; *g = 127; *b =  90; return;  /* warm ferrite amber */
+        *r = 217; *g =  77; *b =  51; return;
     case COMMODITY_CUPRITE_ORE:
-    case COMMODITY_CUPRITE_INGOT:
-        *r = 110; *g = 210; *b = 140; return;  /* cuprite oxide green */
+        *r =  64; *g = 128; *b = 230; return;
     case COMMODITY_CRYSTAL_ORE:
+        *r =  77; *g = 204; *b =  89; return;
+    case COMMODITY_FERRITE_INGOT:
+        *r = 199; *g = 112; *b =  94; return;
+    case COMMODITY_CUPRITE_INGOT:
+        *r = 107; *g = 150; *b = 207; return;
     case COMMODITY_CRYSTAL_INGOT:
-        *r = 180; *g = 140; *b = 255; return;  /* crystal violet */
+        *r = 112; *g = 191; *b = 120; return;
     case COMMODITY_FRAME:
-        *r = 190; *g = 200; *b = 220; return;  /* cool slate */
+        *r = 163; *g = 135; *b = 135; return;
     case COMMODITY_LASER_MODULE:
-        *r = 140; *g = 180; *b = 255; return;  /* nav blue */
+        *r = 135; *g = 156; *b = 191; return;
     case COMMODITY_TRACTOR_MODULE:
-        *r = 120; *g = 235; *b = 200; return;  /* mint */
+        *r = 130; *g = 176; *b = 143; return;
     case COMMODITY_REPAIR_KIT:
-        *r = 240; *g =  90; *b =  90; return;  /* med-cross red — repair signal */
+        *r = 184; *g = 140; *b = 140; return;
     case COMMODITY_COUNT:
     default:
         *r = 200; *g = 220; *b = 230; return;  /* fallback cool white */

--- a/src/palette.h
+++ b/src/palette.h
@@ -159,23 +159,23 @@
 #define PAL_FURNACE_CRYSTAL 0.30f, 0.80f, 0.35f
 #define PAL_FURNACE_CHUNKS  0.85f, 0.85f, 0.90f
 
-/* Commodity colors — derived from the asteroid/ore palette and used
- * to tint hoppers (which buffer one commodity each) and the cross-
- * ring spokes that feed/drain them. The chain refines saturation:
- *   ORE     ← raw asteroid color
- *   INGOT   ← ore color, brightened/cleaner
- *   PRODUCT ← blend of constituent ingots
- * Renderer picks the right tint via commodity_color() below. */
+/* Commodity colors — resource-family language for hoppers and spokes:
+ *   ORE     = full resource color
+ *   INGOT   = resource color with gray-metal accent
+ *   PRODUCT = gray-metal base with resource accent
+ * Single-color callers use the representative blend below; hopper glyphs
+ * draw the base/accent split explicitly in world_draw.c. */
+#define PAL_COMMODITY_METAL_ACCENT      0.58f, 0.62f, 0.66f  /* gray metal */
 #define PAL_COMMODITY_FERRITE_ORE     0.85f, 0.30f, 0.20f  /* rusty red */
 #define PAL_COMMODITY_CUPRITE_ORE     0.25f, 0.50f, 0.90f  /* asteroid blue */
 #define PAL_COMMODITY_CRYSTAL_ORE     0.30f, 0.80f, 0.35f  /* asteroid green */
-#define PAL_COMMODITY_FERRITE_INGOT   0.95f, 0.50f, 0.30f  /* hot iron */
-#define PAL_COMMODITY_CUPRITE_INGOT   0.40f, 0.70f, 1.00f  /* refined copper */
-#define PAL_COMMODITY_CRYSTAL_INGOT   0.50f, 0.95f, 0.50f  /* bright crystal */
-#define PAL_COMMODITY_FRAME           0.95f, 0.78f, 0.25f  /* yellow-gold (ferrite product) */
-#define PAL_COMMODITY_LASER_MODULE    0.45f, 0.75f, 0.95f  /* cuprite+crystal blend, lit */
-#define PAL_COMMODITY_TRACTOR_MODULE  0.50f, 0.55f, 0.85f  /* cuprite-only product */
-#define PAL_COMMODITY_REPAIR_KIT      0.95f, 0.70f, 0.50f  /* warm white-gold, end of chain */
+#define PAL_COMMODITY_FERRITE_INGOT   0.78f, 0.44f, 0.37f  /* ferrite + metal */
+#define PAL_COMMODITY_CUPRITE_INGOT   0.42f, 0.59f, 0.81f  /* cuprite + metal */
+#define PAL_COMMODITY_CRYSTAL_INGOT   0.44f, 0.75f, 0.47f  /* crystal + metal */
+#define PAL_COMMODITY_FRAME           0.64f, 0.53f, 0.53f  /* metal + ferrite */
+#define PAL_COMMODITY_LASER_MODULE    0.53f, 0.61f, 0.75f  /* metal + cuprite */
+#define PAL_COMMODITY_TRACTOR_MODULE  0.51f, 0.69f, 0.56f  /* metal + crystal */
+#define PAL_COMMODITY_REPAIR_KIT      0.72f, 0.55f, 0.55f  /* metal + repair red */
 
 /* Kepler modules */
 #define PAL_MODULE_FRAME_PRESS 0.90f, 0.75f, 0.20f

--- a/src/station_palette.h
+++ b/src/station_palette.h
@@ -2,9 +2,9 @@
  * station_palette.h — render-time palette helpers for station modules.
  *
  * These helpers let the renderer pick a module color based on station
- * context (e.g. how many furnaces a station has, which ring this furnace
- * sits on) without bumping the schema or save format. The simulation
- * remains unaware: it only knows the generic MODULE_FURNACE type.
+ * context. Commodity-tagged furnaces use their instance output when
+ * available; legacy/unconfigured furnaces fall back to the station-wide
+ * ring heuristic without bumping the schema or save format.
  *
  * Test-friendly: defined as a static inline so test_furnace_color.c can
  * include this header and exercise the same logic the renderer uses.
@@ -81,6 +81,38 @@ static inline void station_palette_furnace_color(const station_t *st,
             PAL_UNPACK3(PAL_FURNACE_CHUNKS, *r, *g, *b);
         }
     }
+}
+
+static inline bool station_palette_furnace_commodity_color(commodity_t out,
+                                                           float *r, float *g, float *b) {
+    switch (out) {
+    case COMMODITY_FERRITE_INGOT:
+        PAL_UNPACK3(PAL_FURNACE_FERRITE, *r, *g, *b);
+        return true;
+    case COMMODITY_CUPRITE_INGOT:
+        PAL_UNPACK3(PAL_FURNACE_CUPRITE, *r, *g, *b);
+        return true;
+    case COMMODITY_CRYSTAL_INGOT:
+        PAL_UNPACK3(PAL_FURNACE_CRYSTAL, *r, *g, *b);
+        return true;
+    default:
+        return false;
+    }
+}
+
+static inline void station_palette_furnace_module_color(const station_t *st,
+                                                        const station_module_t *m,
+                                                        float *r, float *g, float *b) {
+    if (m && m->type == MODULE_FURNACE &&
+        (commodity_t)m->commodity != COMMODITY_COUNT &&
+        station_palette_furnace_commodity_color((commodity_t)m->commodity, r, g, b)) {
+        return;
+    }
+    if (st && m) {
+        station_palette_furnace_color(st, (int)m->ring, r, g, b);
+        return;
+    }
+    PAL_UNPACK3(PAL_FURNACE_FERRITE, *r, *g, *b);
 }
 
 #endif /* SIGNAL_STATION_PALETTE_H */

--- a/src/tests/test_commodity.c
+++ b/src/tests/test_commodity.c
@@ -76,23 +76,25 @@ TEST(test_commodity_color_u8_all_branches) {
      * fallback honest so a new commodity can't silently inherit white. */
     uint8_t r, g, b;
     commodity_color_u8(COMMODITY_FERRITE_ORE, &r, &g, &b);
-    ASSERT_EQ_INT(r, 217); ASSERT_EQ_INT(g, 127); ASSERT_EQ_INT(b, 90);
+    ASSERT_EQ_INT(r, 217); ASSERT_EQ_INT(g, 77); ASSERT_EQ_INT(b, 51);
     commodity_color_u8(COMMODITY_CUPRITE_ORE, &r, &g, &b);
-    ASSERT_EQ_INT(r, 110); ASSERT_EQ_INT(g, 210); ASSERT_EQ_INT(b, 140);
+    ASSERT_EQ_INT(r, 64); ASSERT_EQ_INT(g, 128); ASSERT_EQ_INT(b, 230);
     commodity_color_u8(COMMODITY_CRYSTAL_ORE, &r, &g, &b);
-    ASSERT_EQ_INT(r, 180); ASSERT_EQ_INT(g, 140); ASSERT_EQ_INT(b, 255);
+    ASSERT_EQ_INT(r, 77); ASSERT_EQ_INT(g, 204); ASSERT_EQ_INT(b, 89);
     commodity_color_u8(COMMODITY_FERRITE_INGOT, &r, &g, &b);
-    ASSERT_EQ_INT(r, 217);
+    ASSERT_EQ_INT(r, 199); ASSERT_EQ_INT(g, 112); ASSERT_EQ_INT(b, 94);
     commodity_color_u8(COMMODITY_CUPRITE_INGOT, &r, &g, &b);
-    ASSERT_EQ_INT(r, 110);
+    ASSERT_EQ_INT(r, 107); ASSERT_EQ_INT(g, 150); ASSERT_EQ_INT(b, 207);
     commodity_color_u8(COMMODITY_CRYSTAL_INGOT, &r, &g, &b);
-    ASSERT_EQ_INT(r, 180);
+    ASSERT_EQ_INT(r, 112); ASSERT_EQ_INT(g, 191); ASSERT_EQ_INT(b, 120);
     commodity_color_u8(COMMODITY_FRAME, &r, &g, &b);
-    ASSERT_EQ_INT(r, 190);
+    ASSERT_EQ_INT(r, 163); ASSERT_EQ_INT(g, 135); ASSERT_EQ_INT(b, 135);
     commodity_color_u8(COMMODITY_LASER_MODULE, &r, &g, &b);
-    ASSERT_EQ_INT(r, 140);
+    ASSERT_EQ_INT(r, 135); ASSERT_EQ_INT(g, 156); ASSERT_EQ_INT(b, 191);
     commodity_color_u8(COMMODITY_TRACTOR_MODULE, &r, &g, &b);
-    ASSERT_EQ_INT(r, 120);
+    ASSERT_EQ_INT(r, 130); ASSERT_EQ_INT(g, 176); ASSERT_EQ_INT(b, 143);
+    commodity_color_u8(COMMODITY_REPAIR_KIT, &r, &g, &b);
+    ASSERT_EQ_INT(r, 184); ASSERT_EQ_INT(g, 140); ASSERT_EQ_INT(b, 140);
     commodity_color_u8(COMMODITY_COUNT, &r, &g, &b);
     ASSERT_EQ_INT(r, 200); ASSERT_EQ_INT(g, 220); ASSERT_EQ_INT(b, 230);
 }

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -1623,9 +1623,12 @@ TEST(test_seeded_furnaces_tagged) {
 
 TEST(test_seeded_helios_output_hoppers) {
     /* Helios's LASER_FAB and TRACTOR_FAB each have a dedicated
-     * commodity-tagged output hopper on ring 3. */
+     * commodity-tagged output hopper on ring 3, and its shipyard has
+     * the frame / laser / tractor hoppers needed for repair-kit fab. */
     WORLD_DECL;
     world_reset(&w);
+    ASSERT(station_has_module(&w.stations[2], MODULE_SHIPYARD));
+    ASSERT(station_find_hopper_for(&w.stations[2], COMMODITY_FRAME) >= 0);
     ASSERT(station_find_hopper_for(&w.stations[2], COMMODITY_LASER_MODULE)   >= 0);
     ASSERT(station_find_hopper_for(&w.stations[2], COMMODITY_TRACTOR_MODULE) >= 0);
     /* All Helios producers report OK under the new layout rule. */

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -1539,9 +1539,9 @@ TEST(test_station_module_layout_status_no_local_consumer_is_ok) {
      * 1-furnace ferrite station with no on-station frame press. */
     station_t st = {0};
     st.signal_range = 1.0f;
-    add_hopper_for(&st, 2, 0, COMMODITY_FERRITE_ORE);   /* input only */
-    add_furnace_for(&st, 2, 1, COMMODITY_FERRITE_INGOT);
-    const station_module_t *furnace = &st.modules[1];
+    add_furnace_for(&st, 1, 1, COMMODITY_FERRITE_INGOT);
+    add_hopper_for(&st, 2, 0, COMMODITY_FERRITE_ORE);   /* adjacent input only */
+    const station_module_t *furnace = &st.modules[0];
     /* No FRAME_PRESS / LASER_FAB / TRACTOR_FAB on the station, so
      * nothing locally consumes ferrite ingots. Layout is OK without
      * an output hopper. */
@@ -1557,7 +1557,7 @@ TEST(test_station_module_layout_status_furnace_uses_tag) {
     station_t st = {0};
     st.signal_range = 1.0f;
     add_hopper_for(&st, 2, 0, COMMODITY_FERRITE_ORE); /* wrong ore for a CU furnace */
-    add_furnace_for(&st, 2, 1, COMMODITY_CUPRITE_INGOT);
+    add_furnace_for(&st, 1, 1, COMMODITY_CUPRITE_INGOT);
     add_module_at(&st, MODULE_TRACTOR_FAB, 2, 5);     /* consumes CUPRITE_INGOT */
     const station_module_t *fc = &st.modules[1];     /* the furnace */
     ASSERT_EQ_INT(station_module_layout_status(&st, fc),
@@ -1621,16 +1621,49 @@ TEST(test_seeded_furnaces_tagged) {
     ASSERT_EQ_INT(helios_cr, 1);
 }
 
+static bool test_furnace_has_adjacent_ore_hopper(const station_t *st,
+                                                 const station_module_t *furnace) {
+    commodity_t ore = module_instance_input_ore(furnace);
+    if (ore == COMMODITY_COUNT) return false;
+    vec2 furnace_pos = module_world_pos_ring(st, furnace->ring, furnace->slot);
+    float max_pair_dist = HOPPER_PULL_RANGE * 2.0f;
+    float max_pair_sq = max_pair_dist * max_pair_dist;
+    for (int i = 0; i < st->module_count; i++) {
+        const station_module_t *hopper = &st->modules[i];
+        if (hopper->scaffold) continue;
+        if (hopper->type != MODULE_HOPPER) continue;
+        if ((commodity_t)hopper->commodity != ore) continue;
+        int dr = (int)hopper->ring - (int)furnace->ring;
+        if (dr != 1 && dr != -1) continue;
+        vec2 hopper_pos = module_world_pos_ring(st, hopper->ring, hopper->slot);
+        if (v2_dist_sq(furnace_pos, hopper_pos) <= max_pair_sq) return true;
+    }
+    return false;
+}
+
 TEST(test_seeded_helios_output_hoppers) {
     /* Helios's LASER_FAB and TRACTOR_FAB each have a dedicated
      * commodity-tagged output hopper on ring 3, and its shipyard has
-     * the frame / laser / tractor hoppers needed for repair-kit fab. */
+     * the frame / laser / tractor hoppers needed for repair-kit fab.
+     * Its furnaces also each have a matching ore hopper on an adjacent
+     * ring, which the smelt-beam code requires before firing. */
     WORLD_DECL;
     world_reset(&w);
     ASSERT(station_has_module(&w.stations[2], MODULE_SHIPYARD));
     ASSERT(station_find_hopper_for(&w.stations[2], COMMODITY_FRAME) >= 0);
     ASSERT(station_find_hopper_for(&w.stations[2], COMMODITY_LASER_MODULE)   >= 0);
     ASSERT(station_find_hopper_for(&w.stations[2], COMMODITY_TRACTOR_MODULE) >= 0);
+    ASSERT(station_find_hopper_for(&w.stations[2], COMMODITY_CUPRITE_ORE) >= 0);
+    ASSERT(station_find_hopper_for(&w.stations[2], COMMODITY_CRYSTAL_ORE) >= 0);
+    int checked_furnaces = 0;
+    for (int i = 0; i < w.stations[2].module_count; i++) {
+        const station_module_t *m = &w.stations[2].modules[i];
+        if (m->scaffold) continue;
+        if (m->type != MODULE_FURNACE) continue;
+        ASSERT(test_furnace_has_adjacent_ore_hopper(&w.stations[2], m));
+        checked_furnaces++;
+    }
+    ASSERT_EQ_INT(checked_furnaces, 3);
     /* All Helios producers report OK under the new layout rule. */
     for (int i = 0; i < w.stations[2].module_count; i++) {
         const station_module_t *m = &w.stations[2].modules[i];

--- a/src/tests/test_economy.c
+++ b/src/tests/test_economy.c
@@ -499,12 +499,13 @@ TEST(test_kit_fab_requires_shipyard) {
      * commodities should never produce kits. */
     WORLD_DECL;
     world_reset(&w);
-    /* Prospect (station 0) has a dock but no shipyard. Kepler (station 1)
-     * has both. Pre-fill both with kit-fab inputs. */
+    /* Prospect (station 0) has a dock but no shipyard. Kepler and Helios
+     * both have shipyards. Pre-fill all three with kit-fab inputs. */
     ASSERT(station_has_module(&w.stations[0], MODULE_DOCK));
     ASSERT(!station_has_module(&w.stations[0], MODULE_SHIPYARD));
     ASSERT(station_has_module(&w.stations[1], MODULE_SHIPYARD));
-    for (int s = 0; s < 2; s++) {
+    ASSERT(station_has_module(&w.stations[2], MODULE_SHIPYARD));
+    for (int s = 0; s < 3; s++) {
         ASSERT(test_set_station_finished_units(&w.stations[s], COMMODITY_FRAME, 5));
         ASSERT(test_set_station_finished_units(&w.stations[s], COMMODITY_LASER_MODULE, 5));
         ASSERT(test_set_station_finished_units(&w.stations[s], COMMODITY_TRACTOR_MODULE, 5));
@@ -516,6 +517,7 @@ TEST(test_kit_fab_requires_shipyard) {
         world_sim_step(&w, SIM_DT);
     /* Shipyard station produces kits; dock-only station does not. */
     ASSERT(w.stations[1]._inventory_cache[COMMODITY_REPAIR_KIT] > 0.0f);
+    ASSERT(w.stations[2]._inventory_cache[COMMODITY_REPAIR_KIT] > 0.0f);
     ASSERT_EQ_FLOAT(w.stations[0]._inventory_cache[COMMODITY_REPAIR_KIT], 0.0f, 0.01f);
 }
 
@@ -553,12 +555,14 @@ TEST(test_kit_import_contract_skips_shipyard_stations) {
     WORLD_DECL;
     world_reset(&w);
     ASSERT(station_has_module(&w.stations[1], MODULE_SHIPYARD));
+    ASSERT(station_has_module(&w.stations[2], MODULE_SHIPYARD));
     w.stations[1]._inventory_cache[COMMODITY_REPAIR_KIT] = 0.0f;
+    w.stations[2]._inventory_cache[COMMODITY_REPAIR_KIT] = 0.0f;
     for (int i = 0; i < 120; i++) world_sim_step(&w, SIM_DT);
     for (int k = 0; k < MAX_CONTRACTS; k++) {
         contract_t *c = &w.contracts[k];
         if (c->active && c->action == CONTRACT_TRACTOR
-            && c->station_index == 1
+            && (c->station_index == 1 || c->station_index == 2)
             && c->commodity == COMMODITY_REPAIR_KIT) {
             ASSERT(false); /* shouldn't reach here */
         }
@@ -752,13 +756,9 @@ TEST(test_per_row_sell_drains_one_unit_only) {
     sp->session_ready = true;
     memset(sp->session_token, 0xAA, 8);
 
-    /* Dock at Helios — its laser/tractor fabs accept frame ingot input. */
-    int helios = -1;
-    for (int s = 0; s < MAX_STATIONS; s++) {
-        if (!station_is_active(&w->stations[s])) continue;
-        if (station_consumes(&w->stations[s], COMMODITY_FRAME)) { helios = s; break; }
-    }
-    ASSERT(helios >= 0);
+    /* Dock at Helios: its shipyard consumes frames for repair-kit fab. */
+    int helios = 2;
+    ASSERT(station_consumes(&w->stations[helios], COMMODITY_FRAME));
     sp->docked = true;
     sp->current_station = (uint8_t)helios;
     sp->ship.pos = w->stations[helios].pos;

--- a/src/tests/test_furnace_color.c
+++ b/src/tests/test_furnace_color.c
@@ -1,11 +1,11 @@
 /*
  * test_furnace_color.c — per-ring furnace render-tint logic.
  *
- * MODULE_FURNACE is a single sim type; the renderer picks one of four
- * tints (ferrite / cuprite / crystal / chunks-feeder) at draw time
- * based on the station's furnace count and the furnace's ring. The
- * helper lives in src/station_palette.h so both the renderer and these
- * tests share the exact same logic — no schema bump, no save migration.
+ * MODULE_FURNACE is a single sim type; the renderer picks ferrite /
+ * cuprite / crystal from the furnace's instance commodity tag and falls
+ * back to the legacy ring heuristic for untagged furnaces. The helpers
+ * live in src/station_palette.h so both the renderer and these tests
+ * share the exact same logic.
  */
 #include "tests/test_harness.h"
 #include "station_palette.h"
@@ -59,8 +59,8 @@ TEST(test_furnace_color_prospect_is_ferrite_red) {
     EXPECT_RGB(r, g, b, 0.85f, 0.30f, 0.20f); /* ferrite red */
 }
 
-/* (2) Helios (3 furnaces) → inner=crystal, outer=cuprite, middle=chunks. */
-TEST(test_furnace_color_helios_three_ring_pattern) {
+/* (2) Helios (3 furnaces) → each furnace tint follows its commodity tag. */
+TEST(test_furnace_color_helios_uses_instance_tags) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     ASSERT(w != NULL);
     world_reset(w);
@@ -75,37 +75,24 @@ TEST(test_furnace_color_helios_three_ring_pattern) {
     }
     ASSERT(helios >= 0);
 
-    int min_ring = 99, max_ring = 0;
+    int saw_cu = 0, saw_cr = 0;
     for (int i = 0; i < w->stations[helios].module_count; i++) {
-        if (w->stations[helios].modules[i].type != MODULE_FURNACE) continue;
-        int rr = (int)w->stations[helios].modules[i].ring;
-        if (rr < min_ring) min_ring = rr;
-        if (rr > max_ring) max_ring = rr;
-    }
-    ASSERT(min_ring < max_ring);
-
-    /* Walk every furnace and verify the right tint per its ring. */
-    int saw_inner = 0, saw_outer = 0, saw_middle = 0;
-    for (int i = 0; i < w->stations[helios].module_count; i++) {
-        if (w->stations[helios].modules[i].type != MODULE_FURNACE) continue;
-        int rr = (int)w->stations[helios].modules[i].ring;
+        const station_module_t *m = &w->stations[helios].modules[i];
+        if (m->type != MODULE_FURNACE) continue;
         float r = 0, g = 0, b = 0;
-        station_palette_furnace_color(&w->stations[helios], rr, &r, &g, &b);
-        if (rr == min_ring) {
-            EXPECT_RGB(r, g, b, 0.30f, 0.80f, 0.35f); /* crystal green */
-            saw_inner++;
-        } else if (rr == max_ring) {
+        station_palette_furnace_module_color(&w->stations[helios], m, &r, &g, &b);
+        if ((commodity_t)m->commodity == COMMODITY_CUPRITE_INGOT) {
             EXPECT_RGB(r, g, b, 0.25f, 0.50f, 0.90f); /* cuprite blue */
-            saw_outer++;
+            saw_cu++;
+        } else if ((commodity_t)m->commodity == COMMODITY_CRYSTAL_INGOT) {
+            EXPECT_RGB(r, g, b, 0.30f, 0.80f, 0.35f); /* crystal green */
+            saw_cr++;
         } else {
-            EXPECT_RGB(r, g, b, 0.85f, 0.85f, 0.90f); /* chunks white */
-            saw_middle++;
+            ASSERT(false /* unexpected Helios furnace tag */);
         }
     }
-    ASSERT(saw_inner >= 1);
-    ASSERT(saw_outer >= 1);
-    /* Middle is optional (only present when 3 distinct rings used). */
-    (void)saw_middle;
+    ASSERT_EQ_INT(saw_cu, 2);
+    ASSERT_EQ_INT(saw_cr, 1);
 }
 
 /* (3) Outpost growth: as furnaces are added, the inner-most furnace's
@@ -244,7 +231,7 @@ TEST(test_furnace_color_middle_ring_glows_by_last_smelt) {
 void register_furnace_color_tests(void) {
     TEST_SECTION("\nFurnace per-ring color render variants:\n");
     RUN(test_furnace_color_prospect_is_ferrite_red);
-    RUN(test_furnace_color_helios_three_ring_pattern);
+    RUN(test_furnace_color_helios_uses_instance_tags);
     RUN(test_furnace_color_outpost_growth_reshuffles);
     RUN(test_furnace_color_non_furnace_modules_unaffected);
     RUN(test_prospect_modules_after_silo_cleanup);

--- a/src/tests/test_save.c
+++ b/src/tests/test_save.c
@@ -44,6 +44,21 @@ static bool test_patch_catalog_version(const char *path, uint32_t version) {
     return true;
 }
 
+static bool test_furnace_has_adjacent_ore_hopper_save(const station_t *st,
+                                                      const station_module_t *furnace) {
+    commodity_t ore = module_instance_input_ore(furnace);
+    if (ore == COMMODITY_COUNT) return false;
+    for (int i = 0; i < st->module_count; i++) {
+        const station_module_t *hopper = &st->modules[i];
+        if (hopper->scaffold) continue;
+        if (hopper->type != MODULE_HOPPER) continue;
+        if ((commodity_t)hopper->commodity != ore) continue;
+        int dr = (int)hopper->ring - (int)furnace->ring;
+        if (dr == 1 || dr == -1) return true;
+    }
+    return false;
+}
+
 TEST(test_player_save_load_roundtrip) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     world_reset(w);
@@ -63,11 +78,32 @@ TEST(test_player_save_load_roundtrip) {
     remove(TMP("test_player.sav"));
 }
 
-TEST(test_v3_station_catalog_repairs_helios_shipyard_layout) {
+TEST(test_v3_station_catalog_repairs_helios_smelter_layout) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     ASSERT(w != NULL);
     world_reset(w);
     station_t *helios = &w->stations[2];
+
+    int cu_seen = 0;
+    for (int m = 0; m < helios->module_count; m++) {
+        station_module_t *mod = &helios->modules[m];
+        if (mod->type == MODULE_HOPPER) {
+            commodity_t c = (commodity_t)mod->commodity;
+            if (c == COMMODITY_CUPRITE_ORE) {
+                mod->ring = 3; mod->slot = 0;
+            } else if (c == COMMODITY_CRYSTAL_INGOT) {
+                mod->ring = 2; mod->slot = 3;
+            } else if (c == COMMODITY_CRYSTAL_ORE) {
+                mod->ring = 3; mod->slot = 6;
+            }
+        } else if (mod->type == MODULE_FURNACE &&
+                   (commodity_t)mod->commodity == COMMODITY_CUPRITE_INGOT) {
+            if (cu_seen == 1) {
+                mod->ring = 3; mod->slot = 1;
+            }
+            cu_seen++;
+        }
+    }
 
     for (int m = helios->module_count - 1; m >= 0; m--) {
         bool drop = helios->modules[m].type == MODULE_SHIPYARD;
@@ -94,6 +130,14 @@ TEST(test_v3_station_catalog_repairs_helios_shipyard_layout) {
     ASSERT_EQ_INT(station_catalog_load_all(loaded->stations, MAX_STATIONS, dir), 1);
     ASSERT(station_has_module(&loaded->stations[2], MODULE_SHIPYARD));
     ASSERT(station_find_hopper_for(&loaded->stations[2], COMMODITY_FRAME) >= 0);
+    int checked_furnaces = 0;
+    for (int m = 0; m < loaded->stations[2].module_count; m++) {
+        const station_module_t *mod = &loaded->stations[2].modules[m];
+        if (mod->type != MODULE_FURNACE) continue;
+        ASSERT(test_furnace_has_adjacent_ore_hopper_save(&loaded->stations[2], mod));
+        checked_furnaces++;
+    }
+    ASSERT_EQ_INT(checked_furnaces, 3);
     int yard = -1;
     for (int m = 0; m < loaded->stations[2].module_count; m++) {
         if (loaded->stations[2].modules[m].type == MODULE_SHIPYARD) {
@@ -925,7 +969,7 @@ void register_save_persistence_tests(void) {
     RUN(test_player_load_bad_magic_fails);
     RUN(test_world_load_rejects_stale_version);
     RUN(test_world_save_load_preserves_module_ring_slot);
-    RUN(test_v3_station_catalog_repairs_helios_shipyard_layout);
+    RUN(test_v3_station_catalog_repairs_helios_smelter_layout);
     RUN(test_v51_migration_tags_untagged_furnaces_and_fills_hoppers);
     RUN(test_v51_migration_furnace_count_heuristic);
     RUN(test_world_save_load_preserves_smelted_ingots);

--- a/src/tests/test_save.c
+++ b/src/tests/test_save.c
@@ -1,5 +1,49 @@
 #include "tests/test_harness.h"
 
+static uint32_t test_crc32_update(uint32_t crc, const void *buf, size_t len) {
+    const uint8_t *p = (const uint8_t *)buf;
+    crc = ~crc;
+    for (size_t i = 0; i < len; i++) {
+        crc ^= p[i];
+        for (int j = 0; j < 8; j++)
+            crc = (crc >> 1) ^ (0xEDB88320u & (0u - (crc & 1u)));
+    }
+    return ~crc;
+}
+
+static bool test_patch_catalog_version(const char *path, uint32_t version) {
+    FILE *f = fopen(path, "rb+");
+    if (!f) return false;
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    if (len < 12) { fclose(f); return false; }
+    fseek(f, 4, SEEK_SET);
+    if (fwrite(&version, sizeof(version), 1, f) != 1) {
+        fclose(f);
+        return false;
+    }
+    fflush(f);
+
+    fseek(f, 0, SEEK_SET);
+    uint32_t crc = 0;
+    long remaining = len - (long)sizeof(uint32_t);
+    uint8_t chunk[4096];
+    while (remaining > 0) {
+        size_t want = remaining < (long)sizeof(chunk) ? (size_t)remaining : sizeof(chunk);
+        size_t n = fread(chunk, 1, want, f);
+        if (n == 0) { fclose(f); return false; }
+        crc = test_crc32_update(crc, chunk, n);
+        remaining -= (long)n;
+    }
+    fseek(f, len - (long)sizeof(uint32_t), SEEK_SET);
+    if (fwrite(&crc, sizeof(crc), 1, f) != 1) {
+        fclose(f);
+        return false;
+    }
+    fclose(f);
+    return true;
+}
+
 TEST(test_player_save_load_roundtrip) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     world_reset(w);
@@ -17,6 +61,51 @@ TEST(test_player_save_load_roundtrip) {
     /* loaded auto-freed by WORLD_HEAP cleanup */
     /* w auto-freed by WORLD_HEAP cleanup */
     remove(TMP("test_player.sav"));
+}
+
+TEST(test_v3_station_catalog_repairs_helios_shipyard_layout) {
+    WORLD_HEAP w = calloc(1, sizeof(world_t));
+    ASSERT(w != NULL);
+    world_reset(w);
+    station_t *helios = &w->stations[2];
+
+    for (int m = helios->module_count - 1; m >= 0; m--) {
+        bool drop = helios->modules[m].type == MODULE_SHIPYARD;
+        if (helios->modules[m].type == MODULE_HOPPER &&
+            (commodity_t)helios->modules[m].commodity == COMMODITY_FRAME) {
+            drop = true;
+        }
+        if (!drop) continue;
+        for (int k = m + 1; k < helios->module_count; k++)
+            helios->modules[k - 1] = helios->modules[k];
+        helios->module_count--;
+    }
+    ASSERT(!station_has_module(helios, MODULE_SHIPYARD));
+    ASSERT(station_find_hopper_for(helios, COMMODITY_FRAME) < 0);
+
+    const char *dir = TMP("test_v3_helios_cat");
+    ASSERT(station_catalog_save(helios, 2, dir));
+    char path[256];
+    snprintf(path, sizeof(path), "%s/2.cat", dir);
+    ASSERT(test_patch_catalog_version(path, 3));
+
+    WORLD_HEAP loaded = calloc(1, sizeof(world_t));
+    ASSERT(loaded != NULL);
+    ASSERT_EQ_INT(station_catalog_load_all(loaded->stations, MAX_STATIONS, dir), 1);
+    ASSERT(station_has_module(&loaded->stations[2], MODULE_SHIPYARD));
+    ASSERT(station_find_hopper_for(&loaded->stations[2], COMMODITY_FRAME) >= 0);
+    int yard = -1;
+    for (int m = 0; m < loaded->stations[2].module_count; m++) {
+        if (loaded->stations[2].modules[m].type == MODULE_SHIPYARD) {
+            yard = m;
+            break;
+        }
+    }
+    ASSERT(yard >= 0);
+    ASSERT_EQ_INT(station_module_layout_status(&loaded->stations[2],
+                                               &loaded->stations[2].modules[yard]),
+                  STATION_LAYOUT_OK);
+    remove(path);
 }
 
 TEST(test_world_save_load_preserves_stations) {
@@ -836,6 +925,7 @@ void register_save_persistence_tests(void) {
     RUN(test_player_load_bad_magic_fails);
     RUN(test_world_load_rejects_stale_version);
     RUN(test_world_save_load_preserves_module_ring_slot);
+    RUN(test_v3_station_catalog_repairs_helios_shipyard_layout);
     RUN(test_v51_migration_tags_untagged_furnaces_and_fills_hoppers);
     RUN(test_v51_migration_furnace_count_heuristic);
     RUN(test_world_save_load_preserves_smelted_ingots);
@@ -850,4 +940,3 @@ void register_save_format_tests(void) {
     RUN(test_save_v21_module_remap);
     RUN(test_save_future_version_rejected);
 }
-

--- a/src/tests/test_world_sim.c
+++ b/src/tests/test_world_sim.c
@@ -7,6 +7,7 @@ TEST(test_world_reset_creates_stations) {
     ASSERT(station_has_module(&w.stations[0], MODULE_FURNACE));
     ASSERT_STR_EQ(w.stations[1].name, "Kepler Yard");
     ASSERT_STR_EQ(w.stations[2].name, "Helios Works");
+    ASSERT(station_has_module(&w.stations[2], MODULE_SHIPYARD));
 }
 
 TEST(test_world_reset_spawns_asteroids) {
@@ -26,14 +27,23 @@ TEST(test_world_reset_spawns_npcs) {
      * Plus a tow drone at each shipyard (Kepler, Helios). */
     WORLD_DECL;
     world_reset(&w);
-    int miners = 0, haulers = 0;
+    int miners = 0, haulers = 0, tows = 0;
+    int kepler_tows = 0, helios_tows = 0;
     for (int i = 0; i < MAX_NPC_SHIPS; i++) {
         if (!w.npc_ships[i].active) continue;
         if (w.npc_ships[i].role == NPC_ROLE_MINER) miners++;
         if (w.npc_ships[i].role == NPC_ROLE_HAULER) haulers++;
+        if (w.npc_ships[i].role == NPC_ROLE_TOW) {
+            tows++;
+            if (w.npc_ships[i].home_station == 1) kepler_tows++;
+            if (w.npc_ships[i].home_station == 2) helios_tows++;
+        }
     }
     ASSERT_EQ_INT(miners, 3);
     ASSERT_EQ_INT(haulers, 4);
+    ASSERT_EQ_INT(tows, 2);
+    ASSERT_EQ_INT(kepler_tows, 1);
+    ASSERT_EQ_INT(helios_tows, 1);
 }
 
 TEST(test_dead_hauler_auto_respawns) {
@@ -82,6 +92,42 @@ TEST(test_dead_hauler_auto_respawns) {
         if (w->npc_ships[n].home_station == 1) kepler_haulers_after++;
     }
     ASSERT_EQ_INT(kepler_haulers_after, 1);
+}
+
+TEST(test_dead_tow_auto_respawns_at_shipyard) {
+    WORLD_HEAP w = calloc(1, sizeof(world_t));
+    world_reset(w);
+    int target_slot = -1;
+    for (int n = 0; n < MAX_NPC_SHIPS; n++) {
+        if (!w->npc_ships[n].active) continue;
+        if (w->npc_ships[n].role != NPC_ROLE_TOW) continue;
+        if (w->npc_ships[n].home_station != 2) continue;
+        target_slot = n;
+        break;
+    }
+    ASSERT(target_slot >= 0);
+    ship_t *s = world_npc_ship_for(w, target_slot);
+    ASSERT(s != NULL);
+    s->hull = 0.0f;
+    world_sim_step(w, SIM_DT);
+
+    int helios_tows = 0;
+    for (int n = 0; n < MAX_NPC_SHIPS; n++) {
+        if (!w->npc_ships[n].active) continue;
+        if (w->npc_ships[n].role != NPC_ROLE_TOW) continue;
+        if (w->npc_ships[n].home_station == 2) helios_tows++;
+    }
+    ASSERT_EQ_INT(helios_tows, 0);
+
+    for (int i = 0; i < 1900; i++) world_sim_step(w, SIM_DT);
+
+    int helios_tows_after = 0;
+    for (int n = 0; n < MAX_NPC_SHIPS; n++) {
+        if (!w->npc_ships[n].active) continue;
+        if (w->npc_ships[n].role != NPC_ROLE_TOW) continue;
+        if (w->npc_ships[n].home_station == 2) helios_tows_after++;
+    }
+    ASSERT_EQ_INT(helios_tows_after, 1);
 }
 
 TEST(test_player_init_ship_docked) {
@@ -1358,6 +1404,7 @@ void register_world_sim_basic_tests(void) {
     RUN(test_world_reset_spawns_asteroids);
     RUN(test_world_reset_spawns_npcs);
     RUN(test_dead_hauler_auto_respawns);
+    RUN(test_dead_tow_auto_respawns_at_shipyard);
     RUN(test_player_init_ship_docked);
     RUN(test_world_sim_step_advances_time);
     RUN(test_world_sim_step_moves_ship_with_thrust);
@@ -1569,4 +1616,3 @@ void register_world_sim_chunk_tests(void) {
     RUN(test_save_preserves_destroyed_rocks_ledger);
     RUN(test_destroyed_rocks_stays_sorted_after_inserts);
 }
-

--- a/src/world_draw.c
+++ b/src/world_draw.c
@@ -332,6 +332,50 @@ void commodity_color(commodity_t c, float *r, float *g, float *b) {
     }
 }
 
+static bool commodity_is_ore(commodity_t c) {
+    return c == COMMODITY_FERRITE_ORE ||
+           c == COMMODITY_CUPRITE_ORE ||
+           c == COMMODITY_CRYSTAL_ORE;
+}
+
+static bool commodity_is_ingot(commodity_t c) {
+    return c == COMMODITY_FERRITE_INGOT ||
+           c == COMMODITY_CUPRITE_INGOT ||
+           c == COMMODITY_CRYSTAL_INGOT;
+}
+
+static void commodity_resource_color(commodity_t c, float *r, float *g, float *b) {
+    switch (commodity_ore_form(c)) {
+    case COMMODITY_FERRITE_ORE: PAL_UNPACK3(PAL_COMMODITY_FERRITE_ORE, *r, *g, *b); return;
+    case COMMODITY_CUPRITE_ORE: PAL_UNPACK3(PAL_COMMODITY_CUPRITE_ORE, *r, *g, *b); return;
+    case COMMODITY_CRYSTAL_ORE: PAL_UNPACK3(PAL_COMMODITY_CRYSTAL_ORE, *r, *g, *b); return;
+    default:                    PAL_UNPACK3(PAL_COMMODITY_FERRITE_ORE, *r, *g, *b); return;
+    }
+}
+
+static void commodity_hopper_palette(commodity_t c,
+                                     float *base_r, float *base_g, float *base_b,
+                                     float *accent_r, float *accent_g, float *accent_b) {
+    float rr = 0.0f, rg = 0.0f, rb = 0.0f;
+    float mr = 0.0f, mg = 0.0f, mb = 0.0f;
+    commodity_resource_color(c, &rr, &rg, &rb);
+    PAL_UNPACK3(PAL_COMMODITY_METAL_ACCENT, mr, mg, mb);
+
+    if (commodity_is_ore(c)) {
+        *base_r = rr; *base_g = rg; *base_b = rb;
+        *accent_r = rr; *accent_g = rg; *accent_b = rb;
+    } else if (commodity_is_ingot(c)) {
+        *base_r = rr; *base_g = rg; *base_b = rb;
+        *accent_r = mr; *accent_g = mg; *accent_b = mb;
+    } else {
+        *base_r = mr; *base_g = mg; *base_b = mb;
+        *accent_r = rr; *accent_g = rg; *accent_b = rb;
+        if (c == COMMODITY_REPAIR_KIT) {
+            *accent_r = 0.90f; *accent_g = 0.20f; *accent_b = 0.20f;
+        }
+    }
+}
+
 /* ------------------------------------------------------------------ */
 /* Solid module block + corridor to core                              */
 /* ------------------------------------------------------------------ */
@@ -579,14 +623,45 @@ static void draw_module_shape(module_type_t type, float mr, float mg, float mb, 
     }
 }
 
+static void draw_hopper_shape(float br, float bg, float bb,
+                              float ar, float ag, float ab,
+                              float alpha) {
+    /* Triangle pointing outward (-Y) = funnel mouth. The body carries the
+     * resource-family base; the rim/core carries the accent. */
+    sgl_c4f(br * 0.34f, bg * 0.34f, bb * 0.34f, alpha);
+    sgl_begin_triangles();
+    sgl_v2f(-32, -20); sgl_v2f(32, -20); sgl_v2f(0, 28);
+    sgl_end();
+
+    sgl_c4f(ar * 0.95f, ag * 0.95f, ab * 0.95f, alpha);
+    fill_quad(-32, -22, 32, -22, 32, -18, -32, -18);
+
+    fill_circle_local(0, 0, 8, 8, ar * 0.7f, ag * 0.7f, ab * 0.7f, alpha * 0.26f);
+    fill_circle_local(0, 0, 4, 6, ar * 1.0f, ag * 1.0f, ab * 1.0f, alpha * 0.42f);
+
+    sgl_c4f(ar * 0.55f + br * 0.25f,
+            ag * 0.55f + bg * 0.25f,
+            ab * 0.55f + bb * 0.25f,
+            alpha);
+    sgl_begin_lines();
+    sgl_v2f(-32, -20); sgl_v2f(32, -20);
+    sgl_v2f(32, -20); sgl_v2f(0, 28);
+    sgl_v2f(0, 28); sgl_v2f(-32, -20);
+    sgl_end();
+}
+
 static void draw_module_at(vec2 pos, float angle, module_type_t type, bool scaffold, float progress, vec2 station_center,
-                           const station_t *station, int ring, commodity_t hopper_commodity) {
+                           const station_t *station, commodity_t hopper_commodity,
+                           const station_module_t *module) {
     float mr, mg, mb;
+    float hr = 0.0f, hg = 0.0f, hb = 0.0f;
+    bool custom_hopper = false;
     /* Hoppers tint by their commodity tag (each hopper buffers ONE
      * commodity). Non-hoppers fall back to the static module-type
      * palette. */
     if (type == MODULE_HOPPER && hopper_commodity != COMMODITY_COUNT) {
-        commodity_color(hopper_commodity, &mr, &mg, &mb);
+        commodity_hopper_palette(hopper_commodity, &mr, &mg, &mb, &hr, &hg, &hb);
+        custom_hopper = true;
     } else {
         module_color(type, &mr, &mg, &mb);
     }
@@ -595,7 +670,7 @@ static void draw_module_at(vec2 pos, float angle, module_type_t type, bool scaff
      * The sim only knows MODULE_FURNACE; the renderer picks ferrite /
      * cuprite / crystal / chunks-feeder. See station_palette.h. */
     if (type == MODULE_FURNACE && station != NULL) {
-        station_palette_furnace_color(station, ring, &mr, &mg, &mb);
+        station_palette_furnace_module_color(station, module, &mr, &mg, &mb);
     }
 
     sgl_push_matrix();
@@ -649,7 +724,11 @@ static void draw_module_at(vec2 pos, float angle, module_type_t type, bool scaff
             fill_quad(-24, 30, -24 + bar_w, 30, -24 + bar_w, 34, -24, 34);
         }
     } else {
-        draw_module_shape(type, mr, mg, mb, 0.92f);
+        if (custom_hopper) {
+            draw_hopper_shape(mr, mg, mb, hr, hg, hb, 0.92f);
+        } else {
+            draw_module_shape(type, mr, mg, mb, 0.92f);
+        }
 
         /* Demand beacon: a docked station that is starving for some
          * commodity outlines its DOCK module in pulsing yellow so
@@ -842,7 +921,7 @@ void draw_station_rings(const station_t* station, bool is_current, bool is_nearb
                  * furnace contributed static PAL_MODULE_FURNACE green
                  * and every ring with a furnace turned green. */
                 if (station->modules[i].type == MODULE_FURNACE) {
-                    station_palette_furnace_color(station, r,
+                    station_palette_furnace_module_color(station, &station->modules[i],
                         &colors[count][0], &colors[count][1], &colors[count][2]);
                 } else if (station->modules[i].type == MODULE_HOPPER) {
                     /* Hopper color = its commodity's color. Each
@@ -944,8 +1023,8 @@ void draw_station_rings(const station_t* station, bool is_current, bool is_nearb
         for (int i = 0; i < mod_count; i++) {
             const station_module_t *m = &station->modules[mod_idx[i]];
             float angle = module_angle_ring(station, ring, m->slot);
-            draw_module_at(positions[i], angle, m->type, m->scaffold, m->build_progress, station->pos, station, ring,
-                           (commodity_t)m->commodity);
+            draw_module_at(positions[i], angle, m->type, m->scaffold, m->build_progress, station->pos, station,
+                           (commodity_t)m->commodity, m);
 
             /* Furnace: glow + red laser beam to target module when smelting */
             if (!m->scaffold && m->type == MODULE_FURNACE) {
@@ -956,26 +1035,34 @@ void draw_station_rings(const station_t* station, bool is_current, bool is_nearb
                  * PAL_MODULE_FURNACE green and dominates the per-ring
                  * body color. */
                 float fr, fg, fb;
-                station_palette_furnace_color(station, ring, &fr, &fg, &fb);
+                station_palette_furnace_module_color(station, m, &fr, &fg, &fb);
                 float pulse = 0.3f + 0.15f * sinf(g.world.time * 3.0f + (float)m->slot);
 
                 /* Always: warm glow at furnace */
                 draw_circle_filled(positions[i], 44.0f, 12, fr * 0.6f, fg * 0.3f, fb * 0.15f, pulse * 0.3f);
                 draw_circle_filled(positions[i], 28.0f, 10, fr * 0.9f, fg * 0.5f, fb * 0.2f, pulse * 0.4f);
 
-                /* Find nearest module on an adjacent ring (inner or outer) */
+                /* Find nearest matching ore hopper on an adjacent ring.
+                 * This mirrors step_furnace_smelting; otherwise the idle
+                 * line can imply a furnace is connected when the sim would
+                 * never fire. */
                 vec2 target = positions[i];
+                bool has_target = false;
                 {
                     float best_d = 1e18f;
+                    commodity_t ore = module_instance_input_ore(m);
                     int adj_rings[] = { ring + 1, ring - 1 };
                     for (int ri = 0; ri < 2; ri++) {
                         int adj = adj_rings[ri];
                         if (adj < 1 || adj > STATION_NUM_RINGS) continue;
                         for (int mi2 = 0; mi2 < station->module_count; mi2++) {
                             if (station->modules[mi2].ring != adj) continue;
+                            if (station->modules[mi2].scaffold) continue;
+                            if (station->modules[mi2].type != MODULE_HOPPER) continue;
+                            if ((commodity_t)station->modules[mi2].commodity != ore) continue;
                             vec2 mp2 = module_world_pos_ring(station, adj, station->modules[mi2].slot);
                             float dd = v2_dist_sq(positions[i], mp2);
-                            if (dd < best_d) { best_d = dd; target = mp2; }
+                            if (dd < best_d) { best_d = dd; target = mp2; has_target = true; }
                         }
                     }
                 }
@@ -990,7 +1077,7 @@ void draw_station_rings(const station_t* station, bool is_current, bool is_nearb
                     }
                 }
 
-                if (has_smelting) {
+                if (has_smelting && has_target) {
                     /* RED LASER between furnace and target — zappy flicker */
                     float flicker = 0.7f + 0.3f * sinf(g.world.time * 47.0f);
                     float zap1 = sinf(g.world.time * 31.0f) * 0.5f + 0.5f;
@@ -1016,7 +1103,7 @@ void draw_station_rings(const station_t* station, bool is_current, bool is_nearb
                     /* Glow at both ends */
                     draw_circle_filled(positions[i], 36.0f, 10, 1.0f, 0.3f, 0.1f, 0.3f * flicker);
                     draw_circle_filled(target, 28.0f, 8, 1.0f, 0.2f, 0.05f, 0.2f * flicker);
-                } else {
+                } else if (has_target) {
                     /* Idle: faint connection line to target */
                     draw_segment(positions[i], target, fr, fg, fb, pulse * 0.15f);
                 }


### PR DESCRIPTION
Summary:
- add the missing Helios shipyard, frame hopper, and Helios tow drone to the seeded world
- bump station catalog to v4 and repair older Helios catalogs that lack the shipyard layout
- expand tests for seeded Helios layout, shipyard kit fab, NPC tow roster, and catalog migration

Validation:
- make test
- make test-soak
- make build-server
- make build-web (rerun with Emscripten cache permissions)
- pre-push hook: 509 passed