### PR TITLE
[codex] Gate latency smoke tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -338,6 +338,38 @@ jobs:
           name: client-site
           path: _site/
 
+  # Multiplayer latency smoke: exercises the browser client through the local
+  # websocket latency proxy in both high-latency and low-ping/high-ack modes.
+  # The regular browser smoke intentionally skips these cases unless a proxy is
+  # already running; this job owns that orchestration so PRs cannot regress the
+  # correction/ack telemetry path silently.
+  test-latency-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Install Emscripten
+        uses: mymindstorm/setup-emsdk@v16
+        with:
+          version: 4.0.8
+
+      - name: Install native build dependencies
+        run: sudo apt-get update && sudo apt-get install -y libgl-dev libx11-dev libxi-dev libxcursor-dev libasound2-dev
+
+      - name: Install test dependencies
+        run: |
+          npm install
+          npx playwright install chromium --with-deps
+
+      - name: Run latency smoke suite
+        run: PATH="/usr/local/bin:/usr/bin:$PATH" make smoke-latency-suite
+
   # Server Docker build — gated on test-basic so we don't push a
   # broken image to ECR (real cost: ECR storage + ECS rollover risk).
   # Multi-arch QEMU build is the longest pole at ~5 min on its own.
@@ -386,7 +418,7 @@ jobs:
   # diagnostics such as CRAP and sanitizers run after promotion on main.
   deploy:
     runs-on: ubuntu-latest
-    needs: [test-basic, test-soak, test-static, build-client, build-server, native]
+    needs: [test-basic, test-soak, test-static, build-client, test-latency-smoke, build-server, native]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-web build-server build-test build-flight-trace flight-trace build-signal-replay signal-replay build-chain-assets chain-assets neural-gap-ab assets protocol-check test test-serial test-fast test-soak test-all smoke smoke-latency smoke-ack-lag cppcheck crap profile-machine latency-proxy latency-proxy-high latency-proxy-ack-lag dev dev-logs dev-clean stop deploy clean install-hooks
+.PHONY: all build build-web build-server build-test build-flight-trace flight-trace build-signal-replay signal-replay build-chain-assets chain-assets neural-gap-ab assets protocol-check test test-serial test-fast test-soak test-all smoke smoke-latency smoke-ack-lag smoke-latency-suite cppcheck crap profile-machine latency-proxy latency-proxy-high latency-proxy-ack-lag dev dev-logs dev-clean stop deploy clean install-hooks
 
 all: build build-web build-server
 
@@ -251,6 +251,9 @@ smoke-latency:
 
 smoke-ack-lag:
 	SMOKE_URL="$(SMOKE_LATENCY_URL)" SMOKE_ACK_LAG_ASSERT=1 npx playwright test tests/browser-smoke.spec.ts --project=chromium --grep "low-ping high-ack"
+
+smoke-latency-suite: build-web build-server
+	node scripts/smoke-latency-suite.mjs
 
 # --- CRAP (Change Risk Anti-Patterns): complexity * (1 - coverage) ---
 # Rebuilds signal_test with --coverage, runs the fast/non-soak tests,

--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ client-side correction metrics with:
 make smoke-latency
 ```
 
+For a self-contained local run that builds the client/server, starts an
+ephemeral relay, launches both latency proxy modes, and runs both Playwright
+latency assertions:
+
+```sh
+make smoke-latency-suite
+```
+
 The latency smoke reads wasm telemetry for ping RTT, authoritative ack age,
 ack-minus-ping gap, player-state cadence, correction mode counts, replay depth,
 tick skew, unacked inputs, and render-offset bounds.
@@ -222,6 +230,7 @@ make test-soak              # long-running sim/contract/autopilot cases
 make test-all               # fast + soak suites
 make test-serial            # single-process fast suite for debugging
 make smoke                  # build wasm and run Playwright browser smoke
+make smoke-latency-suite    # build, launch local relay/proxies, run latency smokes
 ```
 
 Or invoke the binary directly:

--- a/client/net.h
+++ b/client/net.h
@@ -2,8 +2,8 @@
  * net.h — Multiplayer networking layer for Signal Space Miner.
  *
  * Provides WebSocket-based connectivity to the relay server.
- * Uses emscripten WebSocket API for WASM builds; native builds
- * are stubbed with a TODO for future POSIX implementation.
+ * Uses emscripten WebSocket API for WASM builds and mongoose's
+ * WebSocket client for native builds.
  *
  * Binary protocol (little-endian):
  *   JOIN  (0x01): 1 type + 1 player_id

