### PR TITLE
[codex] smooth station flow and fragment walls

### DIFF
--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -5200,8 +5200,8 @@ void world_reset(world_t *w) {
      * Layout principle: one HOPPER per producer, placed at the
      * cross-ring slot whose canonical angle is closest to the
      * producer's. Hoppers are NOT decorative — every hopper exists
-     * because some producer paired with it. Producers live on rings
-     * 1 or 3; ring 2 hosts the hoppers that feed them.
+     * because some producer paired with it. Starter stations bias
+     * producers inward and use adjacent rings as readable staging belts.
      *   - Slot angles (zero rotation):
      *       ring 1 (3): 0°, 120°, 240°
      *       ring 2 (6): 0°, 60°, 120°, 180°, 240°, 300°
@@ -5272,21 +5272,20 @@ void world_reset(world_t *w) {
     /* Kepler imports laser/tractor modules for its shipyard kit fab. */
     w->stations[1].base_price[COMMODITY_LASER_MODULE]   = 30.0f;
     w->stations[1].base_price[COMMODITY_TRACTOR_MODULE] = 38.0f;
-    /* Ring 1: dock + relay only. Ring-1 slot 2 stays empty. */
+    /* Ring 1: dock + relay + shipyard. The shipyard sits on the inner
+     * ring so its three input hoppers can read as a compact ring-2
+     * staging belt instead of being buried on the outer hull. */
     add_module_at(&w->stations[1], MODULE_DOCK,         1, 0);
     add_module_at(&w->stations[1], MODULE_SIGNAL_RELAY, 1, 1);
-    /* Ring 2: frame press + shipyard. */
+    add_module_at(&w->stations[1], MODULE_SHIPYARD,     1, 2); /* needs FRAME, LASER, TRACTOR */
+    /* Ring 2: frame press + shipyard input hoppers. Frame sits on the
+     * shipyard's centerline; laser/tractor flank it. */
     add_module_at(&w->stations[1], MODULE_FRAME_PRESS,  2, 0); /* needs FERRITE_INGOT */
-    add_module_at(&w->stations[1], MODULE_SHIPYARD,     2, 2); /* needs FRAME, LASER, TRACTOR */
-    /* Ring 3: 4 commodity-tagged hoppers — one for FRAME_PRESS's
-     * ferrite ingot, three for SHIPYARD's three inputs. SHIPYARD
-     * emits 3 spokes (one per commodity), so a busy Kepler shows
-     * ferrite-orange + frame-gold + laser-cyan + tractor-blue lines
-     * radiating from the shipyard. */
-    add_hopper_for(&w->stations[1], 3, 0, COMMODITY_FERRITE_INGOT);  /* feeds FRAME_PRESS */
-    add_hopper_for(&w->stations[1], 3, 2, COMMODITY_FRAME);          /* feeds SHIPYARD    */
-    add_hopper_for(&w->stations[1], 3, 4, COMMODITY_LASER_MODULE);   /* feeds SHIPYARD    */
-    add_hopper_for(&w->stations[1], 3, 6, COMMODITY_TRACTOR_MODULE); /* feeds SHIPYARD    */
+    add_hopper_for(&w->stations[1], 2, 3, COMMODITY_LASER_MODULE);   /* feeds SHIPYARD    */
+    add_hopper_for(&w->stations[1], 2, 4, COMMODITY_FRAME);          /* frame output + shipyard input */
+    add_hopper_for(&w->stations[1], 2, 5, COMMODITY_TRACTOR_MODULE); /* feeds SHIPYARD    */
+    /* Ring 3: just the ferrite-ingot hopper feeding the frame press. */
+    add_hopper_for(&w->stations[1], 3, 0, COMMODITY_FERRITE_INGOT);
     w->stations[1].arm_count = 3;
     w->stations[1].arm_speed[1] = STATION_RING_SPEED; /* ring 2 drift bias */
     rebuild_station_services(&w->stations[1]);

--- a/server/sim_physics.c
+++ b/server/sim_physics.c
@@ -239,12 +239,71 @@ static void resolve_asteroid_module_collision(asteroid_t *a, vec2 mod_pos, float
     a->net_dirty = true;
 }
 
+static void resolve_asteroid_corridor_collision(asteroid_t *a, vec2 center,
+                                                float ring_r, float angle_a,
+                                                float arc_delta) {
+    vec2 delta = v2_sub(a->pos, center);
+    float dist = sqrtf(v2_len_sq(delta));
+    if (dist < 1.0f) return;
+
+    float r_inner = ring_r - STATION_CORRIDOR_HW - a->radius;
+    float r_outer = ring_r + STATION_CORRIDOR_HW + a->radius;
+    if (dist <= r_inner || dist >= r_outer) return;
+
+    float ast_angle = atan2f(delta.y, delta.x);
+    float angular_margin = asinf(fminf(a->radius / dist, 1.0f));
+    float expanded_start = angle_a - angular_margin;
+    float expanded_delta = arc_delta + 2.0f * angular_margin;
+    if (angle_in_arc(ast_angle, expanded_start, expanded_delta) < 0.0f) return;
+
+    vec2 radial = v2_scale(delta, 1.0f / dist);
+    vec2 push_normal;
+    float d_inner = dist - (ring_r - STATION_CORRIDOR_HW);
+    float d_outer = (ring_r + STATION_CORRIDOR_HW) - dist;
+    if (d_inner < d_outer) {
+        a->pos = v2_add(center, v2_scale(radial,
+            ring_r - STATION_CORRIDOR_HW - a->radius - 1.0f));
+        push_normal = v2_scale(radial, -1.0f);
+    } else {
+        a->pos = v2_add(center, v2_scale(radial,
+            ring_r + STATION_CORRIDOR_HW + a->radius + 1.0f));
+        push_normal = radial;
+    }
+
+    float vel_along = v2_dot(a->vel, push_normal);
+    if (vel_along < 0.0f)
+        a->vel = v2_sub(a->vel, v2_scale(push_normal, vel_along));
+    a->net_dirty = true;
+}
+
+static bool asteroid_near_corridor_module(const asteroid_t *a,
+                                          const station_geom_t *geom,
+                                          const geom_corridor_t *cor) {
+    vec2 delta = v2_sub(a->pos, geom->center);
+    float dist = sqrtf(v2_len_sq(delta));
+    if (fabsf(dist - cor->ring_radius) >=
+        STATION_CORRIDOR_HW + a->radius + STATION_MODULE_COL_RADIUS)
+        return false;
+
+    float ast_ang = atan2f(delta.y, delta.x);
+    for (int mi = 0; mi < geom->circle_count; mi++) {
+        const geom_circle_t *circle = &geom->circles[mi];
+        if (circle->ring != cor->ring) continue;
+        float angular_size = (cor->ring_radius > 1.0f)
+            ? (STATION_MODULE_COL_RADIUS + a->radius) / cor->ring_radius
+            : 0.0f;
+        if (fabsf(wrap_angle(ast_ang - circle->angle)) < angular_size)
+            return true;
+    }
+    return false;
+}
+
 void resolve_asteroid_station_collisions(world_t *w) {
     /* Build geometry for all active stations once */
     station_geom_t geom_cache[MAX_STATIONS];
     bool geom_valid[MAX_STATIONS];
     for (int s = 0; s < MAX_STATIONS; s++) {
-        if (station_exists(&w->stations[s])) {
+        if (station_collides(&w->stations[s])) {
             station_build_geom(&w->stations[s], &geom_cache[s]);
             geom_valid[s] = true;
         } else {
@@ -260,9 +319,16 @@ void resolve_asteroid_station_collisions(world_t *w) {
             /* Core collision */
             if (geom->has_core)
                 resolve_asteroid_module_collision(a, geom->core.center, geom->core.radius);
-            /* Module circles (docks already excluded by emitter) */
+            /* Module and dock collision circles. */
             for (int ci = 0; ci < geom->circle_count; ci++)
                 resolve_asteroid_module_collision(a, geom->circles[ci].center, geom->circles[ci].radius);
+            /* Corridor arcs form the visible station wall bands between modules. */
+            for (int ci = 0; ci < geom->corridor_count; ci++) {
+                const geom_corridor_t *cor = &geom->corridors[ci];
+                if (asteroid_near_corridor_module(a, geom, cor)) continue;
+                resolve_asteroid_corridor_collision(a, geom->center,
+                    cor->ring_radius, cor->angle_a, cor->arc_delta);
+            }
         }
     }
 }

--- a/shared/station_geom.h
+++ b/shared/station_geom.h
@@ -95,7 +95,7 @@ typedef struct {
     geom_circle_t core;
     bool has_core;
 
-    /* Module collision circles (docks excluded — docks are passages) */
+    /* Module collision circles; docks get smaller passage-edge circles. */
     geom_circle_t circles[STATION_GEOM_MAX_CIRCLES];
     int circle_count;
 

--- a/src/main.c
+++ b/src/main.c
@@ -123,6 +123,7 @@ static void reset_world(void) {
     g.npc_interp.interval = g.local_server.active ? SIM_DT : 0.1f;
     memset(&g.player_interp, 0, sizeof(g.player_interp));
     g.player_interp.interval = g.local_server.active ? SIM_DT : 0.1f;
+    reset_station_ring_smoothing();
 
     /* Seed interp buffers so first frame has valid data */
     memcpy(g.asteroid_interp.curr, g.world.asteroids, sizeof(g.asteroid_interp.curr));
@@ -725,22 +726,12 @@ static void sim_step(float dt) {
     audio_step(&g.audio, dt);
 
     /* Advance world time locally in multiplayer (server doesn't send it).
-     * Ring rotations are authoritative server-side and arrive with
-     * each station-identity broadcast at ~30Hz. To avoid 33ms-step
-     * chunkiness at 60fps render, interpolate forward from the last
-     * received snapshot using its arm_omega: each frame extends
-     * arm_rotation by omega*dt, and the next snapshot snaps it back
-     * to the authoritative value. The correction per snapshot is
-     * tiny (omega * 33ms) so the snap is invisible. */
+     * Ring rotations are authoritative server-side; client prediction
+     * integrates omega each frame, while net_sync eases any phase correction
+     * from the latest station-identity snapshot instead of snapping. */
     if (g.multiplayer_enabled) {
         g.world.time += dt;
-        for (int s = 0; s < MAX_STATIONS; s++) {
-            station_t *st = &g.world.stations[s];
-            if (!station_exists(st)) continue;
-            for (int a = 0; a < MAX_ARMS; a++) {
-                st->arm_rotation[a] += st->arm_omega[a] * dt;
-            }
-        }
+        step_remote_station_rings(dt);
     }
 
     /* Commission flash countdown */

--- a/src/net_sync.c
+++ b/src/net_sync.c
@@ -9,6 +9,43 @@
 #include "onboarding.h"
 #include "episode.h"
 
+#define STATION_RING_CORRECTION_SEC 0.35f
+
+static float station_ring_correction[MAX_STATIONS][MAX_ARMS];
+static bool station_ring_have_snapshot[MAX_STATIONS];
+
+static float nearest_angle_delta(float from, float to) {
+    float delta = to - from;
+    while (delta >  PI_F) delta -= TWO_PI_F;
+    while (delta < -PI_F) delta += TWO_PI_F;
+    return delta;
+}
+
+void reset_station_ring_smoothing(void) {
+    memset(station_ring_correction, 0, sizeof(station_ring_correction));
+    memset(station_ring_have_snapshot, 0, sizeof(station_ring_have_snapshot));
+}
+
+void step_remote_station_rings(float dt) {
+    for (int s = 0; s < MAX_STATIONS; s++) {
+        station_t *st = &g.world.stations[s];
+        if (!station_exists(st)) continue;
+        for (int a = 0; a < MAX_ARMS; a++) {
+            float correction = station_ring_correction[s][a];
+            float correction_step = 0.0f;
+            if (fabsf(correction) > 0.00001f) {
+                float k = dt / STATION_RING_CORRECTION_SEC;
+                if (k > 1.0f) k = 1.0f;
+                correction_step = correction * k;
+                station_ring_correction[s][a] -= correction_step;
+            } else {
+                station_ring_correction[s][a] = 0.0f;
+            }
+            st->arm_rotation[a] += st->arm_omega[a] * dt + correction_step;
+        }
+    }
+}
+
 static void server_player_cleanup_local(server_player_t *sp) {
     if (!sp) return;
     ship_cleanup(&sp->ship);
@@ -230,6 +267,11 @@ void apply_remote_contracts(const contract_t* contracts, int count) {
 void apply_remote_station_identity(const NetStationIdentity* si) {
     if (si->index >= MAX_STATIONS) return;
     station_t* st = &g.world.stations[si->index];
+    float local_rotation[MAX_ARMS];
+    for (int a = 0; a < MAX_ARMS; a++)
+        local_rotation[a] = st->arm_rotation[a];
+    bool smooth_rotation = station_ring_have_snapshot[si->index];
+
     st->scaffold = (si->flags & 1) != 0;
     st->planned  = (si->flags & 2) != 0;
     st->scaffold_progress = si->scaffold_progress;
@@ -248,9 +290,17 @@ void apply_remote_station_identity(const NetStationIdentity* si) {
     for (int a = 0; a < MAX_ARMS; a++) {
         st->arm_speed[a] = si->arm_speed[a];
         st->ring_offset[a] = si->ring_offset[a];
-        st->arm_rotation[a] = si->arm_rotation[a];
+        if (smooth_rotation) {
+            station_ring_correction[si->index][a] =
+                nearest_angle_delta(local_rotation[a], si->arm_rotation[a]);
+            st->arm_rotation[a] = local_rotation[a];
+        } else {
+            st->arm_rotation[a] = si->arm_rotation[a];
+            station_ring_correction[si->index][a] = 0.0f;
+        }
         st->arm_omega[a] = si->arm_omega[a];
     }
+    station_ring_have_snapshot[si->index] = true;
     /* Placement plans (faction-shared blueprint slots) */
     st->placement_plan_count = si->plan_count;
     for (int p = 0; p < si->plan_count && p < 8; p++) {

--- a/src/net_sync.h
+++ b/src/net_sync.h
@@ -48,6 +48,10 @@ void on_remote_death(uint8_t player_id, float pos_x, float pos_y,
 /* World time sync from server. */
 void on_remote_world_time(float server_time);
 
+/* Multiplayer station ring prediction/correction. */
+void reset_station_ring_smoothing(void);
+void step_remote_station_rings(float dt);
+
 /* Sync local player slot to the network-assigned ID. */
 void sync_local_player_slot_from_network(void);
 

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -1,4 +1,5 @@
 #include "tests/test_harness.h"
+#include "sim_physics.h"
 
 TEST(test_outpost_requires_signal_range) {
     WORLD_DECL;
@@ -380,6 +381,35 @@ TEST(test_238_corridor_blocks_radial_approach) {
     float outer_edge = ring_r + corridor_hw + ship_r;
     /* Player should be at or beyond the outer edge (pushed out) */
     ASSERT(dist_from_center >= outer_edge - 2.0f);
+}
+
+TEST(test_238_fragment_collides_with_corridor_wall) {
+    WORLD_HEAP w = setup_collision_world_heap();
+
+    vec2 st_pos = w->stations[0].pos;
+    float ang1 = module_angle_ring(&w->stations[0], 1, 1);
+    float ang2 = module_angle_ring(&w->stations[0], 1, 2);
+    float mid_ang = (ang1 + ang2) * 0.5f;
+    float ring_r = STATION_RING_RADIUS[1];
+    float radius = 8.0f;
+
+    asteroid_t *a = &w->asteroids[0];
+    a->active = true;
+    a->tier = ASTEROID_TIER_S;
+    a->radius = radius;
+    a->hp = 10.0f;
+    a->max_hp = 10.0f;
+    a->pos = v2_add(st_pos, v2(cosf(mid_ang) * (ring_r + STATION_CORRIDOR_HW + radius - 3.0f),
+                               sinf(mid_ang) * (ring_r + STATION_CORRIDOR_HW + radius - 3.0f)));
+    vec2 radial = v2_norm(v2_sub(a->pos, st_pos));
+    a->vel = v2_scale(radial, -100.0f);
+
+    resolve_asteroid_station_collisions(w);
+
+    float dist_from_center = v2_len(v2_sub(a->pos, st_pos));
+    float outer_edge = ring_r + STATION_CORRIDOR_HW + radius;
+    ASSERT(dist_from_center >= outer_edge);
+    ASSERT(v2_dot(a->vel, radial) >= -0.01f);
 }
 
 TEST(test_238_dock_gap_allows_entry) {
@@ -1921,6 +1951,7 @@ void register_construction_collision238_tests(void) {
     RUN(test_238_station_core_blocks_player);
     RUN(test_238_module_circle_blocks_player);
     RUN(test_238_corridor_blocks_radial_approach);
+    RUN(test_238_fragment_collides_with_corridor_wall);
     RUN(test_238_dock_gap_allows_entry);
     RUN(test_238_corridor_angular_edge_no_clip);
     RUN(test_238_module_corridor_junction_no_jitter);

--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -2164,6 +2164,34 @@ TEST(test_output_hopper_spoke_contributes_torque) {
     ASSERT(dr3 < 0.0f);
 }
 
+TEST(test_seeded_kepler_shipyard_inner_ring_layout) {
+    WORLD_HEAP w = calloc(1, sizeof(world_t));
+    ASSERT(w != NULL);
+    world_reset(w);
+
+    const station_t *st = &w->stations[1];
+    ASSERT_EQ_INT(station_module_at(st, 1, 2), MODULE_SHIPYARD);
+    ASSERT_EQ_INT(station_module_at(st, 2, 0), MODULE_FRAME_PRESS);
+    ASSERT_EQ_INT(ring_module_count(st, 3), 1);
+
+    int frame_hopper = station_find_hopper_for(st, COMMODITY_FRAME);
+    int laser_hopper = station_find_hopper_for(st, COMMODITY_LASER_MODULE);
+    int tractor_hopper = station_find_hopper_for(st, COMMODITY_TRACTOR_MODULE);
+    int ferrite_hopper = station_find_hopper_for(st, COMMODITY_FERRITE_INGOT);
+    ASSERT(frame_hopper >= 0);
+    ASSERT(laser_hopper >= 0);
+    ASSERT(tractor_hopper >= 0);
+    ASSERT(ferrite_hopper >= 0);
+
+    ASSERT_EQ_INT(st->modules[frame_hopper].ring, 2);
+    ASSERT_EQ_INT(st->modules[frame_hopper].slot, 4);
+    ASSERT_EQ_INT(st->modules[laser_hopper].ring, 2);
+    ASSERT_EQ_INT(st->modules[tractor_hopper].ring, 2);
+    ASSERT_EQ_INT(st->modules[ferrite_hopper].ring, 3);
+    ASSERT(station_pair_satisfied(st, 1, 2, MODULE_SHIPYARD));
+    ASSERT(station_pair_satisfied(st, 2, 0, MODULE_FRAME_PRESS));
+}
+
 TEST(test_seed_stations_pair_complete) {
     /* Every producer on every starter station must have its cross-ring
      * pair-intake already satisfied at boot. This is the construction
@@ -2208,6 +2236,7 @@ void register_construction_module_schema_tests(void) {
     RUN(test_module_flow_storage_feeds_consumer);
     RUN(test_pair_neighbors_geometry);
     RUN(test_pair_satisfied_cross_ring);
+    RUN(test_seeded_kepler_shipyard_inner_ring_layout);
     RUN(test_seed_stations_pair_complete);
     RUN(test_helios_ring2_rotates_under_dynamics);
     RUN(test_all_rings_passive_under_spoke_load);

--- a/src/world_draw.c
+++ b/src/world_draw.c
@@ -643,7 +643,6 @@ static void draw_hopper_shape(float br, float bg, float bb,
 
     sgl_c4f(ar * 0.95f, ag * 0.95f, ab * 0.95f, alpha);
     fill_quad(-32, -22, 32, -22, 32, -18, -32, -18);
-    fill_quad(-5, -15, 5, -15, 4, 15, -4, 15);
 
     fill_circle_local(0, 0, 8, 8, ar * 0.7f, ag * 0.7f, ab * 0.7f, alpha * 0.26f);
     fill_circle_local(0, 0, 4, 6, ar * 1.0f, ag * 1.0f, ab * 1.0f, alpha * 0.42f);


### PR DESCRIPTION
## Summary
- Make station corridor walls collide with fragments while preserving module passage behavior
- Remove the extra hopper stripe and keep trim/badge colors readable
- Smooth remote station ring corrections instead of snapping to sparse identity packets
- Move Kepler shipyard to ring 1 with shipyard hoppers staged on rings 2/3

## Tests
- make test
- make test TEST_ARGS=--filter=test_seeded_kepler_shipyard_inner_ring_layout
- pre-push synchronous guard