### PR TITLE
[codex] Tighten manifest authority for hauler finished goods

### DIFF
--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -18,42 +18,61 @@
 #include <math.h>
 #include <string.h>
 
-/* Remove up to `n` cargo units of `c` from a station's manifest.
- * Returns the number actually removed. Walks backward so removing
- * doesn't disturb earlier indices. Used by NPC haulers so the
- * manifest stays in lockstep with the inventory float; otherwise the
- * trade picker (manifest-only) shows phantom rows for stock the
- * hauler already carried away. */
-static int station_manifest_drain_commodity(station_t *st, commodity_t c, int n) {
-    if (!st || !st->manifest.units || n <= 0) return 0;
-    int removed = 0;
-    for (int16_t i = (int16_t)st->manifest.count - 1; i >= 0 && removed < n; i--) {
-        if (st->manifest.units[i].commodity == (uint8_t)c) {
-            if (manifest_remove(&st->manifest, (uint16_t)i, NULL)) removed++;
-        }
-    }
-    return removed;
+static int hauler_reserve_units(void) {
+    return (int)ceilf(HAULER_RESERVE - 0.0001f);
 }
 
-/* Inverse: push `n` synthetic legacy-migrate units of `c` into a
- * station's manifest. Used at NPC unload until haulers get their own
- * manifest_t. The origin is per-hauler so the units are traceable to
+static int station_finished_available_for_hauler(const station_t *st,
+                                                 commodity_t c) {
+    int stock = station_finished_count(st, c);
+    int reserve = hauler_reserve_units();
+    return stock > reserve ? stock - reserve : 0;
+}
+
+static float station_finished_fraction_for_hauler(const station_t *st,
+                                                  commodity_t c) {
+    if (!st || c < COMMODITY_RAW_ORE_COUNT || c >= COMMODITY_COUNT)
+        return 0.0f;
+    float v = st->_inventory_cache[c];
+    float whole = floorf(v + 0.0001f);
+    float frac = v - whole;
+    return (frac > 0.0f && frac < 1.0f) ? frac : 0.0f;
+}
+
+static int station_finished_room_units(const station_t *st, commodity_t c,
+                                       float cap) {
+    int stock = station_finished_count(st, c);
+    float used = (float)stock + station_finished_fraction_for_hauler(st, c);
+    int room = (int)floorf(cap - used + 0.0001f);
+    return room > 0 ? room : 0;
+}
+
+static int npc_load_finished_from_station(station_t *st, npc_ship_t *npc,
+                                          commodity_t c, float space) {
+    if (!st || !npc || c < COMMODITY_RAW_ORE_COUNT || c >= COMMODITY_COUNT)
+        return 0;
+
+    int space_units = (int)floorf(space + 0.0001f);
+    int available = station_finished_available_for_hauler(st, c);
+    int request = available < space_units ? available : space_units;
+    if (request <= 0) return 0;
+
+    int drained = station_finished_drain(st, c, request);
+    if (drained <= 0) return 0;
+    npc->cargo[c] += (float)drained;
+    return drained;
+}
+
+/* Push `n` synthetic legacy-migrate units of `c` into a station via the
+ * manifest-as-truth helper. Used at NPC unload until haulers get their
+ * own manifest_t. The origin is per-hauler so the units are traceable to
  * "delivered by NPC slot K". */
-static int station_manifest_seed_from_npc(station_t *st, commodity_t c, int n,
+static int station_finished_mint_from_npc(station_t *st, commodity_t c, int n,
                                           int npc_slot) {
     if (!st || n <= 0) return 0;
-    if (st->manifest.cap == 0 && !station_manifest_bootstrap(st)) return 0;
     uint8_t origin[8] = { 'N','P','C','D','0','0','0','0' };
     origin[7] = (uint8_t)('0' + (npc_slot % 10));
-    int pushed = 0;
-    for (int i = 0; i < n; i++) {
-        if (st->manifest.count >= st->manifest.cap) break;
-        cargo_unit_t unit = {0};
-        if (!hash_legacy_migrate_unit(origin, c, (uint16_t)i, &unit)) continue;
-        if (!manifest_push(&st->manifest, &unit)) break;
-        pushed++;
-    }
-    return pushed;
+    return station_finished_mint(st, c, n, origin);
 }
 
 static bool station_smelt_pair_for_ore(const station_t *st, commodity_t ore,
@@ -993,7 +1012,8 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                 if (w->contracts[k].station_index == npc->home_station) continue;
                 commodity_t c = w->contracts[k].commodity;
                 if (c < COMMODITY_RAW_ORE_COUNT) continue; /* haulers carry ingots only */
-                if (home->_inventory_cache[c] < 0.5f) continue; /* no stock to fill */
+                if (station_finished_available_for_hauler(home, c) <= 0)
+                    continue; /* no manifest-backed stock to fill */
                 float dist = fmaxf(1.0f, v2_len(v2_sub(w->stations[w->contracts[k].station_index].pos, home->pos)));
                 float score = contract_price(&w->contracts[k]) / dist;
                 if (score > best_score) {
@@ -1006,17 +1026,7 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                 /* Load the commodity for this contract (leave reserve for players) */
                 commodity_t ingot = w->contracts[best_contract].commodity;
                 npc->dest_station = w->contracts[best_contract].station_index;
-                float avail = fmaxf(0.0f, home->_inventory_cache[ingot] - HAULER_RESERVE);
-                float take = fminf(avail, space);
-                if (take > 0.5f) {
-                    npc->cargo[ingot] += take;
-                    home->_inventory_cache[ingot] -= take;
-                    int whole = (int)floorf(take + 0.0001f);
-                    if (whole > 0) {
-                        if (station_manifest_drain_commodity(home, ingot, whole) > 0)
-                            home->manifest_dirty = true;
-                    }
-                }
+                (void)npc_load_finished_from_station(home, npc, ingot, space);
             } else {
                 /* Fallback: original round-trip behavior (leave reserve for players) */
                 station_t *dest = &w->stations[npc->dest_station];
@@ -1040,7 +1050,7 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
 
                 for (int wi = 0; wi < want_count; wi++) {
                     commodity_t ingot = wants[wi];
-                    float avail = fmaxf(0.0f, home->_inventory_cache[ingot] - HAULER_RESERVE);
+                    float avail = (float)station_finished_available_for_hauler(home, ingot);
                     float need;
                     bool seen = false;
 
@@ -1049,7 +1059,8 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                     }
                     if (seen || avail <= 0.5f) continue;
 
-                    need = fmaxf(0.0f, MAX_PRODUCT_STOCK * 0.5f - dest->_inventory_cache[ingot]);
+                    need = fmaxf(0.0f, MAX_PRODUCT_STOCK * 0.5f -
+                                       (float)station_finished_count(dest, ingot));
                     if (need > best_need) {
                         best_need = need;
                         best_ingot = ingot;
@@ -1090,9 +1101,10 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                                 if (alt_wants[wj] == ingot) { seen = true; break; }
                             }
                             if (seen) continue;
-                            float avail = fmaxf(0.0f, home->_inventory_cache[ingot] - HAULER_RESERVE);
+                            float avail = (float)station_finished_available_for_hauler(home, ingot);
                             if (avail <= 0.5f) continue;
-                            float need = fmaxf(0.0f, MAX_PRODUCT_STOCK * 0.5f - alt->_inventory_cache[ingot]);
+                            float need = fmaxf(0.0f, MAX_PRODUCT_STOCK * 0.5f -
+                                                     (float)station_finished_count(alt, ingot));
                             if (need <= 0.0f) continue;
                             float dist = fmaxf(1.0f, v2_len(v2_sub(alt->pos, home->pos)));
                             float score = (avail * need) / dist;
@@ -1110,17 +1122,7 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                 }
 
                 if (best_ingot < COMMODITY_COUNT) {
-                    float avail = fmaxf(0.0f, home->_inventory_cache[best_ingot] - HAULER_RESERVE);
-                    float take = fminf(avail, space);
-                    if (take > 0.5f) {
-                        npc->cargo[best_ingot] += take;
-                        home->_inventory_cache[best_ingot] -= take;
-                        int whole = (int)floorf(take + 0.0001f);
-                        if (whole > 0) {
-                            if (station_manifest_drain_commodity(home, best_ingot, whole) > 0)
-                                home->manifest_dirty = true;
-                        }
-                    }
+                    (void)npc_load_finished_from_station(home, npc, best_ingot, space);
                 }
             }
             float total_carried = 0.0f;
@@ -1133,8 +1135,10 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                     if (s == npc->home_station) continue;
                     if (!station_is_active(&w->stations[s])) continue;
                     float stock = 0.0f;
-                    for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++)
-                        stock += fmaxf(0.0f, w->stations[s]._inventory_cache[c] - HAULER_RESERVE);
+                    for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++) {
+                        stock += (float)station_finished_available_for_hauler(
+                            &w->stations[s], (commodity_t)c);
+                    }
                     if (stock > best_stock) { best_stock = stock; best_src = s; }
                 }
                 /* Stay docked at home and wait for stock or a contract.
@@ -1175,22 +1179,13 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
             station_t *dest = &w->stations[npc->dest_station];
             for (int i = COMMODITY_RAW_ORE_COUNT; i < COMMODITY_COUNT; i++) {
                 if (npc->cargo[i] <= 0.0f) continue;
-                float delivered = npc->cargo[i];
-                float before = dest->_inventory_cache[i];
-                dest->_inventory_cache[i] += delivered;
-                if (dest->_inventory_cache[i] > MAX_PRODUCT_STOCK)
-                    dest->_inventory_cache[i] = MAX_PRODUCT_STOCK;
-                /* Mirror the float bump into the manifest so the trade
-                 * picker (manifest-only) sees the new stock. Use the
-                 * post-clamp delta so overflow doesn't create phantom
-                 * manifest entries. */
-                int int_delta = (int)floorf(dest->_inventory_cache[i] + 0.0001f)
-                              - (int)floorf(before + 0.0001f);
-                if (int_delta > 0) {
-                    if (station_manifest_seed_from_npc(dest, (commodity_t)i,
-                                                       int_delta, n) > 0)
-                        dest->manifest_dirty = true;
-                }
+                int carried_units = (int)floorf(npc->cargo[i] + 0.0001f);
+                int room_units = station_finished_room_units(dest, (commodity_t)i,
+                                                             MAX_PRODUCT_STOCK);
+                int request = carried_units < room_units ? carried_units : room_units;
+                int delivered = station_finished_mint_from_npc(dest, (commodity_t)i,
+                                                               request, n);
+                if (delivered <= 0) continue;
                 /* Pay the NPC for fulfilling a contract. Walk active
                  * TRACTOR contracts at this destination for the same
                  * commodity, prefer the highest contract_price. The
@@ -1208,11 +1203,12 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                     if (ct->commodity != (commodity_t)i) continue;
                     if (ct->base_price > best_price) best_price = ct->base_price;
                 }
-                if (best_price > 0.0f && delivered > 0.01f) {
+                if (best_price > 0.0f) {
                     ledger_earn_from_pool(dest, npc->session_token,
-                                           best_price * delivered);
+                                           best_price * (float)delivered);
                 }
-                npc->cargo[i] = 0.0f;
+                npc->cargo[i] -= (float)delivered;
+                if (npc->cargo[i] < 0.01f) npc->cargo[i] = 0.0f;
             }
             /* Hauler also delivers ingots to scaffold station and modules */
             if (dest->scaffold || dest->module_count > 0) {

--- a/src/tests/test_bug_regression.c
+++ b/src/tests/test_bug_regression.c
@@ -231,7 +231,8 @@ TEST(test_bug22_hauler_stuck_at_empty_station) {
         w.stations[0]._inventory_cache[i] = 0.0f;
     /* Put enough ingots at station 1 to exceed the hauler reserve, so
      * relocation can actually result in a load. */
-    w.stations[1]._inventory_cache[COMMODITY_FERRITE_INGOT] = 40.0f;
+    ASSERT(test_set_station_finished_units(&w.stations[1],
+                                           COMMODITY_FERRITE_INGOT, 40));
     float initial_stock = w.stations[1]._inventory_cache[COMMODITY_FERRITE_INGOT];
     /* Run 60 seconds — haulers should relocate, load from station 1, and deliver */
     for (int i = 0; i < 7200; i++)

--- a/src/tests/test_economy.c
+++ b/src/tests/test_economy.c
@@ -90,6 +90,22 @@ TEST(test_can_afford_upgrade_cargo_only_no_credits_needed) {
     ASSERT(can_afford_upgrade(&station, &ship, SHIP_UPGRADE_HOLD,0.0f));
 }
 
+TEST(test_can_afford_upgrade_rejects_float_only_finished_goods) {
+    SHIP_DECL(ship);
+    STATION_DECL(station);
+    ship.hull_class = HULL_CLASS_MINER;
+    ASSERT(ship_manifest_bootstrap(&ship));
+    ASSERT(station_manifest_bootstrap(&station));
+
+    int need = (int)ceilf(upgrade_product_cost(&ship, SHIP_UPGRADE_HOLD));
+    ship.cargo[COMMODITY_FRAME] = (float)need;
+    station._inventory_cache[COMMODITY_FRAME] = (float)need;
+
+    ASSERT_EQ_INT(ship_finished_count(&ship, COMMODITY_FRAME), 0);
+    ASSERT_EQ_INT(station_finished_count(&station, COMMODITY_FRAME), 0);
+    ASSERT(!can_afford_upgrade(&station, &ship, SHIP_UPGRADE_HOLD, 10000.0f));
+}
+
 TEST(test_contract_generated_from_hopper_deficit) {
     /* A refinery with low ore_buffer should generate an ore contract */
     WORLD_DECL;
@@ -212,9 +228,11 @@ TEST(test_hauler_fills_highest_value_contract) {
         .quantity_needed = 20.0f,
         .base_price = 50.0f, .age = 0.0f,
     };
-    /* Give home station (0) inventory of both */
-    w.stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT] = 20.0f;
-    w.stations[0]._inventory_cache[COMMODITY_CUPRITE_INGOT] = 20.0f;
+    /* Give home station (0) manifest-backed inventory of both. */
+    ASSERT(test_set_station_finished_units(&w.stations[0],
+                                           COMMODITY_FERRITE_INGOT, 20));
+    ASSERT(test_set_station_finished_units(&w.stations[0],
+                                           COMMODITY_CUPRITE_INGOT, 20));
     /* Find the first hauler */
     npc_ship_t *hauler = NULL;
     for (int i = 0; i < MAX_NPC_SHIPS; i++) {
@@ -231,6 +249,48 @@ TEST(test_hauler_fills_highest_value_contract) {
     world_sim_step(&w, SIM_DT);
     /* Hauler should target station 2 (higher value contract) */
     ASSERT(hauler->dest_station == 2);
+}
+
+TEST(test_hauler_ignores_float_only_finished_stock) {
+    WORLD_DECL;
+    world_reset(&w);
+
+    for (int c = COMMODITY_RAW_ORE_COUNT; c < COMMODITY_COUNT; c++)
+        ASSERT(test_set_station_finished_units(&w.stations[0], (commodity_t)c, 0));
+
+    w.contracts[0] = (contract_t){
+        .active = true, .action = CONTRACT_TRACTOR, .station_index = 1,
+        .commodity = COMMODITY_FERRITE_INGOT,
+        .quantity_needed = 20.0f, .base_price = 50.0f,
+    };
+    w.stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT] = 20.0f;
+
+    int hauler_slot = -1;
+    for (int i = 0; i < MAX_NPC_SHIPS; i++) {
+        if (w.npc_ships[i].active && w.npc_ships[i].role == NPC_ROLE_HAULER) {
+            hauler_slot = i;
+            break;
+        }
+    }
+    ASSERT(hauler_slot >= 0);
+    for (int i = 0; i < MAX_NPC_SHIPS; i++) {
+        if (i != hauler_slot) w.npc_ships[i].active = false;
+    }
+
+    npc_ship_t *hauler = &w.npc_ships[hauler_slot];
+    hauler->state = NPC_STATE_DOCKED;
+    hauler->state_timer = 0.0f;
+    hauler->home_station = 0;
+    hauler->dest_station = 1;
+    memset(hauler->cargo, 0, sizeof(hauler->cargo));
+
+    step_npc_ships(&w, SIM_DT);
+
+    ASSERT_EQ_FLOAT(hauler->cargo[COMMODITY_FERRITE_INGOT], 0.0f, 0.001f);
+    ASSERT_EQ_INT(station_finished_count(&w.stations[0],
+                                         COMMODITY_FERRITE_INGOT), 0);
+    ASSERT_EQ_FLOAT(w.stations[0]._inventory_cache[COMMODITY_FERRITE_INGOT],
+                    20.0f, 0.001f);
 }
 
 TEST(test_one_contract_per_station) {
@@ -701,6 +761,63 @@ TEST(test_repair_partial_when_kits_short) {
     ASSERT_EQ_FLOAT(w.players[0].ship.hull, max_hull - 20.0f, 0.01f);
 }
 
+TEST(test_repair_rejects_float_only_kits) {
+    WORLD_DECL;
+    world_reset(&w);
+    player_init_ship(&w.players[0], &w);
+    w.players[0].connected = true;
+    w.players[0].session_ready = true;
+    memset(w.players[0].session_token, 0x04, 8);
+    w.players[0].docked = true;
+    w.players[0].current_station = 0;
+
+    ASSERT(test_set_station_finished_units(&w.stations[0],
+                                           COMMODITY_REPAIR_KIT, 0));
+    ASSERT(test_set_ship_finished_units(&w.players[0].ship,
+                                        COMMODITY_REPAIR_KIT, 0,
+                                        MINING_GRADE_COMMON));
+    w.stations[0]._inventory_cache[COMMODITY_REPAIR_KIT] = 100.0f;
+    w.players[0].ship.cargo[COMMODITY_REPAIR_KIT] = 100.0f;
+
+    float max_hull = ship_max_hull(&w.players[0].ship);
+    w.players[0].ship.hull = max_hull - 20.0f;
+    w.players[0].input.service_repair = true;
+    world_sim_step(&w, SIM_DT);
+
+    ASSERT_EQ_FLOAT(w.players[0].ship.hull, max_hull - 20.0f, 0.01f);
+    ASSERT_EQ_FLOAT(w.players[0].ship.cargo[COMMODITY_REPAIR_KIT],
+                    100.0f, 0.001f);
+}
+
+TEST(test_repair_kit_fab_requires_manifest_inputs) {
+    WORLD_DECL;
+    world_reset(&w);
+
+    int shipyard = -1;
+    for (int s = 0; s < MAX_STATIONS; s++) {
+        if (station_has_module(&w.stations[s], MODULE_SHIPYARD)) {
+            shipyard = s;
+            break;
+        }
+    }
+    ASSERT(shipyard >= 0);
+    station_t *st = &w.stations[shipyard];
+
+    ASSERT(test_set_station_finished_units(st, COMMODITY_FRAME, 0));
+    ASSERT(test_set_station_finished_units(st, COMMODITY_LASER_MODULE, 0));
+    ASSERT(test_set_station_finished_units(st, COMMODITY_TRACTOR_MODULE, 0));
+    ASSERT(test_set_station_finished_units(st, COMMODITY_REPAIR_KIT, 0));
+    st->_inventory_cache[COMMODITY_FRAME] = 5.0f;
+    st->_inventory_cache[COMMODITY_LASER_MODULE] = 5.0f;
+    st->_inventory_cache[COMMODITY_TRACTOR_MODULE] = 5.0f;
+    st->repair_kit_fab_timer = 0.0f;
+
+    step_dock_repair_kit_fab(&w, 60.0f);
+
+    ASSERT_EQ_INT(station_finished_count(st, COMMODITY_REPAIR_KIT), 0);
+    ASSERT_EQ_FLOAT(st->_inventory_cache[COMMODITY_REPAIR_KIT], 0.0f, 0.001f);
+}
+
 TEST(test_furnace_without_hopper_does_not_smelt) {
     /* Under the count-tier rules, a furnace requires at least one
      * hopper on the station before it'll fire. Inverse of the prior
@@ -802,6 +919,7 @@ void register_economy_basic_tests(void) {
     RUN(test_can_afford_upgrade_no_credits_for_dock_fallback);
     RUN(test_can_afford_upgrade_no_product_anywhere);
     RUN(test_can_afford_upgrade_cargo_only_no_credits_needed);
+    RUN(test_can_afford_upgrade_rejects_float_only_finished_goods);
     RUN(test_commodity_volume_kit_dense);
     RUN(test_ship_total_cargo_kit_density);
 }
@@ -813,6 +931,7 @@ void register_economy_contracts_tests(void) {
     RUN(test_contract_closes_when_deficit_filled);
     RUN(test_sell_price_uses_contract_price);
     RUN(test_hauler_fills_highest_value_contract);
+    RUN(test_hauler_ignores_float_only_finished_stock);
     RUN(test_kit_fab_requires_shipyard);
     RUN(test_kit_import_contract_at_consumer_station);
     RUN(test_kit_import_contract_skips_shipyard_stations);
@@ -820,6 +939,8 @@ void register_economy_contracts_tests(void) {
     RUN(test_repair_falls_back_to_station_inventory);
     RUN(test_repair_at_shipyard_no_labor_fee);
     RUN(test_repair_partial_when_kits_short);
+    RUN(test_repair_rejects_float_only_kits);
+    RUN(test_repair_kit_fab_requires_manifest_inputs);
 }
 
 void register_economy_contract3_tests(void) {


### PR DESCRIPTION
## Summary
- make NPC hauler load/unload of finished goods use manifest mint/drain helpers instead of station float authority
- keep hauler reserve, station room, and contract scoring tied to manifest-backed whole units
- add regression coverage for float-only upgrade, repair, repair-kit fab, and hauler stock paths

## Why
This is the next #339 slice: finished goods should be manifest-authoritative, while float caches remain derived/compatibility state. The old hauler path trusted station floats first and patched manifests afterward, which could create float-only cargo or pay for unclamped deliveries.

## Validation
- make test --no-print-directory
- make test-soak --no-print-directory
- pre-push hook: 517 tests passed

Refs #339