### PR TITLE
Fix sanitizer leaks in test cleanup

### DIFF
--- a/src/tests/test_economy.c
+++ b/src/tests/test_economy.c
@@ -47,7 +47,7 @@ TEST(test_can_afford_upgrade_dock_fallback) {
      * credits — dock fills the gap from inventory at retail. */
     ship_t ship = {0};
     ship.hull_class = HULL_CLASS_MINER;
-    station_t station = {0};
+    STATION_DECL(station);
     station.services = STATION_SERVICE_UPGRADE_HOLD;
     ASSERT(test_set_station_finished_units(&station, COMMODITY_FRAME, 100));
     station.base_price[COMMODITY_FRAME] = 22.0f;
@@ -59,7 +59,7 @@ TEST(test_can_afford_upgrade_no_credits_for_dock_fallback) {
      * needs credits, so this must be rejected. */
     ship_t ship = {0};
     ship.hull_class = HULL_CLASS_MINER;
-    station_t station = {0};
+    STATION_DECL(station);
     station.services = STATION_SERVICE_UPGRADE_HOLD;
     ASSERT(test_set_station_finished_units(&station, COMMODITY_FRAME, 100));
     station.base_price[COMMODITY_FRAME] = 22.0f;
@@ -79,7 +79,7 @@ TEST(test_can_afford_upgrade_no_product_anywhere) {
 TEST(test_can_afford_upgrade_cargo_only_no_credits_needed) {
     /* Ship cargo covers the full module cost — credit balance is
      * irrelevant since the dock has nothing to sell. */
-    ship_t ship = {0};
+    SHIP_DECL(ship);
     ship.hull_class = HULL_CLASS_MINER;
     station_t station = {0};
     station.services = STATION_SERVICE_UPGRADE_HOLD;

--- a/src/tests/test_harness.h
+++ b/src/tests/test_harness.h
@@ -78,16 +78,22 @@ extern int g_only_soak;
 #define WORLD_DECL world_t w = {0}
 #define WORLD_DECL_NAME(name) world_t name = {0}
 #define WORLD_HEAP world_t *
+#define SHIP_DECL(name) ship_t name = {0}
+#define STATION_DECL(name) station_t name = {0}
 #define SERVER_PLAYER_DECL(name) server_player_t name = {0}
 #else
 static inline void world_auto_cleanup(world_t *w) { world_cleanup(w); }
 static inline void world_ptr_auto_cleanup(world_t **wp) {
     if (*wp) { world_cleanup(*wp); free(*wp); *wp = NULL; }
 }
+static inline void ship_auto_cleanup(ship_t *ship) { ship_cleanup(ship); }
+static inline void station_auto_cleanup(station_t *station) { station_cleanup(station); }
 static inline void server_player_auto_cleanup(server_player_t *sp) { ship_cleanup(&sp->ship); }
 #define WORLD_DECL world_t __attribute__((cleanup(world_auto_cleanup))) w = {0}
 #define WORLD_DECL_NAME(name) world_t __attribute__((cleanup(world_auto_cleanup))) name = {0}
 #define WORLD_HEAP __attribute__((cleanup(world_ptr_auto_cleanup))) world_t *
+#define SHIP_DECL(name) ship_t __attribute__((cleanup(ship_auto_cleanup))) name = {0}
+#define STATION_DECL(name) station_t __attribute__((cleanup(station_auto_cleanup))) name = {0}
 #define SERVER_PLAYER_DECL(name) \
     server_player_t __attribute__((cleanup(server_player_auto_cleanup))) name = {0}
 #endif

--- a/src/tests/test_relationship_tracking.c
+++ b/src/tests/test_relationship_tracking.c
@@ -109,7 +109,7 @@ TEST(test_relationship_save_load) {
     const char *tmppath = "/tmp/test_relationship_save.sav";
     bool saved = world_save(w, tmppath);
     ASSERT(saved);
-    world_t *w2 = calloc(1, sizeof(world_t));
+    WORLD_HEAP w2 = calloc(1, sizeof(world_t));
     ASSERT(w2 != NULL);
     bool loaded = world_load(w2, tmppath);
     unlink(tmppath);


### PR DESCRIPTION
## Summary
- add cleanup-backed `SHIP_DECL` and `STATION_DECL` test helpers
- use them where manifest bootstrapping on stack `ship_t` / `station_t` leaked under Linux LeakSanitizer
- clean up the loaded relationship save/load world with existing `WORLD_HEAP` ownership

## Verification
- `make test`
- `./build-san/signal_test --quiet`
- `cmake -S . -B build-ubsan -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS_ONLY=ON -DCMAKE_C_FLAGS="-O1 -g -fsanitize=undefined,address -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=undefined,address"`
- `cmake --build build-ubsan`

Note: local macOS execution of the UBSan+ASan binary hits an ASan stack overflow in `register_manifest_tests` before the Linux leak path; the branch CI should validate the Linux sanitizer runner.

Refs #329.