### PR TITLE
Tighten stale action prompt copy

### DIFF
--- a/client/hud.c
+++ b/client/hud.c
@@ -1708,7 +1708,7 @@ static bool build_hud_message(char* label, size_t label_size, char* message, siz
     /* Scaffold tow */
     if (LOCAL_PLAYER.ship.towed_scaffold >= 0) {
         label[0] = '\0';
-        snprintf(message, message_size, "Towing scaffold. E place, tap SPACE release.");
+        snprintf(message, message_size, "Towing scaffold. [E] place, tap [Space] release.");
         *r = 160; *g0 = 150; *b = 100;
         return true;
     }
@@ -2568,7 +2568,7 @@ void draw_hud(void) {
             sdtx_printf("%s // E launch", dock_role);
         } else if (LOCAL_PLAYER.in_dock_range) {
             sdtx_color3b(PAL_SIGNAL_MINT);
-            sdtx_puts("DOCK RING // E dock");
+            sdtx_puts("DOCK RANGE // E dock");
         } else {
             sdtx_color3b(PAL_NAV_BLUE);
             sdtx_printf("%s %d u // %d %s", nav_role, station_distance, bearing_degrees, bearing_mark);

--- a/client/main.c
+++ b/client/main.c
@@ -1568,7 +1568,7 @@ static void render_world(void) {
                 int stock = (int)lroundf(tst->_inventory_cache[sell_c]);
                 int price = (int)lroundf(station_sell_price(tst, sell_c));
                 if (stock > 0)
-                    sdtx_printf("[Fire] buy 1 @ %dcr  (stock %d)", price, stock);
+                    sdtx_printf("Stock %d // dock to trade @ %d cr", stock, price);
                 else
                     sdtx_puts("Out of stock");
             } else switch (tm->type) {
@@ -1576,7 +1576,7 @@ static void render_world(void) {
                     sdtx_puts("Dock to repair hull");
                     break;
                 case MODULE_DOCK:
-                    sdtx_puts("[Fire] dock");
+                    sdtx_puts("[E] dock");
                     break;
                 case MODULE_SIGNAL_RELAY:
                     sdtx_printf("Signal range %.0f", tst->signal_range);


### PR DESCRIPTION
## Summary

- replace stale world-space `[Fire]` module prompts with current `[E]` / dock-to-trade language
- align compact dock-range copy with the wide HUD phrasing
- format scaffold tow keys as `[E]` and `[Space]` like the rest of the HUD

Closes #333.

## Verification

- `cmake --build build --target signal signal_test signal_server`
- `./build/signal_test`
- post-commit hook fast local test: `630 tests run, 630 passed, 0 failed`
- `git diff --check`
