### PR TITLE
Fix deploy smoke gating and tracker drift

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -511,7 +511,7 @@ jobs:
       - name: Smoke test before root client promotion
         id: smoke-pre-promote
         continue-on-error: true
-        run: SMOKE_URL=https://signal.ratimics.com/play/ npx playwright test
+        run: SIGNAL_PRE_PROMOTION_SMOKE=1 SMOKE_URL=https://signal.ratimics.com/play/ npx playwright test
 
       - name: Upload pre-promotion smoke results
         if: steps.smoke-pre-promote.outcome == 'failure'

--- a/client/hud.c
+++ b/client/hud.c
@@ -1676,8 +1676,17 @@ static bool build_hud_message(char* label, size_t label_size, char* message, siz
     /* Plan mode */
     if (g.plan_mode_active) {
         label[0] = '\0';
-        snprintf(message, message_size, "Planning %s. R cycle, E place, B exit.",
-            module_type_name((module_type_t)g.plan_type));
+        if (g.placement_target_ring > 0 && g.placement_target_slot >= 0) {
+            snprintf(message, message_size,
+                     "Planning %s for ring %d slot %d. R changes type; E places; B exits.",
+                     module_type_name((module_type_t)g.plan_type),
+                     g.placement_target_ring,
+                     g.placement_target_slot);
+        } else {
+            snprintf(message, message_size,
+                     "Planning %s. R changes type; E places; B exits.",
+                     module_type_name((module_type_t)g.plan_type));
+        }
         *r = 130; *g0 = 180; *b = 200;
         return true;
     }

--- a/client/input.c
+++ b/client/input.c
@@ -762,7 +762,8 @@ static void plan_mode_handle_ghost_lock(input_intent_t *intent) {
     /* Wait for the server to send back the created station, then switch
      * to real plan mode targeting it. */
     g.plan_mode_grace_until = g.world.time + 1.5f;
-    set_notice("Station locked! [R] type [E] place [B] exit");
+    set_notice("Outpost planned at ring %d slot %d. R changes type; E places; B exits.",
+               g.placement_target_ring, g.placement_target_slot);
 }
 
 /* Plan mode E on a real station: toggle the slot's plan. */
@@ -785,7 +786,8 @@ static void plan_mode_handle_real_place(input_intent_t *intent) {
         intent->cancel_plan_st = (int8_t)ps;
         intent->cancel_plan_ring = (int8_t)pr;
         intent->cancel_plan_sl = (int8_t)psl;
-        set_notice("Plan cleared. [R] type [E] place [B] exit");
+        set_notice("Cleared plan at ring %d slot %d. R changes type; E toggles slot; B exits.",
+                   pr, psl);
         return;
     }
     intent->add_plan = true;
@@ -793,8 +795,8 @@ static void plan_mode_handle_real_place(input_intent_t *intent) {
     intent->plan_ring = (int8_t)pr;
     intent->plan_slot = (int8_t)psl;
     intent->plan_type = (module_type_t)g.plan_type;
-    set_notice("Planned %s. [R] type [E] place [B] exit",
-               module_type_name((module_type_t)g.plan_type));
+    set_notice("Planned %s at ring %d slot %d. R changes type; E toggles slot; B exits.",
+               module_type_name((module_type_t)g.plan_type), pr, psl);
 }
 
 /* Plan mode E dispatch: lock, type-cycle, or place. */
@@ -811,7 +813,7 @@ static void plan_mode_handle_e(input_intent_t *intent, bool ghost_mode) {
         return;
     }
     if (!already && planned_n >= PLAYER_PLAN_TYPE_LIMIT) {
-        set_notice("Plan limit %d types. Cancel one first.", PLAYER_PLAN_TYPE_LIMIT);
+        set_notice("You can plan %d module types. Clear one first.", PLAYER_PLAN_TYPE_LIMIT);
         return;
     }
     if (ghost_mode) plan_mode_handle_ghost_lock(intent);
@@ -846,14 +848,15 @@ static void sample_b_enter_plan(void) {
         g.placement_target_ring = targets[0].ring;
         g.placement_target_slot = targets[0].slot;
         g.plan_target_station = targets[0].station;
-        set_notice("Plan: [R] type [E] place [B] exit");
+        set_notice("Plan mode: ring %d slot %d. R changes type; E places; B exits.",
+                   targets[0].ring, targets[0].slot);
     } else {
         g.plan_mode_active = true;
         g.plan_target_station = -1; /* sentinel: ghost */
         g.placement_target_station = -1;
         g.placement_target_ring = 1;
         g.placement_target_slot = 0;
-        set_notice("Plan: [R] type [E] lock [B] exit");
+        set_notice("Plan mode: new outpost ghost. R changes type; E locks outpost; B exits.");
     }
 }
 

--- a/docs/cargo-architecture.md
+++ b/docs/cargo-architecture.md
@@ -303,10 +303,11 @@ fetching remain future proof-surface work.
 
 Ranked by value-per-effort after the fragment-chain coverage pass.
 
-**1. Extend inspection beyond docked rows.** Trade rows now surface
-representative serial, recipe, parent, origin, epoch, and receipt count
-from local manifests. The next useful slice is scan-to-inspect for held
-cargo, haulers, station stock, and tracked contract matching using the
+**1. Extend inspection beyond the shipped inspect slices.** Trade rows
+now surface representative serial, recipe, parent, origin, epoch, and
+receipt count from local manifests, and NPC/hauler inspect snapshots carry
+the same cargo identity rows. The next useful slice is scan-to-inspect for
+player-held cargo, station stock, and tracked contract matching using the
 same player-facing vocabulary.
 
 **2. Group manifest presentation before showing every hash.** Common

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -600,7 +600,8 @@ test.describe('Browser smoke tests', () => {
     expectNoFatalErrors(logs, { allowExpectedLiveClose: true });
   });
 
-  test('touch controls expose only contextual mobile actions', async ({ page }) => {
+  const touchControlsTest = process.env.SIGNAL_PRE_PROMOTION_SMOKE === '1' ? test.skip : test;
+  touchControlsTest('touch controls expose only contextual mobile actions', async ({ page }) => {
     const logs = installFatalCollectors(page);
     await page.setViewportSize({ width: 390, height: 760 });
     await page.goto(addQueryParam(smokeUrl({ singleplayer: true }), 'touch', '1'));


### PR DESCRIPTION
## Summary

- Skip the client-only mobile touch smoke during pre-promotion deploy smoke runs.
- Keep the touch-control assertion in normal and post-promotion smoke runs.
- Clarify plan-mode HUD/notices with module, ring, and slot context.
- Update cargo architecture docs to reflect that NPC/hauler inspect snapshots already carry cargo identity rows.

## Root Cause

The deploy pre-promotion smoke runs against the currently promoted root client while the new server and versioned bundle are staged. The new touch-controls browser smoke called `signal_mobile_control_flags`, but the old root client did not export that function yet, so pre-promotion smoke failed before root assets could be promoted.

## Validation

- `cmake --build build --target signal signal_test signal_server`
- `./build/signal_test` -> 630 passed, 0 failed
- `SIGNAL_PRE_PROMOTION_SMOKE=1 SMOKE_URL=http://127.0.0.1:1 npx playwright test tests/browser-smoke.spec.ts -g "touch controls" --reporter=line` -> 1 skipped before browser startup

## Tracker

- Fixes the current root cause tracked in #329 once this lands and main deploy passes.
- Follow-up context posted to #333 and #305.
