### PR TITLE
Surface plan and construction states in HUD

### DIFF
--- a/client/hud.c
+++ b/client/hud.c
@@ -12,6 +12,7 @@
 #include "avatar.h"
 #include "mining_client.h"
 #include "mining.h"  /* mining_alphanumeric_callsign — pubkey-derived */
+#include "manifest.h"
 #include "signal_model.h"
 #include "palette.h"
 #include "contract_fit.h"
@@ -1643,6 +1644,145 @@ static void wrap_hud_message_lines(const char *text, int max_cols,
     }
 }
 
+typedef struct {
+    int station_idx;
+    int module_idx;          /* -1 means station shell scaffold. */
+    module_type_t type;
+    commodity_t material;
+    int needed;
+    int held;
+    bool station_shell;
+} hud_construction_need_t;
+
+typedef struct {
+    int station_idx;
+    int ring;
+    int slot;
+    module_type_t type;
+} hud_snapping_scaffold_t;
+
+static const char *hud_station_short_name(int station_idx) {
+    const char *name = station_short_name(station_idx);
+    return (name && name[0] != '?') ? name : "station";
+}
+
+static int hud_ship_material_count(commodity_t material) {
+    if ((unsigned)material >= COMMODITY_COUNT) return 0;
+    if (material >= COMMODITY_RAW_ORE_COUNT)
+        return manifest_count_by_commodity(&LOCAL_PLAYER.ship.manifest, material);
+    return (int)floorf(LOCAL_PLAYER.ship.cargo[material] + 0.001f);
+}
+
+static const char *hud_material_source_hint(commodity_t material) {
+    switch (material) {
+    case COMMODITY_FRAME:
+        return "Make frames at a Frame Press, then dock and press [S].";
+    case COMMODITY_FERRITE_INGOT:
+    case COMMODITY_CUPRITE_INGOT:
+    case COMMODITY_CRYSTAL_INGOT:
+        return "Smelt matching ore at a Furnace, then dock and press [S].";
+    case COMMODITY_LASER_MODULE:
+    case COMMODITY_TRACTOR_MODULE:
+        return "Fabricate modules at a fab, then dock and press [S].";
+    default:
+        return "Haul the material here, then dock and press [S].";
+    }
+}
+
+static bool hud_station_construction_need(const station_t *st, int station_idx,
+                                          hud_construction_need_t *out) {
+    if (!st || !out) return false;
+    if (st->scaffold && st->scaffold_progress < 0.999f) {
+        int needed = (int)ceilf(SCAFFOLD_MATERIAL_NEEDED *
+                                (1.0f - st->scaffold_progress));
+        if (needed < 1) needed = 1;
+        *out = (hud_construction_need_t){
+            .station_idx = station_idx,
+            .module_idx = -1,
+            .type = MODULE_SIGNAL_RELAY,
+            .material = COMMODITY_FRAME,
+            .needed = needed,
+            .held = hud_ship_material_count(COMMODITY_FRAME),
+            .station_shell = true,
+        };
+        return true;
+    }
+
+    for (int m = 0; m < st->module_count; m++) {
+        const station_module_t *mod = &st->modules[m];
+        if (module_build_state(mod) != MODULE_BUILD_AWAITING_SUPPLY) continue;
+        commodity_t material = module_build_material_lookup(mod->type);
+        float cost = module_build_cost_lookup(mod->type);
+        int needed = (int)ceilf(cost * (1.0f - module_supply_fraction(mod)));
+        if (needed < 1) needed = 1;
+        *out = (hud_construction_need_t){
+            .station_idx = station_idx,
+            .module_idx = m,
+            .type = mod->type,
+            .material = material,
+            .needed = needed,
+            .held = hud_ship_material_count(material),
+            .station_shell = false,
+        };
+        return true;
+    }
+    return false;
+}
+
+static bool hud_find_construction_need(hud_construction_need_t *out) {
+    if (!out) return false;
+    int focus = -1;
+    if (LOCAL_PLAYER.docked) focus = LOCAL_PLAYER.current_station;
+    else if (LOCAL_PLAYER.in_dock_range) focus = LOCAL_PLAYER.nearby_station;
+    if (focus >= 0 && focus < MAX_STATIONS &&
+        hud_station_construction_need(&g.world.stations[focus], focus, out)) {
+        return true;
+    }
+
+    const float max_range = 1400.0f;
+    float best_d2 = max_range * max_range;
+    bool found = false;
+    hud_construction_need_t best = {0};
+    for (int s = 0; s < MAX_STATIONS; s++) {
+        const station_t *st = &g.world.stations[s];
+        if (!station_exists(st)) continue;
+        float d2 = v2_dist_sq(st->pos, LOCAL_PLAYER.ship.pos);
+        if (d2 >= best_d2) continue;
+        hud_construction_need_t candidate;
+        if (!hud_station_construction_need(st, s, &candidate)) continue;
+        best = candidate;
+        best_d2 = d2;
+        found = true;
+    }
+    if (found) *out = best;
+    return found;
+}
+
+static bool hud_find_snapping_scaffold(hud_snapping_scaffold_t *out) {
+    if (!out) return false;
+    const float max_range = 900.0f;
+    float best_d2 = max_range * max_range;
+    bool found = false;
+    hud_snapping_scaffold_t best = {0};
+    for (int i = 0; i < MAX_SCAFFOLDS; i++) {
+        const scaffold_t *sc = &g.world.scaffolds[i];
+        if (!sc->active || sc->state != SCAFFOLD_SNAPPING) continue;
+        if (sc->placed_station < 0 || sc->placed_station >= MAX_STATIONS) continue;
+        float d2 = v2_dist_sq(sc->pos, LOCAL_PLAYER.ship.pos);
+        if (d2 >= best_d2) continue;
+        best = (hud_snapping_scaffold_t){
+            .station_idx = sc->placed_station,
+            .ring = sc->placed_ring,
+            .slot = sc->placed_slot,
+            .type = sc->module_type,
+        };
+        best_d2 = d2;
+        found = true;
+    }
+    if (found) *out = best;
+    return found;
+}
+
 
 static bool build_hud_message(char* label, size_t label_size, char* message, size_t message_size, uint8_t* r, uint8_t* g0, uint8_t* b) {
     /* ================================================================
@@ -1675,19 +1815,30 @@ static bool build_hud_message(char* label, size_t label_size, char* message, siz
 
     /* Plan mode */
     if (g.plan_mode_active) {
-        label[0] = '\0';
+        bool ghost = (g.plan_target_station == -1);
+        snprintf(label, label_size, "%s", ghost ? "PLAN GHOST" : "PLAN SLOT");
         if (g.placement_target_ring > 0 && g.placement_target_slot >= 0) {
-            snprintf(message, message_size,
-                     "Planning %s for ring %d slot %d. R changes type; E places; B exits.",
-                     module_type_name((module_type_t)g.plan_type),
-                     g.placement_target_ring,
-                     g.placement_target_slot);
+            if (ghost) {
+                snprintf(message, message_size,
+                         "%s preview ring %d slot %d. [E] locks an outpost; [R] changes type; [B] exits.",
+                         module_type_name((module_type_t)g.plan_type),
+                         g.placement_target_ring,
+                         g.placement_target_slot);
+            } else {
+                snprintf(message, message_size,
+                         "%s at %s ring %d slot %d. [E] toggles this slot; [R] changes type; [B] exits.",
+                         module_type_name((module_type_t)g.plan_type),
+                         hud_station_short_name(g.placement_target_station),
+                         g.placement_target_ring,
+                         g.placement_target_slot);
+            }
         } else {
             snprintf(message, message_size,
-                     "Planning %s. R changes type; E places; B exits.",
+                     "%s planning. [R] changes type; [E] places; [B] exits.",
                      module_type_name((module_type_t)g.plan_type));
         }
-        *r = 130; *g0 = 180; *b = 200;
+        if (ghost) { *r = 180; *g0 = 165; *b = 115; }
+        else       { *r = 130; *g0 = 190; *b = 210; }
         return true;
     }
 
@@ -1699,17 +1850,51 @@ static bool build_hud_message(char* label, size_t label_size, char* message, siz
         return true;
     }
 
-    /* Onboarding */
-    if (onboarding_hint(label, label_size, message, message_size)) {
-        *r = 255; *g0 = 221; *b = 119;
+    /* Scaffold tow */
+    if (LOCAL_PLAYER.ship.towed_scaffold >= 0) {
+        snprintf(label, label_size, "SCAFFOLD TOW");
+        snprintf(message, message_size, "Towing scaffold. [E] place, tap [Space] release.");
+        *r = 160; *g0 = 150; *b = 100;
         return true;
     }
 
-    /* Scaffold tow */
-    if (LOCAL_PLAYER.ship.towed_scaffold >= 0) {
-        label[0] = '\0';
-        snprintf(message, message_size, "Towing scaffold. [E] place, tap [Space] release.");
-        *r = 160; *g0 = 150; *b = 100;
+    hud_snapping_scaffold_t snap;
+    if (hud_find_snapping_scaffold(&snap)) {
+        snprintf(label, label_size, "SCAFFOLD SNAP");
+        snprintf(message, message_size,
+                 "%s snapping to %s ring %d slot %d. Supply starts when it locks.",
+                 module_type_name(snap.type),
+                 hud_station_short_name(snap.station_idx),
+                 snap.ring,
+                 snap.slot);
+        *r = 190; *g0 = 170; *b = 100;
+        return true;
+    }
+
+    hud_construction_need_t need;
+    if (hud_find_construction_need(&need)) {
+        snprintf(label, label_size, "SUPPLY NEED");
+        const char *station = hud_station_short_name(need.station_idx);
+        const char *mat = commodity_short_label(need.material);
+        if (need.held > 0) {
+            snprintf(message, message_size,
+                     "%s needs %d %s at %s. You carry %d; dock and press [S].",
+                     need.station_shell ? "Outpost scaffold" : module_type_name(need.type),
+                     need.needed, mat, station, need.held);
+        } else {
+            snprintf(message, message_size,
+                     "%s needs %d %s at %s. %s",
+                     need.station_shell ? "Outpost scaffold" : module_type_name(need.type),
+                     need.needed, mat, station,
+                     hud_material_source_hint(need.material));
+        }
+        *r = 205; *g0 = 165; *b = 90;
+        return true;
+    }
+
+    /* Onboarding */
+    if (onboarding_hint(label, label_size, message, message_size)) {
+        *r = 255; *g0 = 221; *b = 119;
         return true;
     }
 
@@ -1815,6 +2000,10 @@ enum {
     SMOKE_LOOP_STATE_TOWING = 4,
     SMOKE_LOOP_STATE_HAIL_READY = 5,
     SMOKE_LOOP_STATE_HAIL_NOTICE = 6,
+    SMOKE_LOOP_STATE_PLAN_GHOST = 7,
+    SMOKE_LOOP_STATE_PLAN_SLOT = 8,
+    SMOKE_LOOP_STATE_SCAFFOLD_SNAP = 9,
+    SMOKE_LOOP_STATE_SUPPLY_NEED = 10,
 };
 
 static void smoke_clear_loop_state(void) {
@@ -1851,6 +2040,16 @@ static void smoke_clear_loop_state(void) {
     g.hail_message[0] = '\0';
     g.hail_credits = 0.0f;
     g.hail_station_index = -1;
+    for (int i = 0; i < MAX_SCAFFOLDS; i++) {
+        g.world.scaffolds[i].active = false;
+    }
+    if (MAX_STATIONS > 3) {
+        station_t *ghost = &g.world.stations[3];
+        ghost->scaffold = false;
+        ghost->planned = false;
+        ghost->scaffold_progress = 1.0f;
+        ghost->name[0] = '\0';
+    }
 
     if (g.world.station_count > 0 && station_exists(&g.world.stations[0]))
         sp->ship.pos = g.world.stations[0].pos;
@@ -1895,6 +2094,40 @@ static int smoke_apply_loop_state(int state) {
         g.hail_credits = 123.0f;
         g.hail_timer = 6.0f;
         g.hail_station_index = 0;
+        return 1;
+    case SMOKE_LOOP_STATE_PLAN_GHOST:
+        g.plan_mode_active = true;
+        g.plan_target_station = -1;
+        g.placement_target_station = -1;
+        g.placement_target_ring = 1;
+        g.placement_target_slot = 2;
+        g.plan_type = MODULE_SIGNAL_RELAY;
+        return 1;
+    case SMOKE_LOOP_STATE_PLAN_SLOT:
+        g.plan_mode_active = true;
+        g.plan_target_station = 0;
+        g.placement_target_station = 0;
+        g.placement_target_ring = 1;
+        g.placement_target_slot = 0;
+        g.plan_type = MODULE_HOPPER;
+        return 1;
+    case SMOKE_LOOP_STATE_SCAFFOLD_SNAP:
+        if (MAX_STATIONS <= 3) return 0;
+        g.world.scaffolds[0].active = true;
+        g.world.scaffolds[0].state = SCAFFOLD_SNAPPING;
+        g.world.scaffolds[0].module_type = MODULE_FURNACE;
+        g.world.scaffolds[0].placed_station = 3;
+        g.world.scaffolds[0].placed_ring = 2;
+        g.world.scaffolds[0].placed_slot = 3;
+        g.world.scaffolds[0].pos = sp->ship.pos;
+        return 1;
+    case SMOKE_LOOP_STATE_SUPPLY_NEED:
+        if (MAX_STATIONS <= 3) return 0;
+        g.world.stations[3].pos = sp->ship.pos;
+        g.world.stations[3].scaffold = true;
+        g.world.stations[3].planned = false;
+        g.world.stations[3].scaffold_progress = 0.5f;
+        g.world.stations[3].dock_radius = OUTPOST_DOCK_RADIUS;
         return 1;
     default:
         return 0;

--- a/client/input.c
+++ b/client/input.c
@@ -627,15 +627,22 @@ static void sample_placement_tow(input_intent_t *intent) {
     reticle_target_t targets[RETICLE_MAX_TARGETS];
     int n = collect_reticle_targets(LOCAL_PLAYER.ship.pos, targets, RETICLE_MAX_TARGETS);
     intent->place_outpost = true;
+    const char *scaffold_name = "scaffold";
+    int sc_idx = LOCAL_PLAYER.ship.towed_scaffold;
+    if (sc_idx >= 0 && sc_idx < MAX_SCAFFOLDS && g.world.scaffolds[sc_idx].active)
+        scaffold_name = module_type_name(g.world.scaffolds[sc_idx].module_type);
     if (n > 0) {
         intent->place_target_station = (int8_t)targets[0].station;
         intent->place_target_ring = (int8_t)targets[0].ring;
         intent->place_target_slot = (int8_t)targets[0].slot;
+        set_notice("Placing %s at ring %d slot %d.",
+                   scaffold_name, targets[0].ring, targets[0].slot);
+    } else {
+        set_notice("Placing %s as an outpost seed.", scaffold_name);
     }
     /* No outpost in range falls through with all -1 sentinels — server
      * decides whether to materialize a nearby planned station or found
      * a new outpost from scratch. */
-    set_notice("Placing scaffold...");
 }
 
 /* Plan mode (real station target): pull reticle target every frame so
@@ -762,7 +769,8 @@ static void plan_mode_handle_ghost_lock(input_intent_t *intent) {
     /* Wait for the server to send back the created station, then switch
      * to real plan mode targeting it. */
     g.plan_mode_grace_until = g.world.time + 1.5f;
-    set_notice("Outpost planned at ring %d slot %d. R changes type; E places; B exits.",
+    set_notice("Outpost blueprint locked: %s ring %d slot %d. R changes type; E toggles slot; B exits.",
+               module_type_name((module_type_t)g.plan_type),
                g.placement_target_ring, g.placement_target_slot);
 }
 
@@ -786,7 +794,7 @@ static void plan_mode_handle_real_place(input_intent_t *intent) {
         intent->cancel_plan_st = (int8_t)ps;
         intent->cancel_plan_ring = (int8_t)pr;
         intent->cancel_plan_sl = (int8_t)psl;
-        set_notice("Cleared plan at ring %d slot %d. R changes type; E toggles slot; B exits.",
+        set_notice("Cleared reserved slot ring %d slot %d. R changes type; E toggles slot; B exits.",
                    pr, psl);
         return;
     }
@@ -795,7 +803,7 @@ static void plan_mode_handle_real_place(input_intent_t *intent) {
     intent->plan_ring = (int8_t)pr;
     intent->plan_slot = (int8_t)psl;
     intent->plan_type = (module_type_t)g.plan_type;
-    set_notice("Planned %s at ring %d slot %d. R changes type; E toggles slot; B exits.",
+    set_notice("Reserved %s at ring %d slot %d. R changes type; E toggles slot; B exits.",
                module_type_name((module_type_t)g.plan_type), pr, psl);
 }
 
@@ -848,7 +856,8 @@ static void sample_b_enter_plan(void) {
         g.placement_target_ring = targets[0].ring;
         g.placement_target_slot = targets[0].slot;
         g.plan_target_station = targets[0].station;
-        set_notice("Plan mode: ring %d slot %d. R changes type; E places; B exits.",
+        set_notice("Station plan: %s ring %d slot %d. R changes type; E toggles slot; B exits.",
+                   module_type_name((module_type_t)g.plan_type),
                    targets[0].ring, targets[0].slot);
     } else {
         g.plan_mode_active = true;
@@ -856,7 +865,9 @@ static void sample_b_enter_plan(void) {
         g.placement_target_station = -1;
         g.placement_target_ring = 1;
         g.placement_target_slot = 0;
-        set_notice("Plan mode: new outpost ghost. R changes type; E locks outpost; B exits.");
+        set_notice("Ghost preview: %s ring %d slot %d. R changes type; E locks outpost; B exits.",
+                   module_type_name((module_type_t)g.plan_type),
+                   g.placement_target_ring, g.placement_target_slot);
     }
 }
 

--- a/client/world_draw.c
+++ b/client/world_draw.c
@@ -3301,24 +3301,34 @@ void draw_placement_reticle(void) {
     /* Always draw existing plans on stations (active or planned) */
     draw_placement_plans();
 
-    /* Ghost preview: draw wireframe rings around the player's ship. */
+    /* Ghost preview: local-only, uncommitted. Keep it amber/washed-out so
+     * it does not read as the committed cyan planned-station blueprint. */
     if (g.plan_mode_active && g.plan_target_station == -1) {
         vec2 c = LOCAL_PLAYER.ship.pos;
         float pulse = 0.4f + 0.3f * sinf(g.world.time * 2.5f);
-        /* Ring 1 wireframe (dashed cyan, same style as planned stations) */
+        const float ghost_r = 0.78f;
+        const float ghost_g = 0.70f;
+        const float ghost_b = 0.48f;
+        /* Ring 1 wireframe: long amber ghost dashes. */
         float radius = STATION_RING_RADIUS[1];
-        int dashes = 32;
+        int dashes = 40;
         sgl_begin_lines();
-        sgl_c4f(0.4f, 0.85f, 1.0f, pulse * 0.6f);
-        for (int i = 0; i < dashes; i += 2) {
+        sgl_c4f(ghost_r, ghost_g, ghost_b, pulse * 0.55f);
+        for (int i = 0; i < dashes; i += 4) {
             float a0 = TWO_PI_F * (float)i / (float)dashes;
-            float a1 = TWO_PI_F * (float)(i + 1) / (float)dashes;
+            float a1 = TWO_PI_F * (float)(i + 2) / (float)dashes;
             sgl_v2f(c.x + cosf(a0) * radius, c.y + sinf(a0) * radius);
             sgl_v2f(c.x + cosf(a1) * radius, c.y + sinf(a1) * radius);
         }
         sgl_end();
-        /* Center marker */
-        draw_circle_outline(c, 6.0f, 12, 0.4f, 1.0f, 1.0f, pulse);
+        /* Center marker with a faint cancel-cross: this is preview state,
+         * not physical station state. */
+        draw_circle_outline(c, 8.0f, 12, ghost_r, ghost_g, ghost_b, pulse * 0.8f);
+        sgl_begin_lines();
+        sgl_c4f(ghost_r, ghost_g, ghost_b, pulse * 0.45f);
+        sgl_v2f(c.x - 16.0f, c.y - 16.0f); sgl_v2f(c.x + 16.0f, c.y + 16.0f);
+        sgl_v2f(c.x - 16.0f, c.y + 16.0f); sgl_v2f(c.x + 16.0f, c.y - 16.0f);
+        sgl_end();
         /* Slot dots around ring 1 — all slots shown as small circles */
         int slots_n = STATION_RING_SLOTS[1];
         for (int slot = 0; slot < slots_n; slot++) {
@@ -3333,8 +3343,8 @@ void draw_placement_reticle(void) {
                 draw_circle_outline(sp, 26.0f, 24, mr, mg, mb, ap * 0.7f);
                 draw_circle_filled(sp, 6.0f, 8, mr, mg, mb, ap);
             } else {
-                /* Green dot = empty slot available */
-                draw_circle_filled(sp, 4.0f, 8, 0.3f, 0.9f, 0.5f, pulse * 0.7f);
+                /* Muted amber dots = preview slots only, not reserved slots. */
+                draw_circle_filled(sp, 4.0f, 8, ghost_r, ghost_g, ghost_b, pulse * 0.55f);
             }
         }
     }

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -382,6 +382,10 @@ const smokeLoopState = {
   towing: 4,
   hailReady: 5,
   hailNotice: 6,
+  planGhost: 7,
+  planSlot: 8,
+  scaffoldSnap: 9,
+  supplyNeed: 10,
 } as const;
 
 const mobileFlag = {
@@ -569,6 +573,26 @@ test.describe('Browser smoke tests', () => {
 
     await setSmokeLoopState(page, smokeLoopState.hailNotice);
     expect(await hudHintText(page)).toContain('Prospect: channel open. Balance 123 cr.');
+
+    expectNoFatalErrors(logs);
+  });
+
+  test('exposes deterministic HUD copy for plan, snap, and construction supply states', async ({ page }) => {
+    const logs = installFatalCollectors(page);
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await loadGame(page, false, { singleplayer: true });
+
+    await setSmokeLoopState(page, smokeLoopState.planGhost);
+    expect(await hudHintText(page)).toContain('PLAN GHOST :: Signal Relay preview ring 1 slot 2');
+
+    await setSmokeLoopState(page, smokeLoopState.planSlot);
+    expect(await hudHintText(page)).toContain('PLAN SLOT :: Hopper at Prospect ring 1 slot 0');
+
+    await setSmokeLoopState(page, smokeLoopState.scaffoldSnap);
+    expect(await hudHintText(page)).toContain('SCAFFOLD SNAP :: Furnace snapping to Outpost 3 ring 2 slot 3');
+
+    await setSmokeLoopState(page, smokeLoopState.supplyNeed);
+    expect(await hudHintText(page)).toContain('SUPPLY NEED :: Outpost scaffold needs 30 frames at Outpost 3.');
 
     expectNoFatalErrors(logs);
   });


### PR DESCRIPTION
## Summary

- label plan mode as ghost preview vs reserved station slot, including module, ring, and slot
- give ghost previews a distinct amber visual treatment so they do not read as committed cyan blueprints
- surface scaffold snapping and construction supply needs ahead of generic onboarding hints
- pin deterministic browser-smoke coverage for plan, snap, and supply HUD copy

Closes #305

## Verification

- `cmake --build build --target signal signal_test signal_server`
- `./build/signal_test`
- `make smoke`
- `git diff --check`
