### PR TITLE
Harden ECS deploy stabilization

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -384,7 +384,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [test-basic, test-soak, test-static, build-client, build-server, native]
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
@@ -411,11 +411,21 @@ jobs:
       - name: Snapshot current server task definition
         id: snapshot-server
         run: |
-          CURRENT_TASK_DEF=$(aws ecs describe-services \
+          set -euo pipefail
+          SERVICE_JSON=$(aws ecs describe-services \
             --cluster default \
             --services signal-relay \
-            --query 'services[0].taskDefinition' \
-            --output text)
+            --output json)
+          CURRENT_TASK_DEF=$(
+            jq -r '
+              .services[0].deployments
+              | map(select(.rolloutState == "COMPLETED"))
+              | .[0].taskDefinition // empty
+            ' <<<"$SERVICE_JSON"
+          )
+          if [ -z "$CURRENT_TASK_DEF" ] || [ "$CURRENT_TASK_DEF" = "null" ]; then
+            CURRENT_TASK_DEF=$(jq -r '.services[0].taskDefinition' <<<"$SERVICE_JSON")
+          fi
           echo "task_def_arn=$CURRENT_TASK_DEF" >> "$GITHUB_OUTPUT"
 
       # --- Stage immutable client bundle first ---
@@ -444,6 +454,7 @@ jobs:
           sleep 30
 
       - name: Deploy server to ECS
+        id: deploy_server
         run: |
           set -euo pipefail
           IMAGE_REPO=022118847419.dkr.ecr.us-east-1.amazonaws.com/signal-relay
@@ -457,10 +468,36 @@ jobs:
               --output text |
             jq -r '.manifests[] | select(.platform.architecture == "arm64" and .platform.os == "linux") | .digest'
           )
+          TARGET_IMAGE="${IMAGE_REPO}@${ARM64_DIGEST}"
+          CURRENT_TASK_DEF="${{ steps.snapshot-server.outputs.task_def_arn }}"
           aws ecs describe-task-definition \
-            --task-definition signal-relay-server \
+            --task-definition "$CURRENT_TASK_DEF" \
             --query 'taskDefinition' > taskdef.json
