### PR TITLE
[codex] Harden C safety gates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,6 +153,9 @@ jobs:
       - name: Install analysis tools
         run: sudo apt-get update && sudo apt-get install -y cppcheck clang-tools clang-tidy
 
+      - name: banned APIs
+        run: make banned-apis
+
       - name: cppcheck
         run: make cppcheck
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-web build-server build-test build-flight-trace flight-trace build-signal-replay signal-replay build-chain-assets chain-assets neural-gap-ab assets protocol-check test test-serial test-fast test-soak test-all smoke smoke-latency smoke-ack-lag smoke-latency-suite cppcheck crap profile-machine latency-proxy latency-proxy-high latency-proxy-ack-lag dev dev-logs dev-clean stop deploy clean install-hooks
+.PHONY: all build build-web build-server build-test build-san test-san test-tsan build-flight-trace flight-trace build-signal-replay signal-replay build-chain-assets chain-assets neural-gap-ab assets protocol-check test test-serial test-fast test-soak test-all smoke smoke-latency smoke-ack-lag smoke-latency-suite banned-apis cppcheck crap profile-machine latency-proxy latency-proxy-high latency-proxy-ack-lag dev dev-logs dev-clean stop deploy clean install-hooks
 
 all: build build-web build-server
 
@@ -215,6 +215,36 @@ test-all: build-test
 
 test-serial: build-test
 	./build/signal_test --no-soak $(TEST_QUIET)
+
+SANITIZER ?= address,undefined
+SAN_BUILD_DIR ?= build-san
+SAN_TEST_FLAGS ?= --quiet --no-soak
+
+build-san:
+	cmake $(GENERATOR) -S . -B $(SAN_BUILD_DIR) -DCMAKE_BUILD_TYPE=Debug \
+		-DBUILD_TESTS_ONLY=ON -DGIT_HASH=$(GIT_HASH) \
+		-DCMAKE_C_FLAGS="-O1 -g -fsanitize=$(SANITIZER) -fno-omit-frame-pointer" \
+		-DCMAKE_EXE_LINKER_FLAGS="-fsanitize=$(SANITIZER)"
+	@ln -sf $(SAN_BUILD_DIR)/compile_commands.json compile_commands.json
+	cmake --build $(SAN_BUILD_DIR) --parallel
+
+test-san: build-san
+	ulimit -s 16384 && ASAN_OPTIONS=halt_on_error=1 \
+		UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+		./$(SAN_BUILD_DIR)/signal_test $(SAN_TEST_FLAGS)
+
+test-tsan:
+	cmake $(GENERATOR) -S . -B build-tsan -DCMAKE_BUILD_TYPE=Debug \
+		-DBUILD_TESTS_ONLY=ON -DGIT_HASH=$(GIT_HASH) \
+		-DCMAKE_C_FLAGS="-O1 -g -fsanitize=thread -fno-omit-frame-pointer" \
+		-DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread"
+	@ln -sf build-tsan/compile_commands.json compile_commands.json
+	cmake --build build-tsan --parallel
+	ulimit -s 16384 && TSAN_OPTIONS=halt_on_error=1 \
+		./build-tsan/signal_test $(SAN_TEST_FLAGS)
+
+banned-apis:
+	python3 scripts/check_banned_apis.py
 
 # Static analysis for owned C sources. Avoid --project=compile_commands.json
 # here: it pulls in test fixtures and single-header vendor libraries whose

--- a/client/client.h
+++ b/client/client.h
@@ -30,6 +30,21 @@ static inline void client_session_pseudo_pubkey(const uint8_t token[8], uint8_t 
     if (token) memcpy(out, token, 8);
 }
 
+static inline float client_death_spin_dir(uint32_t seed) {
+    seed ^= seed >> 16;
+    seed *= 0x7FEB352Du;
+    seed ^= seed >> 15;
+    seed *= 0x846CA68Bu;
+    seed ^= seed >> 16;
+    return (seed & 1u) ? 1.0f : -1.0f;
+}
+
+static inline uint32_t client_death_spin_float_bits(float value) {
+    uint32_t bits = 0;
+    memcpy(&bits, &value, sizeof(bits));
+    return bits;
+}
+
 /* Sokol headers (declarations only -- SOKOL_IMPL is in main.c) */
 #include "sokol_app.h"
 #include "sokol_gfx.h"

