### PR TITLE
Scan polish: tighter ring, follow-cam, linger fix, credit-pool heartbeat

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -427,6 +427,7 @@ typedef struct {
      * can compute the delta wherever the records land. */
     float station_heartbeat[MAX_STATIONS];
     float station_prev_inventory[MAX_STATIONS][COMMODITY_COUNT];
+    float station_prev_credit_pool[MAX_STATIONS];
     bool  station_prev_seen[MAX_STATIONS];
     /* --- Hail overlay --- */
     float hail_timer;            /* countdown for hail display */

--- a/src/local_server.c
+++ b/src/local_server.c
@@ -116,21 +116,31 @@ static void mirror_whole_world(const world_t *src) {
     memcpy(g.world.asteroids, src->asteroids, sizeof(g.world.asteroids));
     memcpy(g.world.npc_ships, src->npc_ships, sizeof(g.world.npc_ships));
     for (int i = 0; i < MAX_STATIONS; i++) {
-        /* Diff inventory before the copy clobbers it — heartbeat fires
-         * on production cycles, ore intake, sales. Same threshold as
-         * the multiplayer path in apply_remote_stations(). */
+        /* Diff inventory + credit_pool before the copy clobbers them —
+         * heartbeat fires on production cycles, ore intakes, sales,
+         * and ledger movement. Same thresholds as apply_remote_stations
+         * (MP path). credit_pool is derived from -Σ(ledger.balance);
+         * use station_credit_pool() so this matches the wire value. */
         const station_t *src_st = &src->stations[i];
         if (g.station_prev_seen[i] && station_exists(src_st)) {
+            bool fired = false;
             for (int c = 0; c < COMMODITY_COUNT; c++) {
                 if (fabsf(src_st->_inventory_cache[c] -
                           g.station_prev_inventory[i][c]) >= 0.5f) {
-                    g.station_heartbeat[i] = 1.0f;
+                    fired = true;
                     break;
                 }
             }
+            if (!fired) {
+                float pool = station_credit_pool(src_st);
+                if (fabsf(pool - g.station_prev_credit_pool[i]) >= 5.0f)
+                    fired = true;
+            }
+            if (fired) g.station_heartbeat[i] = 1.0f;
         }
         for (int c = 0; c < COMMODITY_COUNT; c++)
             g.station_prev_inventory[i][c] = src_st->_inventory_cache[c];
+        g.station_prev_credit_pool[i] = station_credit_pool(src_st);
         g.station_prev_seen[i] = station_exists(src_st);
         (void)station_copy(&g.world.stations[i], src_st);
     }

--- a/src/main.c
+++ b/src/main.c
@@ -846,8 +846,16 @@ static void sim_step(float dt) {
         g.commission_timer = fmaxf(0.0f, g.commission_timer - dt);
     if (g.hail_timer > 0.0f)
         g.hail_timer = fmaxf(0.0f, g.hail_timer - dt);
-    if (g.inspect_snapshot_timer > 0.0f)
+    if (g.inspect_snapshot_timer > 0.0f) {
         g.inspect_snapshot_timer = fmaxf(0.0f, g.inspect_snapshot_timer - dt);
+        if (g.inspect_snapshot_timer <= 0.0f) {
+            /* Linger fully decayed — clear so the next idle frame's
+             * apply_*_inspect_snapshot doesn't see had_target=true and
+             * keep re-bumping the timer back to 3.5 indefinitely. */
+            g.inspect_snapshot.target_type = INSPECT_TARGET_NONE;
+            g.inspect_snapshot.target_index = 0xFFu;
+        }
+    }
     /* Station chain-event heartbeats: ~1s decay so a single delta reads
      * as one short pulse, but consecutive ticks compound (clamped 1.0). */
     for (int s = 0; s < MAX_STATIONS; s++) {
@@ -1376,6 +1384,28 @@ static void render_world(void) {
                 float kcen = (1.0f - expf(-3.0f * dt)) * g.boost_center_blend;
                 g.camera_pos.x += (ship.x - g.camera_pos.x) * kcen;
                 g.camera_pos.y += (ship.y - g.camera_pos.y) * kcen;
+            }
+        }
+
+        /* Scan-target framing: bias the camera toward the midpoint
+         * between the local player and the scanned NPC so both stay
+         * visible. Skipped during the death cinematic. Strength
+         * tracks the linger timer normalized to [0,1] so the framing
+         * eases back to neutral as the panel fades out. */
+        if (!g.death_cinematic.active
+            && g.inspect_snapshot.target_type == INSPECT_TARGET_NPC
+            && g.inspect_snapshot_timer > 0.0f
+            && g.inspect_snapshot.target_index < MAX_NPC_SHIPS) {
+            int idx = (int)g.inspect_snapshot.target_index;
+            const npc_ship_t *tn = &g.world.npc_ships[idx];
+            if (tn->active) {
+                vec2 mid = v2(0.5f * (LOCAL_PLAYER.ship.pos.x + tn->ship.pos.x),
+                              0.5f * (LOCAL_PLAYER.ship.pos.y + tn->ship.pos.y));
+                float strength = g.inspect_snapshot_timer < 1.0f
+                                 ? g.inspect_snapshot_timer : 1.0f;
+                float k = (1.0f - expf(-2.5f * dt)) * 0.6f * strength;
+                g.camera_pos.x += (mid.x - g.camera_pos.x) * k;
+                g.camera_pos.y += (mid.y - g.camera_pos.y) * k;
             }
         }
     }

--- a/src/net_sync.c
+++ b/src/net_sync.c
@@ -177,31 +177,36 @@ void apply_remote_npcs(const NetNpcState* npcs, int count) {
 }
 
 void apply_remote_stations(uint8_t index, const float* inventory, float credit_pool) {
-    /* credit_pool is now derived server-side from -Σ(ledger.balance);
-     * still arrives over the wire for protocol stability but no client
-     * code reads it, so we discard it here. */
-    (void)credit_pool;
     if (index >= MAX_STATIONS) return;
     station_t* st = &g.world.stations[index];
-    /* Diff against last seen inventory to fire a chain-event heartbeat
-     * pulse on the world. Threshold is loose (>= 0.5 units of any
-     * commodity) so float drift in the smelter doesn't trigger every
-     * tick — production cycles, ore intakes, sales actually move the
-     * needle in whole units. Mirror the singleplayer path's existence
-     * gate (local_server.c::mirror_whole_world) so an uninhabited slot
-     * with stale prev_seen=true doesn't fire spurious heartbeats. */
+    /* Diff against last seen inventory + credit_pool to fire a chain-
+     * event heartbeat pulse on the world. Inventory tracks production
+     * and consumption; credit_pool tracks commerce (ledger movement
+     * from sales, supplier credits, contract payouts). Together they
+     * cover the chain events visible to a player at-a-glance.
+     * Thresholds are loose so float drift in the smelter (~0.016/tick)
+     * doesn't fire every frame: 0.5 units of any commodity, or 5
+     * credits of pool delta. Mirror the singleplayer existence gate
+     * so an uninhabited slot with stale prev_seen=true doesn't fire. */
     if (g.station_prev_seen[index] && station_exists(st)) {
+        bool fired = false;
         for (int i = 0; i < COMMODITY_COUNT; i++) {
             if (fabsf(inventory[i] - g.station_prev_inventory[index][i]) >= 0.5f) {
-                g.station_heartbeat[index] = 1.0f;
+                fired = true;
                 break;
             }
         }
+        if (!fired
+            && fabsf(credit_pool - g.station_prev_credit_pool[index]) >= 5.0f) {
+            fired = true;
+        }
+        if (fired) g.station_heartbeat[index] = 1.0f;
     }
     for (int i = 0; i < COMMODITY_COUNT; i++) {
         st->_inventory_cache[i] = inventory[i];
         g.station_prev_inventory[index][i] = inventory[i];
     }
+    g.station_prev_credit_pool[index] = credit_pool;
     g.station_prev_seen[index] = station_exists(st);
 }
 
@@ -278,15 +283,19 @@ void apply_remote_hold_ingots(const NetNamedIngotEntry *entries, int count) {
 void apply_remote_inspect_snapshot(const NetInspectSnapshot *snapshot) {
     if (!snapshot) return;
 
-    /* Linger: when the server reports no current target (player let
-     * the scan key go), keep the last frame's snapshot data and let
-     * the panel decay over a few seconds — gives the player time to
-     * read what they just locked onto. The active-scan tick refresh
-     * uses the shorter 0.6s timeout so that a still-locked target
-     * doesn't render the previous frame after the snapshot grows
-     * stale. */
+    /* Linger: hold the last snapshot's data on screen for a few
+     * seconds after the player releases the scan key. Active-scan
+     * frames refresh the timer to 0.60; the release edge bumps it up
+     * to the linger window. After that, the timer counts down on its
+     * own — we mustn't reset it on every subsequent idle frame, which
+     * would clamp it at 3.5 forever. The per-frame decay in main.c
+     * clears target_type when the timer hits 0, so this branch can
+     * trust target_type as a "we already lingered out" signal. */
     if (snapshot->target_type == INSPECT_TARGET_NONE) {
-        g.inspect_snapshot_timer = 3.5f;
+        bool had_target = g.inspect_snapshot.target_type != INSPECT_TARGET_NONE;
+        if (had_target && g.inspect_snapshot_timer <= 0.60f) {
+            g.inspect_snapshot_timer = 3.5f;
+        }
     } else {
         g.inspect_snapshot = *snapshot;
         g.inspect_snapshot_timer = 0.60f;

--- a/src/world_draw.c
+++ b/src/world_draw.c
@@ -1604,8 +1604,14 @@ void draw_npc_ships(void) {
             }
         }
         if (i == scan_npc) {
+            /* Hug the visible ship: ship_radius is the collision radius
+             * and the rendered triangle sits within it, so a tight
+             * fraction reads as "highlighting this ship" rather than
+             * "drawing a halo around general space near it". Pulse is
+             * subtle (±1 unit) so the radius stays visually stable. */
             float pulse = 0.5f + 0.5f * sinf(g.world.time * 6.0f);
-            float r = 22.0f + 1.5f * pulse;
+            float ship_r = npc_hull_def(tnpc)->ship_radius;
+            float r = ship_r * 0.7f + 2.0f + 1.0f * pulse;
             float a = 0.65f + 0.20f * pulse;
             /* Fade with the linger timer so the ring decays in sync
              * with the panel rather than vanishing abruptly. */
@@ -1613,8 +1619,6 @@ void draw_npc_ships(void) {
                           ? g.inspect_snapshot_timer : 1.0f;
             draw_circle_outline(tnpc->ship.pos, r, 28,
                                 0.20f, 0.95f, 0.45f, a * decay);
-            draw_circle_outline(tnpc->ship.pos, r * 1.35f, 28,
-                                0.10f, 0.55f, 0.25f, a * 0.45f * decay);
         }
     }
 }


### PR DESCRIPTION
## Summary

Four follow-ups on the data-mode pass that merged in #564.

### 1. Ring too wide → hugs the ship

`draw_npc_ships` was hardcoded to a 22-unit radius (the hauler's `ship_radius`), which visually sat well outside the rendered triangle. Now pulls from `npc_hull_def(npc)->ship_radius` and uses `r = ship_radius * 0.7 + 2 + 1.0 * pulse`. The outer dim halo dropped — at the tighter inner radius it just added busyness.

### 2. Camera follows the scan target

A new blend layer biases the camera toward the **midpoint** of the local player and the scanned NPC while the inspect snapshot is active. Strength tracks the normalized linger timer, so it eases back to neutral as the panel fades. Skipped during the death cinematic so it doesn't fight the wreckage anchor.

### 3. Linger never expires (the actual bug)

Two compounding problems. The user reported "it also doesn't ever go away":

**Bug A** — `apply_remote_inspect_snapshot` was setting the timer to 3.5 **every frame** the server sent `INSPECT_TARGET_NONE`. Once the player released scan, that's every tick forever — timer never decayed. Replaced with the same edge-detection pattern `local_server.c` uses (`had_target && timer ≤ 0.60` → bump once).

**Bug B** — Even with edge detection, the snapshot's `target_type` retained its NPC value forever. After the linger naturally decayed to 0, the next idle frame still saw `had_target = true`, the timer was now ≤ 0.60, and it re-fired the bump. Infinite re-trigger. Fixed in `main.c`'s per-frame decay: when timer crosses to 0, clear `g.inspect_snapshot.target_type` to `INSPECT_TARGET_NONE`.

### 4. Credit-pool heartbeat (review #564 P3)

The data-mode comment said "fires on inventory or credit_pool deltas" but `apply_remote_stations` explicitly discarded `credit_pool`. Now both MP (`apply_remote_stations`) and SP (`mirror_whole_world`) diff the pool, store the previous value in `g.station_prev_credit_pool[]`, and fire the heartbeat on either an inventory delta (≥ 0.5 units) **or** a pool delta (≥ 5 credits). Threshold is loose enough that whole-unit ledger movements always clear it; float drift can't.

## Files

- `src/client.h:430` — new `station_prev_credit_pool[]`.
- `src/world_draw.c:1606-1621` — ring tightened, outer halo removed.
- `src/main.c:849-859` — timer decay now clears target_type at expire.
- `src/main.c:1389-1410` — scan-target camera blend.
- `src/net_sync.c:179-211` — credit-pool diff + linger edge-detection.
- `src/net_sync.c:288-302` — linger edge-detection on `apply_remote_inspect_snapshot`.
- `src/local_server.c:118-145` — credit-pool diff in mirror_whole_world.

## Test plan

- [x] `make test` — **560/560 pass**
- [x] Native build clean under `-Werror -Wall -Wextra -Wpedantic`
- [x] Wasm build clean
- [ ] Manual: scan an NPC hauler — ring should hug the visible ship; camera glides to bring both ships into frame; release scan and the ring + pane fade out cleanly over ~3.5 s and stay gone.
- [ ] Manual: park near a refinery while scan-active → station heartbeat halo pulses; leave the area while scan still active → camera should pull toward the hauler regardless.
- [ ] Manual: sell ore at a station → halo pulse fires from the credit-pool delta even with no inventory change visible.

## Skipped

No unit-test for Bug B's natural-expire-clears-target-type contract. The logic spans `apply_remote_inspect_snapshot` (in `net_sync.c`, not linked into `signal_test`) and the per-frame tick (in `main.c`, also not linked). Adding a test would require non-trivial harness changes; the fix is small and visible in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)