### PR TITLE
[codex] Fix UBSan station reset leak

### DIFF
--- a/src/tests/test_construction.c
+++ b/src/tests/test_construction.c
@@ -2044,6 +2044,7 @@ TEST(test_pair_satisfied_cross_ring) {
     world_reset(w);
 
     station_t *st = &w->stations[5]; /* unused slot, completely empty */
+    station_cleanup(st);
     memset(st, 0, sizeof(*st));
     st->signal_range = 1.0f;
 
@@ -2060,6 +2061,7 @@ TEST(test_pair_satisfied_cross_ring) {
 
     /* FURNACE accepts ANY ore — one ferrite-ore hopper is enough. */
     station_t *st2 = &w->stations[6];
+    station_cleanup(st2);
     memset(st2, 0, sizeof(*st2));
     st2->signal_range = 1.0f;
     ASSERT(!station_pair_satisfied(st2, 2, 0, MODULE_FURNACE));


### PR DESCRIPTION
## Summary
- clean seeded station manifests before test_pair_satisfied_cross_ring zeroes borrowed station slots
- preserve WORLD_HEAP cleanup behavior without leaking world_reset manifest allocations

## Root cause
Main run 25330006628 passed deploy smoke, then test-ubsan failed LeakSanitizer after test_pair_satisfied_cross_ring. The test used world_reset(), borrowed station slots 5 and 6, and memset those station_t structs, erasing manifest pointers before world_cleanup could release them.

## Validation
- make test
- pre-push hook: 513 tests run, 513 passed
- Local UBSan/ASan cannot reach the focused filter on macOS because this checkout still hits the known Darwin ASan stack overflow in register_manifest_tests; CI Linux UBSan is the intended confirmation.