### PR TITLE
[codex] Ship docked cargo lineage labels

### DIFF
--- a/client/client.h
+++ b/client/client.h
@@ -124,6 +124,16 @@ typedef struct {
     bool           has_lineage;
     uint8_t        origin_station_idx;  /* world index of the producing/smelt station */
     uint64_t       mined_block;          /* signal_channel_post tick at mint */
+    /* Compact #344 inspect payload for the representative cargo_unit_t
+     * behind the visible row. Grade is already a first-class row column;
+     * these fields let the row reveal serial, recipe, parent summary,
+     * origin, and seal count without opening a separate debug screen. */
+    bool           has_inspect;
+    uint8_t        inspect_kind;          /* cargo_kind_t */
+    uint16_t       inspect_recipe_id;     /* recipe_id_t */
+    uint8_t        inspect_chain_len;     /* attached station receipt count, 0 if none */
+    uint8_t        inspect_pub[32];
+    uint8_t        inspect_parent[32];
 } trade_row_t;
 
 /* Why an otherwise-valid row is non-actionable. Drives the status text

--- a/client/station_ui.c
+++ b/client/station_ui.c
@@ -8,6 +8,7 @@
 #include "mining_client.h"
 #include "contract_objective.h"
 #include "manifest.h"
+#include "cargo_lineage.h"
 #include "station_authority.h"
 #include "contract_fit.h"
 /* Grade palette lives in shared/mining.h (pulled in via client.h →
@@ -801,6 +802,35 @@ static int manifest_market_lineage_count_cg(const manifest_t *manifest,
     return n;
 }
 
+static bool station_ui_hash_is_zero(const uint8_t hash[32])
+{
+    return cargo_lineage_hash_is_zero(hash);
+}
+
+static bool cargo_unit_has_player_origin(const cargo_unit_t *u)
+{
+    if (!u) return false;
+    if (u->recipe_id == (uint16_t)RECIPE_LEGACY_MIGRATE) return false;
+    if ((cargo_kind_t)u->kind != CARGO_KIND_INGOT && u->mined_block == 0)
+        return false;
+    if (station_short_name((int)u->origin_station)[0] == '?') return false;
+    return !station_ui_hash_is_zero(u->pub);
+}
+
+static void trade_row_attach_inspect(trade_row_t *row,
+                                     const cargo_unit_t *unit,
+                                     const cargo_receipt_chain_t *chain)
+{
+    if (!row || !unit || station_ui_hash_is_zero(unit->pub)) return;
+    row->has_inspect = true;
+    row->inspect_kind = unit->kind;
+    row->inspect_recipe_id = unit->recipe_id;
+    row->inspect_chain_len = (chain && chain->len <= CARGO_RECEIPT_CHAIN_MAX_LEN)
+        ? chain->len : 0;
+    memcpy(row->inspect_pub, unit->pub, sizeof(row->inspect_pub));
+    memcpy(row->inspect_parent, unit->parent_merkle, sizeof(row->inspect_parent));
+}
+
 static int manifest_find_first_market_cg(const manifest_t *manifest,
                                          commodity_t commodity,
                                          mining_grade_t grade)
@@ -973,13 +1003,15 @@ int build_trade_rows(const station_t *st, const ship_t *ship,
             uint8_t origin_idx = 0;
             uint64_t mined_blk = 0;
             bool has_lineage = false;
+            const cargo_unit_t *inspect_unit = NULL;
+            const cargo_receipt_chain_t *inspect_chain = NULL;
             int represented = manifest_market_count_cg_direct(&st->manifest,
                                                               (commodity_t)c,
                                                               (mining_grade_t)gi);
             int lineage_count = manifest_market_lineage_count_cg(&st->manifest,
                                                                  (commodity_t)c,
                                                                  (mining_grade_t)gi);
-            if (represented == stock && lineage_count == stock) {
+            if (represented == stock) {
                 int rep_idx = manifest_find_first_market_cg(&st->manifest,
                                                             (commodity_t)c,
                                                             (mining_grade_t)gi);
@@ -987,10 +1019,15 @@ int build_trade_rows(const station_t *st, const ship_t *ship,
                     const cargo_unit_t *rep = &st->manifest.units[rep_idx];
                     origin_idx = rep->origin_station;
                     mined_blk = rep->mined_block;
-                    has_lineage = (mined_blk != 0);
+                    has_lineage = (lineage_count == stock && mined_blk != 0) ||
+                                  cargo_unit_has_player_origin(rep);
+                    inspect_unit = rep;
+                    const ship_receipts_t *rcpts = station_get_receipts_const(st);
+                    if (rcpts && (uint16_t)rep_idx < rcpts->count)
+                        inspect_chain = &rcpts->chains[rep_idx];
                 }
             }
-            out[row_count++] = (trade_row_t){
+            trade_row_t row = (trade_row_t){
                 .kind = 0, .commodity = (commodity_t)c, .grade = (mining_grade_t)gi,
                 .stock = stock, .quantity = qty,
                 .unit_price = price, .total_price = price * qty,
@@ -1001,6 +1038,8 @@ int build_trade_rows(const station_t *st, const ship_t *ship,
                 .origin_station_idx = origin_idx,
                 .mined_block = mined_blk,
             };
+            trade_row_attach_inspect(&row, inspect_unit, inspect_chain);
+            out[row_count++] = row;
         }
     }
 
@@ -1047,18 +1086,25 @@ int build_trade_rows(const station_t *st, const ship_t *ship,
             uint8_t origin_idx = 0;
             uint64_t mined_blk = 0;
             bool has_lineage = false;
+            const cargo_unit_t *inspect_unit = NULL;
+            const cargo_receipt_chain_t *inspect_chain = NULL;
             int lineage_count = manifest_lineage_count_cg(&ship->manifest,
                                                           (commodity_t)c,
                                                           (mining_grade_t)gi);
-            if (held > 0 && lineage_count >= held) {
+            if (held > 0) {
                 if (rep_idx >= 0) {
                     const cargo_unit_t *rep = &ship->manifest.units[rep_idx];
                     origin_idx = rep->origin_station;
                     mined_blk = rep->mined_block;
-                    has_lineage = (mined_blk != 0);
+                    has_lineage = (lineage_count >= held && mined_blk != 0) ||
+                                  cargo_unit_has_player_origin(rep);
+                    inspect_unit = rep;
+                    const ship_receipts_t *rcpts = ship_get_receipts_const(ship);
+                    if (rcpts && (uint16_t)rep_idx < rcpts->count)
+                        inspect_chain = &rcpts->chains[rep_idx];
                 }
             }
-            out[row_count++] = (trade_row_t){
+            trade_row_t row = (trade_row_t){
                 .kind = 1, .commodity = (commodity_t)c, .grade = (mining_grade_t)gi,
                 .stock = held, .quantity = held > 0 ? 1 : 0,
                 .unit_price = price, .total_price = price,
@@ -1070,6 +1116,8 @@ int build_trade_rows(const station_t *st, const ship_t *ship,
                 .origin_station_idx = origin_idx,
                 .mined_block = mined_blk,
             };
+            trade_row_attach_inspect(&row, inspect_unit, inspect_chain);
+            out[row_count++] = row;
         }
     }
     return row_count;
@@ -1273,14 +1321,50 @@ static void draw_trade_view(const station_ui_state_t *ui,
             snprintf(commodity_label, sizeof(commodity_label), "%s", cname);
         }
 
-        /* Lineage tag — "from Prospect ep 4422" — drawn as a faded
-         * single-line suffix on rows whose representative cargo_unit
-         * carries real provenance. Anonymous bulk rows and legacy-
-         * migrate rows (mined_block == 0) skip this line so the dock
-         * UI doesn't bloat for cargo with no story to tell. */
-        char lineage_buf[48];
+        /* Lineage tag — compact #344 inspection of the representative
+         * cargo_unit_t behind this row. The row already names grade;
+         * this line adds serial, recipe, parent summary, origin, and
+         * receipt seal count where the client has those bytes locally. */
+        char lineage_buf[112];
         lineage_buf[0] = '\0';
