### PR TITLE
Add PvP feedback: kill confirm, hit SFX, kill counter, scoreboard

### DIFF
--- a/server/net_protocol.h
+++ b/server/net_protocol.h
@@ -930,14 +930,16 @@ static inline void parse_plan(const uint8_t *data, int len, input_intent_t *inte
 /* ------------------------------------------------------------------ */
 
 /* Serialize all events from the current sim step into a NET_MSG_EVENTS
- * packet. Skips DEATH (has its own message) and HAIL_RESPONSE (ditto).
- * Returns total packet length. */
+ * packet. HAIL_RESPONSE has its own per-recipient message and is
+ * skipped here. DEATH is broadcast in stripped form (killer_token +
+ * cause + victim id only) so the killer can render a kill confirm
+ * even though the cinematic payload still goes to the victim via
+ * NET_MSG_DEATH. Returns total packet length. */
 static inline int serialize_events(uint8_t *buf, const sim_events_t *events) {
     int count = 0;
     for (int i = 0; i < events->count; i++) {
         const sim_event_t *ev = &events->events[i];
         /* Skip types that already have dedicated messages */
-        if (ev->type == SIM_EVENT_DEATH) continue;
         if (ev->type == SIM_EVENT_HAIL_RESPONSE) continue;
 
         uint8_t *p = &buf[2 + count * NET_EVENT_RECORD_SIZE];
@@ -965,6 +967,12 @@ static inline int serialize_events(uint8_t *buf, const sim_events_t *events) {
             p[2] = ev->npc_kill.cause;
             p[3] = ev->npc_kill.npc_role;
             memcpy(&p[4], ev->npc_kill.killer_token, 8);
+            break;
+        case SIM_EVENT_DEATH:
+            /* Broadcast the killer-attribution slice only; the
+             * victim's cinematic payload travels in NET_MSG_DEATH. */
+            p[2] = ev->death.cause;
+            memcpy(&p[3], ev->death.killer_token, 8);
             break;
         case SIM_EVENT_OUTPOST_PLACED:
             p[2] = (uint8_t)ev->outpost_placed.slot;

--- a/src/audio.c
+++ b/src/audio.c
@@ -242,3 +242,17 @@ void audio_play_damage(audio_state_t* a, float damage) {
     audio_play_voice(a, AUDIO_WAVE_NOISE, 180.0f, -80.0f, gain, 0.12f, audio_rand_bipolar(a) * 0.22f, 1.0f);
     audio_play_voice(a, AUDIO_WAVE_SQUARE, 130.0f, -160.0f, gain * 0.5f, 0.10f, 0.0f, 0.15f);
 }
+
+void audio_play_hit_thunk(audio_state_t* a) {
+    audio_play_voice(a, AUDIO_WAVE_SINE,     120.0f, -240.0f, 0.10f, 0.08f, 0.0f, 0.10f);
+    audio_play_voice(a, AUDIO_WAVE_TRIANGLE,  90.0f, -120.0f, 0.06f, 0.06f, 0.0f, 0.0f);
+}
+
+void audio_play_tractor_lock(audio_state_t* a) {
+    audio_play_voice(a, AUDIO_WAVE_SINE, 880.0f, 320.0f, 0.05f, 0.04f, 0.0f, 0.0f);
+}
+
+void audio_play_kill_confirm(audio_state_t* a) {
+    audio_play_voice(a, AUDIO_WAVE_SINE,     660.0f, 240.0f, 0.07f, 0.10f, -0.10f, 0.0f);
+    audio_play_voice(a, AUDIO_WAVE_TRIANGLE, 990.0f, 360.0f, 0.05f, 0.12f,  0.10f, 0.0f);
+}

--- a/src/audio.h
+++ b/src/audio.h
@@ -17,6 +17,9 @@ void audio_play_sale(audio_state_t* audio);
 void audio_play_repair(audio_state_t* audio);
 void audio_play_upgrade(audio_state_t* audio, ship_upgrade_t upgrade);
 void audio_play_damage(audio_state_t* audio, float damage);
+void audio_play_hit_thunk(audio_state_t* audio);
+void audio_play_tractor_lock(audio_state_t* audio);
+void audio_play_kill_confirm(audio_state_t* audio);
 void audio_play_commission(audio_state_t* audio);
 
 #endif

--- a/src/client.h
+++ b/src/client.h
@@ -210,6 +210,36 @@ typedef struct {
      * dies). Text + remaining lifetime; 0 = empty. */
     char  kill_feed_text[64];
     float kill_feed_timer;
+    /* Killer-side confirm banner: shown to the local player for ~3 s
+     * when a SIM_EVENT_DEATH or SIM_EVENT_NPC_KILL credits the kill
+     * to their session token. Distinct from kill_feed_text so the
+     * victim copy doesn't overwrite the killer's confirm. */
+    char  kill_confirm_text[64];
+    float kill_confirm_timer;
+    /* Per-session kill tally on the HUD. Incremented when the local
+     * player gets a kill confirm (NPC or PvP). Reset only on a fresh
+     * client launch — survives respawn within session. NOT persisted
+     * and NOT mirrored to a server-side stat (per the per-station-
+     * ledger sovereignty rule — combat counters are local UX). */
+    int   kill_count_session;
+    int   death_count_session;
+    /* PvP scoreboard — aggregated client-side from observed
+     * SIM_EVENT_DEATH and SIM_EVENT_NPC_KILL events this session.
+     * Toggled with [Tab] while undocked. Keyed by attribution token
+     * (8 bytes from killer_token / session_token). NPC entries also
+     * land here for completeness; the local player's row shows the
+     * session callsign. */
+    struct {
+        bool show;
+        struct {
+            uint8_t token[8];
+            char    label[16];   /* callsign or "Hauler" / "Miner" */
+            uint16_t kills;
+            uint16_t deaths;
+            bool     is_npc;
+        } rows[16];
+        int row_count;
+    } scoreboard;
     /* Per-station manifest summary — [commodity][grade] unit counts.
      * Unified read path for the TRADE UI whether we're in singleplayer
      * (populated every frame from g.world.stations[s].manifest) or

--- a/src/hud.c
+++ b/src/hud.c
@@ -535,6 +535,111 @@ static void hud_draw_kill_feed(float screen_w, float screen_h) {
     (void)screen_h;
 }
 
+/* Killer-side confirm banner — sits one line below the kill feed so
+ * both can be visible if a kill confirm and a separate feed event
+ * happen close together. Brighter / hotter color to read as an
+ * achievement notification rather than a scoreboard entry. */
+static void hud_draw_kill_confirm(float screen_w, float screen_h) {
+    if (g.kill_confirm_timer <= 0.0f) return;
+    if (g.kill_confirm_text[0] == '\0') return;
+    float cell = 8.0f;
+    float a = 1.0f;
+    if (g.kill_confirm_timer > 2.8f) a = (3.0f - g.kill_confirm_timer) / 0.2f;
+    else if (g.kill_confirm_timer < 0.5f) a = g.kill_confirm_timer / 0.5f;
+    if (a < 0.0f) a = 0.0f;
+    if (a > 1.0f) a = 1.0f;
+    uint8_t a8 = (uint8_t)(a * 255.0f);
+    sdtx_canvas(screen_w, screen_h);
+    sdtx_origin(0.0f, 0.0f);
+    sdtx_color4b(255, 90, 60, a8);
+    sdtx_centered_text(screen_w * 0.5f, (screen_h * 0.08f + 18.0f) / cell, cell,
+                       g.kill_confirm_text);
+}
+
+/* Session kill counter, top-right under the version line. Compact
+ * "K 3" so it fits beside the v<hash>/connection status without
+ * crowding the alpha banner above. */
+static void hud_draw_kill_counter(float screen_w) {
+    if (g.kill_count_session <= 0) return;
+    float x = ui_text_pos(fmaxf(8.0f, screen_w - 60.0f));
+    float y = ui_text_pos(22.0f);
+    sdtx_pos(x, y);
+    sdtx_color3b(255, 200, 80);
+    sdtx_printf("K %d", g.kill_count_session);
+}
+
+/* Session scoreboard, toggled with [Tab] while undocked. Kills/deaths
+ * are aggregated client-side from observed SIM_EVENT_DEATH /
+ * SIM_EVENT_NPC_KILL events. Sorted by kills desc; ties broken by
+ * fewer deaths. Single-pass insertion sort -- the row pool is 16. */
+static void hud_draw_scoreboard(float screen_w, float screen_h) {
+    if (!g.scoreboard.show) return;
+    float cell = 8.0f;
+    int order[16];
+    int n = g.scoreboard.row_count;
+    if (n > 16) n = 16;
+    for (int i = 0; i < n; i++) order[i] = i;
+    for (int i = 1; i < n; i++) {
+        int k = order[i];
+        int j = i - 1;
+        while (j >= 0) {
+            int a = order[j];
+            bool worse =
+                (g.scoreboard.rows[a].kills < g.scoreboard.rows[k].kills) ||
+                (g.scoreboard.rows[a].kills == g.scoreboard.rows[k].kills &&
+                 g.scoreboard.rows[a].deaths > g.scoreboard.rows[k].deaths);
+            if (!worse) break;
+            order[j + 1] = order[j];
+            j--;
+        }
+        order[j + 1] = k;
+    }
+
+    float panel_w = 280.0f;
+    float panel_x = (screen_w - panel_w) * 0.5f;
+    float panel_y = screen_h * 0.18f;
+    sdtx_canvas(screen_w, screen_h);
+    sdtx_origin(0.0f, 0.0f);
+
+    sdtx_color3b(255, 220, 100);
+    sdtx_pos(panel_x / cell, panel_y / cell);
+    sdtx_puts("== SCOREBOARD ==  [Tab to close]");
+
+    sdtx_color3b(180, 180, 180);
+    sdtx_pos(panel_x / cell, (panel_y + 16.0f) / cell);
+    sdtx_puts("PILOT             K   D   K/D");
+
+    if (n == 0) {
+        sdtx_color3b(140, 140, 140);
+        sdtx_pos(panel_x / cell, (panel_y + 32.0f) / cell);
+        sdtx_puts("(no kills or deaths yet)");
+        return;
+    }
+    for (int rank = 0; rank < n; rank++) {
+        int idx = order[rank];
+        const char *label = g.scoreboard.rows[idx].label[0]
+                          ? g.scoreboard.rows[idx].label : "????";
+        bool is_me = memcmp(g.scoreboard.rows[idx].token,
+                            g.world.players[g.local_player_slot].session_token, 8) == 0;
+        if (is_me) sdtx_color3b(255, 220, 100);
+        else       sdtx_color3b(200, 200, 200);
+        char kdr[8];
+        if (g.scoreboard.rows[idx].deaths == 0) {
+            snprintf(kdr, sizeof(kdr), "%d.0", g.scoreboard.rows[idx].kills);
+        } else {
+            float r = (float)g.scoreboard.rows[idx].kills /
+                      (float)g.scoreboard.rows[idx].deaths;
+            snprintf(kdr, sizeof(kdr), "%.2f", r);
+        }
+        sdtx_pos(panel_x / cell, (panel_y + 32.0f + (float)rank * 12.0f) / cell);
+        sdtx_printf("%-16s %3d %3d %5s",
+                    label,
+                    g.scoreboard.rows[idx].kills,
+                    g.scoreboard.rows[idx].deaths,
+                    kdr);
+    }
+}
+
 static void hud_draw_shared_panels(float screen_w, float screen_h, float sig_quality, bool compact) {
     hud_draw_alpha_banner_and_mp_indicator(screen_w, compact);
     hud_draw_nav_label(screen_w, screen_h);
@@ -543,6 +648,9 @@ static void hud_draw_shared_panels(float screen_w, float screen_h, float sig_qua
     hud_draw_signal_lost_warning(screen_w, screen_h, sig_quality);
     hud_draw_hit_indicator(screen_w, screen_h);
     hud_draw_kill_feed(screen_w, screen_h);
+    hud_draw_kill_confirm(screen_w, screen_h);
+    hud_draw_kill_counter(screen_w);
+    hud_draw_scoreboard(screen_w, screen_h);
     /* Hit feedback vignette — drawn last so it sits above the HUD
      * readouts, but the inset rectangle in the middle leaves the
      * action row + flight readouts unobscured. */

--- a/src/main.c
+++ b/src/main.c
@@ -424,6 +424,9 @@ static void sim_on_upgrade(const sim_event_t *ev) {
 static void sim_on_damage(const sim_event_t *ev) {
     if (!ev_is_local(ev)) return;
     audio_play_damage(&g.audio, ev->damage.amount);
+    /* Sharper "thunk" overlay so a rock impact reads as a single hit
+     * over the broader damage hiss. */
+    audio_play_hit_thunk(&g.audio);
     /* Screen shake scales with damage. Tunables chosen so a minor scrape
      * (~2 hp) wiggles a few pixels and a full ramming hit (~30 hp)
      * noticeably jolts. */
@@ -450,6 +453,30 @@ static void sim_on_damage(const sim_event_t *ev) {
     }
 }
 
+/* Find or create a scoreboard row for the given attribution token. */
+static int scoreboard_row_for_token(const uint8_t token[8], const char *label, bool is_npc) {
+    for (int i = 0; i < g.scoreboard.row_count; i++) {
+        if (memcmp(g.scoreboard.rows[i].token, token, 8) == 0) return i;
+    }
+    int cap = (int)(sizeof(g.scoreboard.rows) / sizeof(g.scoreboard.rows[0]));
+    if (g.scoreboard.row_count >= cap) return -1;
+    int idx = g.scoreboard.row_count++;
+    memset(&g.scoreboard.rows[idx], 0, sizeof(g.scoreboard.rows[idx]));
+    memcpy(g.scoreboard.rows[idx].token, token, 8);
+    if (label && label[0])
+        snprintf(g.scoreboard.rows[idx].label, sizeof(g.scoreboard.rows[idx].label), "%s", label);
+    g.scoreboard.rows[idx].is_npc = is_npc;
+    return idx;
+}
+
+static bool token_matches_local(const uint8_t token[8]) {
+    /* Zero token = unattributed; never counts as the local player. */
+    bool nonzero = false;
+    for (int i = 0; i < 8; i++) { if (token[i]) { nonzero = true; break; } }
+    if (!nonzero) return false;
+    return memcmp(token, g.world.players[g.local_player_slot].session_token, 8) == 0;
+}
+
 static void sim_on_npc_kill(const sim_event_t *ev) {
     /* Kill-feed line. Prefer the local player's perspective: if I'm
      * the killer, prepend "You killed"; otherwise show the killer's
@@ -474,6 +501,27 @@ static void sim_on_npc_kill(const sim_event_t *ev) {
                  "%s killed by %s", role, weapon);
     }
     g.kill_feed_timer = 3.0f;
+
+    /* Killer-side feedback: counter, banner, SFX. NPC kills don't have
+     * a victim token to attribute against on the scoreboard, but the
+     * killer entry still gets credited. */
+    if (you_killed) {
+        g.kill_count_session++;
+        snprintf(g.kill_confirm_text, sizeof(g.kill_confirm_text),
+                 "KILL: %s", role);
+        g.kill_confirm_timer = 3.0f;
+        audio_play_kill_confirm(&g.audio);
+        const uint8_t *me = g.world.players[g.local_player_slot].session_token;
+        const char *cs = LOCAL_PLAYER.callsign[0] ? LOCAL_PLAYER.callsign : "YOU";
+        int row = scoreboard_row_for_token(me, cs, false);
+        if (row >= 0) g.scoreboard.rows[row].kills++;
+    } else {
+        /* Some other player killed the NPC. Credit them on the
+         * scoreboard — label is the role since we have no
+         * token→callsign map for kills attributed to remotes. */
+        int row = scoreboard_row_for_token(ev->npc_kill.killer_token, "Player", false);
+        if (row >= 0) g.scoreboard.rows[row].kills++;
+    }
 }
 
 static void sim_on_contract_complete(const sim_event_t *ev) {
@@ -526,7 +574,52 @@ static void death_cinematic_spawn(const sim_event_t *ev) {
 }
 
 static void sim_on_death(const sim_event_t *ev) {
+    /* Scoreboard + kill confirm fire for ANY death we see, not just
+     * the local player's. A remote death observed via the broadcast
+     * SIM_EVENT_DEATH stream is still useful telemetry for the killer. */
+    int vid = ev->player_id;
+    const uint8_t *vtoken = NULL;
+    const char *vlabel = "Pilot";
+    if (vid >= 0 && vid < MAX_PLAYERS) {
+        vtoken = g.world.players[vid].session_token;
+        if (g.world.players[vid].callsign[0])
+            vlabel = g.world.players[vid].callsign;
+    }
+    bool i_killed_them =
+        !ev_is_local(ev) && token_matches_local(ev->death.killer_token);
+    if (i_killed_them) {
+        g.kill_count_session++;
+        snprintf(g.kill_confirm_text, sizeof(g.kill_confirm_text),
+                 "KILL: %s", vlabel);
+        g.kill_confirm_timer = 3.0f;
+        audio_play_kill_confirm(&g.audio);
+        const uint8_t *me = g.world.players[g.local_player_slot].session_token;
+        const char *cs = LOCAL_PLAYER.callsign[0] ? LOCAL_PLAYER.callsign : "YOU";
+        int row = scoreboard_row_for_token(me, cs, false);
+        if (row >= 0) g.scoreboard.rows[row].kills++;
+    } else if (!ev_is_local(ev)) {
+        /* Someone else got the kill — credit them on the scoreboard. */
+        bool nonzero = false;
+        for (int i = 0; i < 8; i++)
+            if (ev->death.killer_token[i]) { nonzero = true; break; }
+        if (nonzero) {
+            int row = scoreboard_row_for_token(ev->death.killer_token, "Player", false);
+            if (row >= 0) g.scoreboard.rows[row].kills++;
+        }
+    }
+    if (vtoken) {
+        int vrow = scoreboard_row_for_token(vtoken, vlabel, false);
+        if (vrow >= 0) g.scoreboard.rows[vrow].deaths++;
+    }
+
     if (!ev_is_local(ev)) return;
+    g.death_count_session++;
+    /* In MP the cinematic + payload come via NET_MSG_DEATH (only the
+     * victim receives that). The broadcast SIM_EVENT_DEATH stream
+     * exists only for kill-confirm + scoreboard attribution and
+     * carries zeroed cinematic fields, so don't try to render off it
+     * in MP. */
+    if (g.multiplayer_enabled) return;
     g.death_ore_mined = ev->death.ore_mined;
     g.death_credits_earned = ev->death.credits_earned;
     g.death_credits_spent = ev->death.credits_spent;
@@ -970,6 +1063,26 @@ static void sim_step(float dt) {
             g.kill_feed_timer = 0.0f;
             g.kill_feed_text[0] = '\0';
         }
+    }
+    if (g.kill_confirm_timer > 0.0f) {
+        g.kill_confirm_timer -= dt;
+        if (g.kill_confirm_timer < 0.0f) {
+            g.kill_confirm_timer = 0.0f;
+            g.kill_confirm_text[0] = '\0';
+        }
+    }
+    /* Tractor-lock pulse: 0->positive towed_count edge plays a short
+     * "lock" tone so the player has audio feedback the grab took. */
+    {
+        static int prev_towed = 0;
+        int now_towed = LOCAL_PLAYER.ship.towed_count;
+        if (now_towed > prev_towed) audio_play_tractor_lock(&g.audio);
+        prev_towed = now_towed;
+    }
+    /* Tab while undocked toggles the session scoreboard. Docked Tab is
+     * already taken (cycle station tabs); the gating mirrors that. */
+    if (!LOCAL_PLAYER.docked && g.input.key_pressed[SAPP_KEYCODE_TAB]) {
+        g.scoreboard.show = !g.scoreboard.show;
     }
     if (g.action_predict_timer > 0.0f)
         g.action_predict_timer = fmaxf(0.0f, g.action_predict_timer - dt);

--- a/src/net.c
+++ b/src/net.c
@@ -725,6 +725,14 @@ static void handle_message(const uint8_t* data, int len) {
                     ev->npc_kill.cause    = p[2];
                     ev->npc_kill.npc_role = p[3];
                     memcpy(ev->npc_kill.killer_token, &p[4], 8); break;
+                case SIM_EVENT_DEATH:
+                    /* Broadcast slice only (cinematic fields stay
+                     * zero — the victim gets the full payload via
+                     * NET_MSG_DEATH; non-victims just need to know a
+                     * death happened so they can render a kill
+                     * confirm + scoreboard tally). */
+                    ev->death.cause = p[2];
+                    memcpy(ev->death.killer_token, &p[3], 8); break;
                 case SIM_EVENT_OUTPOST_PLACED:
                     ev->outpost_placed.slot = (int)p[2]; break;
                 case SIM_EVENT_OUTPOST_ACTIVATED:


### PR DESCRIPTION
## Summary
- Killer-side feedback for rock-fling combat. Attribution data was already on `SIM_EVENT_DEATH` / `SIM_EVENT_NPC_KILL` via `killer_token`; this wires it through to the client so the killer hears, sees, and tracks their own kills.
- Kill confirm banner ("KILL: <victim>") + procedural confirm tone when local `session_token` matches the event's killer.
- Procedural hit-thunk on damage and tractor-lock pulse on towed-count 0→positive edge (no asset files — short tone bursts in `src/audio.c`).
- Top-right session "K N" counter; `Tab` while undocked toggles a client-aggregated K/D scoreboard.
- Server now broadcasts `SIM_EVENT_DEATH` stripped to `killer_token` + `cause` so MP killers see confirms; victim cinematic still travels via `NET_MSG_DEATH` to avoid double-spawn.

Per-session, client-only counters — no global player wallet, ledger model untouched.

## Test plan
- [x] `make test` — 512/512 pass
- [x] Native + wasm build clean
- [x] Existing `test_thrown_rock_self_damage_prevented` still passes (self-kills don't credit)
- [ ] Manual: SP — fling rock at NPC, confirm banner + thunk + counter increment
- [ ] Manual: SP — `Tab` undocked toggles scoreboard, doesn't conflict with docked tab cycler
- [ ] Manual: MP — two clients, kill exchange, both sides see correct attribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)