-          jq --arg image "${IMAGE_REPO}@${ARM64_DIGEST}" '
+          CURRENT_IMAGE=$(jq -r '.containerDefinitions[0].image' taskdef.json)
+          SERVICE_JSON=$(aws ecs describe-services \
+            --cluster default \
+            --services signal-relay \
+            --output json)
+          DEPLOYMENT_COUNT=$(jq -r '.services[0].deployments | length' <<<"$SERVICE_JSON")
+          CURRENT_SERVICE_TASK_DEF=$(jq -r '.services[0].taskDefinition' <<<"$SERVICE_JSON")
+          if [ "$CURRENT_IMAGE" = "$TARGET_IMAGE" ]; then
+            if [ "$DEPLOYMENT_COUNT" = "1" ] && [ "$CURRENT_SERVICE_TASK_DEF" = "$CURRENT_TASK_DEF" ]; then
+              echo "Server already uses $TARGET_IMAGE and ECS is on the stable task definition; skipping ECS update."
+              echo "updated=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Server image is already $TARGET_IMAGE, but ECS has an in-progress deployment; returning to stable task definition $CURRENT_TASK_DEF."
+            aws ecs update-service \
+              --cluster default \
+              --service signal-relay \
+              --health-check-grace-period-seconds 180 \
+              --deployment-configuration 'maximumPercent=200,minimumHealthyPercent=100,deploymentCircuitBreaker={enable=true,rollback=true}' \
+              --task-definition "$CURRENT_TASK_DEF"
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+            echo "task_def_arn=$CURRENT_TASK_DEF" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          jq --arg image "$TARGET_IMAGE" '
             def upsert_env($name; $value):
               .containerDefinitions[0].environment =
                 ((.containerDefinitions[0].environment // [])
@@ -490,12 +527,88 @@ jobs:
           aws ecs update-service \
             --cluster default \
             --service signal-relay \
+            --health-check-grace-period-seconds 180 \
+            --deployment-configuration 'maximumPercent=200,minimumHealthyPercent=100,deploymentCircuitBreaker={enable=true,rollback=true}' \
             --task-definition "$TASK_DEF_ARN"
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+          echo "task_def_arn=$TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
 
       - name: Wait for ECS stabilization
+        id: ecs_stabilization
+        continue-on-error: true
         run: |
+          set -euo pipefail
           echo "Waiting for new server task to be running..."
-          aws ecs wait services-stable --cluster default --services signal-relay
+          for attempt in $(seq 1 100); do
+            SERVICE_JSON=$(aws ecs describe-services \
+              --cluster default \
+              --services signal-relay \
+              --output json)
+            jq -r '
+              .services[0] as $svc |
+              "attempt '"$attempt"': desired=\($svc.desiredCount) running=\($svc.runningCount) pending=\($svc.pendingCount) deployments=\($svc.deployments | length)",
+              ($svc.deployments[] |
+                "  \(.status) \(.rolloutState // "UNKNOWN") desired=\(.desiredCount) running=\(.runningCount) pending=\(.pendingCount) failed=\(.failedTasks // 0) \(.taskDefinition)")
+            ' <<<"$SERVICE_JSON"
+            if jq -e '
+              .services[0] as $svc |
+              ($svc.deployments | length == 1) and
+              ($svc.deployments[0].rolloutState == "COMPLETED" or ($svc.deployments[0].rolloutState // "") == "") and
+              ($svc.runningCount == $svc.desiredCount) and
+              ($svc.pendingCount == 0)
+            ' <<<"$SERVICE_JSON" >/dev/null; then
+              echo "ECS service is stable."
+              exit 0
+            fi
+            if jq -e '.services[0].deployments[] | select((.rolloutState // "") == "FAILED")' <<<"$SERVICE_JSON" >/dev/null; then
+              echo "::error::ECS deployment entered FAILED rollout state"
+              exit 1
+            fi
+            sleep 15
+          done
+          aws ecs describe-services \
+            --cluster default \
+            --services signal-relay \
+            --query 'services[0].events[0:10].message' \
+            --output text
+          echo "::error::ECS service did not stabilize within 25 minutes"
+          exit 1
+
+      - name: Rollback server after stabilization failure
+        if: steps.ecs_stabilization.outcome == 'failure'
+        run: |
+          set -euo pipefail
+          echo "::error::ECS stabilization failed — rolling back server to previous stable task definition"
+          aws ecs update-service \
+            --cluster default \
+            --service signal-relay \
+            --health-check-grace-period-seconds 180 \
+            --deployment-configuration 'maximumPercent=200,minimumHealthyPercent=100,deploymentCircuitBreaker={enable=true,rollback=true}' \
+            --task-definition "${{ steps.snapshot-server.outputs.task_def_arn }}"
+          for attempt in $(seq 1 80); do
+            SERVICE_JSON=$(aws ecs describe-services \
+              --cluster default \
+              --services signal-relay \
+              --output json)
+            jq -r '
+              .services[0] as $svc |
+              "rollback attempt '"$attempt"': desired=\($svc.desiredCount) running=\($svc.runningCount) pending=\($svc.pendingCount) deployments=\($svc.deployments | length)",
+              ($svc.deployments[] |
+                "  \(.status) \(.rolloutState // "UNKNOWN") desired=\(.desiredCount) running=\(.runningCount) pending=\(.pendingCount) failed=\(.failedTasks // 0) \(.taskDefinition)")
+            ' <<<"$SERVICE_JSON"
+            if jq -e '
+              .services[0] as $svc |
+              ($svc.deployments | length == 1) and
+              ($svc.runningCount == $svc.desiredCount) and
+              ($svc.pendingCount == 0)
+            ' <<<"$SERVICE_JSON" >/dev/null; then
+              echo "Rollback service is stable."
+              exit 1
+            fi
+            sleep 15
+          done
+          echo "::error::Rollback did not stabilize within 20 minutes"
+          exit 1
 
       # --- Smoke test staged server against the already-published pinned bundle ---
       - name: Setup Node.js
@@ -527,6 +640,8 @@ jobs:
           aws ecs update-service \
             --cluster default \
             --service signal-relay \
+            --health-check-grace-period-seconds 180 \
+            --deployment-configuration 'maximumPercent=200,minimumHealthyPercent=100,deploymentCircuitBreaker={enable=true,rollback=true}' \
             --task-definition "${{ steps.snapshot-server.outputs.task_def_arn }}"
           aws ecs wait services-stable --cluster default --services signal-relay
 

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -501,6 +501,8 @@ async function driveCoreControls(page: Page, canvas: Locator): Promise<void> {
 }
 
 test.describe('Browser smoke tests', () => {
+  const rootBundleSmokeTest = process.env.SIGNAL_PRE_PROMOTION_SMOKE === '1' ? test.skip : test;
+
   test('boots, renders, and persists browser identity across reload', async ({ page }) => {
     const logs = installFatalCollectors(page);
 
@@ -551,7 +553,7 @@ test.describe('Browser smoke tests', () => {
     expectNoFatalErrors(logs, { allowExpectedLiveClose: true });
   });
 
-  test('exposes deterministic HUD copy for fragment, tractor, tow, and hail states', async ({ page }) => {
+  rootBundleSmokeTest('exposes deterministic HUD copy for fragment, tractor, tow, and hail states', async ({ page }) => {
     const logs = installFatalCollectors(page);
     await page.setViewportSize({ width: 1280, height: 720 });
     await loadGame(page, false, { singleplayer: true });
@@ -577,7 +579,7 @@ test.describe('Browser smoke tests', () => {
     expectNoFatalErrors(logs);
   });
 
-  test('exposes deterministic HUD copy for plan, snap, and construction supply states', async ({ page }) => {
+  rootBundleSmokeTest('exposes deterministic HUD copy for plan, snap, and construction supply states', async ({ page }) => {
     const logs = installFatalCollectors(page);
     await page.setViewportSize({ width: 1280, height: 720 });
     await loadGame(page, false, { singleplayer: true });
@@ -624,8 +626,7 @@ test.describe('Browser smoke tests', () => {
     expectNoFatalErrors(logs, { allowExpectedLiveClose: true });
   });
 
-  const touchControlsTest = process.env.SIGNAL_PRE_PROMOTION_SMOKE === '1' ? test.skip : test;
-  touchControlsTest('touch controls expose only contextual mobile actions', async ({ page }) => {
+  rootBundleSmokeTest('touch controls expose only contextual mobile actions', async ({ page }) => {
     const logs = installFatalCollectors(page);
     await page.setViewportSize({ width: 390, height: 760 });
     await page.goto(addQueryParam(smokeUrl({ singleplayer: true }), 'touch', '1'));


### PR DESCRIPTION
## Summary
- set ECS health-check grace and circuit-breaker rollback on server deploy and rollback updates
- make ECS deploy idempotent when the target image digest is already running, and replace the blind service waiter with verbose stabilization plus rollback
- skip root-bundle-only browser smoke tests during pre-promotion smoke; full root smoke still runs after promotion

## Verification
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml")'
- SIGNAL_PRE_PROMOTION_SMOKE=1 SMOKE_URL=https://signal.ratimics.com/play/ npx playwright test: 3 passed, 4 skipped
- SMOKE_URL=https://signal.ratimics.com/play/ npx playwright test: 6 passed, 1 skipped
- post-commit local test: 630 passed
- live ECS recovered: desired/running 1/1, task definition 745, health-check grace 180s, circuit breaker rollback enabled, /health 200 on 5d41f87