--- a/scripts/smoke-latency-suite.mjs
+++ b/scripts/smoke-latency-suite.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const isWindows = process.platform === 'win32';
+const signalServerBin = path.join(repoRoot, 'build', isWindows ? 'signal_server.exe' : 'signal_server');
+const npxBin = isWindows ? 'npx.cmd' : 'npx';
+
+const children = [];
+const tempDirs = [];
+let cleaningUp = false;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function appendTail(current, chunk, max = 24000) {
+  const next = current + chunk.toString('utf8');
+  return next.length > max ? next.slice(next.length - max) : next;
+}
+
+function log(message) {
+  console.log(`[smoke-latency-suite] ${message}`);
+}
+
+async function freePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address !== 'object') {
+        server.close();
+        reject(new Error('could not allocate a local port'));
+        return;
+      }
+      const { port } = address;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+function startBackground(name, command, args, options = {}) {
+  const child = spawn(command, args, {
+    cwd: repoRoot,
+    env: { ...process.env, ...(options.env || {}) },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const proc = {
+    name,
+    child,
+    stdout: '',
+    stderr: '',
+    exited: false,
+    code: null,
+    signal: null,
+    done: null,
+  };
+  proc.done = new Promise((resolve) => {
+    child.once('exit', (code, signal) => {
+      proc.exited = true;
+      proc.code = code;
+      proc.signal = signal;
+      resolve({ code, signal });
+    });
+  });
+  child.stdout.on('data', (chunk) => {
+    proc.stdout = appendTail(proc.stdout, chunk);
+  });
+  child.stderr.on('data', (chunk) => {
+    proc.stderr = appendTail(proc.stderr, chunk);
+  });
+  child.once('error', (err) => {
+    proc.exited = true;
+    proc.stderr = appendTail(proc.stderr, `${err.message}\n`);
+  });
+  children.push(proc);
+  return proc;
+}
+
+function processTail(proc) {
+  return [
+    proc.stdout.trim() ? `--- ${proc.name} stdout ---\n${proc.stdout.trim()}` : '',
+    proc.stderr.trim() ? `--- ${proc.name} stderr ---\n${proc.stderr.trim()}` : '',
+  ].filter(Boolean).join('\n');
+}
+
+function assertAlive(proc) {
+  if (!proc.exited) return;
+  const code = proc.signal ? proc.signal : proc.code;
+  throw new Error(`${proc.name} exited early (${code})\n${processTail(proc)}`);
+}
+
+async function stopProcess(proc) {
+  if (!proc || proc.exited) return;
+  proc.child.kill('SIGTERM');
+  const timeout = sleep(3000).then(() => 'timeout');
+  const result = await Promise.race([proc.done, timeout]);
+  if (result === 'timeout' && !proc.exited) {
+    proc.child.kill('SIGKILL');
+    await proc.done;
+  }
+}
+
+async function cleanup() {
+  if (cleaningUp) return;
+  cleaningUp = true;
+  for (const proc of [...children].reverse()) {
+    await stopProcess(proc);
+  }
+  for (const dir of tempDirs.reverse()) {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function withCleanup(fn) {
+  const abort = async () => {
+    await cleanup();
+    process.exit(130);
+  };
+  process.once('SIGINT', abort);
+  process.once('SIGTERM', abort);
+  try {
+    return await fn();
+  } finally {
+    process.removeListener('SIGINT', abort);
+    process.removeListener('SIGTERM', abort);
+    await cleanup();
+  }
+}
+
+function httpStatus(url) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, (res) => {
+      res.resume();
+      res.on('end', () => resolve(res.statusCode || 0));
+    });
+    req.setTimeout(1000, () => {
+      req.destroy(new Error(`timeout waiting for ${url}`));
+    });
+    req.once('error', reject);
+  });
+}
+
+async function waitForHttp(url, label, backgroundProcs, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = '';
+  while (Date.now() < deadline) {
+    for (const proc of backgroundProcs) assertAlive(proc);
+    try {
+      const status = await httpStatus(url);
+      if (status >= 200 && status < 500) return;
+      lastError = `HTTP ${status}`;
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+    await sleep(250);
+  }
+  throw new Error(`${label} did not become ready at ${url}: ${lastError}`);
+}
+
+async function waitForProxy(proc, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    assertAlive(proc);
+    const match = proc.stderr.match(/listening ws:\/\/[^:]+:(\d+)\//);
+    if (match) return Number(match[1]);
+    await sleep(50);
+  }
+  throw new Error(`latency proxy did not start\n${processTail(proc)}`);
+}
+
+async function runForeground(name, command, args, env) {
+  log(name);
+  const child = spawn(command, args, {
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+    stdio: 'inherit',
+  });
+  const { code, signal, error } = await new Promise((resolve) => {
+    child.once('error', (err) => {
+      resolve({ code: null, signal: null, error: err });
+    });
+    child.once('exit', (exitCode, exitSignal) => {
+      resolve({ code: exitCode, signal: exitSignal, error: null });
+    });
+  });
+  if (error) {
+    throw new Error(`${name} failed to start: ${error.message}`);
+  }
+  if (code !== 0) {
+    throw new Error(`${name} failed (${signal || code})`);
+  }
+}
+
+async function runLatencyCase({
+  name,
+  grep,
+  envFlag,
+  httpPort,
+  serverPort,
+  proxyArgs,
+}) {
+  const proxy = startBackground(name, process.execPath, [
+    'scripts/ws-latency-proxy.mjs',
+    '--listen=127.0.0.1:0',
+    `--upstream=ws://127.0.0.1:${serverPort}/ws`,
+    ...proxyArgs,
+  ]);
+  const proxyPort = await waitForProxy(proxy);
+  const smokeUrl =
+    `http://127.0.0.1:${httpPort}/play.html?server=ws://127.0.0.1:${proxyPort}/ws`;
+
+  try {
+    await runForeground(`running ${name}`, npxBin, [
+      'playwright',
+      'test',
+      'tests/browser-smoke.spec.ts',
+      '--project=chromium',
+      '--grep',
+      grep,
+    ], {
+      SMOKE_URL: smokeUrl,
+      [envFlag]: '1',
+    });
+  } finally {
+    await stopProcess(proxy);
+  }
+}
+
+await withCleanup(async () => {
+  const serverPort = await freePort();
+  const httpPort = await freePort();
+  const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'signal-latency-smoke-'));
+  tempDirs.push(dataDir);
+
+  log(`starting signal_server on :${serverPort}`);
+  const server = startBackground('signal_server', signalServerBin, [], {
+    env: {
+      PORT: String(serverPort),
+      SIGNAL_PERSISTENCE_MODE: 'ephemeral',
+      SIGNAL_DATA_DIR: dataDir,
+      SIGNAL_WORLD_SEED: '2037',
+      SIGNAL_WORLD_SEQ: '1',
+    },
+  });
+  await waitForHttp(`http://127.0.0.1:${serverPort}/health`, 'signal_server', [server], 30000);
+
+  log(`starting static build-web server on :${httpPort}`);
+  const staticServer = startBackground('static-http', 'python3', [
+    '-m',
+    'http.server',
+    String(httpPort),
+    '--bind',
+    '127.0.0.1',
+    '--directory',
+    path.join(repoRoot, 'build-web'),
+  ]);
+  await waitForHttp(`http://127.0.0.1:${httpPort}/play.html`, 'static server', [server, staticServer], 10000);
+
+  await runLatencyCase({
+    name: 'high-latency proxy smoke',
+    grep: 'high-latency',
+    envFlag: 'SMOKE_LATENCY_ASSERT',
+    httpPort,
+    serverPort,
+    proxyArgs: [
+      '--client-ms=450',
+      '--server-ms=450',
+      '--jitter-ms=150',
+    ],
+  });
+
+  await runLatencyCase({
+    name: 'low-ping high-ack proxy smoke',
+    grep: 'low-ping high-ack',
+    envFlag: 'SMOKE_ACK_LAG_ASSERT',
+    httpPort,
+    serverPort,
+    proxyArgs: [
+      '--client-ms=20',
+      '--server-ms=20',
+      '--server-world-players-ms=550',
+      '--jitter-ms=10',
+    ],
+  });
+
+  log('latency proxy browser smokes passed');
+});


### PR DESCRIPTION
## Summary

- add a self-contained latency smoke suite that starts an ephemeral local relay, static web server, and both websocket latency proxy modes
- wire the suite into `make smoke-latency-suite` and the Build & Deploy workflow as `test-latency-smoke`
- document the new gate and fix the stale native networking comment

## Why

The default browser smoke skipped the high-latency and low-ping/high-ack assertions unless a proxy was already running. This makes those assertions a normal local and CI gate so multiplayer correction and ack telemetry regressions cannot slip through silently.

## Validation

- `make smoke-latency-suite`
- `make test`
- `npm run test:latency-proxy`
- `node --check scripts/smoke-latency-suite.mjs`
- `git diff --check`
- YAML parse check for `.github/workflows/deploy.yml`
- post-commit fast test: 690 passed, 0 failed
