### PR TITLE
[codex] expose station layout diagnostics

### DIFF
--- a/server/net_protocol.h
+++ b/server/net_protocol.h
@@ -509,14 +509,19 @@ static inline int serialize_station_identity(uint8_t *buf, int index, const stat
         write_f32_le(&buf[59 + c * 4], st->base_price[c]);
     write_f32_le(&buf[59 + COMMODITY_COUNT * 4], st->scaffold_progress);
     int moff = 59 + COMMODITY_COUNT * 4 + 4;  /* after scaffold_progress */
-    buf[moff] = (uint8_t)st->module_count;
+    int module_count = st->module_count;
+    if (module_count < 0) module_count = 0;
+    if (module_count > MAX_MODULES_PER_STATION) module_count = MAX_MODULES_PER_STATION;
+    buf[moff] = (uint8_t)module_count;
     moff++;
     for (int m = 0; m < MAX_MODULES_PER_STATION; m++) {
-        buf[moff]     = (m < st->module_count) ? (uint8_t)st->modules[m].type : 0;
-        buf[moff + 1] = (m < st->module_count && st->modules[m].scaffold) ? 1 : 0;
-        buf[moff + 2] = (m < st->module_count) ? st->modules[m].ring : 0;
-        buf[moff + 3] = (m < st->module_count) ? st->modules[m].slot : 0;
-        write_f32_le(&buf[moff + 4], (m < st->module_count) ? st->modules[m].build_progress : 0.0f);
+        bool live = m < module_count;
+        buf[moff]     = live ? (uint8_t)st->modules[m].type : 0;
+        buf[moff + 1] = (live && st->modules[m].scaffold) ? 1 : 0;
+        buf[moff + 2] = live ? st->modules[m].ring : 0;
+        buf[moff + 3] = live ? st->modules[m].slot : 0;
+        write_f32_le(&buf[moff + 4], live ? st->modules[m].build_progress : 0.0f);
+        buf[moff + 8] = live ? st->modules[m].commodity : (uint8_t)COMMODITY_COUNT;
         moff += STATION_MODULE_RECORD_SIZE;
     }
     /* Ring rotation speeds + offsets */

--- a/shared/protocol.h
+++ b/shared/protocol.h
@@ -367,12 +367,12 @@ _Static_assert(NET_ACTION_DELIVER_COMMODITY + COMMODITY_COUNT <= 256,
 #define NPC_RECORD_SIZE 26
 
 /* Station identity: [index:1][flags:1][services:4][pos:2xf32][radius:f32][dock_radius:f32][signal_range:f32][name:32]
- * [base_price:COMMODITY_COUNT×f32][scaffold_progress:f32][module_count:1][modules:MAX_MODULES×8]
+ * [base_price:COMMODITY_COUNT×f32][scaffold_progress:f32][module_count:1][modules:MAX_MODULES×9]
  * [arm_count:1][arm_speed:MAX_ARMS×f32][ring_offset:MAX_ARMS×f32]
  * [plan_count:1][plans:8 × (type:1, ring:1, slot:1, owner:1)]
  * [pending_count:1][pending:4 × (type:1, owner:1)]
  * flags: bit0=scaffold, bit1=planned */
-#define STATION_MODULE_RECORD_SIZE 8  /* type:1 + scaffold:1 + ring:1 + slot:1 + build_progress:f32 */
+#define STATION_MODULE_RECORD_SIZE 9  /* type:1 + scaffold:1 + ring:1 + slot:1 + build_progress:f32 + commodity:1 */
 #define STATION_PLAN_RECORD_SIZE 4    /* type:1 + ring:1 + slot:1 + owner:1 */
 #define STATION_PLAN_RECORD_COUNT 8
 #define STATION_PENDING_SCAFFOLD_RECORD_SIZE 2  /* type:1 + owner:1 */

--- a/src/net.c
+++ b/src/net.c
@@ -585,6 +585,9 @@ static void handle_message(const uint8_t* data, int len) {
                 si.modules[m].ring = data[moff + 2];
                 si.modules[m].slot = data[moff + 3];
                 si.modules[m].build_progress = read_f32_le(&data[moff + 4]);
+                si.modules[m].commodity = data[moff + 8];
+                if (si.modules[m].commodity > COMMODITY_COUNT)
+                    si.modules[m].commodity = (uint8_t)COMMODITY_COUNT;
                 moff += STATION_MODULE_RECORD_SIZE;
             }
             /* Skip over unused module record slots to reach arm data */

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -1569,6 +1569,20 @@ TEST(test_station_module_layout_status_furnace_uses_tag) {
     ASSERT_EQ_INT(station_module_layout_status(&st, fc), STATION_LAYOUT_OK);
 }
 
+TEST(test_station_module_layout_status_furnace_requires_adjacent_ore_hopper) {
+    station_t st = {0};
+    st.signal_range = 1.0f;
+    add_furnace_for(&st, 2, 1, COMMODITY_CUPRITE_INGOT);
+    add_hopper_for(&st, 2, 2, COMMODITY_CUPRITE_ORE);
+    const station_module_t *fc = &st.modules[0];
+
+    ASSERT_EQ_INT(station_module_layout_status(&st, fc),
+                  STATION_LAYOUT_MISSING_INPUT_HOPPER);
+
+    add_hopper_for(&st, 3, 3, COMMODITY_CUPRITE_ORE);
+    ASSERT_EQ_INT(station_module_layout_status(&st, fc), STATION_LAYOUT_OK);
+}
+
 TEST(test_seeded_stations_layout_ok) {
     /* Slice 1 — every producer module on every seeded station reports
      * STATION_LAYOUT_OK (i.e., its inputs and output have matching
@@ -2149,6 +2163,7 @@ void register_construction_module_schema_tests(void) {
     RUN(test_station_module_layout_status_missing_output);
     RUN(test_station_module_layout_status_no_local_consumer_is_ok);
     RUN(test_station_module_layout_status_furnace_uses_tag);
+    RUN(test_station_module_layout_status_furnace_requires_adjacent_ore_hopper);
     RUN(test_station_module_layout_status_shipyard_exempt);
     RUN(test_seeded_furnaces_tagged);
     RUN(test_seeded_helios_output_hoppers);

--- a/src/tests/test_protocol.c
+++ b/src/tests/test_protocol.c
@@ -254,6 +254,57 @@ TEST(test_roundtrip_stations) {
     ASSERT_EQ_FLOAT(read_f32_le(&p[1 + COMMODITY_FRAME * 4]), 15.5f, 0.1f);
 }
 
+TEST(test_station_identity_serializes_module_commodities) {
+    station_t st;
+    memset(&st, 0, sizeof(st));
+    st.services = STATION_SERVICE_REPAIR;
+    st.pos = v2(10.0f, -20.0f);
+    st.radius = 60.0f;
+    st.dock_radius = 110.0f;
+    st.signal_range = 2000.0f;
+    snprintf(st.name, sizeof(st.name), "Wire Test");
+    st.module_count = 3;
+    st.modules[0] = (station_module_t){
+        .type = MODULE_HOPPER,
+        .ring = 1,
+        .slot = 0,
+        .scaffold = false,
+        .commodity = (uint8_t)COMMODITY_CUPRITE_ORE,
+        .build_progress = 1.0f,
+    };
+    st.modules[1] = (station_module_t){
+        .type = MODULE_HOPPER,
+        .ring = 2,
+        .slot = 1,
+        .scaffold = false,
+        .commodity = (uint8_t)COMMODITY_FRAME,
+        .build_progress = 1.0f,
+    };
+    st.modules[2] = (station_module_t){
+        .type = MODULE_FURNACE,
+        .ring = 3,
+        .slot = 2,
+        .scaffold = false,
+        .commodity = (uint8_t)COMMODITY_CRYSTAL_INGOT,
+        .build_progress = 1.0f,
+    };
+
+    uint8_t buf[STATION_IDENTITY_SIZE] = {0};
+    int len = serialize_station_identity(buf, 4, &st);
+
+    ASSERT_EQ_INT(len, STATION_IDENTITY_SIZE);
+    ASSERT_EQ_INT(STATION_MODULE_RECORD_SIZE, 9);
+
+    int moff = 59 + COMMODITY_COUNT * 4 + 4;
+    ASSERT_EQ_INT(buf[moff], 3);
+    moff++;
+    ASSERT_EQ_INT(buf[moff + 8], COMMODITY_CUPRITE_ORE);
+    moff += STATION_MODULE_RECORD_SIZE;
+    ASSERT_EQ_INT(buf[moff + 8], COMMODITY_FRAME);
+    moff += STATION_MODULE_RECORD_SIZE;
+    ASSERT_EQ_INT(buf[moff + 8], COMMODITY_CRYSTAL_INGOT);
+}
+
 TEST(test_bug92_station_record_size_matches_buffer) {
     /* Bug 92: station broadcast buffer must match serialized record size.
      * STATION_RECORD_SIZE is validated at compile time via _Static_assert,
@@ -410,6 +461,7 @@ void register_protocol_main_tests(void) {
     RUN(test_roundtrip_asteroids_full_includes_inactive_slots);
     RUN(test_roundtrip_npcs);
     RUN(test_roundtrip_stations);
+    RUN(test_station_identity_serializes_module_commodities);
     RUN(test_bug92_station_record_size_matches_buffer);
     RUN(test_bug93_hint_mines_small_shard_with_minor_desync);
     RUN(test_roundtrip_player_ship);

--- a/src/world_draw.c
+++ b/src/world_draw.c
@@ -502,17 +502,18 @@ static void draw_module_shape(module_type_t type, float mr, float mg, float mb, 
     /* ---- FURNACE: Circle ---- */
     case MODULE_FURNACE: {
         /* Filled circle hull */
-        fill_circle_local(0, 0, 28, 20, mr*0.30f, mg*0.30f, mb*0.30f, alpha);
-        /* Ore-type accent glow — warm layered halo */
-        fill_circle_local(0, 0, 24, 16, mr*0.12f, mg*0.04f, mb*0.02f, alpha*0.4f);
-        fill_circle_local(0, 0, 18, 14, mr*0.25f, mg*0.10f, mb*0.04f, alpha*0.5f);
-        fill_circle_local(0, 0, 12, 12, mr*0.50f, mg*0.20f, mb*0.08f, alpha*0.6f);
-        fill_circle_local(0, 0, 7,  10, mr*0.80f, mg*0.40f, mb*0.15f, alpha*0.75f);
-        fill_circle_local(0, 0, 3,  8,  mr*1.0f,  mg*0.70f, mb*0.30f, alpha*0.95f);
+        fill_circle_local(0, 0, 28, 20, mr*0.42f, mg*0.42f, mb*0.42f, alpha);
+        /* Ore-type accent glow. Keep this commodity colored, not generic
+         * orange, so furnace role matches the hopper resource at a glance. */
+        fill_circle_local(0, 0, 24, 16, mr*0.20f, mg*0.20f, mb*0.20f, alpha*0.45f);
+        fill_circle_local(0, 0, 18, 14, mr*0.36f, mg*0.30f, mb*0.26f, alpha*0.55f);
+        fill_circle_local(0, 0, 12, 12, mr*0.62f, mg*0.48f, mb*0.34f, alpha*0.65f);
+        fill_circle_local(0, 0, 7,  10, mr*0.90f, mg*0.66f, mb*0.42f, alpha*0.80f);
+        fill_circle_local(0, 0, 3,  8,  mr*1.0f,  mg*0.82f, mb*0.56f, alpha*0.95f);
         /* Bright hot core dot */
         fill_circle_local(0, 0, 1.5f, 6, 1.0f, 0.95f, 0.7f, alpha*0.8f);
         /* Bold outline */
-        outline_ngon(20, 28, mr*0.7f, mg*0.7f, mb*0.7f, alpha);
+        outline_ngon(20, 29, mr*0.95f, mg*0.95f, mb*0.95f, alpha);
         break;
     }
 
@@ -628,13 +629,21 @@ static void draw_hopper_shape(float br, float bg, float bb,
                               float alpha) {
     /* Triangle pointing outward (-Y) = funnel mouth. The body carries the
      * resource-family base; the rim/core carries the accent. */
-    sgl_c4f(br * 0.34f, bg * 0.34f, bb * 0.34f, alpha);
+    sgl_c4f(br * 0.46f, bg * 0.46f, bb * 0.46f, alpha);
     sgl_begin_triangles();
     sgl_v2f(-32, -20); sgl_v2f(32, -20); sgl_v2f(0, 28);
     sgl_end();
 
+    /* Large inset keeps ore hoppers visibly "full resource" instead of
+     * reading as a dark generic triangle at station scale. */
+    sgl_c4f(br * 0.82f, bg * 0.82f, bb * 0.82f, alpha * 0.72f);
+    sgl_begin_triangles();
+    sgl_v2f(-22, -14); sgl_v2f(22, -14); sgl_v2f(0, 18);
+    sgl_end();
+
     sgl_c4f(ar * 0.95f, ag * 0.95f, ab * 0.95f, alpha);
     fill_quad(-32, -22, 32, -22, 32, -18, -32, -18);
+    fill_quad(-5, -15, 5, -15, 4, 15, -4, 15);
 
     fill_circle_local(0, 0, 8, 8, ar * 0.7f, ag * 0.7f, ab * 0.7f, alpha * 0.26f);
     fill_circle_local(0, 0, 4, 6, ar * 1.0f, ag * 1.0f, ab * 1.0f, alpha * 0.42f);
@@ -650,9 +659,48 @@ static void draw_hopper_shape(float br, float bg, float bb,
     sgl_end();
 }
 
+static void draw_layout_warning_outline(module_type_t type,
+                                        station_layout_status_t status,
+                                        float pulse) {
+    if (status == STATION_LAYOUT_OK) return;
+
+    float wr = 1.0f, wg = 0.25f, wb = 0.10f;
+    if (status == STATION_LAYOUT_MISSING_OUTPUT_HOPPER) {
+        wr = 1.0f; wg = 0.72f; wb = 0.18f;
+    }
+    float a = 0.60f + 0.25f * pulse;
+
+    if (type == MODULE_FURNACE) {
+        outline_ngon(20, 35.0f, wr, wg, wb, a);
+    } else if (type == MODULE_FRAME_PRESS ||
+               type == MODULE_LASER_FAB ||
+               type == MODULE_TRACTOR_FAB) {
+        outline_ngon(5, 35.0f, wr, wg, wb, a);
+    } else {
+        sgl_c4f(wr, wg, wb, a);
+        sgl_begin_lines();
+        sgl_v2f(-34, -34); sgl_v2f( 34, -34);
+        sgl_v2f( 34, -34); sgl_v2f( 34,  34);
+        sgl_v2f( 34,  34); sgl_v2f(-34,  34);
+        sgl_v2f(-34,  34); sgl_v2f(-34, -34);
+        sgl_end();
+    }
+
+    /* Broken-connection ticks make the warning legible even when the
+     * module shape color is already warm. */
+    sgl_c4f(wr, wg, wb, a);
+    sgl_begin_lines();
+    sgl_v2f(-38, -30); sgl_v2f(-24, -38);
+    sgl_v2f( 24, -38); sgl_v2f( 38, -30);
+    sgl_v2f(-38,  30); sgl_v2f(-24,  38);
+    sgl_v2f( 24,  38); sgl_v2f( 38,  30);
+    sgl_end();
+}
+
 static void draw_module_at(vec2 pos, float angle, module_type_t type, bool scaffold, float progress, vec2 station_center,
                            const station_t *station, commodity_t hopper_commodity,
-                           const station_module_t *module) {
+                           const station_module_t *module,
+                           station_layout_status_t layout_status) {
     float mr, mg, mb;
     float hr = 0.0f, hg = 0.0f, hb = 0.0f;
     bool custom_hopper = false;
@@ -666,9 +714,8 @@ static void draw_module_at(vec2 pos, float angle, module_type_t type, bool scaff
         module_color(type, &mr, &mg, &mb);
     }
     (void)station_center;
-    /* Furnaces tint per-ring based on station context (count + ring).
-     * The sim only knows MODULE_FURNACE; the renderer picks ferrite /
-     * cuprite / crystal / chunks-feeder. See station_palette.h. */
+    /* Furnaces tint from their instance commodity tag when present, with
+     * legacy ring fallback for old/untagged stations. See station_palette.h. */
     if (type == MODULE_FURNACE && station != NULL) {
         station_palette_furnace_module_color(station, module, &mr, &mg, &mb);
     }
@@ -729,6 +776,8 @@ static void draw_module_at(vec2 pos, float angle, module_type_t type, bool scaff
         } else {
             draw_module_shape(type, mr, mg, mb, 0.92f);
         }
+        draw_layout_warning_outline(type, layout_status,
+                                    0.5f + 0.5f * sinf(g.world.time * 5.0f + (float)(pos.x + pos.y) * 0.01f));
 
         /* Demand beacon: a docked station that is starving for some
          * commodity outlines its DOCK module in pulsing yellow so
@@ -1023,8 +1072,9 @@ void draw_station_rings(const station_t* station, bool is_current, bool is_nearb
         for (int i = 0; i < mod_count; i++) {
             const station_module_t *m = &station->modules[mod_idx[i]];
             float angle = module_angle_ring(station, ring, m->slot);
+            station_layout_status_t layout_status = station_module_layout_status(station, m);
             draw_module_at(positions[i], angle, m->type, m->scaffold, m->build_progress, station->pos, station,
-                           (commodity_t)m->commodity, m);
+                           (commodity_t)m->commodity, m, layout_status);
 
             /* Furnace: glow + red laser beam to target module when smelting */
             if (!m->scaffold && m->type == MODULE_FURNACE) {


### PR DESCRIPTION
## Summary
- strengthen furnace and hopper commodity colors so resource roles read at station scale
- draw warning outlines on producers when the shared layout validator reports missing input/output hoppers
- add a regression test proving same-ring furnace ore hoppers still count as disconnected

## Why
The Helios issue was hard to diagnose because the renderer made disconnected smelters look like cosmetic placement differences. This makes the production graph legible: matching furnace/hopper colors show intended flow, and broken producers pulse with an explicit warning outline.

## Validation
- make test
- make test-soak
- make build-server
- make build-web (rerun with escalated cache access after sandbox blocked Emscripten cache lock)
- pre-push hook: 510 tests passed