### PR TITLE
Fix four scan-linger edge cases

### DIFF
--- a/src/hud.c
+++ b/src/hud.c
@@ -630,11 +630,21 @@ static void hud_station_name_for_pubkey(const uint8_t pub[32],
 static void hud_draw_inspect_snapshot_pane(float screen_w, float screen_h) {
     if (g.inspect_snapshot_timer <= 0.0f) return;
     if (LOCAL_PLAYER.docked) return;
+    /* Suppress during the death cinematic — the camera framing and
+     * sepia tint are doing their own thing; the inspect pane would
+     * undermine that with stale info from before the death. */
+    if (g.death_cinematic.active) return;
     /* The timer alone gates visibility — the panel lingers for a few
      * seconds after scan release so the player can read what they
      * just locked onto. */
     const NetInspectSnapshot *snap = &g.inspect_snapshot;
     if (snap->target_type != INSPECT_TARGET_NPC) return;
+    /* Bug D: the linger keeps showing the pane after the scanned NPC
+     * despawns — drop it for stale targets. The world ring already
+     * gates on npc_ships[i].active, so this keeps the two surfaces
+     * in sync. */
+    if (snap->target_index < MAX_NPC_SHIPS
+        && !g.world.npc_ships[snap->target_index].active) return;
 
     float px = fmaxf(16.0f, screen_w - 360.0f);
     float py = (screen_h < 520.0f) ? 76.0f : 92.0f;

--- a/src/main.c
+++ b/src/main.c
@@ -123,6 +123,7 @@ static void reset_world(void) {
     g.inspect_snapshot.home_station = 0xFFu;
     g.inspect_snapshot.dest_station = 0xFFu;
     g.inspect_snapshot_timer = 0.0f;
+    g.inspect_was_active = false;
     memset(&g.asteroid_interp, 0, sizeof(g.asteroid_interp));
     g.asteroid_interp.interval = g.local_server.active ? SIM_DT : 0.1f;
     memset(&g.npc_interp, 0, sizeof(g.npc_interp));
@@ -848,10 +849,12 @@ static void sim_step(float dt) {
         g.hail_timer = fmaxf(0.0f, g.hail_timer - dt);
     if (g.inspect_snapshot_timer > 0.0f) {
         g.inspect_snapshot_timer = fmaxf(0.0f, g.inspect_snapshot_timer - dt);
-        if (g.inspect_snapshot_timer <= 0.0f) {
+        /* fmaxf clamps to exactly 0.0f; equality here matches the only
+         * value the previous line can produce as the floor. */
+        if (g.inspect_snapshot_timer == 0.0f) {
             /* Linger fully decayed — clear so the next idle frame's
-             * apply_*_inspect_snapshot doesn't see had_target=true and
-             * keep re-bumping the timer back to 3.5 indefinitely. */
+             * apply_*_inspect_snapshot doesn't see was_active stuck
+             * true and re-bump the timer. */
             g.inspect_snapshot.target_type = INSPECT_TARGET_NONE;
             g.inspect_snapshot.target_index = 0xFFu;
         }
@@ -1389,9 +1392,12 @@ static void render_world(void) {
 
         /* Scan-target framing: bias the camera toward the midpoint
          * between the local player and the scanned NPC so both stay
-         * visible. Skipped during the death cinematic. Strength
-         * tracks the linger timer normalized to [0,1] so the framing
-         * eases back to neutral as the panel fades out. */
+         * visible. Skipped during the death cinematic. Strength is
+         * full while actively scanning (the active-refresh timer
+         * sits at 0.6, so a naive "strength = clamp(timer)" would
+         * weaken active framing to 60% — backwards from the intent).
+         * Once released, fall back to the linger timer so the
+         * framing eases back to neutral as the panel fades. */
         if (!g.death_cinematic.active
             && g.inspect_snapshot.target_type == INSPECT_TARGET_NPC
             && g.inspect_snapshot_timer > 0.0f
@@ -1401,8 +1407,10 @@ static void render_world(void) {
             if (tn->active) {
                 vec2 mid = v2(0.5f * (LOCAL_PLAYER.ship.pos.x + tn->ship.pos.x),
                               0.5f * (LOCAL_PLAYER.ship.pos.y + tn->ship.pos.y));
-                float strength = g.inspect_snapshot_timer < 1.0f
-                                 ? g.inspect_snapshot_timer : 1.0f;
+                float strength = g.inspect_was_active
+                                 ? 1.0f
+                                 : (g.inspect_snapshot_timer < 1.0f
+                                    ? g.inspect_snapshot_timer : 1.0f);
                 float k = (1.0f - expf(-2.5f * dt)) * 0.6f * strength;
                 g.camera_pos.x += (mid.x - g.camera_pos.x) * k;
                 g.camera_pos.y += (mid.y - g.camera_pos.y) * k;

--- a/src/world_draw.c
+++ b/src/world_draw.c
@@ -1585,7 +1585,8 @@ void draw_npc_ships(void) {
     int scan_npc = -1;
     if (g.inspect_snapshot_timer > 0.0f
         && g.inspect_snapshot.target_type == INSPECT_TARGET_NPC
-        && g.inspect_snapshot.target_index != 0xFFu) {
+        && g.inspect_snapshot.target_index != 0xFFu
+        && !g.death_cinematic.active) {
         scan_npc = (int)g.inspect_snapshot.target_index;
     }
 


### PR DESCRIPTION
Self-review of the post-#566 inspect/linger state caught four issues; landing them together since they all live in the same area.

## A — `reset_world` doesn't reset `inspect_was_active` (latent)

`src/main.c:reset_world` cleared `g.inspect_snapshot` and the timer but missed the new `g.inspect_was_active` flag. After self-destruct (`X` in SP), MP→SP swap, or any other reset path, the persistent flag triggers a phantom 3.5-second linger drawn from now-zeroed snapshot fields. One-line fix.

## B — Death cinematic doesn't suppress the pane/ring

The scan-target camera blend at `src/main.c:1396` correctly skips when `g.death_cinematic.active`, but the inspect pane (`src/hud.c`) and the world ring (`src/world_draw.c::draw_npc_ships`) didn't. Both kept rendering through the death sequence, fighting the wreckage framing with stale info from before the kill. Two `if (g.death_cinematic.active) ...` gates added.

## C — Camera-follow strength was *weaker* during active scan than during the linger

The strength formula was:
```c
float strength = g.inspect_snapshot_timer < 1.0f
                 ? g.inspect_snapshot_timer : 1.0f;
```
Active-scan timer sits at 0.60 (refreshed every server tick), so active framing was at 60% follow. The linger starts at 3.5 → strength = 1.0. Releasing the scan key made the camera **lurch toward the target**.

Fixed by using the existing `inspect_was_active` flag: full strength during active scan, fall back to the timer ramp only during the linger fade.

## D — Inspect pane keeps showing manifest of despawned NPC

The world ring gated on `g.world.npc_ships[i].active` so it correctly skipped dead targets. The pane didn't — it kept showing the cargo manifest of the despawned ship for the full 3.5s linger. Two-line fix to mirror the ring's check.

## Style nit (not a bug)

`if (g.inspect_snapshot_timer <= 0.0f)` after `fmaxf(0.0f, ...)` only ever fires on exact equality. Changed to `==` to match the only value the preceding line can produce as the floor; reads more honestly.

## Test plan

- [x] `make test` — **560/560 pass**
- [x] Native build clean under `-Werror -Wall -Wextra -Wpedantic`
- [x] Wasm build clean
- [ ] Manual: SP, scan a hauler, press X (self-destruct) — no phantom ring/pane after respawn
- [ ] Manual: scan a hauler, get hit by a rock → die → no pane/ring during the death cinematic
- [ ] Manual: scan a hauler — camera follow shouldn't lurch when you release the scan key
- [ ] Manual: scan an NPC, NPC dies before linger expires — pane should fade with the ring, not outlast it

🤖 Generated with [Claude Code](https://claude.com/claude-code)