--- a/client/main.c
+++ b/client/main.c
@@ -653,7 +653,11 @@ static void death_cinematic_spawn(const sim_event_t *ev) {
     float impact_speed = sqrtf(ev->death.vel_x * ev->death.vel_x +
                                ev->death.vel_y * ev->death.vel_y);
     float severity = clampf(impact_speed / 260.0f, 0.8f, 2.4f);
-    float spin_dir = ((rand() & 1) != 0) ? 1.0f : -1.0f;
+    uint32_t spin_seed = ((uint32_t)ev->death.respawn_station << 24) ^
+                         ((uint32_t)ev->death.cause << 16) ^
+                         ((uint32_t)ev->death.killer_token[0] << 8) ^
+                         client_death_spin_float_bits(impact_speed);
+    float spin_dir = client_death_spin_dir(spin_seed);
     g.death_cinematic.active = true;
     g.death_cinematic.phase = 0;
     g.death_cinematic.pos = v2(ev->death.pos_x, ev->death.pos_y);

--- a/client/motd_json.h
+++ b/client/motd_json.h
@@ -39,10 +39,13 @@
 
 #include "avatar.h"
 
+#include <errno.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 /* Default band layout if the JSON omits the "bands" object or fails to
@@ -242,6 +245,57 @@ static inline bool motd_json_find_key(const char **p, const char *end,
     return false;
 }
 
+static inline bool motd_json_copy_number(const char **p, const char *end,
+                                         char *buf, size_t cap) {
+    const char *q = motd_json_skip_ws(*p, end);
+    const char *start = q;
+    if (q < end && (*q == '-' || *q == '+')) q++;
+    while (q < end && *q >= '0' && *q <= '9') q++;
+    if (q < end && *q == '.') {
+        q++;
+        while (q < end && *q >= '0' && *q <= '9') q++;
+    }
+    if (q < end && (*q == 'e' || *q == 'E')) {
+        const char *exp = q++;
+        if (q < end && (*q == '-' || *q == '+')) q++;
+        const char *digits = q;
+        while (q < end && *q >= '0' && *q <= '9') q++;
+        if (digits == q) q = exp;
+    }
+    size_t len = (size_t)(q - start);
+    if (len == 0 || len >= cap) return false;
+    memcpy(buf, start, len);
+    buf[len] = '\0';
+    *p = q;
+    return true;
+}
+
+static inline bool motd_json_parse_float(const char **p, const char *end,
+                                         float *out) {
+    char buf[48];
+    char *tail = NULL;
+    if (!motd_json_copy_number(p, end, buf, sizeof(buf))) return false;
+    errno = 0;
+    float v = strtof(buf, &tail);
+    if (errno != 0 || tail == buf || *tail != '\0') return false;
+    *out = v;
+    return true;
+}
+
+static inline bool motd_json_parse_uint(const char **p, const char *end,
+                                        unsigned *out) {
+    char buf[32];
+    char *tail = NULL;
+    if (!motd_json_copy_number(p, end, buf, sizeof(buf))) return false;
+    if (buf[0] == '-' || buf[0] == '+') return false;
+    errno = 0;
+    unsigned long v = strtoul(buf, &tail, 10);
+    if (errno != 0 || tail == buf || *tail != '\0') return false;
+    if (v > UINT_MAX) return false;
+    *out = (unsigned)v;
+    return true;
+}
+
 /* Parse the MOTD JSON document into the avatar cache entry. Returns
  * true on success (all 4 tier strings extracted). On failure,
  * tier text is left zeroed and bands are set to MOTD_DEFAULT_BANDS.
@@ -284,13 +338,20 @@ static inline bool motd_parse(avatar_cache_t *entry, const char *json,
                 const char *tier = bands;
                 if (!motd_json_find_key(&tier, end, MOTD_TIER_NAMES[i])) continue;
                 if (tier >= end || *tier != '[') continue;
-                /* Two floats inside [ ... ]. sscanf handles whitespace
-                 * and signed/decimal forms; we don't care about
-                 * trailing junk beyond the second number. */
+                /* Two floats inside [ ... ]. Keep parsing length-bounded;
+                 * this header is used on fetched network data. */
                 float lo = 0.0f, hi = 0.0f;
-                if (sscanf(tier + 1, " %f , %f", &lo, &hi) == 2) {
-                    entry->tiers[i].band_min = lo;
-                    entry->tiers[i].band_max = hi;
+                const char *num = tier + 1;
+                if (motd_json_parse_float(&num, end, &lo)) {
+                    num = motd_json_skip_ws(num, end);
+                    if (num < end && *num == ',') {
+                        const char *after_comma = num + 1;
+                        if (!motd_json_parse_float(&after_comma, end, &hi)) continue;
+                        after_comma = motd_json_skip_ws(after_comma, end);
+                        if (after_comma >= end || *after_comma != ']') continue;
+                        entry->tiers[i].band_min = lo;
+                        entry->tiers[i].band_max = hi;
+                    }
                 }
             }
         }
