### PR TITLE
[codex] Speed up CRAP coverage gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -181,11 +181,14 @@ jobs:
             2>&1 | tee clang-tidy-output.txt
           if grep -q "error:" clang-tidy-output.txt; then exit 1; fi
 
-  # CRAP score (complexity * uncovered). Tested-code report GATES the
-  # deploy at threshold 25 — the codebase already passes this, so the
-  # gate engages only on new regressions. Client complexity budget is
-  # informational only (signal_test does not link client code, so
-  # coverage is structurally 0 and CRAP collapses to complexity).
+  # CRAP score (complexity * uncovered). This runs the fast/non-soak
+  # suite under coverage instrumentation; long-horizon sim coverage
+  # belongs in the parallel test-soak job or a scheduled coverage pass.
+  # Tested-code report GATES the deploy at threshold 25 — the codebase
+  # already passes this, so the gate engages only on new regressions.
+  # Client complexity budget is informational only (signal_test does not
+  # link client code, so coverage is structurally 0 and CRAP collapses
+  # to complexity).
   test-crap:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -205,7 +208,8 @@ jobs:
       - name: Run tests (collect coverage)
         run: |
           ulimit -s 16384
-          ./build-coverage/signal_test --quiet
+          find build-coverage -name '*.gcda' -delete
+          ./build-coverage/signal_test --quiet --no-soak
 
       - name: Generate gcovr JSON
         run: |

--- a/Makefile
+++ b/Makefile
@@ -125,17 +125,28 @@ smoke: build-web
 	npm run smoke
 
 # --- CRAP (Change Risk Anti-Patterns): complexity * (1 - coverage) ---
-# Rebuilds signal_test with --coverage, runs it, then joins gcovr line
-# coverage with lizard per-function complexity to score each function.
+# Rebuilds signal_test with --coverage, runs the fast/non-soak tests,
+# then joins gcovr line coverage with lizard per-function complexity to
+# score each function. Long-horizon sim coverage belongs in test-soak or
+# a scheduled coverage pass; duplicating it here is especially expensive
+# under --coverage -O0.
 # Vendored code (mongoose, stb_image, pl_mpeg, minimp3) is excluded on
 # both sides — we aren't going to fix it, so it shouldn't pollute the
 # report. Requires: lizard, gcovr (pip install lizard gcovr).
+CRAP_TESTED_PATHS := server/game_sim.c server/sim_ai.c server/sim_autopilot.c \
+	server/sim_flight.c server/sim_nav.c server/sim_save.c \
+	server/sim_catalog.c server/sim_asteroid.c server/sim_physics.c \
+	server/sim_production.c server/sim_construction.c \
+	src/commodity.c src/manifest.c src/ship.c src/economy.c \
+	src/asteroid.c src/rng.c shared
+
 crap:
 	cmake -S . -B build-coverage -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS_ONLY=ON \
 		-DCMAKE_C_FLAGS="--coverage -O0 -g" \
 		-DCMAKE_EXE_LINKER_FLAGS="--coverage"
 	cmake --build build-coverage --target signal_test
-	ulimit -s 16384 && ./build-coverage/signal_test --quiet
+	find build-coverage -name '*.gcda' -delete
+	ulimit -s 16384 && ./build-coverage/signal_test --quiet --no-soak
 	gcovr -r . --json coverage.json --gcov-ignore-parse-errors \
 		--filter 'server/.*' --filter 'src/.*' --filter 'shared/.*' \
 		--exclude 'server/mongoose\..*' \
@@ -144,7 +155,9 @@ crap:
 		--exclude 'src/minimp3\.h' \
 		build-coverage
 	python3 scripts/crap.py --coverage coverage.json \
-		--paths server src shared --json-out crap.json
+		--paths $(CRAP_TESTED_PATHS) \
+		--top 30 --threshold 25 --fail-on-exceed \
+		--json-out crap.json
 
 # --- Local dev = docker compose (single source of truth) ---
 # One canonical local path. The container's entrypoint cd's into

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -205,63 +205,96 @@ static int g_loaded_save_version = SAVE_VERSION;
  * Idempotent — running it again on an already-migrated world is a
  * no-op (tagged furnaces are skipped; existing output hoppers
  * satisfy the search).