-        if (r->has_lineage) {
+        if (r->has_inspect) {
+            cargo_unit_t inspect = {0};
+            inspect.kind = r->inspect_kind;
+            inspect.commodity = (uint8_t)r->commodity;
+            inspect.grade = (uint8_t)r->grade;
+            inspect.recipe_id = r->inspect_recipe_id;
+            inspect.origin_station = r->origin_station_idx;
+            inspect.quantity = 1;
+            inspect.mined_block = r->mined_block;
+            memcpy(inspect.pub, r->inspect_pub, sizeof(inspect.pub));
+            memcpy(inspect.parent_merkle, r->inspect_parent,
+                   sizeof(inspect.parent_merkle));
+            char serial[12], parent[8], origin[24];
+            cargo_lineage_serial_label(&inspect, serial, sizeof(serial));
+            cargo_lineage_parent_label(&inspect, parent, sizeof(parent));
+            bool origin_known = inspect.recipe_id != (uint16_t)RECIPE_LEGACY_MIGRATE &&
+                ((cargo_kind_t)inspect.kind == CARGO_KIND_INGOT ||
+                 inspect.mined_block != 0 || r->inspect_chain_len > 0);
+            if (origin_known)
+                cargo_lineage_origin_label(&inspect, origin, sizeof(origin));
+            else
+                snprintf(origin, sizeof(origin), "origin ?");
+            const char *recipe = cargo_lineage_recipe_label(&inspect);
+            char seal[16] = "";
+            if (r->inspect_chain_len > 0)
+                snprintf(seal, sizeof(seal), " seal x%u",
+                         (unsigned)r->inspect_chain_len);
+            if (r->mined_block != 0) {
+                snprintf(lineage_buf, sizeof(lineage_buf),
+                         "serial %s  %s parent %s  %s ep%llu%s",
+                         serial, recipe, parent, origin,
+                         (unsigned long long)r->mined_block, seal);
+            } else {
+                snprintf(lineage_buf, sizeof(lineage_buf),
+                         "serial %s  %s parent %s  %s%s",
+                         serial, recipe, parent, origin, seal);
+            }
+        } else if (r->has_lineage) {
             snprintf(lineage_buf, sizeof(lineage_buf),
                      "from %s, ep %llu",
                      station_short_name((int)r->origin_station_idx),
@@ -1301,8 +1385,12 @@ static void draw_trade_view(const station_ui_state_t *ui,
             /* Optional third line — lineage flavor. Drawn dim so it
              * reads as background context, not actionable state. */
             if (lineage_buf[0]) {
+                char lineage_fit[112];
+                int lineage_chars = (int)floorf((inner_right - (cx + 32.0f)) / 8.0f);
+                ui_fit_text(lineage_buf, lineage_chars, lineage_fit,
+                            sizeof(lineage_fit));
                 cell_t lineage[] = {
-                    {  4, lineage_buf, COL_FADED },
+                    {  4, lineage_fit, COL_FADED },
                 };
                 draw_row_cells(cx, my, lineage, 1);
                 my += row_h;
@@ -1322,8 +1410,12 @@ static void draw_trade_view(const station_ui_state_t *ui,
             /* Wide mode also gets a lineage line beneath the row.
              * Same dim styling, indented under the commodity label. */
             if (lineage_buf[0]) {
+                char lineage_fit[112];
+                int lineage_chars = (int)floorf((inner_right - (cx + 32.0f)) / 8.0f);
+                ui_fit_text(lineage_buf, lineage_chars, lineage_fit,
+                            sizeof(lineage_fit));
                 cell_t lineage[] = {
-                    {  4, lineage_buf, COL_FADED },
+                    {  4, lineage_fit, COL_FADED },
                 };
                 draw_row_cells(cx, my, lineage, 1);
                 my += row_h;

--- a/docs/cargo-architecture.md
+++ b/docs/cargo-architecture.md
@@ -285,28 +285,29 @@ The decision is picked: pure fragment-tow to ingot pipeline. Tests now
 assert that directly seeded raw ore does not smelt, does not drain through
 raw hopper flow, and does not emit zero-fragment `CHAIN_EVT_SMELT`.
 
-### Gap 3 — Players can't see provenance at all
+### Closed gap — Docked cargo rows show player-readable lineage
 
-The HUD shows hold contents as a commodity-and-grade summary. There's no
-display surface that says "this ferrite ingot came from Belt-7's
-fracture by 0F3H-CH at tick 4422." The substrate has the data; the UI
-ignores it.
+The docked TRADE view now surfaces the representative cargo unit behind
+held and station-stock rows. Rows backed by a concrete `cargo_unit_t`
+show a compact inspection line with the unit serial/callsign, recipe,
+parent summary, origin station, mint epoch when available, and attached
+receipt seal count when the local manifest has the chain.
 
-The fix is the "lineage-as-name" mechanic from the prior design
-discussion. Cargo rows render with a one-line provenance haiku
-generated from `cargo_unit_t.parent_merkle` walked against the chain
-log. No new screens, no new keys, just a string format change.
+This is intentionally a player-facing first slice, not a full proof
+endpoint. It makes the existing manifest/receipt substrate visible in
+normal trade without adding a debug screen or new keybinding. Full tree
+walks, station-root freshness, credit-note panels, and on-demand proof
+fetching remain future proof-surface work.
 
 ## Recommended next moves
 
 Ranked by value-per-effort after the fragment-chain coverage pass.
 
-**1. Build the lineage display layer.** Trade rows now surface
-representative `origin_station` / `mined_block` text from local
-manifests, and multiplayer preserves detailed named-ingot snapshots.
-Anonymous ingots and fabricated goods still need either richer wire
-records or a compact provenance-summary record if they should display
-the same player-facing history.
+**1. Extend inspection beyond docked rows.** Trade rows now surface
+representative serial, recipe, parent, origin, epoch, and receipt count
+from local manifests. The next useful slice is scan-to-inspect for held
+cargo, haulers, station stock, and tracked contract matching using the
+same player-facing vocabulary.
 
 **2. Group manifest presentation before showing every hash.** Common
 anonymous stock should compress into commodity/grade buckets, while

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -174,6 +174,10 @@ static int station_manifest_craft_product_batch(world_t *w, station_t *st,
                           (uint16_t)out_idx, &product)) {
             break;
         }
+        if (w && st >= w->stations && st < w->stations + MAX_STATIONS) {
+            product.origin_station = (uint8_t)(st - w->stations);
+            product.mined_block = (uint64_t)(w->time * 120.0);
+        }
         if (!station_manifest_push_finished(st, &product)) break;
         crafted++;
 
@@ -1176,6 +1180,7 @@ void step_dock_repair_kit_fab(world_t *w, float dt) {
                               (uint16_t)k, &unit))
                 break;
             unit.origin_station = (uint8_t)s;
+            unit.mined_block = (uint64_t)(w->time * 120.0);
             if (!station_manifest_push_finished(st, &unit)) break;
             actual_minted++;
         }

--- a/shared/cargo_lineage.h
+++ b/shared/cargo_lineage.h
@@ -1,0 +1,77 @@
+/*
+ * cargo_lineage.h -- Small player-facing labels for cargo provenance.
+ *
+ * These helpers deliberately format the same cargo_unit_t fields that
+ * verifiers consume, but with UI language: serial, parent, recipe, origin.
+ */
+#ifndef SHARED_CARGO_LINEAGE_H
+#define SHARED_CARGO_LINEAGE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "manifest.h"
+#include "mining.h"
+#include "station_util.h"
+
+static inline bool cargo_lineage_hash_is_zero(const uint8_t hash[32]) {
+    if (!hash) return true;
+    for (int i = 0; i < 32; i++) {
+        if (hash[i] != 0) return false;
+    }
+    return true;
+}
+
+static inline void cargo_lineage_serial_label(const cargo_unit_t *unit,
+                                              char *out, size_t cap) {
+    if (cap == 0) return;
+    out[0] = '\0';
+    if (!unit || cargo_lineage_hash_is_zero(unit->pub)) {
+        snprintf(out, cap, "-");
+        return;
+    }
+    char label[12];
+    mining_render_callsign(unit->pub, label);
+    snprintf(out, cap, "%s", label);
+}
+
+static inline void cargo_lineage_parent_label(const cargo_unit_t *unit,
+                                              char *out, size_t cap) {
+    if (cap == 0) return;
+    out[0] = '\0';
+    if (!unit || cargo_lineage_hash_is_zero(unit->parent_merkle)) {
+        snprintf(out, cap, "none");
+        return;
+    }
+    char label[8];
+    mining_callsign_from_pubkey(unit->parent_merkle, label);
+    snprintf(out, cap, "%s", label);
+}
+
+static inline const char *cargo_lineage_recipe_label(const cargo_unit_t *unit) {
+    if (!unit) return "unknown";
+    switch ((recipe_id_t)unit->recipe_id) {
+        case RECIPE_SMELT:          return "smelt";
+        case RECIPE_FRAME_BASIC:    return "frame";
+        case RECIPE_LASER_BASIC:    return "laser";
+        case RECIPE_TRACTOR_COIL:   return "tractor";
+        case RECIPE_REPAIR_KIT_FAB: return "repair kit";
+        case RECIPE_LEGACY_MIGRATE: return "legacy";
+        default:                    return "unknown";
+    }
+}
+
+static inline void cargo_lineage_origin_label(const cargo_unit_t *unit,
+                                              char *out, size_t cap) {
+    if (cap == 0) return;
+    out[0] = '\0';
+    if (!unit) {
+        snprintf(out, cap, "?");
+        return;
+    }
+    snprintf(out, cap, "%s", station_short_name((int)unit->origin_station));
+}
+
+#endif /* SHARED_CARGO_LINEAGE_H */

--- a/shared/types.h
+++ b/shared/types.h
@@ -169,7 +169,7 @@ typedef struct {
                                  * production; >1 reserved for grouped rows.
                                  * Was _pad pre-v45; legacy saves with
                                  * quantity == 0 migrate to 1 on load. */
-    uint64_t mined_block;       /* chain block id at mint (0 for non-ingot) */
+    uint64_t mined_block;       /* mint tick/event marker when known; 0 = unknown/legacy */
     uint8_t  pub[32];           /* content hash */
     uint8_t  parent_merkle[32]; /* sorted-input merkle root */
 } cargo_unit_t;                 /* 80 bytes */

--- a/tests/c/test_cargo_lineage.c
+++ b/tests/c/test_cargo_lineage.c
@@ -10,6 +10,7 @@
  * renderer uses to format the "from <station>" suffix.
  */
 #include "test_harness.h"
+#include "cargo_lineage.h"
 #include "station_util.h"
 
 TEST(test_station_short_name_founders) {
@@ -47,10 +48,48 @@ TEST(test_station_short_name_invalid_returns_sentinel) {
     ASSERT_STR_EQ(station_short_name(MAX_STATIONS + 100), "?");
 }
 
+TEST(test_cargo_lineage_labels_ingot) {
+    uint8_t fragment[32] = {0};
+    for (int i = 0; i < 32; i++) fragment[i] = (uint8_t)(0x20 + i);
+
+    cargo_unit_t unit = {0};
+    ASSERT(hash_ingot(COMMODITY_FERRITE_INGOT, MINING_GRADE_FINE,
+                      fragment, 2, &unit));
+    unit.origin_station = 1;
+    unit.mined_block = 4422;
+
+    char serial[12], parent[8], origin[24];
+    cargo_lineage_serial_label(&unit, serial, sizeof(serial));
+    cargo_lineage_parent_label(&unit, parent, sizeof(parent));
+    cargo_lineage_origin_label(&unit, origin, sizeof(origin));
+
+    ASSERT(strlen(serial) > 0);
+    ASSERT(strlen(parent) > 0);
+    ASSERT_STR_EQ(origin, "Kepler");
+    ASSERT_STR_EQ(cargo_lineage_recipe_label(&unit), "smelt");
+}
+
+TEST(test_cargo_lineage_labels_legacy_parentless) {
+    uint8_t origin_seed[8] = {'T','E','S','T','v','1',0,0};
+    cargo_unit_t unit = {0};
+    ASSERT(hash_legacy_migrate_unit(origin_seed, COMMODITY_FRAME, 3, &unit));
+    unit.origin_station = 2;
+
+    char parent[8], origin[24];
+    cargo_lineage_parent_label(&unit, parent, sizeof(parent));
+    cargo_lineage_origin_label(&unit, origin, sizeof(origin));
+
+    ASSERT_STR_EQ(parent, "none");
+    ASSERT_STR_EQ(origin, "Helios");
+    ASSERT_STR_EQ(cargo_lineage_recipe_label(&unit), "legacy");
+}
+
 void register_cargo_lineage_tests(void);
 void register_cargo_lineage_tests(void) {
     TEST_SECTION("\nCargo lineage display:\n");
     RUN(test_station_short_name_founders);
     RUN(test_station_short_name_outposts);
     RUN(test_station_short_name_invalid_returns_sentinel);
+    RUN(test_cargo_lineage_labels_ingot);
+    RUN(test_cargo_lineage_labels_legacy_parentless);
 }


### PR DESCRIPTION
## Summary

- Add shared player-facing cargo lineage labels: serial, recipe, parent, origin.
- Attach representative cargo inspect data to docked TRADE BUY/SELL rows and render compact provenance lines.
- Stamp newly fabricated products and repair kits with origin station and mint tick when known.
- Update the cargo architecture docs to mark the docked-row provenance visibility gap closed.

## Why

#344 was groomed down to the first player-readable provenance slice: make lineage visible in the existing mining/hauling/trade loop before building deeper proof endpoints or a full overlay.

The deferred beyond-docked inspection work is tracked in #573. Credit notes, hull roots, station-contract trust, and permaweb settlement remain parked on #405, #343, #568, and #359.

## Validation

- `cmake --build build --target signal_test signal signal_server`
- `./build/signal_test` -> 628 passed, 0 failed
- post-commit local sync rebuilt wasm/server and passed its cached fast test -> 628 passed, 0 failed

Closes #344