@@ -301,12 +362,12 @@ static inline bool motd_parse(avatar_cache_t *entry, const char *json,
         const char *gen = p;
         if (motd_json_find_key(&gen, end, "generated_at")) {
             unsigned u = 0;
-            if (sscanf(gen, "%u", &u) == 1) entry->generated_at = u;
+            if (motd_json_parse_uint(&gen, end, &u)) entry->generated_at = u;
         }
         const char *seed = p;
         if (motd_json_find_key(&seed, end, "seed")) {
             unsigned u = 0;
-            if (sscanf(seed, "%u", &u) == 1) entry->seed = u;
+            if (motd_json_parse_uint(&seed, end, &u)) entry->seed = u;
         }
     }
 

--- a/client/net_sync.c
+++ b/client/net_sync.c
@@ -2,7 +2,6 @@
  * net_sync.c -- Multiplayer network state synchronization for the
  * Signal Space Miner client.
  */
-#include <stdlib.h>  /* rand, RAND_MAX */
 #include "net_sync.h"
 #include "input.h"   /* set_notice() */
 #include "manifest.h"
@@ -1400,7 +1399,11 @@ void on_remote_death(uint8_t player_id, float pos_x, float pos_y,
     net_replay_reset();
     float impact_speed = sqrtf(vel_x * vel_x + vel_y * vel_y);
     float severity = clampf(impact_speed / 260.0f, 0.8f, 2.4f);
-    float spin_dir = ((rand() & 1) != 0) ? 1.0f : -1.0f;
+    uint32_t spin_seed = ((uint32_t)player_id << 24) ^
+                         ((uint32_t)respawn_station << 16) ^
+                         ((uint32_t)asteroids_fractured << 1) ^
+                         client_death_spin_float_bits(impact_speed);
+    float spin_dir = client_death_spin_dir(spin_seed);
     g.death_ore_mined = ore_mined;
     g.death_credits_earned = credits_earned;
     g.death_credits_spent = credits_spent;

--- a/docs/c_safety_policy.md
+++ b/docs/c_safety_policy.md
@@ -1,0 +1,78 @@
+# Signal C Safety Policy
+
+Signal remains a C project, so memory safety is enforced by project mechanics:
+strict builds, length-carrying data at boundaries, explicit ownership, bounded
+parsing, sanitizer runs, static analysis, and review rules.
+
+## Current Gates
+
+- Normal C targets compile with `-Wall -Wextra -Wpedantic -Werror`.
+- Linux, macOS, and Windows native builds run in GitHub Actions.
+- `make test` rebuilds and runs fast `signal_test` shards.
+- `make test-soak` runs the long-horizon sim tests.
+- `make test-san` runs `signal_test` with ASan+UBSan locally.
+- `make test-tsan` is available for threaded changes.
+- `make banned-apis` fails on banned libc calls in owned C source.
+- `make cppcheck`, scan-build, and clang-tidy run in CI static analysis.
+- Nightly Valgrind checks run against the non-soak test suite.
+
+## Banned APIs
+
+Owned source must not introduce:
+
+`gets`, `strcpy`, `strcat`, `sprintf`, `vsprintf`, `scanf`, `sscanf`, `fscanf`,
+`strncpy`, `strncat`, `atoi`, `atol`, `atoll`, `rand`, `tmpnam`, `mktemp`.
+
+Use `snprintf` with checked return values, `memcpy` only after a visible length
+check, `strtol`/`strtof` with full-tail validation, and `shared/rng.h` or an
+explicit deterministic generator for random behavior.
+
+Vendored sources are excluded from the banned API gate. Do not weaken the
+project gate to accommodate vendor code.
+
+## Pointers And Ownership
+
+- Pointer parameters are non-null unless the name says `maybe_` or `optional_`.
+- Returned or stored pointers need an ownership comment in public headers.
+- Functions must not retain borrowed pointers unless documented.
+- Pointer arithmetic belongs only in low-level serialization, parsing, or
+geometry modules where bounds are visible.
+- Free functions should null caller-owned pointers when practical.
+
+## Buffers And Strings
+
+- New public APIs should pass a length-carrying type from `shared/safe_types.h`
+or an explicit pointer plus length/capacity pair.
+- No write may occur unless the destination capacity is known in the same
+scope or encoded in the target type.
+- C strings are boundary data. Internal parsing and protocol paths should carry
+lengths and add a NUL only when calling C-string APIs.
+- `memcpy` and `memmove` are allowed for fixed-width protocol fields and
+validated slices; reviewers should be able to see the bound.
+
+## Integer Safety
+
+- Allocation size calculations must use checked arithmetic.
+- Sizes, indexes, and capacities should use unsigned size types unless the
+wire/save format requires otherwise.
+- Signed/unsigned conversions and truncating casts need a visible range check
+or a comment explaining the wire-format cap.
+
+## Error Paths
+
+- Resource-owning functions should use one cleanup path.
+- Functions that can fail should return `bool`, status enum, or a count with a
+documented sentinel.
+- Out-parameters are initialized only on success unless the function documents
+a different contract.
+- Every fixed memory or bounds bug gets a regression test.
+
+## Review Checklist
+
+- Who owns every pointer crossing this function boundary?
+- Can any stored pointer outlive its allocation or arena?
+- Does every write know the destination capacity?
+- Are all length calculations overflow-checked?
+- Are parser failures tested, including short input and malformed input?
+- Does ASan+UBSan pass for code touching parsing, serialization, save/load, or
+network state?

--- a/scripts/check_banned_apis.py
+++ b/scripts/check_banned_apis.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Fail on high-risk C library calls in owned source files."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+BANNED = {
+    "gets": "use fgets with an explicit buffer size",
+    "strcpy": "use memcpy/snprintf with a visible capacity check",
+    "strcat": "use a length-tracked append helper",
+    "sprintf": "use snprintf and check the return value",
+    "vsprintf": "use vsnprintf and check the return value",
+    "scanf": "use bounded parsing with strtol/strtof or a project parser",
+    "sscanf": "use bounded parsing with strtol/strtof or a project parser",
+    "fscanf": "use fgets plus bounded parsing",
+    "strncpy": "do not use truncating pseudo-safe copies",
+    "strncat": "use a length-tracked append helper",
+    "atoi": "use strtol with full-tail validation",
+    "atol": "use strtol with full-tail validation",
+    "atoll": "use strtoll with full-tail validation",
+    "rand": "use shared/rng.h or an explicit deterministic generator",
+    "tmpnam": "use mkstemp or a platform secure-temp helper",
+    "mktemp": "use mkstemp or a platform secure-temp helper",
+}
+
+EXCLUDED_PREFIXES = (
+    "vendor/",
+)
+
+EXCLUDED_FILES = {
+    "client/stb_image.h",
+    "client/minimp3.h",
+    "client/pl_mpeg.h",
+    "server/mongoose.c",
+    "server/mongoose.h",
+}
+
+CALL_RE = re.compile(r"\b(" + "|".join(map(re.escape, sorted(BANNED))) + r")\s*\(")
+
+
+def tracked_c_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard", "--", "*.c", "*.h"],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    files: list[Path] = []
+    for raw in result.stdout.splitlines():
+        if raw.startswith(EXCLUDED_PREFIXES) or raw in EXCLUDED_FILES:
+            continue
+        files.append(ROOT / raw)
+    return files
+
+
+def strip_line_comments(line: str, in_block: bool) -> tuple[str, bool]:
+    out: list[str] = []
+    i = 0
+    while i < len(line):
+        if in_block:
+            end = line.find("*/", i)
+            if end == -1:
+                return "".join(out), True
+            i = end + 2
+            in_block = False
+            continue
+        if line.startswith("/*", i):
+            in_block = True
+            i += 2
+            continue
+        if line.startswith("//", i):
+            break
+        out.append(line[i])
+        i += 1
+    return "".join(out), in_block
+
+
+def main() -> int:
+    findings: list[tuple[str, int, str, str]] = []
+    for path in tracked_c_files():
+        rel = path.relative_to(ROOT).as_posix()
+        in_block_comment = False
+        for lineno, raw in enumerate(path.read_text(errors="replace").splitlines(), 1):
+            line, in_block_comment = strip_line_comments(raw, in_block_comment)
+            for match in CALL_RE.finditer(line):
+                api = match.group(1)
+                findings.append((rel, lineno, api, BANNED[api]))
+
+    if findings:
+        print("Banned C APIs found:", file=sys.stderr)
+        for rel, lineno, api, replacement in findings:
+            print(
+                f"  {rel}:{lineno}: {api}() is banned; {replacement}",
+                file=sys.stderr,
+            )
+        return 1
+
+    print("banned API check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/main.c
+++ b/server/main.c
@@ -2312,6 +2312,16 @@ static bool station_mutation_set_currency_name(int station_idx,
     return true;
 }
 
+static bool parse_query_long(const char *text, long *out) {
+    char *tail = NULL;
+    if (!text || !out) return false;
+    errno = 0;
+    long v = strtol(text, &tail, 10);
+    if (errno != 0 || tail == text || *tail != '\0') return false;
+    *out = v;
+    return true;
+}
+
 static bool station_mutation_set_price(int station_idx, long commodity,
                                        double price_val, float *out_price,
                                        const char **out_error) {
@@ -3376,8 +3386,10 @@ static void ev_handler(struct mg_connection *c, int ev, void *ev_data) {
                  * since mongoose gives us hm->query as a raw string. */
                 long since = 0, limit = 50;
                 char tmp[32];
-                if (mg_http_get_var(&hm->query, "since", tmp, sizeof(tmp)) > 0) since = atol(tmp);
-                if (mg_http_get_var(&hm->query, "limit", tmp, sizeof(tmp)) > 0) limit = atol(tmp);
+                if (mg_http_get_var(&hm->query, "since", tmp, sizeof(tmp)) > 0)
+                    (void)parse_query_long(tmp, &since);
+                if (mg_http_get_var(&hm->query, "limit", tmp, sizeof(tmp)) > 0)
+                    (void)parse_query_long(tmp, &limit);
                 if (limit < 1) limit = 1;
                 if (limit > 100) limit = 100;
 

--- a/shared/safe_types.h
+++ b/shared/safe_types.h
@@ -1,0 +1,62 @@
+#ifndef SIGNAL_SAFE_TYPES_H
+#define SIGNAL_SAFE_TYPES_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+    const uint8_t *ptr;
+    size_t len;
+} signal_byte_slice_t;
+
+typedef struct {
+    uint8_t *ptr;
+    size_t len;
+} signal_byte_slice_mut_t;
+
+typedef struct {
+    const char *ptr;
+    size_t len;
+} signal_str_t;
+
+typedef struct {
+    char *ptr;
+    size_t len;
+} signal_str_mut_t;
+
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
+static inline bool signal_checked_add_size(size_t a, size_t b, size_t *out) {
+    if (out == NULL) return false;
+#if __has_builtin(__builtin_add_overflow)
+    return !__builtin_add_overflow(a, b, out);
+#else
+    if ((size_t)-1 - a < b) return false;
+    *out = a + b;
+    return true;
+#endif
+}
+
+static inline bool signal_checked_mul_size(size_t a, size_t b, size_t *out) {
+    if (out == NULL) return false;
+#if __has_builtin(__builtin_mul_overflow)
+    return !__builtin_mul_overflow(a, b, out);
+#else
+    if (a != 0 && b > (size_t)-1 / a) return false;
+    *out = a * b;
+    return true;
+#endif
+}
+
+static inline signal_str_t signal_str_from_cstr(const char *s) {
+    signal_str_t out = {0};
+    if (s == NULL) return out;
+    while (s[out.len] != '\0') out.len++;
+    out.ptr = s;
+    return out;
+}
+
+#endif /* SIGNAL_SAFE_TYPES_H */

--- a/tests/c/test_main.c
+++ b/tests/c/test_main.c
@@ -1,5 +1,8 @@
 #include "test_harness.h"
 
+#include <errno.h>
+#include <limits.h>
+
 /* Already-extracted subsystem registries */
 void register_commodity_tests(void);
 void register_math_tests(void);
@@ -72,6 +75,22 @@ void register_laser_tests(void);
 void register_inspect_anim_tests(void);
 void register_gossip_tests(void);
 
+static int parse_shard_arg(const char *arg, int *out_index, int *out_total) {
+    char *slash = NULL;
+    char *tail = NULL;
+    errno = 0;
+    long k = strtol(arg, &slash, 10);
+    if (errno != 0 || slash == arg || *slash != '/') return 0;
+    errno = 0;
+    long n = strtol(slash + 1, &tail, 10);
+    if (errno != 0 || tail == slash + 1 || *tail != '\0') return 0;
+    if (n <= 0 || k < 0 || k >= n) return 0;
+    if (k > INT_MAX || n > INT_MAX) return 0;
+    *out_index = (int)k;
+    *out_total = (int)n;
+    return 1;
+}
+
 int main(int argc, char **argv) {
     setbuf(stdout, NULL); /* unbuffered so crash location is visible */
 
@@ -85,7 +104,7 @@ int main(int argc, char **argv) {
     for (int i = 1; i < argc; i++) {
         if (strncmp(argv[i], "--shard=", 8) == 0) {
             int k = 0, n = 1;
-            if (sscanf(argv[i] + 8, "%d/%d", &k, &n) == 2 && n > 0 && k >= 0 && k < n) {
+            if (parse_shard_arg(argv[i] + 8, &k, &n)) {
                 g_shard_index = k;
                 g_shard_total = n;
                 printf("[shard %d/%d] ", k, n);

--- a/tests/c/test_math.c
+++ b/tests/c/test_math.c
@@ -1,4 +1,5 @@
 #include "test_harness.h"
+#include "safe_types.h"
 
 TEST(test_v2_add) {
     vec2 a = v2(1.0f, 2.0f);
@@ -52,6 +53,18 @@ TEST(test_ingot_idx) {
     ASSERT_EQ_INT(INGOT_COUNT, 7);
 }
 
+TEST(test_signal_checked_size_arithmetic) {
+    size_t out = 0;
+    ASSERT(signal_checked_add_size(40u, 2u, &out));
+    ASSERT_EQ_INT((int)out, 42);
+    ASSERT(!signal_checked_add_size((size_t)-1, 1u, &out));
+
+    ASSERT(signal_checked_mul_size(6u, 7u, &out));
+    ASSERT_EQ_INT((int)out, 42);
+    ASSERT(!signal_checked_mul_size(((size_t)-1 / 2u) + 1u, 2u, &out));
+    ASSERT(!signal_checked_mul_size(2u, 2u, NULL));
+}
+
 void register_math_tests(void) {
     TEST_SECTION("\nMath tests:\n");
     RUN(test_v2_add);
@@ -64,4 +77,5 @@ void register_math_tests(void) {
 
     TEST_SECTION("\nType tests:\n");
     RUN(test_ingot_idx);
+    RUN(test_signal_checked_size_arithmetic);
 }

--- a/tests/c/test_motd_rarity.c
+++ b/tests/c/test_motd_rarity.c
@@ -21,19 +21,19 @@ TEST(test_motd_tier_for_signal) {
 
     av.tiers[0].band_min = 0.80f;
     av.tiers[0].band_max = 1.00f;
-    strcpy(av.tiers[0].text, "COMMON");
+    memcpy(av.tiers[0].text, "COMMON", sizeof("COMMON"));
 
     av.tiers[1].band_min = 0.50f;
     av.tiers[1].band_max = 0.80f;
-    strcpy(av.tiers[1].text, "UNCOMMON");
+    memcpy(av.tiers[1].text, "UNCOMMON", sizeof("UNCOMMON"));
 
     av.tiers[2].band_min = 0.20f;
     av.tiers[2].band_max = 0.50f;
-    strcpy(av.tiers[2].text, "RARE");
+    memcpy(av.tiers[2].text, "RARE", sizeof("RARE"));
 
     av.tiers[3].band_min = 0.00f;
     av.tiers[3].band_max = 0.20f;
-    strcpy(av.tiers[3].text, "ULTRA_RARE");
+    memcpy(av.tiers[3].text, "ULTRA_RARE", sizeof("ULTRA_RARE"));
 
     /* Test boundary conditions for each tier. */
     ASSERT_EQ_INT(avatar_motd_tier_for_signal(&av, 1.00f), 0);  /* CORE lower bound */

--- a/tools/flight_trace.c
+++ b/tools/flight_trace.c
@@ -237,7 +237,7 @@ static int parse_shard_arg(const char *text, int *out_index, int *out_total)
     if (strlen(slash + 1) == 0 || strlen(slash + 1) >= sizeof(right)) return 0;
     memcpy(left, text, left_len);
     left[left_len] = '\0';
-    strcpy(right, slash + 1);
+    memcpy(right, slash + 1, strlen(slash + 1) + 1u);
     if (!parse_int_arg(left, 0, &index) || !parse_int_arg(right, 1, &total)) return 0;
     if (index >= total) return 0;
     *out_index = index;

--- a/tools/signal_verify.c
+++ b/tools/signal_verify.c
@@ -25,6 +25,7 @@
 #include "sha256.h"
 #include "signal_crypto.h"
 
+#include <ctype.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -155,7 +156,19 @@ static void registry_load(const char *path) {
         if (line[0] == '#' || line[0] == '\n') continue;
         char b58[80] = {0};
         char name[64] = {0};
-        if (sscanf(line, "%79s %63[^\n]", b58, name) >= 1) {
+        char *cursor = line;
+        while (*cursor && isspace((unsigned char)*cursor)) cursor++;
+        char *b58_start = cursor;
+        while (*cursor && !isspace((unsigned char)*cursor)) cursor++;
+        size_t b58_len = (size_t)(cursor - b58_start);
+        if (b58_len > 0 && b58_len < sizeof(b58)) {
+            memcpy(b58, b58_start, b58_len);
+            b58[b58_len] = '\0';
+            while (*cursor && isspace((unsigned char)*cursor)) cursor++;
+            size_t name_len = strcspn(cursor, "\r\n");
+            if (name_len >= sizeof(name)) name_len = sizeof(name) - 1u;
+            memcpy(name, cursor, name_len);
+            name[name_len] = '\0';
             uint8_t pub[32];
             if (base58_decode(b58, pub, 32) == 32) {
                 memcpy(g_registry[g_registry_count].pubkey, pub, 32);


### PR DESCRIPTION
## Summary
- add a C safety policy plus local sanitizer and banned-API make targets
- wire the banned-API scan into CI static analysis
- replace remaining owned uses of unchecked libc parsing/copy/random calls in touched paths with bounded parsing/copying or deterministic helpers
- add checked size arithmetic helpers and tests

## Validation
- make banned-apis
- git diff --check
- workflow YAML parse
- make test
- make test-san
- make build-server
- make cppcheck
- post-commit local-sync fast test pass