- *
- * Exposed (non-static) so tests can break a fresh world to look
+ */
+static bool cargo_schema_live_furnace(const station_module_t *mod) {
+    return mod->type == MODULE_FURNACE && !mod->scaffold;
+}
+
+static bool cargo_schema_ingot_furnace_tag(commodity_t c) {
+    return c == COMMODITY_FERRITE_INGOT ||
+           c == COMMODITY_CUPRITE_INGOT ||
+           c == COMMODITY_CRYSTAL_INGOT;
+}
+
+static int cargo_schema_live_furnace_count(const station_t *st) {
+    int n_furnaces = 0;
+    for (int m = 0; m < st->module_count; m++) {
+        if (cargo_schema_live_furnace(&st->modules[m])) n_furnaces++;
+    }
+    return n_furnaces;
+}
+
+static commodity_t cargo_schema_furnace_tag(int n_furnaces, int seen) {
+    if (n_furnaces >= 3) {
+        return seen == 1 ? COMMODITY_CRYSTAL_INGOT
+                         : COMMODITY_CUPRITE_INGOT;
+    }
+    if (n_furnaces == 2) {
+        return seen == 0 ? COMMODITY_FERRITE_INGOT
+                         : COMMODITY_CUPRITE_INGOT;
+    }
+    return COMMODITY_FERRITE_INGOT;
+}
+
+static void cargo_schema_tag_furnaces(station_t *st) {
+    int n_furnaces = cargo_schema_live_furnace_count(st);
+    int seen = 0;
+    for (int m = 0; m < st->module_count; m++) {
+        station_module_t *mod = &st->modules[m];
+        if (!cargo_schema_live_furnace(mod)) continue;
+        if (cargo_schema_ingot_furnace_tag((commodity_t)mod->commodity)) {
+            seen++;
+            continue;
+        }
+        mod->commodity = (uint8_t)cargo_schema_furnace_tag(n_furnaces, seen);
+        seen++;
+    }
+}
+
+static bool cargo_schema_find_hopper_slot(const station_t *st,
+                                          int *out_ring,
+                                          int *out_slot) {
+    for (int r = 2; r <= STATION_NUM_RINGS; r++) {
+        int slot = station_ring_free_slot(st, r, STATION_RING_SLOTS[r]);
+        if (slot < 0) continue;
+        *out_ring = r;
+        *out_slot = slot;
+        return true;
+    }
+
+    int slot = station_ring_free_slot(st, 1, STATION_RING_SLOTS[1]);
+    if (slot < 0) return false;
+    *out_ring = 1;
+    *out_slot = slot;
+    return true;
+}
+
+static void cargo_schema_add_missing_hoppers(station_t *st) {
+    /* Snapshot module_count to avoid iterating into freshly-added hoppers. */
+    int snap = st->module_count;
+    for (int m = 0; m < snap; m++) {
+        const station_module_t *mod = &st->modules[m];
+        if (mod->scaffold) continue;
+        if (!module_is_producer(mod->type)) continue;
+        commodity_t out = module_instance_output(mod);
+        if (out == COMMODITY_COUNT) continue; /* shipyard etc. exempt */
+        if (station_find_hopper_for(st, out) >= 0) continue;
+        int placed_ring = -1;
+        int placed_slot = -1;
+        if (!cargo_schema_find_hopper_slot(st, &placed_ring, &placed_slot))
+            continue;
+        add_hopper_for(st, (uint8_t)placed_ring, (uint8_t)placed_slot, out);
+    }
+}
+
+/* Exposed (non-static) so tests can break a fresh world to look
  * pre-Slice-1 and exercise this directly. */
 void world_apply_cargo_schema_migration(world_t *w) {
     for (int i = 0; i < MAX_STATIONS; i++) {
         station_t *st = &w->stations[i];
         if (st->module_count <= 0) continue;
-        int n_furnaces = 0;
-        for (int m = 0; m < st->module_count; m++) {
-            if (st->modules[m].type == MODULE_FURNACE && !st->modules[m].scaffold)
-                n_furnaces++;
-        }
-        int seen = 0;
-        for (int m = 0; m < st->module_count; m++) {
-            if (st->modules[m].type != MODULE_FURNACE) continue;
-            if (st->modules[m].scaffold) continue;
-            if ((commodity_t)st->modules[m].commodity == COMMODITY_FERRITE_INGOT ||
-                (commodity_t)st->modules[m].commodity == COMMODITY_CUPRITE_INGOT ||
-                (commodity_t)st->modules[m].commodity == COMMODITY_CRYSTAL_INGOT) {
-                seen++;
-                continue;
-            }
-            commodity_t tag;
-            if (n_furnaces >= 3) {
-                if      (seen == 0) tag = COMMODITY_CUPRITE_INGOT;
-                else if (seen == 1) tag = COMMODITY_CRYSTAL_INGOT;
-                else                tag = COMMODITY_CUPRITE_INGOT;
-            } else if (n_furnaces == 2) {
-                tag = (seen == 0) ? COMMODITY_FERRITE_INGOT
-                                  : COMMODITY_CUPRITE_INGOT;
-            } else {
-                tag = COMMODITY_FERRITE_INGOT;
-            }
-            st->modules[m].commodity = (uint8_t)tag;
-            seen++;
-        }
-        /* Auto-spawn missing output hoppers. Snapshot module_count to
-         * avoid iterating into freshly-added hoppers. */
-        int snap = st->module_count;
-        for (int m = 0; m < snap; m++) {
-            if (st->modules[m].scaffold) continue;
-            if (!module_is_producer(st->modules[m].type)) continue;
-            commodity_t out = module_instance_output(&st->modules[m]);
-            if (out == COMMODITY_COUNT) continue; /* shipyard etc. exempt */
-            if (station_find_hopper_for(st, out) >= 0) continue;
-            int placed_ring = -1, placed_slot = -1;
-            for (int r = 2; r <= STATION_NUM_RINGS && placed_ring < 0; r++) {
-                int slot = station_ring_free_slot(st, r, STATION_RING_SLOTS[r]);
-                if (slot >= 0) { placed_ring = r; placed_slot = slot; }
-            }
-            if (placed_ring < 0) {
-                int slot = station_ring_free_slot(st, 1, STATION_RING_SLOTS[1]);
-                if (slot >= 0) { placed_ring = 1; placed_slot = slot; }
-            }
-            if (placed_ring < 0) continue; /* no room — skip silently */
-            add_hopper_for(st, (uint8_t)placed_ring, (uint8_t)placed_slot, out);
-        }
+        cargo_schema_tag_furnaces(st);
+        cargo_schema_add_missing_hoppers(st);
         rebuild_station_services(st);
     }
 }

