### PR TITLE
Fix scan linger never expiring (timer-threshold trick → stateful flag)

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -406,6 +406,14 @@ typedef struct {
     int inspect_module;      /* module info pane: module index */
     NetInspectSnapshot inspect_snapshot;
     float inspect_snapshot_timer;
+    /* True while the player has an active scan target. The release
+     * edge (was_active=true → now_active=false) bumps the timer
+     * once into the linger window; subsequent idle frames see this
+     * flag false and don't keep re-bumping the timer. The previous
+     * timer-threshold trick (`timer ≤ 0.6 → bump`) re-fired when
+     * the linger naturally crossed back below 0.6 on its way to 0,
+     * causing the panel/ring to never expire. */
+    bool inspect_was_active;
     /* Per-row scramble-resolve animation state for the inspect snapshot
      * pane. sig is a content fingerprint of the row (cargo_pub +
      * receipt_head + prefix + commodity + grade + qty); a change retriggers

--- a/src/local_server.c
+++ b/src/local_server.c
@@ -250,18 +250,14 @@ static void local_server_sync_inspect_snapshot(const local_server_t *ls,
     snap.dest_station = 0xFFu;
 
     if (!src->scan_active || src->scan_target_type == INSPECT_TARGET_NONE) {
-        /* Linger: hold the last snapshot's data on screen for a few
-         * seconds after the player releases the scan key. Active-scan
-         * frames refresh the timer to 0.60; seeing ≤ 0.60 here means
-         * we just hit the release edge and should bump up to the
-         * linger window. After that the timer counts down naturally —
-         * we mustn't reset it on every subsequent idle frame. */
-        bool had_target = g.inspect_snapshot.target_type != INSPECT_TARGET_NONE;
-        if (had_target && g.inspect_snapshot_timer <= 0.60f) {
+        /* Linger: bump the timer once on the active→idle edge and
+         * leave it alone on subsequent idle frames so it can decay.
+         * The earlier `timer ≤ 0.60` trick silently re-fired ~2.9s
+         * in when the timer crossed back below 0.60 on its way down,
+         * trapping the panel/ring on screen forever. */
+        if (g.inspect_was_active) {
             g.inspect_snapshot_timer = 3.5f;
-        } else if (!had_target) {
-            g.inspect_snapshot = snap;
-            g.inspect_snapshot_timer = 0.0f;
+            g.inspect_was_active = false;
         }
         return;
     }
@@ -343,6 +339,7 @@ static void local_server_sync_inspect_snapshot(const local_server_t *ls,
 
     g.inspect_snapshot = snap;
     g.inspect_snapshot_timer = 0.60f;
+    g.inspect_was_active = true;
 }
 
 void local_server_sync_to_client(const local_server_t *ls) {

--- a/src/net_sync.c
+++ b/src/net_sync.c
@@ -283,22 +283,23 @@ void apply_remote_hold_ingots(const NetNamedIngotEntry *entries, int count) {
 void apply_remote_inspect_snapshot(const NetInspectSnapshot *snapshot) {
     if (!snapshot) return;
 
-    /* Linger: hold the last snapshot's data on screen for a few
-     * seconds after the player releases the scan key. Active-scan
-     * frames refresh the timer to 0.60; the release edge bumps it up
-     * to the linger window. After that, the timer counts down on its
-     * own — we mustn't reset it on every subsequent idle frame, which
-     * would clamp it at 3.5 forever. The per-frame decay in main.c
-     * clears target_type when the timer hits 0, so this branch can
-     * trust target_type as a "we already lingered out" signal. */
+    /* Linger: keep the snapshot on screen for ~3.5s after release.
+     * The was_active flag marks the active→idle edge. Once we've
+     * bumped the timer into the linger window, was_active is false
+     * and this branch is a no-op until the next active scan — the
+     * timer counts down naturally. Earlier `timer ≤ 0.60` trick
+     * silently re-fired ~2.9s into the linger when the timer
+     * crossed back below 0.60 on its way to zero, restarting the
+     * countdown indefinitely. */
     if (snapshot->target_type == INSPECT_TARGET_NONE) {
-        bool had_target = g.inspect_snapshot.target_type != INSPECT_TARGET_NONE;
-        if (had_target && g.inspect_snapshot_timer <= 0.60f) {
+        if (g.inspect_was_active) {
             g.inspect_snapshot_timer = 3.5f;
+            g.inspect_was_active = false;
         }
     } else {
         g.inspect_snapshot = *snapshot;
         g.inspect_snapshot_timer = 0.60f;
+        g.inspect_was_active = true;
     }
 
     if (g.local_player_slot < 0 || g.local_player_slot >= MAX_PLAYERS) return;


### PR DESCRIPTION
## Summary

The fix in #565 didn't fully solve the never-expiring scan pane. The `had_target && timer ≤ 0.60` edge-detection trick fires twice during a single linger cycle:

1. **On release** (intended): timer was 0.60 from active scan, drops to ~0.59 next frame, the next idle frame sees `≤ 0.60` and bumps to 3.5.
2. **~2.9 seconds in (the bug)**: the 3.5-second linger naturally decays. When it crosses below 0.60 on its way to zero, the same condition fires again — bump back to 3.5. Infinite loop. Panel and ring never go away.

The user reported this directly: *"the scan outline and details never vanish"*.

## Fix

Replace the timer-threshold trick with a stateful boolean `g.inspect_was_active`. Set it true whenever an active-scan snapshot refreshes the panel; clear it exactly once on the active→idle release edge (after bumping the timer to 3.5). Subsequent idle frames see the flag false and don't touch the timer. The timer counts down naturally and `main.c`'s per-frame decay clears `target_type` at expire — the renderer goes dark.

Both apply paths updated:
- `src/net_sync.c::apply_remote_inspect_snapshot` (multiplayer)
- `src/local_server.c::local_server_sync_inspect_snapshot` (singleplayer)

## Files

- `src/client.h:408-415` — new `inspect_was_active` field with comment explaining why the flag exists.
- `src/net_sync.c:288-302` — flag-based release-edge detection.
- `src/local_server.c:252-261` — same pattern in SP path.
- `src/local_server.c:341` — set flag true on the active-scan refresh.

## Test plan

- [x] `make test` — **560/560 pass**
- [x] Native build clean under `-Werror`
- [x] Wasm build clean
- [ ] Manual: scan an NPC hauler, release → ring + pane should fade out over ~3.5s and stay gone permanently
- [ ] Manual: scan, release, scan again → second scan should re-trigger normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)