### PR TITLE
[codex] Fix smoke runtime readiness wait

### DIFF
--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -146,8 +146,15 @@ async function readCanvasStats(canvas: Locator): Promise<CanvasStats> {
 async function waitForRuntime(page: Page): Promise<void> {
   await page.waitForFunction(
     () => {
-      const mod = (window as unknown as { Module?: { ccall?: unknown } }).Module;
-      return !!mod && typeof mod.ccall === 'function';
+      const mod = (window as unknown as {
+        Module?: { ccall?: unknown; calledRun?: boolean; _get_signal_strength?: unknown };
+      }).Module;
+      return (
+        !!mod &&
+        mod.calledRun === true &&
+        typeof mod.ccall === 'function' &&
+        typeof mod._get_signal_strength === 'function'
+      );
     },
     undefined,
     { timeout: 20_000 },


### PR DESCRIPTION
## Summary
- wait for Emscripten to finish runtime startup before smoke tests call exported C helpers
- require the exported _get_signal_strength symbol, not just ccall, so smoke does not race WASM export assignment

## Root cause
Main run 25328184636 reached deploy smoke with ccall visible before the WASM export table was callable, then signalStrength hit an undefined export.

## Validation
- make smoke
- pre-push hook: 513 tests run, 513 passed