--- a/src/tests/test_econ_sim.c
+++ b/src/tests/test_econ_sim.c
@@ -786,10 +786,10 @@ TEST(test_e2e_kit_import_contract_lifecycle) {
 
 void register_econ_sim_sim_tests(void) {
     TEST_SECTION("\nEconomy simulations:\n");
-    RUN(test_econ_sim_npc_only_5min);
+    RUN_SOAK(test_econ_sim_npc_only_5min);
     RUN(test_econ_sim_credit_circulation);
     RUN_SOAK(test_grade_aware_sell_pays_per_unit_grade);
-    RUN(test_e2e_kit_chain_converges);
+    RUN_SOAK(test_e2e_kit_chain_converges);
     RUN(test_e2e_npc_dock_auto_repair_drains_kits);
     RUN_SOAK(test_e2e_kit_import_contract_lifecycle);
 }


### PR DESCRIPTION
## Summary

- run CRAP coverage with explicit `--no-soak` and clear stale `.gcda` files before collection
- move the two 300-second economy simulation checks into `RUN_SOAK`
- align local `make crap` with the CI tested-code gate
- split cargo schema save migration into smaller helpers so the CRAP gate stays actionable after the coverage split

## Why

Coverage instrumentation runs at `--coverage -O0`, so long-horizon simulation tests cost much more there than in the optimized fast/soak jobs. Those scenarios still run in `test-soak`; CRAP now focuses on fast coverage plus tested-code complexity.

## Validation

- `make --no-print-directory test` -> 511 passed
- `make --no-print-directory test-soak` -> 9 passed
- `env PATH=/private/tmp/signal-crap-venv/bin:... make --no-print-directory crap` -> 511 passed; 0/180 tested functions exceed threshold 25
- pre-push hook -> 511 passed at `14ad442`
