### PR TITLE
[codex] Finalize multiplayer prediction gates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,16 @@ endif()
 # new server .c file only needs editing here.
 # ------------------------------------------------------------------
 
+set(SIGNAL_STATIC_FLIGHT_BRAIN_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}/client/integration/work/signal")
+set(SIGNAL_STATIC_FLIGHT_BRAIN_SOURCES)
+if(EXISTS "${SIGNAL_STATIC_FLIGHT_BRAIN_DIR}/signal_client_flight.c" AND
+   EXISTS "${SIGNAL_STATIC_FLIGHT_BRAIN_DIR}/signal_client_flight.h")
+    list(APPEND SIGNAL_STATIC_FLIGHT_BRAIN_SOURCES
+        client/integration/work/signal/signal_client_flight.c)
+    add_compile_definitions(SIGNAL_HAS_STATIC_FLIGHT_BRAIN=1)
+endif()
+
 # Headless simulation — used by signal_server, signal_test, and the
 # client (which runs the same sim in-process for singleplayer via
 # local_server.c). New server sim files go here.
@@ -168,6 +178,9 @@ set(SIGNAL_INCLUDE_DIRS
     "${CMAKE_CURRENT_SOURCE_DIR}/shared"
     "${CMAKE_CURRENT_SOURCE_DIR}/server"
 )
+if(SIGNAL_STATIC_FLIGHT_BRAIN_SOURCES)
+    list(APPEND SIGNAL_INCLUDE_DIRS "${SIGNAL_STATIC_FLIGHT_BRAIN_DIR}")
+endif()
 
 # ------------------------------------------------------------------
 # signal_server — authoritative game server (also the Docker image).
@@ -179,6 +192,7 @@ if(NOT EMSCRIPTEN AND NOT BUILD_TESTS_ONLY)
         server/highscore.c
         ${SIGNAL_SIM_SOURCES}
         ${SIGNAL_SIM_HELPERS}
+        ${SIGNAL_STATIC_FLIGHT_BRAIN_SOURCES}
         ${SIGNAL_CRYPTO_SOURCES}
     )
     target_include_directories(signal_server PRIVATE
@@ -268,6 +282,7 @@ if(NOT EMSCRIPTEN AND NOT BUILD_SERVER_ONLY)
         client/identity.c
         ${SIGNAL_SIM_SOURCES}
         ${SIGNAL_SIM_HELPERS}
+        ${SIGNAL_STATIC_FLIGHT_BRAIN_SOURCES}
         ${SIGNAL_CRYPTO_SOURCES}
     )
     target_include_directories(signal_test PRIVATE
@@ -350,6 +365,7 @@ if(BUILD_TOOLS AND NOT EMSCRIPTEN)
         tools/flight_trace.c
         ${SIGNAL_SIM_SOURCES}
         ${SIGNAL_SIM_HELPERS}
+        ${SIGNAL_STATIC_FLIGHT_BRAIN_SOURCES}
         ${SIGNAL_CRYPTO_SOURCES}
     )
     target_include_directories(flight_trace PRIVATE
@@ -368,6 +384,7 @@ if(BUILD_TOOLS AND NOT EMSCRIPTEN)
         tools/signal_replay.c
         ${SIGNAL_SIM_SOURCES}
         ${SIGNAL_SIM_HELPERS}
+        ${SIGNAL_STATIC_FLIGHT_BRAIN_SOURCES}
         ${SIGNAL_CRYPTO_SOURCES}
     )
     target_include_directories(signal_replay PRIVATE
@@ -388,6 +405,7 @@ if(BUILD_WASM_REPLAY AND EMSCRIPTEN)
         tools/signal_replay.c
         ${SIGNAL_SIM_SOURCES}
         ${SIGNAL_SIM_HELPERS}
+        ${SIGNAL_STATIC_FLIGHT_BRAIN_SOURCES}
         ${SIGNAL_CRYPTO_SOURCES}
     )
     target_include_directories(signal_replay PRIVATE
@@ -510,6 +528,7 @@ if(EMSCRIPTEN)
         "'_get_player_pos_y'"
         "'_get_player_vel_x'"
         "'_get_player_vel_y'"
+        "'_get_player_angle'"
         "'_get_player_docked'"
         "'_get_camera_narrow_focus'"
         "'_reset_net_motion_telemetry'"
@@ -524,6 +543,9 @@ if(EMSCRIPTEN)
         "'_get_net_motion_player_interval_ms'"
         "'_get_net_motion_max_player_interval_ms'"
         "'_get_net_motion_max_player_jitter_ms'"
+        "'_get_net_motion_raw_player_interval_ms'"
+        "'_get_net_motion_max_raw_player_interval_ms'"
+        "'_get_net_motion_max_raw_player_jitter_ms'"
         "'_get_net_motion_max_ack_rtt_ms'"
         "'_get_net_motion_current_render_offset'"
         "'_get_net_motion_max_render_offset'"
@@ -533,6 +555,8 @@ if(EMSCRIPTEN)
         "'_get_net_motion_total_input_acks'"
         "'_get_net_motion_tick_skew'"
         "'_get_net_motion_max_tick_skew_abs'"
+        "'_get_net_motion_input_apply_error_ticks'"
+        "'_get_net_motion_max_input_apply_error_abs'"
         "'_get_net_motion_replay_depth'"
         "'_get_net_motion_unacked_inputs'"
         "'_get_net_motion_action_queue_depth'"

--- a/client/client.h
+++ b/client/client.h
@@ -277,6 +277,7 @@ typedef struct {
 typedef struct {
     uint16_t seq;
     float sent_at;
+    uint32_t target_tick;
 } net_input_timing_t;
 
 typedef struct {
@@ -437,7 +438,9 @@ typedef struct {
     uint16_t net_input_seq;
     uint16_t net_last_server_ack;
     uint32_t net_last_server_tick;
+    float net_last_server_tick_time;
     bool net_input_tick_protocol;
+    bool net_local_state_ready;
     float net_last_ack_rtt;
     float net_last_ping_rtt;
     float net_last_ping_server_turnaround_ms;
@@ -656,16 +659,21 @@ typedef struct {
     vec2 local_player_render_offset; /* visual-only correction smoothing for local ship */
     struct {
         float packet_interval;
+        float raw_packet_interval;
         float correction_dist;
         float applied_correction_dist;
         float velocity_error;
         float max_packet_interval_run;
         float max_packet_jitter_run;
+        float max_raw_packet_interval_run;
+        float max_raw_packet_jitter_run;
         float max_correction_5s;
         float max_applied_correction_5s;
         float window_elapsed;
         int32_t tick_skew;
         int32_t max_tick_skew_abs;
+        int32_t input_apply_error_ticks;
+        int32_t max_input_apply_error_abs;
         uint32_t samples;
         uint32_t deferred_samples;
         uint32_t replayed_samples;

--- a/client/input.c
+++ b/client/input.c
@@ -74,17 +74,6 @@ static float action_predict_window_sec(void) {
     return window;
 }
 
-static void translate_towed_pods_for_local_launch(vec2 delta) {
-    if (v2_len_sq(delta) <= 0.001f) return;
-    for (int t = 0; t < LOCAL_PLAYER.ship.towed_pod_count && t < 10; t++) {
-        int idx = LOCAL_PLAYER.ship.towed_pods[t];
-        if (idx < 0 || idx >= MAX_CARGO_PODS) continue;
-        cargo_pod_t *pod = &g.world.cargo_pods[idx];
-        if (!pod->active) continue;
-        pod->pos = v2_add(pod->pos, delta);
-    }
-}
-
 static void frame_camera_on_local_launch(void) {
     g.camera_pos = LOCAL_PLAYER.ship.pos;
     g.camera_initialized = true;
@@ -109,8 +98,6 @@ static void predict_local_launch_from_dock(void) {
     const station_t *st = &g.world.stations[station_idx];
     if (!station_exists(st)) return;
 
-    vec2 pre_anchor_pos = LOCAL_PLAYER.ship.pos;
-    anchor_ship_in_station(&LOCAL_PLAYER, &g.world);
     vec2 launch_pos = LOCAL_PLAYER.ship.pos;
 
     LOCAL_PLAYER.docked = false;
@@ -129,11 +116,8 @@ static void predict_local_launch_from_dock(void) {
         len = 1.0f;
     }
 
-    LOCAL_PLAYER.ship.pos = launch_pos;
     LOCAL_PLAYER.ship.angle = fixp_atan2f(away.y, away.x);
     LOCAL_PLAYER.ship.vel = v2_scale(away, 95.0f / len);
-    translate_towed_pods_for_local_launch(
-        v2_sub(launch_pos, pre_anchor_pos));
     frame_camera_on_local_launch();
 }
 

--- a/client/input.c
+++ b/client/input.c
@@ -74,53 +74,6 @@ static float action_predict_window_sec(void) {
     return window;
 }
 
-static void frame_camera_on_local_launch(void) {
-    g.camera_pos = LOCAL_PLAYER.ship.pos;
-    g.camera_initialized = true;
-    g.camera_station_index = -1;
-    g.camera_station_side = 0;
-    g.camera_station_v_side = 0;
-    g.camera_drift_timer = 0.0f;
-    g.local_player_render_offset = v2(0.0f, 0.0f);
-}
-
-static void predict_local_launch_from_dock(void) {
-    int station_idx = LOCAL_PLAYER.current_station;
-    if (station_idx < 0 || station_idx >= MAX_STATIONS ||
-        !station_exists(&g.world.stations[station_idx])) {
-        station_idx = (LOCAL_PLAYER.nearby_station >= 0 &&
-                       LOCAL_PLAYER.nearby_station < MAX_STATIONS &&
-                       station_exists(&g.world.stations[LOCAL_PLAYER.nearby_station]))
-            ? LOCAL_PLAYER.nearby_station
-            : 0;
-        LOCAL_PLAYER.current_station = station_idx;
-    }
-    const station_t *st = &g.world.stations[station_idx];
-    if (!station_exists(st)) return;
-
-    vec2 launch_pos = LOCAL_PLAYER.ship.pos;
-
-    LOCAL_PLAYER.docked = false;
-    LOCAL_PLAYER.in_dock_range = false;
-    LOCAL_PLAYER.docking_approach = false;
-    LOCAL_PLAYER.nearby_station = -1;
-    LOCAL_PLAYER.boost_hold_timer = 0.0f;
-    LOCAL_PLAYER.ship.tractor_active = false;
-
-    vec2 away = v2_sub(launch_pos, st->pos);
-    away = player_launch_lane_for_berth(
-        st, LOCAL_PLAYER.dock_berth, g.local_player_slot, away);
-    float len = v2_len(away);
-    if (len <= 0.001f) {
-        away = v2(0.0f, -1.0f);
-        len = 1.0f;
-    }
-
-    LOCAL_PLAYER.ship.angle = fixp_atan2f(away.y, away.x);
-    LOCAL_PLAYER.ship.vel = v2_scale(away, 95.0f / len);
-    frame_camera_on_local_launch();
-}
-
 void clear_input_state(void) {
     memset(g.input.key_down, 0, sizeof(g.input.key_down));
     memset(g.input.key_pressed, 0, sizeof(g.input.key_pressed));
@@ -1221,7 +1174,7 @@ void submit_input(const input_intent_t *intent, float dt) {
     /* Client prediction is stable only when the server snapshots and local
      * frames share the input-tick clock. Pre-tick remote servers remain
      * server-authoritative while the client still sends inputs normally. */
-    if (net_local_prediction_enabled()) {
+    if (net_local_prediction_enabled() && !LOCAL_PLAYER.docked) {
         net_replay_record_prediction(intent, dt);
         world_sim_step_player_only(&g.world, g.local_player_slot, dt);
     }
@@ -1297,9 +1250,6 @@ void submit_input(const input_intent_t *intent, float dt) {
     if (has_action && g.net_authority_enabled && net_is_connected()) {
         if (intent->interact) {
             g.pending_net_action = LOCAL_PLAYER.docked ? 2 : 1;
-            if (LOCAL_PLAYER.docked) {
-                predict_local_launch_from_dock();
-            }
         } else if (intent->service_sell && intent->service_sell_only < COMMODITY_COUNT) {
             g.pending_net_action = NET_ACTION_DELIVER_COMMODITY + (uint8_t)intent->service_sell_only;
             /* Per-row sell rides the same 5th-byte slot as buy_grade.

--- a/client/main.c
+++ b/client/main.c
@@ -2968,7 +2968,8 @@ static void frame(void) {
             bool heartbeat_due = g.net_input_timer <= 0.0f;
             if (input_changed || heartbeat_due || action_due) {
                 bool seq_advanced = false;
-                if (input_changed || action != NET_ACTION_NONE) {
+                if (input_changed || action != NET_ACTION_NONE ||
+                    (active_controls && heartbeat_due)) {
                     g.net_input_seq++;
                     if (g.net_input_seq == 0) g.net_input_seq++;
                     seq_advanced = true;

--- a/client/main.c
+++ b/client/main.c
@@ -53,6 +53,27 @@
 
 game_t g;
 
+#ifdef __EMSCRIPTEN__
+static bool g_mobile_virtual_key_down[KEY_COUNT];
+
+static void mobile_restore_virtual_keys(void) {
+    for (int kc = 0; kc < KEY_COUNT; kc++) {
+        if (g_mobile_virtual_key_down[kc]) {
+            g.input.key_down[kc] = true;
+        }
+    }
+}
+
+static void mobile_clear_virtual_keys(void) {
+    memset(g_mobile_virtual_key_down, 0, sizeof(g_mobile_virtual_key_down));
+}
+
+static void clear_input_state_for_canvas_focus_loss(void) {
+    clear_input_state();
+    mobile_restore_virtual_keys();
+}
+#endif
+
 static const int MAX_SIM_STEPS_PER_FRAME = 8;
 
 static float camera_view_narrow_focus(float fallback_w, float fallback_h) {
@@ -199,6 +220,19 @@ static bool start_local_loopback_authority(const NetCallbacks *cbs) {
 
 static bool net_tick_after_u32(uint32_t a, uint32_t b) {
     return (int32_t)(a - b) > 0;
+}
+
+static bool net_input_seq_after_u16(uint16_t a, uint16_t b) {
+    return (int16_t)(a - b) > 0;
+}
+
+static uint16_t net_unacked_input_count(void) {
+    if (g.net_input_seq == 0) return 0;
+    if (g.net_last_server_ack == 0) return g.net_input_seq;
+    if (g.net_input_seq == g.net_last_server_ack) return 0;
+    if (!net_input_seq_after_u16(g.net_input_seq, g.net_last_server_ack))
+        return 0;
+    return (uint16_t)(g.net_input_seq - g.net_last_server_ack);
 }
 
 static uint32_t net_input_lead_ticks(void) {
@@ -2399,7 +2433,7 @@ int get_net_motion_replay_depth(void) {
 EMSCRIPTEN_KEEPALIVE
 #endif
 int get_net_motion_unacked_inputs(void) {
-    return (int)((uint16_t)(g.net_input_seq - g.net_last_server_ack));
+    return (int)net_unacked_input_count();
 }
 
 #ifdef __EMSCRIPTEN__
@@ -2857,7 +2891,7 @@ static void frame(void) {
                     get_net_motion_last_ack_gap_ms(),
                     g.net_last_ping_server_turnaround_ms,
                     g.net_motion.packet_interval * 1000.0f,
-                    (uint16_t)(g.net_input_seq - g.net_last_server_ack),
+                    net_unacked_input_count(),
                     g.net_replay_count,
                     g.net_action_queue_count);
                 g.net_metrics_timer = NET_CLIENT_METRICS_SEC;
@@ -3025,8 +3059,18 @@ static void event(const sapp_event* event) {
         }
 
         case SAPP_EVENTTYPE_UNFOCUSED:
+#ifdef __EMSCRIPTEN__
+            clear_input_state_for_canvas_focus_loss();
+#else
+            clear_input_state();
+#endif
+            break;
+
         case SAPP_EVENTTYPE_SUSPENDED:
         case SAPP_EVENTTYPE_ICONIFIED:
+#ifdef __EMSCRIPTEN__
+            mobile_clear_virtual_keys();
+#endif
             clear_input_state();
             break;
 
@@ -3351,16 +3395,19 @@ void signal_mobile_key(int action, int down) {
     if (kc < 0 || kc >= KEY_COUNT) return;
 
     if (down) {
+        g_mobile_virtual_key_down[kc] = true;
         if (!g.input.key_down[kc])
             g.input.key_pressed[kc] = true;
         g.input.key_down[kc] = true;
     } else {
+        g_mobile_virtual_key_down[kc] = false;
         g.input.key_down[kc] = false;
     }
 }
 
 EMSCRIPTEN_KEEPALIVE
 void signal_mobile_clear(void) {
+    mobile_clear_virtual_keys();
     clear_input_state();
 }
 

--- a/client/main.c
+++ b/client/main.c
@@ -123,8 +123,8 @@ static void mix_external_audio(float *buffer, int frames, int channels, void *us
 
 /* station_dock_anchor, ship_cargo_space: see game_sim.c */
 
-#define NET_INPUT_HEARTBEAT_SEC (1.0f / 6.0f)
-#define NET_ACTIVE_INPUT_HEARTBEAT_SEC (1.0f / 12.0f)
+#define NET_INPUT_HEARTBEAT_SEC ((float)NET_INPUT_IDLE_HEARTBEAT_MS / 1000.0f)
+#define NET_ACTIVE_INPUT_HEARTBEAT_SEC ((float)NET_INPUT_ACTIVE_HEARTBEAT_MS / 1000.0f)
 #define NET_ACTION_RESEND_SEC (1.0f / 12.0f)
 #define NET_ACTION_RETRY_SEC 6.0f
 #define NET_CLIENT_METRICS_SEC 15.0f
@@ -162,6 +162,8 @@ static void on_remote_action_ack(uint16_t action_id, uint16_t input_seq,
 static void on_remote_action_result(uint16_t action_id, uint16_t input_seq,
                                     uint8_t status, uint8_t action,
                                     uint32_t server_tick);
+static void on_remote_input_applied(uint16_t input_seq, uint32_t server_tick,
+                                    uint32_t input_tick_ack);
 static void on_remote_handoff_ticket(uint8_t status, uint8_t source_station,
                                      uint8_t dest_station,
                                      const handoff_ticket_t *ticket);
@@ -178,6 +180,7 @@ static void configure_net_callbacks(NetCallbacks *cbs) {
     cbs->on_leave = on_player_leave;
     cbs->on_players_begin = begin_player_state_batch;
     cbs->on_state = apply_remote_player_state;
+    cbs->on_input_applied = on_remote_input_applied;
     cbs->on_asteroids = apply_remote_asteroids;
     cbs->on_npcs = apply_remote_npcs;
     cbs->on_stations = apply_remote_stations;
@@ -251,20 +254,15 @@ static uint32_t net_input_lead_ticks(void) {
 
 static uint32_t net_next_input_apply_tick(void) {
     if (g.net_last_server_tick != 0) {
-        uint32_t target = g.net_last_server_tick + net_input_lead_ticks();
-        if (g.net_prediction_tick_valid) {
-            uint32_t predicted_next = g.net_prediction_tick + 1u;
-            if (net_tick_after_u32(predicted_next, g.net_last_server_tick) &&
-                net_tick_after_u32(target, predicted_next)) {
-                target = predicted_next;
-            }
-        }
-        if (!net_tick_after_u32(target, g.net_last_server_tick))
-            target = g.net_last_server_tick + 1u;
+        uint32_t server_tick =
+            net_estimated_server_tick_now(g.net_last_server_tick);
+        uint32_t target = server_tick + net_input_lead_ticks();
+        if (!net_tick_after_u32(target, server_tick))
+            target = server_tick + 1u;
         return target;
     }
     if (g.net_prediction_tick_valid) return g.net_prediction_tick + 1u;
-    return 1u;
+    return 0u;
 }
 
 static void clear_collection_feedback(void) {
@@ -343,20 +341,8 @@ static void reset_world(void) {
     g.thrusting = false;
     g.notice[0] = '\0';
     g.notice_timer = 0.0f;
-    g.pending_net_action = NET_ACTION_NONE;
-    g.pending_net_buy_grade = MINING_GRADE_COUNT; /* sentinel = any */
-    g.pending_net_place_station = -1;
-    g.pending_net_place_ring    = -1;
-    g.pending_net_place_slot    = -1;
-    g.net_input_timer = 0.0f;
     g.net_time = 0.0f;
-    g.net_input_have_last = false;
-    g.net_last_sent_flags = 0;
-    g.net_last_sent_mining_target = 0xFFFFu;
-    g.net_input_seq = 0;
-    g.net_last_server_ack = 0;
-    g.net_last_server_tick = 0;
-    g.net_input_tick_protocol = false;
+    net_reset_local_input_stream();
     g.net_last_ack_rtt = 0.0f;
     g.net_last_ping_rtt = 0.0f;
     g.net_last_ping_server_turnaround_ms = 0.0f;
@@ -367,17 +353,6 @@ static void reset_world(void) {
     g.net_metrics_seq = 0;
     g.net_max_ack_rtt_5s = 0.0f;
     g.net_ack_window_elapsed = 0.0f;
-    g.net_input_packets_sent = 0;
-    g.net_action_packets_sent = 0;
-    g.net_action_resend_packets = 0;
-    g.net_action_dropped = 0;
-    g.net_next_action_id = 1;
-    g.net_action_queue_start = 0;
-    g.net_action_queue_count = 0;
-    memset(&g.net_motion, 0, sizeof(g.net_motion));
-    memset(g.net_action_queue, 0, sizeof(g.net_action_queue));
-    memset(g.net_input_timing, 0, sizeof(g.net_input_timing));
-    net_replay_reset();
     audio_clear_voices(&g.audio);
     clear_collection_feedback();
 
@@ -2215,6 +2190,14 @@ float get_player_vel_y(void) {
 #ifdef __EMSCRIPTEN__
 EMSCRIPTEN_KEEPALIVE
 #endif
+float get_player_angle(void) {
+    if (g.local_player_slot < 0) return 0.0f;
+    return LOCAL_PLAYER.ship.angle;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
 int get_player_docked(void) {
     if (g.local_player_slot < 0) return 0;
     return LOCAL_PLAYER.docked ? 1 : 0;
@@ -2362,6 +2345,27 @@ float get_net_motion_max_player_jitter_ms(void) {
 #ifdef __EMSCRIPTEN__
 EMSCRIPTEN_KEEPALIVE
 #endif
+float get_net_motion_raw_player_interval_ms(void) {
+    return g.net_motion.raw_packet_interval * 1000.0f;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+float get_net_motion_max_raw_player_interval_ms(void) {
+    return g.net_motion.max_raw_packet_interval_run * 1000.0f;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+float get_net_motion_max_raw_player_jitter_ms(void) {
+    return g.net_motion.max_raw_packet_jitter_run * 1000.0f;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
 float get_net_motion_max_ack_rtt_ms(void) {
     return g.net_motion.max_ack_rtt_run * 1000.0f;
 }
@@ -2420,6 +2424,20 @@ EMSCRIPTEN_KEEPALIVE
 #endif
 int get_net_motion_max_tick_skew_abs(void) {
     return (int)g.net_motion.max_tick_skew_abs;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int get_net_motion_input_apply_error_ticks(void) {
+    return (int)g.net_motion.input_apply_error_ticks;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int get_net_motion_max_input_apply_error_abs(void) {
+    return (int)g.net_motion.max_input_apply_error_abs;
 }
 
 #ifdef __EMSCRIPTEN__
@@ -2635,13 +2653,17 @@ static void on_remote_action_result(uint16_t action_id, uint16_t input_seq,
             g.station_balance,
             (unsigned)g.net_action_queue_count);
     if (server_tick != 0) {
-        g.net_last_server_tick = server_tick;
+        net_observe_server_tick(server_tick);
         if (!g.net_prediction_tick_valid) {
-            g.net_prediction_tick = server_tick;
-            g.net_prediction_tick_valid = true;
+            net_anchor_prediction_tick(server_tick, false);
         }
     }
     g.action_predict_timer = 0.0f;
+}
+
+static void on_remote_input_applied(uint16_t input_seq, uint32_t server_tick,
+                                    uint32_t input_tick_ack) {
+    net_record_input_ack(input_seq, server_tick, input_tick_ack);
 }
 
 static void on_remote_handoff_ticket(uint8_t status, uint8_t source_station,
@@ -2857,11 +2879,12 @@ static void net_action_queue_mark_sent(uint16_t input_seq) {
     g.net_action_packets_sent++;
 }
 
-static void net_track_input_send(uint16_t seq) {
+static void net_track_input_send(uint16_t seq, uint32_t target_tick) {
     if (seq == 0) return;
     int index = (int)(seq % NET_INPUT_TIMING_CAP);
     g.net_input_timing[index].seq = seq;
     g.net_input_timing[index].sent_at = g.net_time;
+    g.net_input_timing[index].target_tick = target_tick;
 }
 
 static void frame(void) {
@@ -2983,7 +3006,7 @@ static void frame(void) {
                                buy_grade_byte, place_station, place_ring,
                                place_slot, action_id, input_tick);
                 g.net_input_packets_sent++;
-                if (seq_advanced) net_track_input_send(g.net_input_seq);
+                if (seq_advanced) net_track_input_send(g.net_input_seq, input_tick);
                 if (action != NET_ACTION_NONE)
                     net_action_queue_mark_sent(g.net_input_seq);
                 g.net_input_timer = active_controls

--- a/client/net.c
+++ b/client/net.c
@@ -650,6 +650,19 @@ static void handle_message(const uint8_t* data, int len) {
         }
         break;
 
+    case NET_MSG_INPUT_APPLIED:
+        if (len < NET_INPUT_APPLIED_SIZE) break;
+        {
+            uint16_t input_seq = read_u16_le(&data[1]);
+            uint32_t server_tick = read_u32_le(&data[3]);
+            uint32_t input_tick_ack = read_u32_le(&data[7]);
+            if (net_state.callbacks.on_input_applied) {
+                net_state.callbacks.on_input_applied(input_seq, server_tick,
+                                                     input_tick_ack);
+            }
+        }
+        break;
+
     case NET_MSG_HANDOFF_TICKET:
         if ((size_t)len < 4u + HANDOFF_TICKET_SIZE) break;
         {

--- a/client/net.h
+++ b/client/net.h
@@ -91,6 +91,9 @@ typedef struct {
 typedef void (*net_on_player_join_fn)(uint8_t player_id);
 typedef void (*net_on_player_leave_fn)(uint8_t player_id);
 typedef void (*net_on_player_state_fn)(const NetPlayerState* state);
+typedef void (*net_on_input_applied_fn)(uint16_t input_seq,
+                                        uint32_t server_tick,
+                                        uint32_t input_tick_ack);
 typedef void (*net_on_asteroids_fn)(const NetAsteroidState* asteroids, int count);
 typedef void (*net_on_npcs_fn)(const NetNpcState* npcs, int count);
 /* Packed player ship state (from PLAYER_SHIP 0x15). */
@@ -385,6 +388,7 @@ typedef struct {
     net_on_player_join_fn on_join;
     net_on_player_leave_fn on_leave;
     net_on_player_state_fn on_state;
+    net_on_input_applied_fn on_input_applied;
     net_on_players_begin_fn on_players_begin;
     net_on_asteroids_fn on_asteroids;
     net_on_npcs_fn on_npcs;

--- a/client/net_sync.c
+++ b/client/net_sync.c
@@ -27,6 +27,7 @@
 #define CARGO_POD_RENDER_CORRECTION_SEC 0.18f
 #define CARGO_POD_RENDER_EXTRAPOLATE_MAX_SEC 0.60f
 #define REMOTE_PENDING_RECEIPT_CAP 64
+#define NET_INPUT_JITTER_BUFFER_TICKS 1u
 /* Replay is keyed to server-anchored sim ticks. Movement packets carry the
  * client-predicted target tick, and the server only applies them during the
  * matching world_sim_step(), so snapshots and prediction frames share one
@@ -38,6 +39,8 @@ static bool station_ring_have_snapshot[MAX_STATIONS];
 static cargo_receipt_chain_t remote_pending_receipts[REMOTE_PENDING_RECEIPT_CAP];
 static uint8_t remote_pending_receipt_pub[REMOTE_PENDING_RECEIPT_CAP][32];
 static uint8_t remote_pending_receipt_count;
+
+static void net_replay_clear_frames(void);
 
 bool net_local_prediction_enabled(void) {
     if (!g.net_authority_enabled) return true;
@@ -86,6 +89,51 @@ static bool replay_tick_after(uint32_t a, uint32_t b) {
 
 static bool net_input_seq_after(uint16_t a, uint16_t b) {
     return (int16_t)(a - b) > 0;
+}
+
+static uint32_t net_one_way_latency_ticks(void) {
+    float rtt = g.net_last_ping_rtt > 0.0f
+        ? g.net_last_ping_rtt
+        : g.net_last_ack_rtt;
+    if (rtt <= 0.0f) return 0;
+    uint32_t ticks = (uint32_t)lroundf((rtt * 0.5f) / SIM_DT);
+    if (ticks > NET_INPUT_APPLY_FUTURE_MAX_TICKS)
+        ticks = NET_INPUT_APPLY_FUTURE_MAX_TICKS;
+    return ticks;
+}
+
+void net_observe_server_tick(uint32_t server_tick) {
+    if (server_tick == 0) return;
+    g.net_last_server_tick = server_tick;
+    g.net_last_server_tick_time = g.net_time;
+}
+
+uint32_t net_estimated_server_tick_now(uint32_t server_tick) {
+    if (server_tick == 0) return 0;
+
+    uint32_t tick = server_tick + net_one_way_latency_ticks();
+    if (g.net_last_ping_rtt > 0.0f || g.net_last_ack_rtt > 0.0f)
+        tick += NET_INPUT_JITTER_BUFFER_TICKS;
+
+    if (g.net_last_server_tick == server_tick &&
+        g.net_last_server_tick_time > 0.0f &&
+        g.net_time >= g.net_last_server_tick_time) {
+        uint32_t elapsed_ticks =
+            (uint32_t)floorf((g.net_time - g.net_last_server_tick_time) /
+                             SIM_DT);
+        tick += elapsed_ticks;
+    }
+    return tick;
+}
+
+void net_anchor_prediction_tick(uint32_t server_tick, bool clear_replay) {
+    if (server_tick == 0) return;
+    net_observe_server_tick(server_tick);
+    uint32_t anchor_tick = net_estimated_server_tick_now(server_tick);
+    if (anchor_tick == 0) anchor_tick = server_tick;
+    g.net_prediction_tick = anchor_tick;
+    g.net_prediction_tick_valid = true;
+    if (clear_replay) net_replay_clear_frames();
 }
 
 static bool net_latest_input_unacked(const NetPlayerState *state) {
@@ -204,9 +252,35 @@ static bool net_replay_has_turn_after(uint32_t server_tick) {
     return false;
 }
 
+static bool replay_frame_has_motion(const input_replay_frame_t *frame) {
+    if (!frame) return false;
+    const input_intent_t *intent = &frame->intent;
+    return fabsf(intent->turn) > 0.01f ||
+           fabsf(intent->thrust) > 0.01f ||
+           intent->boost ||
+           intent->reverse_thrust;
+}
+
+static bool net_replay_has_motion_after(uint32_t server_tick) {
+    int first_after = net_replay_first_after(server_tick);
+    if (first_after < 0) return false;
+    for (int i = first_after; i < (int)g.net_replay_count; i++) {
+        if (replay_frame_has_motion(net_replay_frame_at(i))) return true;
+    }
+    return false;
+}
+
 static bool net_local_turn_prediction_active(uint32_t server_tick) {
     return fabsf(LOCAL_PLAYER.input.turn) > 0.01f ||
            net_replay_has_turn_after(server_tick);
+}
+
+static bool net_local_motion_prediction_active(uint32_t server_tick) {
+    return fabsf(LOCAL_PLAYER.input.turn) > 0.01f ||
+           fabsf(LOCAL_PLAYER.input.thrust) > 0.01f ||
+           LOCAL_PLAYER.input.boost ||
+           LOCAL_PLAYER.input.reverse_thrust ||
+           net_replay_has_motion_after(server_tick);
 }
 
 static bool should_defer_stale_unacked_motion(const NetPlayerState *state,
@@ -221,6 +295,17 @@ static bool should_defer_stale_unacked_motion(const NetPlayerState *state,
     return !net_replay_has_frames_after(state->server_tick);
 }
 
+static bool should_defer_active_prediction_motion(const NetPlayerState *state,
+                                                  float dist_sq) {
+    if (!state || !net_local_prediction_enabled() || !net_replay_enabled())
+        return false;
+    if ((state->flags & 4) != 0) return false;
+    float defer_dist = LOCAL_PLAYER_STALE_ACK_DEFER_DIST;
+    if (dist_sq > defer_dist * defer_dist) return false;
+    if (!net_replay_has_frames_after(state->server_tick)) return false;
+    return net_local_motion_prediction_active(state->server_tick);
+}
+
 static void apply_authoritative_local_motion(const NetPlayerState *state,
                                              server_player_t *sp) {
     sp->ship.pos.x = state->x;
@@ -232,6 +317,91 @@ static void apply_authoritative_local_motion(const NetPlayerState *state,
         sp->docked = false;
 }
 
+static void apply_local_player_remote_flags(const NetPlayerState *state,
+                                            server_player_t *sp) {
+    sp->beam_active      = (state->flags & 2) != 0;
+    sp->beam_ineffective = (state->flags & 32) != 0;
+    sp->beam_hit         = (state->flags & 64) != 0;
+    sp->scan_active      = (state->flags & 8) != 0;
+    sp->beam_start = v2(state->beam_start_x, state->beam_start_y);
+    sp->beam_end   = v2(state->beam_end_x,   state->beam_end_y);
+    sp->ship.tractor_active = (state->flags & 16) != 0;
+    g.server_thrusting = (state->flags & 1) != 0;
+}
+
+static void sync_local_dock_state_from_authority(const NetPlayerState *state,
+                                                 server_player_t *sp) {
+    bool state_docked = (state->flags & 4) != 0;
+    sp->docked = state_docked;
+    sp->docking_approach = false;
+    if (state_docked) {
+        int station = nearest_station_index(sp->ship.pos);
+        if (station >= 0 && station < MAX_STATIONS &&
+            station_exists(&g.world.stations[station])) {
+            sp->current_station = station;
+            sp->nearby_station = station;
+        }
+        sp->in_dock_range = true;
+    } else {
+        sp->in_dock_range = false;
+        sp->nearby_station = -1;
+    }
+}
+
+static void frame_camera_on_authoritative_baseline(const server_player_t *sp) {
+    if (!sp) return;
+    g.camera_pos = sp->ship.pos;
+    g.camera_initialized = true;
+    g.camera_station_index = -1;
+    g.camera_station_side = 0;
+    g.camera_station_v_side = 0;
+    g.camera_drift_timer = 0.0f;
+    g.local_player_render_offset = v2(0.0f, 0.0f);
+}
+
+static void accept_initial_local_player_state(const NetPlayerState *state,
+                                              server_player_t *sp) {
+    bool state_docked = (state->flags & 4) != 0;
+    apply_authoritative_local_motion(state, sp);
+    sync_local_dock_state_from_authority(state, sp);
+    apply_local_player_remote_flags(state, sp);
+
+    net_replay_reset();
+    net_anchor_prediction_tick(state->server_tick, false);
+    g.net_local_state_ready = true;
+    g.was_docked = state_docked;
+    g.action_predict_timer = 0.0f;
+    frame_camera_on_authoritative_baseline(sp);
+}
+
+static void accept_docked_local_player_state(const NetPlayerState *state,
+                                             server_player_t *sp) {
+    vec2 before_pos = sp->ship.pos;
+    apply_authoritative_local_motion(state, sp);
+    sync_local_dock_state_from_authority(state, sp);
+    apply_local_player_remote_flags(state, sp);
+    net_replay_reset();
+    net_anchor_prediction_tick(state->server_tick, false);
+    g.was_docked = true;
+    if (!g.camera_initialized ||
+        v2_dist_sq(before_pos, sp->ship.pos) > 20.0f * 20.0f) {
+        frame_camera_on_authoritative_baseline(sp);
+    } else {
+        g.local_player_render_offset = v2(0.0f, 0.0f);
+    }
+}
+
+static void accept_authoritative_local_launch_state(const NetPlayerState *state,
+                                                    server_player_t *sp) {
+    apply_authoritative_local_motion(state, sp);
+    sync_local_dock_state_from_authority(state, sp);
+    apply_local_player_remote_flags(state, sp);
+    net_replay_reset();
+    net_anchor_prediction_tick(state->server_tick, false);
+    g.action_predict_timer = 0.0f;
+    frame_camera_on_authoritative_baseline(sp);
+}
+
 static bool net_replay_reconcile_local_player(const NetPlayerState *state,
                                               server_player_t *sp,
                                               int *out_replayed) {
@@ -241,19 +411,18 @@ static bool net_replay_reconcile_local_player(const NetPlayerState *state,
     if (server_tick == 0 && !g.net_prediction_tick_valid) return false;
 
     if (!g.net_prediction_tick_valid) {
-        g.net_prediction_tick = server_tick;
-        g.net_prediction_tick_valid = true;
-        net_replay_clear_frames();
+        net_anchor_prediction_tick(server_tick, true);
     }
 
     if ((state->flags & 4) != 0) {
         apply_authoritative_local_motion(state, sp);
-        g.net_prediction_tick = server_tick;
-        net_replay_clear_frames();
+        net_anchor_prediction_tick(server_tick, true);
         return true;
     }
 
     int first_after = net_replay_first_after(server_tick);
+    if (first_after < 0 && replay_tick_after(g.net_prediction_tick, server_tick))
+        return false;
     if (net_replay_missing_prefix(server_tick, first_after)) return false;
 
     sim_events_t saved_events = g.world.events;
@@ -399,9 +568,43 @@ static cargo_pod_t cargo_pod_render_state_at(int slot, float elapsed) {
     return out;
 }
 
-void reset_remote_dynamic_sync(void) {
+void net_reset_local_input_stream(void) {
+    g.pending_net_action = NET_ACTION_NONE;
+    g.pending_net_buy_grade = MINING_GRADE_COUNT;
+    g.pending_net_place_station = -1;
+    g.pending_net_place_ring = -1;
+    g.pending_net_place_slot = -1;
+    g.action_predict_timer = 0.0f;
+
+    g.net_input_timer = 0.0f;
+    g.net_input_have_last = false;
+    g.net_last_sent_flags = 0;
+    g.net_last_sent_mining_target = 0xFFFFu;
+    g.net_input_seq = 0;
+    g.net_last_server_ack = 0;
+    g.net_last_server_tick = 0;
+    g.net_last_server_tick_time = 0.0f;
     g.net_input_tick_protocol = false;
+    g.net_local_state_ready = false;
+    g.net_last_ack_rtt = 0.0f;
+    g.net_max_ack_rtt_5s = 0.0f;
+    g.net_ack_window_elapsed = 0.0f;
+    g.net_input_packets_sent = 0;
+    g.net_action_packets_sent = 0;
+    g.net_action_resend_packets = 0;
+    g.net_action_dropped = 0;
+    g.net_next_action_id = 1;
+    g.net_action_queue_start = 0;
+    g.net_action_queue_count = 0;
+    memset(g.net_action_queue, 0, sizeof(g.net_action_queue));
+    memset(g.net_input_timing, 0, sizeof(g.net_input_timing));
+    memset(&g.net_motion, 0, sizeof(g.net_motion));
+    g.local_player_render_offset = v2(0.0f, 0.0f);
     net_replay_reset();
+}
+
+void reset_remote_dynamic_sync(void) {
+    net_reset_local_input_stream();
     memset(g.scanned_players, 0, sizeof(g.scanned_players));
 
     memset(g.world.asteroids, 0, sizeof(g.world.asteroids));
@@ -1224,8 +1427,17 @@ void begin_player_state_batch(void) {
            sizeof(g.player_interp.prev));
     memset(g.player_interp.curr, 0, sizeof(g.player_interp.curr));
     float prev_interval = g.net_motion.packet_interval;
-    float elapsed = g.player_interp.t * g.player_interp.interval;
-    elapsed = clampf(elapsed, 0.03f, 0.15f);
+    float prev_raw_interval = g.net_motion.raw_packet_interval;
+    float raw_elapsed = g.player_interp.t * g.player_interp.interval;
+    g.net_motion.raw_packet_interval = raw_elapsed;
+    if (raw_elapsed > g.net_motion.max_raw_packet_interval_run)
+        g.net_motion.max_raw_packet_interval_run = raw_elapsed;
+    if (prev_raw_interval > 0.0f) {
+        float raw_jitter = fabsf(raw_elapsed - prev_raw_interval);
+        if (raw_jitter > g.net_motion.max_raw_packet_jitter_run)
+            g.net_motion.max_raw_packet_jitter_run = raw_jitter;
+    }
+    float elapsed = clampf(raw_elapsed, 0.03f, 0.15f);
     g.net_motion.packet_interval = elapsed;
     if (elapsed > g.net_motion.max_packet_interval_run)
         g.net_motion.max_packet_interval_run = elapsed;
@@ -1239,14 +1451,34 @@ void begin_player_state_batch(void) {
     g.player_interp.t = 0.0f;
 }
 
-void net_record_input_ack(uint16_t input_seq_ack) {
+void net_record_input_ack(uint16_t input_seq_ack,
+                          uint32_t server_tick,
+                          uint32_t input_tick_ack) {
     if (input_seq_ack == 0) return;
+    if (input_tick_ack != 0) g.net_input_tick_protocol = true;
+    net_observe_server_tick(server_tick);
+    if (server_tick != 0 && !g.net_prediction_tick_valid) {
+        net_anchor_prediction_tick(server_tick, true);
+    }
+    if (g.net_last_server_ack == 0 ||
+        input_seq_ack == g.net_last_server_ack ||
+        net_input_seq_after(input_seq_ack, g.net_last_server_ack)) {
+        g.net_last_server_ack = input_seq_ack;
+    }
+
     int index = (int)(input_seq_ack % NET_INPUT_TIMING_CAP);
     net_input_timing_t *timing = &g.net_input_timing[index];
     if (timing->seq != input_seq_ack || timing->sent_at <= 0.0f) return;
 
     float rtt = g.net_time - timing->sent_at;
     if (rtt < 0.0f || rtt > 30.0f) return;
+    if (timing->target_tick != 0 && input_tick_ack != 0) {
+        int32_t error = (int32_t)(input_tick_ack - timing->target_tick);
+        int32_t abs_error = error < 0 ? -error : error;
+        g.net_motion.input_apply_error_ticks = error;
+        if (abs_error > g.net_motion.max_input_apply_error_abs)
+            g.net_motion.max_input_apply_error_abs = abs_error;
+    }
     g.net_last_ack_rtt = rtt;
     if (rtt > g.net_max_ack_rtt_5s) g.net_max_ack_rtt_5s = rtt;
     if (rtt > g.net_motion.max_ack_rtt_run)
@@ -1254,6 +1486,7 @@ void net_record_input_ack(uint16_t input_seq_ack) {
     g.net_motion.total_input_acks++;
     timing->seq = 0;
     timing->sent_at = 0.0f;
+    timing->target_tick = 0;
 }
 
 static void record_local_player_motion_telemetry(float correction_dist,
@@ -1287,13 +1520,15 @@ static void record_local_player_motion_telemetry(float correction_dist,
     }
     if (g.net_motion.window_elapsed < NET_MOTION_TELEMETRY_WINDOW_SEC) return;
 
-    printf("[net-motion] pkt=%.3fs corr=%.1f max5=%.1f applied=%.1f maxapp5=%.1f velerr=%.1f deferred=%u/%u replayed=%u/%u frames=%u\n",
+    printf("[net-motion] pkt=%.3fs raw=%.3fs corr=%.1f max5=%.1f applied=%.1f maxapp5=%.1f velerr=%.1f input_tick_err=%d deferred=%u/%u replayed=%u/%u frames=%u\n",
            g.net_motion.packet_interval,
+           g.net_motion.raw_packet_interval,
            g.net_motion.correction_dist,
            g.net_motion.max_correction_5s,
            g.net_motion.applied_correction_dist,
            g.net_motion.max_applied_correction_5s,
            g.net_motion.velocity_error,
+           (int)g.net_motion.input_apply_error_ticks,
            (unsigned)g.net_motion.deferred_samples,
            (unsigned)g.net_motion.samples,
            (unsigned)g.net_motion.replayed_samples,
@@ -1382,15 +1617,26 @@ void apply_remote_player_state(const NetPlayerState* state) {
                 g.net_input_seq = state->input_seq_ack;
                 g.net_input_have_last = false;
             }
-            if (g.net_last_server_ack == 0 ||
-                state->input_seq_ack == g.net_last_server_ack ||
-                net_input_seq_after(state->input_seq_ack,
-                                    g.net_last_server_ack)) {
-                g.net_last_server_ack = state->input_seq_ack;
-            }
-            net_record_input_ack(state->input_seq_ack);
+            net_record_input_ack(state->input_seq_ack,
+                                 state->server_tick,
+                                 state->input_tick_ack);
         }
-        if (state->server_tick != 0) g.net_last_server_tick = state->server_tick;
+        net_observe_server_tick(state->server_tick);
+
+        if (!g.net_local_state_ready) {
+            accept_initial_local_player_state(state, sp);
+            return;
+        }
+
+        bool state_docked = (state->flags & 4) != 0;
+        if (state_docked && sp->docked) {
+            accept_docked_local_player_state(state, sp);
+            return;
+        }
+        if (!state_docked && sp->docked) {
+            accept_authoritative_local_launch_state(state, sp);
+            return;
+        }
 
         float target_x = state->x;
         float target_y = state->y;
@@ -1403,7 +1649,6 @@ void apply_remote_player_state(const NetPlayerState* state) {
         float dvy = state->vy - sp->ship.vel.y;
         float velocity_error = sqrtf(dvx * dvx + dvy * dvy);
 
-        bool state_docked = (state->flags & 4) != 0;
         int replayed_frames = 0;
         bool used_replay = false;
         bool used_snap = false;
@@ -1416,8 +1661,7 @@ void apply_remote_player_state(const NetPlayerState* state) {
         if (force_rebase) {
             apply_authoritative_local_motion(state, sp);
             net_replay_clear_frames();
-            g.net_prediction_tick = state->server_tick;
-            g.net_prediction_tick_valid = state->server_tick != 0;
+            net_anchor_prediction_tick(state->server_tick, false);
             used_snap = true;
         } else if (defer_predicted_undock) {
             defer_motion_correction = true;
@@ -1430,7 +1674,8 @@ void apply_remote_player_state(const NetPlayerState* state) {
                 net_replay_reconcile_local_player(state, sp, &replayed_frames);
         if (!force_rebase && !defer_motion_correction && !used_replay) {
             defer_motion_correction =
-                should_defer_stale_unacked_motion(state, has_unacked_input, dist_sq);
+                should_defer_stale_unacked_motion(state, has_unacked_input, dist_sq) ||
+                should_defer_active_prediction_motion(state, dist_sq);
         }
         if (!force_rebase && !used_replay && !defer_motion_correction) {
             if (dist_sq > 200.0f * 200.0f) {
@@ -1453,10 +1698,7 @@ void apply_remote_player_state(const NetPlayerState* state) {
                 sp->ship.vel.y = lerpf(sp->ship.vel.y, state->vy, 0.2f);
             }
             net_replay_reset();
-            if (state->server_tick != 0) {
-                g.net_prediction_tick = state->server_tick;
-                g.net_prediction_tick_valid = true;
-            }
+            net_anchor_prediction_tick(state->server_tick, false);
         }
         if (used_snap) g.net_motion.total_snap_samples++;
         if (used_lerp) g.net_motion.total_lerp_samples++;
@@ -1481,23 +1723,9 @@ void apply_remote_player_state(const NetPlayerState* state) {
         if (!used_replay && !defer_motion_correction &&
             !has_local_turn_prediction)
             sp->ship.angle = lerp_angle(sp->ship.angle, state->angle, 0.3f);
-        /* Beam state is server-authoritative for the local player too —
-         * the autopilot fires server-side and the client never predicts
-         * its laser. Combat / hit prediction will eventually rely on
-         * this same path. */
-        sp->beam_active      = (state->flags & 2) != 0;
-        sp->beam_ineffective = (state->flags & 32) != 0;
-        sp->beam_hit         = (state->flags & 64) != 0;
-        sp->scan_active      = (state->flags & 8) != 0;
-        sp->beam_start = v2(state->beam_start_x, state->beam_start_y);
-        sp->beam_end   = v2(state->beam_end_x,   state->beam_end_y);
-        /* Tractor active is server-authoritative — autopilot owns it
-         * server-side and the client never predicts toggles under network authority.
-         * Without this, the HUD shows stale "TRACTOR OFF" while the
-         * server is actively pulling fragments. */
-        sp->ship.tractor_active = (state->flags & 16) != 0;
-        /* Thrust flag — drives flame visual when autopilot is active. */
-        g.server_thrusting = (state->flags & 1) != 0;
+        /* Beam/tractor/thrust visual flags are server-authoritative for the
+         * local player too; autopilot and mining effects run server-side. */
+        apply_local_player_remote_flags(state, sp);
     } else {
         /* Remote player: update curr for interpolation.
          * begin_player_state_batch() already shifted prev←curr. */
@@ -1579,7 +1807,7 @@ void sync_local_player_slot_from_network(void) {
         return;
     }
 
-    net_replay_reset();
+    net_reset_local_input_stream();
     have_previous = server_player_copy_local(&previous, &g.world.players[g.local_player_slot]);
     server_player_t* assigned = &g.world.players[net_id];
     server_player_cleanup_local(&g.world.players[g.local_player_slot]);

--- a/client/net_sync.c
+++ b/client/net_sync.c
@@ -194,6 +194,16 @@ static bool net_replay_has_frames_after(uint32_t server_tick) {
     return net_replay_first_after(server_tick) >= 0;
 }
 
+static bool net_replay_has_turn_after(uint32_t server_tick) {
+    int first_after = net_replay_first_after(server_tick);
+    if (first_after < 0) return false;
+    for (int i = first_after; i < (int)g.net_replay_count; i++) {
+        const input_replay_frame_t *frame = net_replay_frame_at(i);
+        if (fabsf(frame->intent.turn) > 0.01f) return true;
+    }
+    return false;
+}
+
 static bool should_defer_stale_unacked_motion(const NetPlayerState *state,
                                               bool has_unacked_input,
                                               float dist_sq) {
@@ -1385,6 +1395,9 @@ void apply_remote_player_state(const NetPlayerState* state) {
         bool used_replay = false;
         bool used_snap = false;
         bool used_lerp = false;
+        bool has_unacked_turn = has_unacked_input &&
+            (fabsf(LOCAL_PLAYER.input.turn) > 0.01f ||
+             net_replay_has_turn_after(state->server_tick));
         bool defer_motion_correction = false;
         bool defer_predicted_undock =
             state_docked && !sp->docked && g.action_predict_timer > 0.0f;
@@ -1448,7 +1461,11 @@ void apply_remote_player_state(const NetPlayerState* state) {
             sp->nearby_station = -1;
         }
         frame_camera_on_authoritative_undock(sp, state_docked);
-        if (!used_replay && !defer_motion_correction)
+        /* A/D changes often have tiny position error, so stale snapshots can
+         * look "safe" to accept while still carrying the pre-turn angle. Keep
+         * the predicted heading until the server acks that input or replay
+         * reconciles it, otherwise steering appears to twitch then reset. */
+        if (!used_replay && !defer_motion_correction && !has_unacked_turn)
             sp->ship.angle = lerp_angle(sp->ship.angle, state->angle, 0.3f);
         /* Beam state is server-authoritative for the local player too —
          * the autopilot fires server-side and the client never predicts

--- a/client/net_sync.c
+++ b/client/net_sync.c
@@ -204,6 +204,11 @@ static bool net_replay_has_turn_after(uint32_t server_tick) {
     return false;
 }
 
+static bool net_local_turn_prediction_active(uint32_t server_tick) {
+    return fabsf(LOCAL_PLAYER.input.turn) > 0.01f ||
+           net_replay_has_turn_after(server_tick);
+}
+
 static bool should_defer_stale_unacked_motion(const NetPlayerState *state,
                                               bool has_unacked_input,
                                               float dist_sq) {
@@ -1395,9 +1400,8 @@ void apply_remote_player_state(const NetPlayerState* state) {
         bool used_replay = false;
         bool used_snap = false;
         bool used_lerp = false;
-        bool has_unacked_turn = has_unacked_input &&
-            (fabsf(LOCAL_PLAYER.input.turn) > 0.01f ||
-             net_replay_has_turn_after(state->server_tick));
+        bool has_local_turn_prediction =
+            net_local_turn_prediction_active(state->server_tick);
         bool defer_motion_correction = false;
         bool defer_predicted_undock =
             state_docked && !sp->docked && g.action_predict_timer > 0.0f;
@@ -1462,10 +1466,12 @@ void apply_remote_player_state(const NetPlayerState* state) {
         }
         frame_camera_on_authoritative_undock(sp, state_docked);
         /* A/D changes often have tiny position error, so stale snapshots can
-         * look "safe" to accept while still carrying the pre-turn angle. Keep
-         * the predicted heading until the server acks that input or replay
-         * reconciles it, otherwise steering appears to twitch then reset. */
-        if (!used_replay && !defer_motion_correction && !has_unacked_turn)
+         * look "safe" to accept while still carrying an older angle. Ack
+         * timing can also outrun replay pruning, so key this to active local
+         * steering rather than only "latest input unacked"; otherwise the
+         * ship visibly turns, then gets blended back by authority. */
+        if (!used_replay && !defer_motion_correction &&
+            !has_local_turn_prediction)
             sp->ship.angle = lerp_angle(sp->ship.angle, state->angle, 0.3f);
         /* Beam state is server-authoritative for the local player too —
          * the autopilot fires server-side and the client never predicts

--- a/client/net_sync.c
+++ b/client/net_sync.c
@@ -84,6 +84,18 @@ static bool replay_tick_after(uint32_t a, uint32_t b) {
     return (int32_t)(a - b) > 0;
 }
 
+static bool net_input_seq_after(uint16_t a, uint16_t b) {
+    return (int16_t)(a - b) > 0;
+}
+
+static bool net_latest_input_unacked(const NetPlayerState *state) {
+    if (!state || g.net_input_seq == 0) return false;
+    uint16_t ack = state->input_seq_ack;
+    if (ack == g.net_input_seq) return false;
+    if (ack == 0) return true;
+    return net_input_seq_after(g.net_input_seq, ack);
+}
+
 static input_intent_t replay_movement_intent(const input_intent_t *intent) {
     input_intent_t out = {0};
     if (!intent) return out;
@@ -1345,11 +1357,14 @@ void apply_remote_player_state(const NetPlayerState* state) {
             force_rebase = skew > (int32_t)NET_REPLAY_REBASE_SKEW_TICKS;
         }
         bool has_input_ack = state->input_seq_ack != 0;
-        bool has_unacked_input =
-            has_input_ack && g.net_input_seq != 0 &&
-            state->input_seq_ack != g.net_input_seq;
+        bool has_unacked_input = net_latest_input_unacked(state);
         if (has_input_ack) {
-            g.net_last_server_ack = state->input_seq_ack;
+            if (g.net_last_server_ack == 0 ||
+                state->input_seq_ack == g.net_last_server_ack ||
+                net_input_seq_after(state->input_seq_ack,
+                                    g.net_last_server_ack)) {
+                g.net_last_server_ack = state->input_seq_ack;
+            }
             net_record_input_ack(state->input_seq_ack);
         }
         if (state->server_tick != 0) g.net_last_server_tick = state->server_tick;

--- a/client/net_sync.c
+++ b/client/net_sync.c
@@ -1374,6 +1374,14 @@ void apply_remote_player_state(const NetPlayerState* state) {
         bool has_input_ack = state->input_seq_ack != 0;
         bool has_unacked_input = net_latest_input_unacked(state);
         if (has_input_ack) {
+            /* A restored/reconnected ship can briefly carry an ack from a
+             * previous browser input stream. Fast-forward so fresh held
+             * controls advance past it instead of being treated as stale. */
+            if (g.net_input_seq == 0 ||
+                net_input_seq_after(state->input_seq_ack, g.net_input_seq)) {
+                g.net_input_seq = state->input_seq_ack;
+                g.net_input_have_last = false;
+            }
             if (g.net_last_server_ack == 0 ||
                 state->input_seq_ack == g.net_last_server_ack ||
                 net_input_seq_after(state->input_seq_ack,

--- a/client/net_sync.h
+++ b/client/net_sync.h
@@ -13,11 +13,38 @@
 void on_player_join(uint8_t player_id);
 void on_player_leave(uint8_t player_id);
 
-/* Local input prediction history used to replay after server correction. */
+/* Local prediction/reconciliation contract
+ *
+ * Multiplayer flight prediction is enabled only after the server proves the
+ * tick-addressed input protocol by acknowledging an applied input tick. Until
+ * then, snapshots are plain server authority.
+ *
+ * Once enabled, the client owns only the local player's movement controls
+ * inside the predicted window: thrust, reverse thrust, boost, mining/tractor
+ * holds, steering input, and the heading those inputs integrate. Prediction
+ * frames are keyed by target server tick and replayed from the newest
+ * authoritative baseline. Stale snapshots must not blend angle/steering over
+ * active local turn prediction; they can only prune or rebase replay history.
+ *
+ * The server remains authoritative for docked/undocked state, launch
+ * acceptance, position/velocity outside the replayable window, large tick
+ * skew, damage/cargo/economy state, beams/scans/tractor visuals, and every
+ * one-shot action result. When the server reports a docked state, an
+ * accepted launch, an initial local state, or a correction too far ahead of
+ * replay, the client accepts that baseline and resets or prunes prediction.
+ *
+ * Reconnects and local slot changes start a new input stream: pending actions,
+ * input sequence/ack tracking, replay frames, tick anchors, action queues, and
+ * motion telemetry are cleared. Fresh low sequence numbers after reconnect
+ * must be accepted instead of compared against the previous stream.
+ */
 bool net_local_prediction_enabled(void);
 float net_prediction_latency_blend(void);
 void net_replay_reset(void);
 void net_replay_record_prediction(const input_intent_t *intent, float dt);
+uint32_t net_estimated_server_tick_now(uint32_t server_tick);
+void net_observe_server_tick(uint32_t server_tick);
+void net_anchor_prediction_tick(uint32_t server_tick, bool clear_replay);
 
 /* Apply server-authoritative world state. */
 void reset_remote_dynamic_sync(void);
@@ -56,7 +83,10 @@ void apply_remote_inspect_snapshot(const NetInspectSnapshot *snapshot);
 void apply_remote_highscores(const NetHighscoreEntry *entries, int count);
 void apply_remote_events(const sim_event_t *events, int count);
 void begin_player_state_batch(void);
-void net_record_input_ack(uint16_t input_seq_ack);
+void net_record_input_ack(uint16_t input_seq_ack,
+                          uint32_t server_tick,
+                          uint32_t input_tick_ack);
+void net_reset_local_input_stream(void);
 bool net_remote_player_scanned(int player_id);
 void net_update_remote_player_scans(const NetPlayerState *players);
 void apply_remote_player_state(const NetPlayerState* state);

--- a/server/chain_log.c
+++ b/server/chain_log.c
@@ -427,7 +427,7 @@ int chain_log_read_route_history_tail(const station_t *s,
     fclose(f);
     int n = count < cap ? count : cap;
     if (count > cap) {
-        chain_route_history_tail_t ordered[ROUTE_HISTORY_TAIL_MAX];
+        chain_route_history_tail_t ordered[ROUTE_HISTORY_TAIL_MAX] = {0};
         int start = count % cap;
         for (int i = 0; i < cap; i++)
             ordered[i] = out[(start + i) % cap];

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -575,6 +575,39 @@ static float signal_strength_unboosted(const world_t *w, vec2 pos) {
     return best;
 }
 
+#define OFF_RELAY_DOCK_BEACON_RANGE 180.0f
+
+/* Off-relay docks still need a short-range local beacon so launches don't
+ * immediately fall into near-zero control. This does not reconnect the
+ * station to the relay network; it only restores handling right at the berth. */
+static float off_relay_dock_beacon_strength(const station_t *st, vec2 pos) {
+    if (!st || !station_provides_docking(st) || st->planned || st->scaffold ||
+        st->signal_range > 0.0f)
+        return 0.0f;
+
+    float best = 0.0f;
+    for (int i = 0; i < st->module_count; i++) {
+        const station_module_t *module = &st->modules[i];
+        if (module->scaffold || module->type != MODULE_DOCK) continue;
+        vec2 dock_pos = module_world_pos_ring(st, module->ring, module->slot);
+        float dist = v2_len(v2_sub(pos, dock_pos));
+        float strength =
+            fmaxf(0.0f, 1.0f - dist / OFF_RELAY_DOCK_BEACON_RANGE);
+        if (strength > best) best = strength;
+    }
+    return best;
+}
+
+static float off_relay_dock_beacon_strength_world(const world_t *w, vec2 pos) {
+    if (!w) return 0.0f;
+    float best = 0.0f;
+    for (int s = 0; s < MAX_STATIONS; s++) {
+        float strength = off_relay_dock_beacon_strength(&w->stations[s], pos);
+        if (strength > best) best = strength;
+    }
+    return best;
+}
+
 /* Raw signal computation — scans all stations. Used to build the cache
  * and as fallback for positions outside the cached grid.
  *
@@ -595,9 +628,15 @@ static float signal_strength_raw(const world_t *w, vec2 pos) {
         if (strength > 0.0f) overlap_count++;
         if (strength > best) best = strength;
     }
-    if (overlap_count <= 1) return best;
-    int boost = overlap_count < 3 ? overlap_count : 3;
-    return fminf(1.0f, best * (float)boost);
+    float signal = best;
+    if (overlap_count > 1) {
+        int boost = overlap_count < 3 ? overlap_count : 3;
+        signal = fminf(1.0f, best * (float)boost);
+    }
+
+    float beacon = off_relay_dock_beacon_strength_world(w, pos);
+    if (beacon > signal) signal = beacon;
+    return signal;
 }
 
 /* Build/rebuild the signal cache grid. Called after topology changes
@@ -635,8 +674,12 @@ static void signal_grid_build(world_t *w) {
  * Falls back to raw computation for out-of-bounds positions or
  * when the cache hasn't been built yet. */
 float signal_strength_at(const world_t *w, vec2 pos) {
+    float dock_beacon = off_relay_dock_beacon_strength_world(w, pos);
     const signal_grid_t *sg = &w->signal_cache;
-    if (!sg->valid || !sg->strength) return signal_strength_raw(w, pos);
+    if (!sg->valid || !sg->strength) {
+        float raw = signal_strength_raw(w, pos);
+        return dock_beacon > raw ? dock_beacon : raw;
+    }
 
     /* Map world position to continuous grid coordinate. */
     float gx = (pos.x + sg->offset_x) / SIGNAL_CELL_SIZE - 0.5f;
@@ -644,8 +687,10 @@ float signal_strength_at(const world_t *w, vec2 pos) {
 
     /* Bounds check — fall back to raw for positions outside the grid. */
     if (gx < 0.0f || gy < 0.0f ||
-        gx >= (float)(SIGNAL_GRID_DIM - 1) || gy >= (float)(SIGNAL_GRID_DIM - 1))
-        return signal_strength_raw(w, pos);
+        gx >= (float)(SIGNAL_GRID_DIM - 1) || gy >= (float)(SIGNAL_GRID_DIM - 1)) {
+        float raw = signal_strength_raw(w, pos);
+        return dock_beacon > raw ? dock_beacon : raw;
+    }
 
     /* Bilinear interpolation from the 4 nearest cell centers. */
     int x0 = (int)gx, y0 = (int)gy;
@@ -656,7 +701,8 @@ float signal_strength_at(const world_t *w, vec2 pos) {
     float s11 = sg->strength[(y0 + 1) * SIGNAL_GRID_DIM + x0 + 1];
     float top = s00 + (s10 - s00) * fx;
     float bot = s01 + (s11 - s01) * fx;
-    return top + (bot - top) * fy;
+    float signal = top + (bot - top) * fy;
+    return dock_beacon > signal ? dock_beacon : signal;
 }
 
 /* ================================================================== */
@@ -1730,20 +1776,6 @@ vec2 player_launch_lane_for_berth(const station_t *st, int dock_berth,
     return v2_from_angle(angle);
 }
 
-static void translate_towed_pods_for_ship_snap(world_t *w,
-                                               const server_player_t *sp,
-                                               vec2 delta) {
-    if (!w || !sp) return;
-    if (v2_len_sq(delta) <= 0.001f) return;
-    for (int t = 0; t < sp->ship.towed_pod_count && t < 10; t++) {
-        int idx = sp->ship.towed_pods[t];
-        if (idx < 0 || idx >= MAX_CARGO_PODS) continue;
-        cargo_pod_t *pod = &w->cargo_pods[idx];
-        if (!pod->active) continue;
-        pod->pos = v2_add(pod->pos, delta);
-    }
-}
-
 static void launch_ship(world_t *w, server_player_t *sp) {
     if (!player_claim_waiting_ship_asset(w, sp)) {
         if (sp) {
@@ -1761,17 +1793,15 @@ static void launch_ship(world_t *w, server_player_t *sp) {
             ? sp->nearby_station
             : 0;
     }
-    int player_slot = player_slot_for_ptr(w, sp);
-    vec2 pre_anchor_pos = sp->ship.pos;
-    anchor_ship_in_station(sp, w);
     vec2 launch_pos = sp->ship.pos;
+    int player_slot = player_slot_for_ptr(w, sp);
     sp->docked = false;
     sp->in_dock_range = false;
     sp->docking_approach = false;
     sp->nearby_station = -1;
     sp->boost_hold_timer = 0.0f;
     sp->ship.tractor_active = false;
-    /* Launch from the exact docked berth: no relocation, just an outward kick.
+    /* Launch from the current docked position: no relocation, just an outward kick.
      * Preserve continuous flight input so controls respond immediately after
      * undock; one-shot launch/dock flags are cleared at the end of step_player. */
     const station_t *st = &w->stations[sp->current_station];
@@ -1782,15 +1812,14 @@ static void launch_ship(world_t *w, server_player_t *sp) {
         away = v2(0.0f, -1.0f);
         len = 1.0f;
     }
-    sp->ship.pos = launch_pos;
     sp->ship.angle = fixp_atan2f(away.y, away.x);
     sp->ship.vel = v2_scale(away, 95.0f / len);
     /* First launch: "Hull integrity 94%" */
     if (sp->ship.stat_ore_mined < 0.01f && sp->ship.stat_credits_earned < 0.01f)
         sp->ship.hull = ship_max_hull(&sp->ship) * 0.94f;
-    translate_towed_pods_for_ship_snap(
-        w, sp, v2_sub(launch_pos, pre_anchor_pos));
-    SIM_LOG("[sim] player %d launched\n", sp->id);
+    SIM_LOG("[sim] player %d launched station=%d pos=(%.1f,%.1f) vel=(%.1f,%.1f)\n",
+            sp->id, sp->current_station, sp->ship.pos.x, sp->ship.pos.y,
+            sp->ship.vel.x, sp->ship.vel.y);
     emit_event(w, (sim_event_t){.type = SIM_EVENT_LAUNCH, .player_id = sp->id});
 }
 
@@ -7166,8 +7195,13 @@ static void step_player(world_t *w, server_player_t *sp, float dt) {
             }
         }
     } else {
-        update_docking_state(w, sp, dt);
-        if (!w->player_only_mode)
+        bool launch_requested =
+            !w->player_only_mode && (sp->input.launch || sp->input.interact);
+        if (launch_requested)
+            step_station_interaction_system(w, sp, &sp->input);
+        if (sp->docked)
+            update_docking_state(w, sp, dt);
+        if (!launch_requested && !w->player_only_mode)
             step_station_interaction_system(w, sp, &sp->input);
     }
 
@@ -9558,6 +9592,10 @@ void server_player_queue_movement_input(server_player_t *sp,
             movement_input_cmd_t *cmd = &sp->movement_queue[i];
             if (cmd->input_seq == input_seq) {
                 cmd->intent = movement;
+                return;
+            }
+            if (cmd->input_seq != 0 &&
+                !input_seq_after(input_seq, cmd->input_seq)) {
                 return;
             }
         }

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -11354,6 +11354,7 @@ bool server_dispatch_register_pubkey_message(
     sp->pubkey_set = true;
     sp->pubkey_proof_ok = false;
     sp->pubkey_identity_finalized = false;
+    sp->preserve_live_state_on_pubkey_finalize = false;
     return true;
 }
 
@@ -11507,6 +11508,7 @@ void server_player_clear_live_session_identity(server_player_t *sp) {
     sp->pubkey_set = false;
     sp->pubkey_proof_ok = false;
     sp->pubkey_identity_finalized = false;
+    sp->preserve_live_state_on_pubkey_finalize = false;
     sp->last_signed_nonce = 0;
 }
 

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -9628,10 +9628,11 @@ static void apply_movement_intent(server_player_t *sp,
     sp->input.reverse_thrust = intent->reverse_thrust;
 }
 
-void server_player_queue_movement_input(server_player_t *sp,
-                                        const input_intent_t *intent,
-                                        uint16_t input_seq,
-                                        uint32_t apply_tick) {
+static void server_player_queue_movement_input_impl(server_player_t *sp,
+                                                    const input_intent_t *intent,
+                                                    uint16_t input_seq,
+                                                    uint32_t apply_tick,
+                                                    bool preserve_apply_tick) {
     if (!sp || !intent || apply_tick == 0) return;
 
     input_intent_t movement = movement_intent_from_input(intent);
@@ -9662,12 +9663,24 @@ void server_player_queue_movement_input(server_player_t *sp,
         sp->movement_queue_count = count;
     }
 
+    if (!preserve_apply_tick && input_seq != 0 && count > 0) {
+        uint32_t last_tick = sp->movement_queue[count - 1].apply_tick;
+        if (!sim_tick_after(apply_tick, last_tick)) {
+            apply_tick = last_tick + 1u;
+            if (apply_tick == 0) apply_tick = last_tick;
+        }
+    }
+
     int insert = (int)count;
-    while (insert > 0 &&
-           sim_tick_after(sp->movement_queue[insert - 1].apply_tick,
-                          apply_tick)) {
-        sp->movement_queue[insert] = sp->movement_queue[insert - 1];
-        insert--;
+    if (count > 0 &&
+        sim_tick_after(sp->movement_queue[count - 1].apply_tick,
+                       apply_tick)) {
+        while (insert > 0 &&
+               sim_tick_after(sp->movement_queue[insert - 1].apply_tick,
+                              apply_tick)) {
+            sp->movement_queue[insert] = sp->movement_queue[insert - 1];
+            insert--;
+        }
     }
     sp->movement_queue[insert] = (movement_input_cmd_t){
         .apply_tick = apply_tick,
@@ -9675,6 +9688,22 @@ void server_player_queue_movement_input(server_player_t *sp,
         .intent = movement,
     };
     sp->movement_queue_count = (uint8_t)(count + 1u);
+}
+
+void server_player_queue_movement_input(server_player_t *sp,
+                                        const input_intent_t *intent,
+                                        uint16_t input_seq,
+                                        uint32_t apply_tick) {
+    server_player_queue_movement_input_impl(sp, intent, input_seq, apply_tick,
+                                            false);
+}
+
+void server_player_queue_ticked_movement_input(server_player_t *sp,
+                                               const input_intent_t *intent,
+                                               uint16_t input_seq,
+                                               uint32_t apply_tick) {
+    server_player_queue_movement_input_impl(sp, intent, input_seq, apply_tick,
+                                            true);
 }
 
 uint32_t server_input_apply_tick_for_world(const world_t *w,
@@ -9809,7 +9838,12 @@ bool server_dispatch_input_message(world_t *w, int player_idx,
     server_input_intent_wire_defaults(&parsed);
     parse_input(input_data, input_len, &parsed);
     uint32_t apply_tick = server_input_apply_tick_for_world(w, client_tick);
-    server_player_queue_movement_input(sp, &parsed, input_seq, apply_tick);
+    if (client_tick != 0) {
+        server_player_queue_ticked_movement_input(sp, &parsed, input_seq,
+                                                  apply_tick);
+    } else {
+        server_player_queue_movement_input(sp, &parsed, input_seq, apply_tick);
+    }
 
     int station_dirty = -1;
     if ((effective_action >= NET_ACTION_BUY_SCAFFOLD_TYPED &&
@@ -10449,8 +10483,10 @@ bool server_dispatch_handoff_present(
 static void server_player_apply_queued_movement(server_player_t *sp,
                                                 uint32_t tick) {
     if (!sp) return;
-    while (sp->movement_queue_count > 0) {
-        const movement_input_cmd_t *cmd = &sp->movement_queue[0];
+    uint8_t consumed = 0;
+    uint8_t count = sp->movement_queue_count;
+    while (consumed < count) {
+        const movement_input_cmd_t *cmd = &sp->movement_queue[consumed];
         if (sim_tick_after(cmd->apply_tick, tick)) break;
         if (cmd->input_seq == 0 || sp->last_input_seq == 0 ||
             input_seq_after(cmd->input_seq, sp->last_input_seq)) {
@@ -10458,11 +10494,13 @@ static void server_player_apply_queued_movement(server_player_t *sp,
             sp->last_input_seq = cmd->input_seq;
             sp->last_input_tick = tick;
         }
-        sp->movement_queue_count--;
-        if (sp->movement_queue_count > 0) {
-            memmove(&sp->movement_queue[0], &sp->movement_queue[1],
-                    sp->movement_queue_count * sizeof(sp->movement_queue[0]));
-        }
+        consumed++;
+    }
+    if (consumed == 0) return;
+    sp->movement_queue_count = (uint8_t)(count - consumed);
+    if (sp->movement_queue_count > 0) {
+        memmove(&sp->movement_queue[0], &sp->movement_queue[consumed],
+                sp->movement_queue_count * sizeof(sp->movement_queue[0]));
     }
 }
 

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -11564,6 +11564,16 @@ void server_player_clear_live_session_identity(server_player_t *sp) {
     sp->last_signed_nonce = 0;
 }
 
+void server_player_reset_input_stream(server_player_t *sp) {
+    if (!sp) return;
+    memset(sp->movement_queue, 0, sizeof(sp->movement_queue));
+    sp->movement_queue_count = 0;
+    sp->last_input_seq = 0;
+    sp->last_input_tick = 0;
+    sp->last_input_action_id = 0;
+    sp->last_input_action_id_valid = false;
+}
+
 void server_player_clear_transient_input(server_player_t *sp) {
     if (!sp) return;
     sp->input = (input_intent_t){
@@ -11582,10 +11592,7 @@ void server_player_clear_transient_input(server_player_t *sp) {
         .buy_grade = MINING_GRADE_COUNT,
         .mining_target_hint = -1,
     };
-    memset(sp->movement_queue, 0, sizeof(sp->movement_queue));
-    sp->movement_queue_count = 0;
-    sp->last_input_seq = 0;
-    sp->last_input_tick = 0;
+    server_player_reset_input_stream(sp);
     sp->boost_hold_timer = 0.0f;
     sp->actual_thrusting = false;
     sp->docking_approach = false;

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -1817,8 +1817,9 @@ static void launch_ship(world_t *w, server_player_t *sp) {
     /* First launch: "Hull integrity 94%" */
     if (sp->ship.stat_ore_mined < 0.01f && sp->ship.stat_credits_earned < 0.01f)
         sp->ship.hull = ship_max_hull(&sp->ship) * 0.94f;
-    SIM_LOG("[sim] player %d launched station=%d pos=(%.1f,%.1f) vel=(%.1f,%.1f)\n",
-            sp->id, sp->current_station, sp->ship.pos.x, sp->ship.pos.y,
+    SIM_LOG("[sim] player %d launched station=%d berth=%d pos=(%.1f,%.1f) vel=(%.1f,%.1f)\n",
+            sp->id, sp->current_station, sp->dock_berth,
+            sp->ship.pos.x, sp->ship.pos.y,
             sp->ship.vel.x, sp->ship.vel.y);
     emit_event(w, (sim_event_t){.type = SIM_EVENT_LAUNCH, .player_id = sp->id});
 }
@@ -4142,6 +4143,40 @@ static void resolve_world_collisions(world_t *w, server_player_t *sp) {
 #define BERTHS_PER_DOCK 3          /* berths per MODULE_DOCK */
 #define DOCK_SNAP_DISTANCE 30.0f   /* snap-to-docked threshold */
 
+static int dock_berth_index(int berth) {
+    return berth >= 0 ? berth : 0;
+}
+
+static float dock_fallback_radial_angle(int berth) {
+    int lane = dock_berth_index(berth) % 8;
+    return -PI_F * 0.5f + (float)lane * (TWO_PI_F / 8.0f);
+}
+
+static float dock_fallback_radius(const station_t *st) {
+    if (!st) return DOCK_BERTH_OFFSET;
+    float r = st->dock_radius;
+    if (!isfinite(r) || r < st->radius)
+        r = st->radius;
+    if (!isfinite(r) || r < 0.0f)
+        r = 0.0f;
+    return r + DOCK_BERTH_OFFSET;
+}
+
+static vec2 dock_fallback_berth_pos(const station_t *st, int berth) {
+    if (!st) return v2(0.0f, 0.0f);
+    float angle = dock_fallback_radial_angle(berth);
+    return v2_add(st->pos, v2_scale(v2_from_angle(angle), dock_fallback_radius(st)));
+}
+
+static bool dock_berth_position_is_valid(const station_t *st, vec2 pos) {
+    if (!st) return false;
+    if (!isfinite(pos.x) || !isfinite(pos.y)) return false;
+    float min_r = st->radius + 1.0f;
+    if (!isfinite(min_r) || min_r < 1.0f)
+        min_r = 1.0f;
+    return v2_dist_sq(pos, st->pos) >= min_r * min_r;
+}
+
 /* Count dock modules on a station */
 static int station_dock_count(const station_t *st) {
     int count = 0;
@@ -4170,12 +4205,18 @@ static int station_dock_module(const station_t *st, int dock_index) {
 /* Dock berth position: 0=outward end, 1=left side, 2=right side.
  * End berth is past the dock, side berths flank the module. */
 static vec2 dock_berth_pos(const station_t *st, int berth) {
-    int dock_idx = berth / BERTHS_PER_DOCK;
-    int sub = berth % BERTHS_PER_DOCK;
+    if (!st) return v2(0.0f, 0.0f);
+    int normalized = dock_berth_index(berth);
+    int dock_idx = normalized / BERTHS_PER_DOCK;
+    int sub = normalized % BERTHS_PER_DOCK;
     int mi = station_dock_module(st, dock_idx);
-    if (mi < 0) return st->pos;
+    if (mi < 0) return dock_fallback_berth_pos(st, berth);
     int ring = st->modules[mi].ring;
     int slot = st->modules[mi].slot;
+    if (ring < 1 || ring > STATION_NUM_RINGS ||
+        STATION_RING_SLOTS[ring] <= 0) {
+        return dock_fallback_berth_pos(st, berth);
+    }
     vec2 mod_pos = module_world_pos_ring(st, ring, slot);
     float angle = module_angle_ring(st, ring, slot);
     vec2 radial = v2_from_angle(angle);  /* center → module (outward) */
@@ -4188,32 +4229,43 @@ static vec2 dock_berth_pos(const station_t *st, int berth) {
     vec2 gap_dir = v2_from_angle(gap_angle);
     vec2 gap_tangent = v2(-gap_dir.y, gap_dir.x); /* not used but clarifies intent */
     (void)gap_tangent;
+    vec2 pos;
     if (sub == 0) {
         /* Outward berth: radially away from center */
-        return v2_add(mod_pos, v2_scale(radial, DOCK_BERTH_OFFSET));
+        pos = v2_add(mod_pos, v2_scale(radial, DOCK_BERTH_OFFSET));
     } else if (sub == 1) {
         /* Inward berth: radially toward center */
-        return v2_add(mod_pos, v2_scale(radial, -DOCK_BERTH_OFFSET));
+        pos = v2_add(mod_pos, v2_scale(radial, -DOCK_BERTH_OFFSET));
     } else {
         /* Gap-side berth: tangentially toward the ring gap */
         vec2 gap_tangent_dir = v2(-radial.y, radial.x);
         /* Dock at slot 0: gap is at negative tangent; higher slots: positive */
         float dir = (slot == 0) ? -1.0f : 1.0f;
-        return v2_add(mod_pos, v2_scale(gap_tangent_dir, dir * DOCK_BERTH_OFFSET));
+        pos = v2_add(mod_pos, v2_scale(gap_tangent_dir, dir * DOCK_BERTH_OFFSET));
     }
+    if (!dock_berth_position_is_valid(st, pos))
+        return dock_fallback_berth_pos(st, berth);
+    return pos;
 }
 
 /* Dock berth angle: face toward the dock module */
 static float dock_berth_angle(const station_t *st, int berth) {
-    int dock_idx = berth / BERTHS_PER_DOCK;
-    int sub = berth % BERTHS_PER_DOCK;
+    if (!st) return 0.0f;
+    int normalized = dock_berth_index(berth);
+    int dock_idx = normalized / BERTHS_PER_DOCK;
+    int sub = normalized % BERTHS_PER_DOCK;
     int mi = station_dock_module(st, dock_idx);
-    if (mi < 0) return 0.0f;
-    float angle = module_angle_ring(st, st->modules[mi].ring, st->modules[mi].slot);
+    if (mi < 0) return dock_fallback_radial_angle(berth) + PI_F;
+    int ring = st->modules[mi].ring;
+    int slot = st->modules[mi].slot;
+    if (ring < 1 || ring > STATION_NUM_RINGS ||
+        STATION_RING_SLOTS[ring] <= 0) {
+        return dock_fallback_radial_angle(berth) + PI_F;
+    }
+    float angle = module_angle_ring(st, ring, slot);
     if (sub == 0) return angle + PI_F;       /* outward: face inward */
     if (sub == 1) return angle;              /* inward: face outward */
     /* Gap-side: face toward dock along tangent */
-    int slot = st->modules[mi].slot;
     float dir = (slot == 0) ? 1.0f : -1.0f;
     float tang_angle = angle + PI_F * 0.5f * dir;
     return tang_angle;

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -643,6 +643,10 @@ void server_player_queue_movement_input(server_player_t *sp,
                                         const input_intent_t *intent,
                                         uint16_t input_seq,
                                         uint32_t apply_tick);
+void server_player_queue_ticked_movement_input(server_player_t *sp,
+                                               const input_intent_t *intent,
+                                               uint16_t input_seq,
+                                               uint32_t apply_tick);
 
 typedef struct {
     input_intent_t intent;

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -777,6 +777,7 @@ void player_init_ship(server_player_t *sp, world_t *w);
 bool server_player_has_live_session(const server_player_t *sp);
 bool server_player_is_gameplay_ready(const server_player_t *sp);
 void server_player_clear_live_session_identity(server_player_t *sp);
+void server_player_reset_input_stream(server_player_t *sp);
 void server_player_clear_transient_input(server_player_t *sp);
 
 /* Layer A.2 of #479 — pubkey registry. */

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -352,6 +352,10 @@ typedef struct {
     bool    pubkey_set;
     bool    pubkey_proof_ok;
     bool    pubkey_identity_finalized;
+    /* Runtime-only reconnect latch. Session reattach can happen before
+     * PROVE_PUBKEY arrives; when it does, skip the pubkey save reload that
+     * would otherwise overwrite the live transferred ship state. */
+    bool    preserve_live_state_on_pubkey_finalize;
     /* Layer A.3 of #479 — monotonic per-player nonce for NET_MSG_SIGNED_ACTION.
      * Persisted in the player save (PLY6+). Any signed action whose nonce is
      * <= this value is rejected as a replay; on accept, this becomes the

--- a/server/main.c
+++ b/server/main.c
@@ -787,7 +787,11 @@ static void finalize_verified_pubkey_identity(struct mg_connection *c, int pid,
            pid, pk[0], pk[1], pk[2], pk[3]);
     analytics_log_player_event("player_identity", pid, sp, now, 0);
 
-    if (preserve_live_state || transferred_live_state) {
+    bool keep_live_state = preserve_live_state || transferred_live_state ||
+                           sp->preserve_live_state_on_pubkey_finalize;
+    sp->preserve_live_state_on_pubkey_finalize = false;
+
+    if (keep_live_state) {
         printf("[server] player %d: kept live pubkey reconnect state\n", pid);
     } else if (true &&
         player_load_by_pubkey(sp, &world, PLAYER_SAVE_DIR, pk)) {
@@ -1160,6 +1164,7 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
                 broadcast(leave_old, 2);
                 printf("[server] player %d: reconnected (was slot %d)\n", pid, reattach);
                 reattached_live_state = true;
+                world.players[pid].preserve_live_state_on_pubkey_finalize = true;
             } else {
                 if (!server_apply_session_message(&world, pid, &session))
                     break;

--- a/server/main.c
+++ b/server/main.c
@@ -402,7 +402,6 @@ static uint64_t last_player_state_emit = 0;
 /* Timing intervals in milliseconds */
 #define SIM_TICK_MS   8     /* ~120 Hz poll gate; sim uses SIM_DT accumulator */
 #define STATE_TICK_MS 50    /* 20 Hz player state broadcast */
-#define PLAYER_ACK_FLUSH_MIN_MS 25 /* active-input ack flush cap (~40 Hz) */
 #define WORLD_TICK_MS 100   /* 10 Hz world state broadcast */
 #define SHIP_TICK_MS  250   /* 4 Hz full ship state (cargo, hull, etc.) */
 #define MAX_SIM_STEPS 8     /* cap sub-steps per poll to prevent spiral */
@@ -601,6 +600,16 @@ static void send_action_result(struct mg_connection *c, uint16_t action_id,
     uint8_t buf[NET_ACTION_RESULT_SIZE];
     int len = serialize_action_result(buf, action_id, input_seq, status,
                                       action, server_tick);
+    ws_send(c, buf, (size_t)len);
+}
+
+static void send_input_applied(struct mg_connection *c, uint16_t input_seq,
+                               uint32_t server_tick,
+                               uint32_t input_tick_ack) {
+    if (!c || input_seq == 0) return;
+    uint8_t buf[NET_INPUT_APPLIED_SIZE];
+    int len = serialize_input_applied(buf, input_seq, server_tick,
+                                      input_tick_ack);
     ws_send(c, buf, (size_t)len);
 }
 
@@ -2854,6 +2863,7 @@ static const char *protocol_msg_name(uint8_t msg) {
     case NET_MSG_LATENCY_PING: return "LATENCY_PING";
     case NET_MSG_LATENCY_PONG: return "LATENCY_PONG";
     case NET_MSG_CLIENT_METRICS: return "CLIENT_METRICS";
+    case NET_MSG_INPUT_APPLIED: return "INPUT_APPLIED";
     case NET_MSG_STATION_IDENTITY: return "STATION_IDENTITY";
     case NET_MSG_STATION_DIAG: return "STATION_DIAG";
     case NET_MSG_WORLD_PLAYERS: return "WORLD_PLAYERS";
@@ -3179,6 +3189,10 @@ static void ev_handler(struct mg_connection *c, int ev, void *ev_data) {
                        "\"frontier_virtual_supply_deliveries\":%u,"
                        "\"server_bot_brain_mode\":\"%s\","
                        "\"server_intelligence_backend\":\"%s\","
+                       "\"server_intelligence_flight_builtin\":%s,"
+                       "\"server_intelligence_flight_feature_set\":\"%s\","
+                       "\"server_intelligence_flight_encoder_version\":%u,"
+                       "\"server_intelligence_flight_checkpoint_hash\":\"%s\","
                        "\"server_brain_loaded\":%s,"
                        "\"server_brain_inferences\":%llu,"
                        "\"server_contract_brain_loaded\":%s,"
@@ -3205,6 +3219,10 @@ static void ev_handler(struct mg_connection *c, int ev, void *ev_data) {
                        world.frontier_virtual_supply_deliveries,
                        server_bot_brain_mode_name,
                        signal_intelligence_backend_name(),
+                       signal_intelligence_flight_builtin_available() ? "true" : "false",
+                       signal_intelligence_flight_feature_set(),
+                       (unsigned)signal_intelligence_flight_feature_encoder_version(),
+                       signal_intelligence_flight_checkpoint_hash(),
                        signal_intelligence_flight_loaded() ? "true" : "false",
                        (unsigned long long)signal_intelligence_flight_inference_count(),
                        signal_intelligence_contract_loaded() ? "true" : "false",
@@ -3798,13 +3816,28 @@ static bool read_env_config(char *listen_url, size_t listen_url_size) {
         server_bot_npc_worker_brain_checkpoint =
             getenv("SIGNAL_BOT_NPC_WORKER_BRAIN_CHECKPOINT");
         if (server_bot_brain_mode == SERVER_BRAIN_MODE_NEURAL_FLIGHT &&
-            (!server_bot_brain_checkpoint || server_bot_brain_checkpoint[0] == '\0')) {
+            (!server_bot_brain_checkpoint || server_bot_brain_checkpoint[0] == '\0') &&
+            !signal_intelligence_flight_builtin_available()) {
             fprintf(stderr, "[FATAL] SIGNAL_BOT_BRAIN_MODE=neural requires "
-                            "SIGNAL_BOT_BRAIN_CHECKPOINT\n");
+                            "SIGNAL_BOT_BRAIN_CHECKPOINT or a linked "
+                            "CRLPLRIMES static flight bundle\n");
             return false;
         }
         if (server_bot_player_target > 0) {
             printf("[server] Server bot brain mode: %s\n", server_bot_brain_mode_name);
+            if (server_bot_brain_mode == SERVER_BRAIN_MODE_NEURAL_FLIGHT) {
+                if (server_bot_brain_checkpoint &&
+                    server_bot_brain_checkpoint[0] != '\0') {
+                    printf("[server] Server bot flight brain checkpoint: %s\n",
+                           server_bot_brain_checkpoint);
+                } else if (signal_intelligence_flight_builtin_available()) {
+                    printf("[server] Server bot flight brain: built-in CRLPLRIMES "
+                           "%s encoder=%u hash=%.12s\n",
+                           signal_intelligence_flight_feature_set(),
+                           (unsigned)signal_intelligence_flight_feature_encoder_version(),
+                           signal_intelligence_flight_checkpoint_hash());
+                }
+            }
             if (server_bot_contract_brain_checkpoint &&
                 server_bot_contract_brain_checkpoint[0] != '\0') {
                 printf("[server] Server bot contract brain checkpoint: %s\n",
@@ -4204,7 +4237,7 @@ static void mark_station_identity_dirty_for_hull_inventory_changes(void) {
 /* Run as many fixed-step sim ticks as `sim_accum` covers, up to
  * MAX_SIM_STEPS, broadcasting per-event side effects after each tick.
  * Caller passes the running accumulator + the elapsed-since-last-call
- * seconds. Returns true if it emitted an input-ack player-state flush. */
+ * seconds. Returns true if it emitted an immediate player-state flush. */
 static bool run_sim_ticks(float *sim_accum, float elapsed, uint64_t now) {
     uint16_t input_ack_before[MAX_PLAYERS];
     for (int i = 0; i < MAX_PLAYERS; i++)
@@ -4212,7 +4245,7 @@ static bool run_sim_ticks(float *sim_accum, float elapsed, uint64_t now) {
 
     *sim_accum += elapsed;
     int steps = 0;
-    bool input_ack_changed = false;
+    (void)now;
     while (*sim_accum >= SIM_DT && steps < MAX_SIM_STEPS) {
         world_sim_step(&world, SIM_DT);
         mark_station_identity_dirty_for_hull_inventory_changes();
@@ -4221,7 +4254,8 @@ static bool run_sim_ticks(float *sim_accum, float elapsed, uint64_t now) {
             if (!server_player_is_gameplay_ready(sp)) continue;
             if (sp->last_input_seq != 0 &&
                 sp->last_input_seq != input_ack_before[p]) {
-                input_ack_changed = true;
+                send_input_applied(sp->conn, sp->last_input_seq,
+                                   world.tick, sp->last_input_tick);
                 input_ack_before[p] = sp->last_input_seq;
             }
         }
@@ -4238,13 +4272,6 @@ static bool run_sim_ticks(float *sim_accum, float elapsed, uint64_t now) {
         steps++;
     }
     if (*sim_accum > SIM_DT) *sim_accum = 0.0f; /* prevent spiral */
-    if (input_ack_changed &&
-        (last_player_state_emit == 0 ||
-         now - last_player_state_emit >= PLAYER_ACK_FLUSH_MIN_MS)) {
-        broadcast_player_states();
-        last_player_state_emit = now;
-        return true;
-    }
     return false;
 }
 
@@ -4411,15 +4438,27 @@ int main(void) {
     frontier_virtual_pilots_set(&world, frontier_virtual_pilot_target);
     signal_intelligence_holographic_init();
     if (server_bot_brain_mode == SERVER_BRAIN_MODE_NEURAL_FLIGHT) {
-        char err[256];
-        if (!signal_intelligence_load_flight_checkpoint(
-                server_bot_brain_checkpoint, err, sizeof(err))) {
-            fprintf(stderr, "[FATAL] failed to load SIGNAL_BOT_BRAIN_CHECKPOINT=%s: %s\n",
-                    server_bot_brain_checkpoint, err);
+        if (server_bot_brain_checkpoint &&
+            server_bot_brain_checkpoint[0] != '\0') {
+            char err[256];
+            if (!signal_intelligence_load_flight_checkpoint(
+                    server_bot_brain_checkpoint, err, sizeof(err))) {
+                fprintf(stderr, "[FATAL] failed to load SIGNAL_BOT_BRAIN_CHECKPOINT=%s: %s\n",
+                        server_bot_brain_checkpoint, err);
+                return 1;
+            }
+            printf("[server] loaded neural bot brain checkpoint: %s\n",
+                   server_bot_brain_checkpoint);
+        } else if (signal_intelligence_flight_builtin_available()) {
+            printf("[server] using built-in CRLPLRIMES flight brain: "
+                   "%s encoder=%u hash=%.12s\n",
+                   signal_intelligence_flight_feature_set(),
+                   (unsigned)signal_intelligence_flight_feature_encoder_version(),
+                   signal_intelligence_flight_checkpoint_hash());
+        } else {
+            fprintf(stderr, "[FATAL] no neural flight backend available\n");
             return 1;
         }
-        printf("[server] loaded neural bot brain checkpoint: %s\n",
-               server_bot_brain_checkpoint);
         if (server_bot_contract_brain_checkpoint &&
             server_bot_contract_brain_checkpoint[0] != '\0') {
             char contract_err[256];

--- a/server/main.c
+++ b/server/main.c
@@ -745,10 +745,12 @@ static void finalize_verified_pubkey_identity(struct mg_connection *c, int pid,
     int existing = registry_lookup_by_pubkey(&world, pk);
     if (existing >= 0 && existing != pid) {
         server_player_t *old = &world.players[existing];
-        if (memcmp(old->session_token, sp->session_token, 8) != 0) {
-            if (world_player_transfer_ship_state(&world, pid, existing)) {
-                struct mg_connection *old_conn =
-                    (struct mg_connection *)old->conn;
+        bool session_token_changed =
+            memcmp(old->session_token, sp->session_token, 8) != 0;
+        if (world_player_transfer_ship_state(&world, pid, existing)) {
+            struct mg_connection *old_conn =
+                (struct mg_connection *)old->conn;
+            if (session_token_changed) {
                 uint8_t old_pseudo[32] = {0};
                 uint8_t new_pseudo[32] = {0};
                 memcpy(old_pseudo, old->session_token, 8);
@@ -763,22 +765,22 @@ static void finalize_verified_pubkey_identity(struct mg_connection *c, int pid,
                         }
                     }
                 }
-
-                old->connected = false;
-                old->grace_period = false;
-                old->conn = NULL;
-                server_player_clear_live_session_identity(old);
-                server_player_clear_transient_input(old);
-                if (old_conn && old_conn != c) {
-                    mg_ws_send(old_conn, NULL, 0, WEBSOCKET_OP_CLOSE);
-                    old_conn->is_closing = 1;
-                }
-                uint8_t leave_old[] = { NET_MSG_LEAVE, (uint8_t)existing };
-                broadcast(leave_old, 2);
-                transferred_live_state = true;
-                printf("[server] player %d: pubkey reconnect (was slot %d)\n",
-                       pid, existing);
             }
+
+            old->connected = false;
+            old->grace_period = false;
+            old->conn = NULL;
+            server_player_clear_live_session_identity(old);
+            server_player_clear_transient_input(old);
+            if (old_conn && old_conn != c) {
+                mg_ws_send(old_conn, NULL, 0, WEBSOCKET_OP_CLOSE);
+                old_conn->is_closing = 1;
+            }
+            uint8_t leave_old[] = { NET_MSG_LEAVE, (uint8_t)existing };
+            broadcast(leave_old, 2);
+            transferred_live_state = true;
+            printf("[server] player %d: pubkey reconnect (was slot %d)\n",
+                   pid, existing);
         }
     }
 

--- a/server/main.c
+++ b/server/main.c
@@ -733,7 +733,8 @@ static bool ws_message_allowed_before_session(uint8_t type) {
 }
 
 static void finalize_verified_pubkey_identity(struct mg_connection *c, int pid,
-                                              uint64_t now) {
+                                              uint64_t now,
+                                              bool preserve_live_state) {
     if (pid < 0 || pid >= MAX_PLAYERS) return;
     server_player_t *sp = &world.players[pid];
     if (!server_player_can_use_pubkey_persistence(sp)) return;
@@ -786,7 +787,7 @@ static void finalize_verified_pubkey_identity(struct mg_connection *c, int pid,
            pid, pk[0], pk[1], pk[2], pk[3]);
     analytics_log_player_event("player_identity", pid, sp, now, 0);
 
-    if (transferred_live_state) {
+    if (preserve_live_state || transferred_live_state) {
         printf("[server] player %d: kept live pubkey reconnect state\n", pid);
     } else if (true &&
         player_load_by_pubkey(sp, &world, PLAYER_SAVE_DIR, pk)) {
@@ -1023,7 +1024,7 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
         if (server_dispatch_register_pubkey_message(&world, pid, data, len,
                                                     &result)) {
             if (result.same_pubkey) {
-                finalize_verified_pubkey_identity(c, pid, now);
+                finalize_verified_pubkey_identity(c, pid, now, false);
                 break;
             }
             printf("[server] player %d: registered pubkey pending proof %02x%02x%02x%02x...\n",
@@ -1038,7 +1039,7 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
         if (server_dispatch_pubkey_proof_message(&world, pid, data, len,
                                                  &result) &&
             result.verified) {
-            finalize_verified_pubkey_identity(c, pid, now);
+            finalize_verified_pubkey_identity(c, pid, now, false);
         } else if (result.status != SERVER_PUBKEY_PROOF_MALFORMED) {
             printf("[server] player %d: pubkey proof rejected (%s)\n",
                    pid, server_pubkey_proof_status_name(result.status));
@@ -1141,6 +1142,7 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
                     break;
                 }
             }
+            bool reattached_live_state = false;
             if (reattach >= 0) {
                 /* Reattach: copy state from grace slot to new slot */
                 server_player_t *old = &world.players[reattach];
@@ -1157,6 +1159,7 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
                 uint8_t leave_old[] = { NET_MSG_LEAVE, (uint8_t)reattach };
                 broadcast(leave_old, 2);
                 printf("[server] player %d: reconnected (was slot %d)\n", pid, reattach);
+                reattached_live_state = true;
             } else {
                 if (!server_apply_session_message(&world, pid, &session))
                     break;
@@ -1174,7 +1177,8 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
             world.players[pid].last_input_action_id = 0;
             world.players[pid].last_input_action_id_valid = false;
             world.players[pid].pending_action_result_valid = false;
-            finalize_verified_pubkey_identity(c, pid, now);
+            finalize_verified_pubkey_identity(c, pid, now,
+                                              reattached_live_state);
             uint8_t join_msg[] = { NET_MSG_JOIN, (uint8_t)pid };
             broadcast_except(pid, join_msg, 2);
             analytics_record_activity(&world.players[pid], now);

--- a/server/main.c
+++ b/server/main.c
@@ -794,6 +794,8 @@ static void finalize_verified_pubkey_identity(struct mg_connection *c, int pid,
     sp->preserve_live_state_on_pubkey_finalize = false;
 
     if (keep_live_state) {
+        server_player_reset_input_stream(sp);
+        force_player_authoritative_resync(sp);
         printf("[server] player %d: kept live pubkey reconnect state\n", pid);
     } else if (true &&
         player_load_by_pubkey(sp, &world, PLAYER_SAVE_DIR, pk)) {
@@ -1181,8 +1183,8 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
                 /* Seed starting credits now that session_token is set */
                 player_seed_credits(&world.players[pid], &world);
             }
-            world.players[pid].last_input_action_id = 0;
-            world.players[pid].last_input_action_id_valid = false;
+            server_player_reset_input_stream(&world.players[pid]);
+            force_player_authoritative_resync(&world.players[pid]);
             world.players[pid].pending_action_result_valid = false;
             finalize_verified_pubkey_identity(c, pid, now,
                                               reattached_live_state);

--- a/server/net_protocol.h
+++ b/server/net_protocol.h
@@ -107,6 +107,16 @@ static inline int serialize_action_result(uint8_t *buf, uint16_t action_id,
     return NET_ACTION_RESULT_SIZE;
 }
 
+static inline int serialize_input_applied(uint8_t *buf, uint16_t input_seq,
+                                          uint32_t server_tick,
+                                          uint32_t input_tick_ack) {
+    buf[0] = NET_MSG_INPUT_APPLIED;
+    write_u16_le(&buf[1], input_seq);
+    write_u32_le(&buf[3], server_tick);
+    write_u32_le(&buf[7], input_tick_ack);
+    return NET_INPUT_APPLIED_SIZE;
+}
+
 static inline int serialize_cargo_receipt_bundle(
     uint8_t *buf,
     const cargo_receipt_chain_t *chain) {
@@ -313,7 +323,13 @@ static inline int serialize_protocol_info(uint8_t *buf,
     ADD_PROTOCOL_STREAM(NET_MSG_INPUT, PROTOCOL_STREAM_CLASS_LIVE,
                         PROTOCOL_STREAM_FLAG_CLIENT_TO_SERVER |
                         PROTOCOL_STREAM_FLAG_FIXED_SIZE,
-                        NET_INPUT_MSG_SIZE, 0, 1, sim_tick_ms);
+                        NET_INPUT_MSG_SIZE, 0, 1,
+                        NET_INPUT_ACTIVE_HEARTBEAT_MS);
+    ADD_PROTOCOL_STREAM(NET_MSG_INPUT_APPLIED, PROTOCOL_STREAM_CLASS_LIVE,
+                        PROTOCOL_STREAM_FLAG_SERVER_TO_CLIENT |
+                        PROTOCOL_STREAM_FLAG_PER_PLAYER |
+                        PROTOCOL_STREAM_FLAG_FIXED_SIZE,
+                        NET_INPUT_APPLIED_SIZE, 0, 1, sim_tick_ms);
     ADD_PROTOCOL_STREAM(NET_MSG_STATION_IDENTITY, PROTOCOL_STREAM_CLASS_STATIC,
                         PROTOCOL_STREAM_FLAG_SERVER_TO_CLIENT |
                         PROTOCOL_STREAM_FLAG_DIRTY_ONLY |

--- a/server/signal_intelligence.c
+++ b/server/signal_intelligence.c
@@ -3,7 +3,20 @@
  */
 #include "signal_intelligence.h"
 
+#include <math.h>
+#include <string.h>
+
+#ifdef SIGNAL_HAS_STATIC_FLIGHT_BRAIN
+#include "signal_client_flight.h"
+#endif
+
+static uint64_t g_static_flight_inference_count = 0;
+
 const char *signal_intelligence_backend_name(void) {
+#ifdef SIGNAL_HAS_STATIC_FLIGHT_BRAIN
+    if (signal_intelligence_flight_builtin_available())
+        return "crlplrimes-static-flight+legacy-facade";
+#endif
     return "legacy-checkpoint-facade";
 }
 
@@ -11,18 +24,62 @@ void signal_intelligence_holographic_init(void) {
     signal_brain_holographic_init();
 }
 
+bool signal_intelligence_flight_builtin_available(void) {
+#ifdef SIGNAL_HAS_STATIC_FLIGHT_BRAIN
+    return signal_client_flight_feature_set &&
+           strcmp(signal_client_flight_feature_set,
+                  "signal-flight-live-v2") == 0 &&
+           signal_client_flight_feature_encoder_version == 2u &&
+           SIGNAL_CLIENT_FLIGHT_INPUT_COUNT ==
+               SIGNAL_BRAIN_FLIGHT_FEATURE_COUNT;
+#else
+    return false;
+#endif
+}
+
+const char *signal_intelligence_flight_feature_set(void) {
+#ifdef SIGNAL_HAS_STATIC_FLIGHT_BRAIN
+    if (signal_intelligence_flight_builtin_available())
+        return signal_client_flight_feature_set;
+#endif
+    return "legacy-checkpoint";
+}
+
+uint32_t signal_intelligence_flight_feature_encoder_version(void) {
+#ifdef SIGNAL_HAS_STATIC_FLIGHT_BRAIN
+    if (signal_intelligence_flight_builtin_available())
+        return (uint32_t)signal_client_flight_feature_encoder_version;
+#endif
+    return 0;
+}
+
+const char *signal_intelligence_flight_checkpoint_hash(void) {
+#ifdef SIGNAL_HAS_STATIC_FLIGHT_BRAIN
+    if (signal_intelligence_flight_builtin_available())
+        return signal_client_flight_checkpoint_hash;
+#endif
+    return "";
+}
+
 bool signal_intelligence_load_flight_checkpoint(const char *path,
                                                 char *err,
                                                 size_t err_size) {
+    if ((!path || path[0] == '\0') &&
+        signal_intelligence_flight_builtin_available()) {
+        if (err && err_size > 0) err[0] = '\0';
+        return true;
+    }
     return signal_brain_load_checkpoint(path, err, err_size);
 }
 
 bool signal_intelligence_flight_loaded(void) {
-    return signal_brain_loaded();
+    return signal_intelligence_flight_builtin_available() ||
+           signal_brain_loaded();
 }
 
 uint64_t signal_intelligence_flight_inference_count(void) {
-    return signal_brain_inference_count();
+    return g_static_flight_inference_count +
+           signal_brain_inference_count();
 }
 
 bool signal_intelligence_load_contract_checkpoint(const char *path,
@@ -69,7 +126,66 @@ uint64_t signal_intelligence_npc_worker_teacher_decision_count(void) {
     return signal_npc_worker_brain_teacher_decision_count();
 }
 
+static bool signal_intelligence_drive_static_flight(world_t *w,
+                                                    server_player_t *sp) {
+#ifdef SIGNAL_HAS_STATIC_FLIGHT_BRAIN
+    if (!signal_intelligence_flight_builtin_available() || !w || !sp ||
+        sp->server_brain_mode != SERVER_BRAIN_MODE_NEURAL_FLIGHT ||
+        sp->autopilot_mode == 0 || sp->docked) {
+        return false;
+    }
+
+    float features[SIGNAL_BRAIN_FLIGHT_ACTION_COUNT *
+                   SIGNAL_BRAIN_FLIGHT_FEATURE_COUNT] = {0.0f};
+    uint8_t allowed[SIGNAL_BRAIN_FLIGHT_ACTION_COUNT] = {0};
+    int forward_blocked = 0;
+    if (!signal_brain_build_flight_candidate_features(
+            w, sp, features, allowed, &forward_blocked)) {
+        return false;
+    }
+
+    if (forward_blocked) {
+        sp->input.turn = 0.0f;
+        sp->input.thrust = -1.0f;
+        sp->input.reverse_thrust = true;
+        sp->input.mine = false;
+        return true;
+    }
+
+    float scores[SIGNAL_BRAIN_FLIGHT_ACTION_COUNT] = {0.0f};
+    int best_raw = signal_client_flight_select_best(
+        features, SIGNAL_BRAIN_FLIGHT_ACTION_COUNT, scores);
+    if (best_raw < 0) return false;
+
+    g_static_flight_inference_count += SIGNAL_BRAIN_FLIGHT_ACTION_COUNT;
+
+    int best = -1;
+    float best_score = -INFINITY;
+    for (int i = 0; i < SIGNAL_BRAIN_FLIGHT_ACTION_COUNT; i++) {
+        if (!allowed[i] || !isfinite(scores[i])) continue;
+        if (best < 0 || scores[i] > best_score) {
+            best = i;
+            best_score = scores[i];
+        }
+    }
+    if (best < 0) best = best_raw;
+
+    const signal_brain_flight_action_t *action =
+        signal_brain_flight_action(best);
+    if (!action) return false;
+    sp->input.turn = (float)action->turn;
+    sp->input.thrust = (float)action->thrust;
+    sp->input.reverse_thrust = false;
+    return true;
+#else
+    (void)w;
+    (void)sp;
+    return false;
+#endif
+}
+
 void signal_intelligence_drive_player(world_t *w, server_player_t *sp, float dt) {
+    if (signal_intelligence_drive_static_flight(w, sp)) return;
     signal_brain_drive(w, sp, dt);
 }
 

--- a/server/signal_intelligence.h
+++ b/server/signal_intelligence.h
@@ -32,6 +32,11 @@ const char *signal_intelligence_backend_name(void);
 
 void signal_intelligence_holographic_init(void);
 
+bool signal_intelligence_flight_builtin_available(void);
+const char *signal_intelligence_flight_feature_set(void);
+uint32_t signal_intelligence_flight_feature_encoder_version(void);
+const char *signal_intelligence_flight_checkpoint_hash(void);
+
 bool signal_intelligence_load_flight_checkpoint(const char *path,
                                                 char *err,
                                                 size_t err_size);

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -5064,7 +5064,10 @@ static void npc_choose_assignment(world_t *w, int npc_slot, npc_ship_t *npc) {
     ship_t *ship = npc_ship_for(w, npc_slot);
     if (!npc_can_reassign(npc, ship)) return;
     if (npc->home_station < 0 || npc->home_station >= MAX_STATIONS) return;
-    if (npc->state == NPC_STATE_DOCKED && npc->state_timer > 0.0f) return;
+    if ((npc->state == NPC_STATE_DOCKED || npc->state == NPC_STATE_IDLE) &&
+        npc->state_timer > 0.0f) {
+        return;
+    }
 
     npc_job_offer_t early_repair_offer;
     bool has_early_repair = npc_make_repair_job_offer(w, npc, ship,

--- a/server/sim_catalog.c
+++ b/server/sim_catalog.c
@@ -395,9 +395,17 @@ static bool station_catalog_load_one(station_t *st, int index, const char *dir) 
 int station_catalog_load_all(station_t *stations, int max_stations, const char *dir) {
     int loaded = 0;
     for (int i = 0; i < max_stations; i++) {
-        if (station_catalog_load_one(&stations[i], i, dir)) {
-            loaded++;
+        station_t staged = {0};
+        if (station_catalog_load_one(&staged, i, dir)) {
+            if (station_copy(&stations[i], &staged))
+                loaded++;
+        } else {
+            /* Keep the caller's already-seeded fallback station intact. A
+             * corrupt per-station catalog should not erase relay geometry. */
+            station_cleanup(&staged);
+            continue;
         }
+        station_cleanup(&staged);
     }
     return loaded;
 }

--- a/server/sim_ship.c
+++ b/server/sim_ship.c
@@ -174,26 +174,8 @@ float resolve_ship_asteroid_pushback(ship_t *ship, asteroid_t *a) {
 }
 
 void step_ship_motion(ship_t *s, float dt, const world_t *w, float cached_signal) {
+    (void)w;
+    (void)cached_signal;
     s->vel = v2_scale(s->vel, 1.0f / (1.0f + (ship_hull_def(s)->drag * dt)));
     s->pos = v2_add(s->pos, v2_scale(s->vel, dt));
-
-    /* Signal-based boundary: push back when in frontier zone. */
-    float boundary = signal_boundary_push(cached_signal);
-    if (boundary > 0.0f) {
-        float best_d_sq = 1e18f;
-        int best_s = 0;
-        for (int i = 0; i < MAX_STATIONS; i++) {
-            float d_sq = v2_dist_sq(s->pos, w->stations[i].pos);
-            if (d_sq < best_d_sq) { best_d_sq = d_sq; best_s = i; }
-        }
-        vec2 to_station = v2_sub(w->stations[best_s].pos, s->pos);
-        float d = v2_len(to_station);
-        if (d > 0.001f) {
-            /* Strong pull — at zero signal this is the only way back.
-             * Scales with boundary (0 at frontier, 1 at zero signal). */
-            float push_strength = boundary * 2.0f;
-            vec2 push = v2_scale(to_station, push_strength / d);
-            s->vel = v2_add(s->vel, push);
-        }
-    }
 }

--- a/shared/base64.h
+++ b/shared/base64.h
@@ -9,9 +9,9 @@ static const char BASE64_ALPHABET[] =
 static inline int base64_encode(const uint8_t *data, size_t len, char *out, size_t out_cap) {
     size_t i = 0, j = 0;
     while (i < len) {
-        size_t consumed = 0;
+        size_t consumed = 1;
         uint32_t a = 0, b = 0, c = 0;
-        if (i < len) { a = data[i++]; consumed++; }
+        a = data[i++];
         if (i < len) { b = data[i++]; consumed++; }
         if (i < len) { c = data[i++]; consumed++; }
         uint32_t triple = (a << 16) | (b << 8) | c;
@@ -48,8 +48,14 @@ static inline int base64_decode(const char *in, uint8_t *out, size_t out_cap) {
         uint32_t triple = ((uint32_t)a << 18) | ((uint32_t)b << 12) | ((uint32_t)c << 6) | (uint32_t)d;
         if (j >= out_cap) return -1;
         out[j++] = (uint8_t)(triple >> 16);
-        if (in[i+2] != '=' && j < out_cap) out[j++] = (uint8_t)(triple >> 8);
-        if (in[i+3] != '=' && j < out_cap) out[j++] = (uint8_t)triple;
+        if (in[i+2] != '=') {
+            if (j >= out_cap) return -1;
+            out[j++] = (uint8_t)(triple >> 8);
+        }
+        if (in[i+3] != '=') {
+            if (j >= out_cap) return -1;
+            out[j++] = (uint8_t)triple;
+        }
     }
     return (int)j;
 }

--- a/shared/protocol.h
+++ b/shared/protocol.h
@@ -12,6 +12,7 @@
  *   LATENCY_PONG    (0x3D): [type:1][seq:u32][client_sent_ms:u32][server_recv_ms:u32][server_send_ms:u32]
  *   ACTION_ACK      (0x3A): [type:1][action_id:u16][input_seq:u16][status:1][action:1]
  *   ACTION_RESULT   (0x3B): [type:1][action_id:u16][input_seq:u16][status:1][action:1][server_tick:u32]
+ *   INPUT_APPLIED   (0x48): [type:1][input_seq:u16][server_tick:u32][input_tick_ack:u32]
  *   WORLD_ASTEROIDS (0x10): [type:1][count:u16] + count * ASTEROID_RECORD_SIZE records
  *   WORLD_NPCS      (0x11): [type:1][count:1] + count * NPC_RECORD_SIZE records
  *   WORLD_STATIONS  (0x12): [type:1][count:1] + count * STATION_RECORD_SIZE records
@@ -263,6 +264,16 @@ enum {
                                             *
                                             *   [type:1=0x47][count:1]
                                             *     count × DELIVERY_LEDGER_RECORD_SIZE */
+    NET_MSG_INPUT_APPLIED          = 0x48, /* server -> client. Private applied-input
+                                            * receipt for movement sync.
+                                            *
+                                            *   [type:1=0x48][input_seq:u16]
+                                            *   [server_tick:u32][input_tick_ack:u32]
+                                            *
+                                            * WORLD_PLAYERS still mirrors the latest
+                                            * ack for compatibility; this small packet
+                                            * decouples input timing from full pose
+                                            * broadcast cadence. */
     NET_MSG_INSPECT_SNAPSHOT       = 0x38, /* server -> client. Laser/scan inspection snapshot.
                                             *
                                             *   [type:1=0x38][target_type:1][target_index:1]
@@ -311,6 +322,7 @@ enum {
     SIGNAL_PROTOCOL_CAP_INSPECT_SNAPSHOT= 1u << 5,
     SIGNAL_PROTOCOL_CAP_HANDOFF_TICKETS = 1u << 6,
     SIGNAL_PROTOCOL_CAP_DELIVERY_SHIPMENTS = 1u << 7,
+    SIGNAL_PROTOCOL_CAP_INPUT_APPLIED_ACK = 1u << 8,
 };
 
 enum {
@@ -348,7 +360,8 @@ enum {
         SIGNAL_PROTOCOL_CAP_RECEIPT_CHAINS |
         SIGNAL_PROTOCOL_CAP_INSPECT_SNAPSHOT |
         SIGNAL_PROTOCOL_CAP_HANDOFF_TICKETS |
-        SIGNAL_PROTOCOL_CAP_DELIVERY_SHIPMENTS,
+        SIGNAL_PROTOCOL_CAP_DELIVERY_SHIPMENTS |
+        SIGNAL_PROTOCOL_CAP_INPUT_APPLIED_ACK,
 };
 
 /* Layer A.4 of #479 — legacy-save migration constants. */
@@ -718,10 +731,14 @@ enum {
 };
 
 #define NET_INPUT_MSG_SIZE 18
+#define NET_INPUT_APPLIED_SIZE 11
 #define NET_LATENCY_PING_SIZE 9
 #define NET_LATENCY_PONG_SIZE 17
 #define NET_CLIENT_METRICS_SIZE 21
 #define NET_DEATH_MSG_SIZE 43
+
+#define NET_INPUT_ACTIVE_HEARTBEAT_MS 83u
+#define NET_INPUT_IDLE_HEARTBEAT_MS 167u
 
 /* Input prediction horizon, in fixed SIM_DT ticks. The server only accepts
  * future-dated movement this far ahead; the client should rebase before replay

--- a/shared/signal_model.h
+++ b/shared/signal_model.h
@@ -7,7 +7,7 @@
  *
  * Signal bands:
  *   0.00–0.15  FRONTIER  No NPC support, heavy control penalty,
- *                        minimal mining efficiency, boundary push.
+ *                        minimal mining efficiency, drift only.
  *   0.15–0.50  FRINGE    Some mining viability, NPCs cautious,
  *                        moderate control penalty.
  *   0.50–0.80  OPERATIONAL  NPCs operate normally, reasonable mining,
@@ -53,11 +53,11 @@ static inline float signal_npc_confidence(float quality) {
     return (quality - SIGNAL_BAND_FRONTIER) / (SIGNAL_BAND_OPERATIONAL - SIGNAL_BAND_FRONTIER);
 }
 
-/* Boundary push strength: returns >0 when signal is in frontier band.
- * Used to gently push ships back toward coverage. */
+/* Boundary push is intentionally disabled for player ships. Low signal
+ * attenuates controls; it must not inject hidden velocity toward a station. */
 static inline float signal_boundary_push(float quality) {
-    if (quality >= SIGNAL_BAND_FRONTIER) return 0.0f;
-    return (SIGNAL_BAND_FRONTIER - quality) / SIGNAL_BAND_FRONTIER;
+    (void)quality;
+    return 0.0f;
 }
 
 /* Visual saturation: full color in operational/core signal, fading to

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -22,6 +22,13 @@ type CanvasStats = {
   avgLuma: number;
 };
 
+type TouchControlRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
 type NetMotionSnapshot = {
   samples: number;
   deferredSamples: number;
@@ -39,6 +46,9 @@ type NetMotionSnapshot = {
   playerIntervalMs: number;
   maxPlayerIntervalMs: number;
   maxPlayerJitterMs: number;
+  rawPlayerIntervalMs: number;
+  maxRawPlayerIntervalMs: number;
+  maxRawPlayerJitterMs: number;
   maxAckRttMs: number;
   currentRenderOffset: number;
   maxRenderOffset: number;
@@ -48,6 +58,8 @@ type NetMotionSnapshot = {
   inputAcks: number;
   tickSkew: number;
   maxTickSkewAbs: number;
+  inputApplyErrorTicks: number;
+  maxInputApplyErrorAbs: number;
   replayDepth: number;
   unackedInputs: number;
   actionQueueDepth: number;
@@ -64,6 +76,7 @@ type PlayerStateSnapshot = {
   y: number;
   vx: number;
   vy: number;
+  angle: number;
   docked: number;
 };
 
@@ -228,103 +241,85 @@ async function waitForRuntime(page: Page): Promise<void> {
   );
 }
 
-async function signalStrength(page: Page): Promise<number | null> {
-  return page.evaluate(() => {
+async function wasmNumber(page: Page, name: string): Promise<number | null> {
+  return page.evaluate((fnName) => {
     const mod = (window as unknown as {
-      Module?: { ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => number };
+      Module?: {
+        ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => number;
+        [key: string]: unknown;
+      };
     }).Module;
-    if (!mod || typeof mod.ccall !== 'function') return null;
-    const value = mod.ccall('get_signal_strength', 'number', [], []);
-    return Number.isFinite(value) ? value : null;
-  });
+    if (!mod) return null;
+    try {
+      const direct = mod[`_${fnName}`];
+      const value = typeof direct === 'function'
+        ? (direct as () => number)()
+        : typeof mod.ccall === 'function'
+          ? mod.ccall(fnName, 'number', [], [])
+          : null;
+      return Number.isFinite(value) ? value : null;
+    } catch {
+      return null;
+    }
+  }, name);
+}
+
+async function signalStrength(page: Page): Promise<number | null> {
+  return wasmNumber(page, 'get_signal_strength');
 }
 
 async function signalVisualSaturation(page: Page): Promise<number | null> {
-  return page.evaluate(() => {
-    const mod = (window as unknown as {
-      Module?: { ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => number };
-    }).Module;
-    if (!mod || typeof mod.ccall !== 'function') return null;
-    const value = mod.ccall('get_signal_visual_saturation', 'number', [], []);
-    return Number.isFinite(value) ? value : null;
-  });
+  return wasmNumber(page, 'get_signal_visual_saturation');
 }
 
 async function signalVisualBaseSaturation(page: Page): Promise<number | null> {
-  return page.evaluate(() => {
-    const mod = (window as unknown as {
-      Module?: { ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => number };
-    }).Module;
-    if (!mod || typeof mod.ccall !== 'function') return null;
-    const value = mod.ccall('get_signal_visual_base_saturation', 'number', [], []);
-    return Number.isFinite(value) ? value : null;
-  });
+  return wasmNumber(page, 'get_signal_visual_base_saturation');
 }
 
 async function signalVisualCueSaturation(page: Page): Promise<number | null> {
-  return page.evaluate(() => {
-    const mod = (window as unknown as {
-      Module?: { ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => number };
-    }).Module;
-    if (!mod || typeof mod.ccall !== 'function') return null;
-    const value = mod.ccall('get_signal_visual_cue_saturation', 'number', [], []);
-    return Number.isFinite(value) ? value : null;
-  });
+  return wasmNumber(page, 'get_signal_visual_cue_saturation');
 }
 
 async function signalVisualPlayerSaturation(page: Page): Promise<number | null> {
-  return page.evaluate(() => {
-    const mod = (window as unknown as {
-      Module?: { ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => number };
-    }).Module;
-    if (!mod || typeof mod.ccall !== 'function') return null;
-    const value = mod.ccall('get_signal_visual_player_saturation', 'number', [], []);
-    return Number.isFinite(value) ? value : null;
-  });
+  return wasmNumber(page, 'get_signal_visual_player_saturation');
 }
 
 async function playerCameraSnapshot(page: Page): Promise<PlayerCameraSnapshot | null> {
-  return page.evaluate(() => {
-    const mod = (window as unknown as {
-      Module?: { ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => number };
-    }).Module;
-    if (!mod || typeof mod.ccall !== 'function') return null;
-    const offsetX = mod.ccall('get_player_camera_offset_x', 'number', [], []);
-    const offsetY = mod.ccall('get_player_camera_offset_y', 'number', [], []);
-    const narrowFocus = mod.ccall('get_camera_narrow_focus', 'number', [], []);
+  const [offsetX, offsetY, narrowFocus] = await Promise.all([
+    wasmNumber(page, 'get_player_camera_offset_x'),
+    wasmNumber(page, 'get_player_camera_offset_y'),
+    wasmNumber(page, 'get_camera_narrow_focus'),
+  ]);
     if (![offsetX, offsetY, narrowFocus].every(Number.isFinite)) return null;
-    return { offsetX, offsetY, narrowFocus };
-  });
+  return { offsetX: offsetX!, offsetY: offsetY!, narrowFocus: narrowFocus! };
 }
 
 async function playerStateSnapshot(page: Page): Promise<PlayerStateSnapshot | null> {
-  return page.evaluate(() => {
-    const mod = (window as unknown as {
-      Module?: { ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => number };
-    }).Module;
-    if (!mod || typeof mod.ccall !== 'function') return null;
-    const x = mod.ccall('get_player_pos_x', 'number', [], []);
-    const y = mod.ccall('get_player_pos_y', 'number', [], []);
-    const vx = mod.ccall('get_player_vel_x', 'number', [], []);
-    const vy = mod.ccall('get_player_vel_y', 'number', [], []);
-    const docked = mod.ccall('get_player_docked', 'number', [], []);
-    if (![x, y, vx, vy, docked].every(Number.isFinite)) return null;
-    return { x, y, vx, vy, docked };
-  });
+  const [x, y, vx, vy, angle, docked] = await Promise.all([
+    wasmNumber(page, 'get_player_pos_x'),
+    wasmNumber(page, 'get_player_pos_y'),
+    wasmNumber(page, 'get_player_vel_x'),
+    wasmNumber(page, 'get_player_vel_y'),
+    wasmNumber(page, 'get_player_angle'),
+    wasmNumber(page, 'get_player_docked'),
+  ]);
+  if (![x, y, vx, vy, angle, docked].every(Number.isFinite)) return null;
+  return { x: x!, y: y!, vx: vx!, vy: vy!, angle: angle!, docked: docked! };
 }
 
 function playerDistance(a: PlayerStateSnapshot, b: PlayerStateSnapshot): number {
   return Math.hypot(b.x - a.x, b.y - a.y);
 }
 
+function playerAngleDistance(a: number, b: number): number {
+  let delta = b - a;
+  while (delta > Math.PI) delta -= Math.PI * 2;
+  while (delta < -Math.PI) delta += Math.PI * 2;
+  return Math.abs(delta);
+}
+
 async function heldControlMask(page: Page): Promise<number> {
-  return page.evaluate(() => {
-    const mod = (window as unknown as {
-      Module?: { ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => number };
-    }).Module;
-    if (!mod || typeof mod.ccall !== 'function') return -1;
-    return mod.ccall('signal_debug_held_control_mask', 'number', [], []) | 0;
-  });
+  return ((await wasmNumber(page, 'signal_debug_held_control_mask')) ?? -1) | 0;
 }
 
 async function netMotionSnapshot(page: Page): Promise<NetMotionSnapshot> {
@@ -332,7 +327,7 @@ async function netMotionSnapshot(page: Page): Promise<NetMotionSnapshot> {
     const mod = (window as unknown as {
       Module?: { ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => number };
     }).Module;
-    if (!mod || typeof mod.ccall !== 'function') {
+    if (!mod) {
       return {
         samples: 0,
         deferredSamples: 0,
@@ -350,6 +345,9 @@ async function netMotionSnapshot(page: Page): Promise<NetMotionSnapshot> {
         playerIntervalMs: 0,
         maxPlayerIntervalMs: 0,
         maxPlayerJitterMs: 0,
+        rawPlayerIntervalMs: 0,
+        maxRawPlayerIntervalMs: 0,
+        maxRawPlayerJitterMs: 0,
         maxAckRttMs: 0,
         currentRenderOffset: 0,
         maxRenderOffset: 0,
@@ -359,6 +357,8 @@ async function netMotionSnapshot(page: Page): Promise<NetMotionSnapshot> {
         inputAcks: 0,
         tickSkew: 0,
         maxTickSkewAbs: 0,
+        inputApplyErrorTicks: 0,
+        maxInputApplyErrorAbs: 0,
         replayDepth: 0,
         unackedInputs: 0,
         actionQueueDepth: 0,
@@ -366,8 +366,17 @@ async function netMotionSnapshot(page: Page): Promise<NetMotionSnapshot> {
     }
 
     const read = (name: string) => {
-      const value = mod.ccall!(name, 'number', [], []);
-      return Number.isFinite(value) ? value : 0;
+      try {
+        const direct = (mod as Record<string, unknown>)[`_${name}`];
+        const value = typeof direct === 'function'
+          ? (direct as () => number)()
+          : typeof mod.ccall === 'function'
+            ? mod.ccall(name, 'number', [], [])
+            : 0;
+        return Number.isFinite(value) ? value : 0;
+      } catch {
+        return 0;
+      }
     };
 
     return {
@@ -387,6 +396,9 @@ async function netMotionSnapshot(page: Page): Promise<NetMotionSnapshot> {
       playerIntervalMs: read('get_net_motion_player_interval_ms'),
       maxPlayerIntervalMs: read('get_net_motion_max_player_interval_ms'),
       maxPlayerJitterMs: read('get_net_motion_max_player_jitter_ms'),
+      rawPlayerIntervalMs: read('get_net_motion_raw_player_interval_ms'),
+      maxRawPlayerIntervalMs: read('get_net_motion_max_raw_player_interval_ms'),
+      maxRawPlayerJitterMs: read('get_net_motion_max_raw_player_jitter_ms'),
       maxAckRttMs: read('get_net_motion_max_ack_rtt_ms'),
       currentRenderOffset: read('get_net_motion_current_render_offset'),
       maxRenderOffset: read('get_net_motion_max_render_offset'),
@@ -396,10 +408,28 @@ async function netMotionSnapshot(page: Page): Promise<NetMotionSnapshot> {
       inputAcks: read('get_net_motion_total_input_acks'),
       tickSkew: read('get_net_motion_tick_skew'),
       maxTickSkewAbs: read('get_net_motion_max_tick_skew_abs'),
+      inputApplyErrorTicks: read('get_net_motion_input_apply_error_ticks'),
+      maxInputApplyErrorAbs: read('get_net_motion_max_input_apply_error_abs'),
       replayDepth: read('get_net_motion_replay_depth'),
       unackedInputs: read('get_net_motion_unacked_inputs'),
       actionQueueDepth: read('get_net_motion_action_queue_depth'),
     };
+  });
+}
+
+async function resetNetMotionTelemetry(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const mod = (window as unknown as {
+      Module?: {
+        ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => number;
+        _reset_net_motion_telemetry?: () => number;
+      };
+    }).Module;
+    if (mod && typeof mod._reset_net_motion_telemetry === 'function') {
+      mod._reset_net_motion_telemetry();
+    } else if (mod && typeof mod.ccall === 'function') {
+      mod.ccall('reset_net_motion_telemetry', 'number', [], []);
+    }
   });
 }
 
@@ -550,6 +580,40 @@ async function expectTouchControlsFit(page: Page): Promise<void> {
     return issues;
   });
   expect(problems).toEqual([]);
+}
+
+async function touchControlRects(page: Page, controlNames: string[]): Promise<Record<string, TouchControlRect>> {
+  return page.evaluate((names) => {
+    const rects: Record<string, TouchControlRect> = {};
+    for (const name of names) {
+      const el = document.querySelector<HTMLElement>(`[data-control="${name}"]`);
+      if (!el) continue;
+      const rect = el.getBoundingClientRect();
+      const style = window.getComputedStyle(el);
+      if (style.display === 'none' || rect.width <= 0 || rect.height <= 0) continue;
+      rects[name] = {
+        x: rect.x,
+        y: rect.y,
+        width: rect.width,
+        height: rect.height,
+      };
+    }
+    return rects;
+  }, controlNames);
+}
+
+function expectTouchControlsKeepSlots(
+  before: Record<string, TouchControlRect>,
+  after: Record<string, TouchControlRect>,
+  controlNames: string[],
+): void {
+  for (const name of controlNames) {
+    expect(before[name], `${name} should have an initial slot`).toBeTruthy();
+    expect(after[name], `${name} should keep a later slot`).toBeTruthy();
+    for (const key of ['x', 'y', 'width', 'height'] as const) {
+      expect(Math.abs(before[name][key] - after[name][key]), `${name} ${key} shifted`).toBeLessThanOrEqual(1.5);
+    }
+  }
 }
 
 async function setSmokeLoopState(page: Page, state: number): Promise<void> {
@@ -770,7 +834,7 @@ test.describe('Browser smoke tests', () => {
       !process.env.SMOKE_LIVE_RELAY_ASSERT,
       'set SMOKE_LIVE_RELAY_ASSERT=1 to require live relay input acks',
     );
-    test.setTimeout(45_000);
+    test.setTimeout(60_000);
 
     const logs = installFatalCollectors(page);
     await page.setViewportSize({ width: 1280, height: 720 });
@@ -803,6 +867,10 @@ test.describe('Browser smoke tests', () => {
       Math.abs(cameraAfterLaunch!.offsetY),
     )).toBeLessThan(140);
 
+    const launchMotion = await netMotionSnapshot(page);
+    expect(launchMotion.maxAppliedCorrection).toBeLessThan(80);
+
+    await resetNetMotionTelemetry(page);
     const acksBefore = (await netMotionSnapshot(page)).inputAcks;
     await page.keyboard.down('W');
     try {
@@ -831,6 +899,105 @@ test.describe('Browser smoke tests', () => {
     expect(motion.samples).toBeGreaterThan(0);
     expect(motion.unackedInputs).toBeLessThan(16);
     expect(motion.actionQueueDepth).toBe(0);
+    expect(motion.maxAppliedCorrection).toBeLessThan(40);
+
+    await resetNetMotionTelemetry(page);
+    const turnAcksBefore = (await netMotionSnapshot(page)).inputAcks;
+    const angleBeforeTurn = (await playerStateSnapshot(page))?.angle;
+    expect(angleBeforeTurn).toBeDefined();
+    await page.keyboard.down('A');
+    try {
+      await expect
+        .poll(async () => heldControlMask(page), {
+          timeout: 3_000,
+          message: 'A should register as a held flight control',
+        })
+        .toBe(1 << 2);
+      await page.waitForTimeout(1_000);
+    } finally {
+      await page.keyboard.up('A');
+    }
+    const stateAfterTurn = await playerStateSnapshot(page);
+    expect(stateAfterTurn).toBeTruthy();
+    expect(playerAngleDistance(angleBeforeTurn!, stateAfterTurn!.angle)).toBeGreaterThan(0.08);
+    await expect
+      .poll(async () => (await netMotionSnapshot(page)).inputAcks, {
+        timeout: 10_000,
+        message: 'held left turn should receive authoritative acks',
+      })
+      .toBeGreaterThan(turnAcksBefore);
+    expect((await netMotionSnapshot(page)).maxAppliedCorrection).toBeLessThan(40);
+
+    await page.reload();
+    const reloadedCanvas = page.locator('canvas');
+    await waitForRenderedGame(page, reloadedCanvas, true);
+    await expect
+      .poll(async () => {
+        const flags = await mobileControlFlags(page);
+        return (flags & mobileFlag.docked) === 0 &&
+          (flags & mobileFlag.canFlight) !== 0;
+      }, {
+        timeout: 10_000,
+        message: 'live reload should preserve flight authority without a correction snap',
+      })
+      .toBeTruthy();
+    const reloadMotion = await netMotionSnapshot(page);
+    expect(reloadMotion.maxAppliedCorrection).toBeLessThan(80);
+
+    const positionAfterReload = await playerStateSnapshot(page);
+    expect(positionAfterReload).toBeTruthy();
+    expect(positionAfterReload!.docked).toBe(0);
+    await resetNetMotionTelemetry(page);
+    const reloadAcksBefore = (await netMotionSnapshot(page)).inputAcks;
+    await page.keyboard.down('W');
+    try {
+      await expect
+        .poll(async () => heldControlMask(page), {
+          timeout: 3_000,
+          message: 'W should register after a live reload',
+        })
+        .toBe(1);
+      await page.waitForTimeout(1_000);
+    } finally {
+      await page.keyboard.up('W');
+    }
+    const positionAfterReloadThrust = await playerStateSnapshot(page);
+    expect(positionAfterReloadThrust).toBeTruthy();
+    expect(playerDistance(positionAfterReload!, positionAfterReloadThrust!)).toBeGreaterThan(12);
+    await expect
+      .poll(async () => (await netMotionSnapshot(page)).inputAcks, {
+        timeout: 10_000,
+        message: 'held flight input should keep receiving acks after reload',
+      })
+      .toBeGreaterThan(reloadAcksBefore);
+    expect((await netMotionSnapshot(page)).maxAppliedCorrection).toBeLessThan(40);
+
+    await resetNetMotionTelemetry(page);
+    const reloadTurnAcksBefore = (await netMotionSnapshot(page)).inputAcks;
+    const angleBeforeReloadTurn = (await playerStateSnapshot(page))?.angle;
+    expect(angleBeforeReloadTurn).toBeDefined();
+    await page.keyboard.down('D');
+    try {
+      await expect
+        .poll(async () => heldControlMask(page), {
+          timeout: 3_000,
+          message: 'D should register after a live reload',
+        })
+        .toBe(1 << 3);
+      await page.waitForTimeout(1_000);
+    } finally {
+      await page.keyboard.up('D');
+    }
+    const stateAfterReloadTurn = await playerStateSnapshot(page);
+    expect(stateAfterReloadTurn).toBeTruthy();
+    expect(playerAngleDistance(angleBeforeReloadTurn!, stateAfterReloadTurn!.angle)).toBeGreaterThan(0.08);
+    await expect
+      .poll(async () => (await netMotionSnapshot(page)).inputAcks, {
+        timeout: 10_000,
+        message: 'held right turn should keep receiving acks after reload',
+      })
+      .toBeGreaterThan(reloadTurnAcksBefore);
+    expect((await netMotionSnapshot(page)).maxAppliedCorrection).toBeLessThan(40);
     expectNoFatalErrors(logs, { allowExpectedLiveClose: true });
   });
 
@@ -871,6 +1038,7 @@ test.describe('Browser smoke tests', () => {
 
     const thrust = page.locator('[data-control="thrust"]');
     await expect(thrust).toBeVisible();
+    await expect(thrust).toBeEnabled();
     const box = await thrust.boundingBox();
     expect(box).toBeTruthy();
     await page.mouse.move(box!.x + box!.width * 0.5, box!.y + box!.height * 0.5);
@@ -915,6 +1083,7 @@ test.describe('Browser smoke tests', () => {
 
     const thrust = page.locator('[data-control="thrust"]');
     await expect(thrust).toBeVisible();
+    await expect(thrust).toBeEnabled();
     const box = await thrust.boundingBox();
     expect(box).toBeTruthy();
 
@@ -1181,28 +1350,38 @@ test.describe('Browser smoke tests', () => {
     expectNoFatalErrors(logs, { allowExpectedLiveClose: true });
   });
 
-  rootBundleSmokeTest('touch controls expose only contextual mobile actions', async ({ page }) => {
+  rootBundleSmokeTest('touch controls keep stable slots while enabling contextual mobile actions', async ({ page }) => {
     const logs = installFatalCollectors(page);
     await page.setViewportSize({ width: 390, height: 760 });
     await page.goto(addQueryParam(smokeUrl({ singleplayer: true }), 'touch', '1'));
     await waitForRenderedGame(page, page.locator('canvas'), false);
     const touchScriptSrc = await page.locator('script[src*="signal-touch-controls.js"]').getAttribute('src');
     expect(touchScriptSrc).toMatch(/[?&]v=/);
+    const primaryControls = ['use', 'fire', 'thrust', 'tractor', 'brake', 'scan', 'auto', 'plan', 'cycle', 'boost', 'left', 'right'];
+    const stationControls = ['tab', 'page', 'sell', 'repair', 'laser', 'cargo', 'tractorUpgrade', 'one', 'two', 'three', 'four', 'five'];
 
     await expect
       .poll(async () => (await mobileControlFlags(page)) & mobileFlag.docked, { timeout: 5_000 })
       .toBe(mobileFlag.docked);
     await expect(page.locator('[data-control="use"]')).toHaveText('Launch');
-    await expect(page.locator('[data-control="left"]')).toBeHidden();
-    await expect(page.locator('[data-control="thrust"]')).toBeHidden();
+    await expect(page.locator('[data-control="left"]')).toBeVisible();
+    await expect(page.locator('[data-control="left"]')).toBeDisabled();
+    await expect(page.locator('[data-control="thrust"]')).toBeVisible();
+    await expect(page.locator('[data-control="thrust"]')).toBeDisabled();
     await expect(page.locator('[data-control="tab"]')).toBeVisible();
     await expect(page.locator('[data-control="tab"]')).toHaveText('Panel');
+    await expect(page.locator('[data-control="page"]')).toBeVisible();
+    await expect(page.locator('[data-control="page"]')).toBeDisabled();
     await expect.poll(async () => stationPanelLabel(page)).toBe('SHIP');
     await expect.poll(async () => stationPanelLegend(page)).toBe('[R] repair  [M/C/T] refit  [TAB] panel');
+    const dockedPrimarySlots = await touchControlRects(page, primaryControls);
+    const shipStationSlots = await touchControlRects(page, stationControls);
+    await expectTouchControlsFit(page);
 
     await tap(page, 'Tab');
     await expect.poll(async () => stationPanelLabel(page)).toBe('TRADE');
     await expect.poll(async () => stationPanelLegend(page)).toBe('[1-5] trade  [F] page  [S] sell all  [TAB] panel');
+    expectTouchControlsKeepSlots(shipStationSlots, await touchControlRects(page, stationControls), stationControls);
     await expect
       .poll(async () => (await mobileControlFlags(page)) & mobileFlag.stationTrade)
       .toBe(mobileFlag.stationTrade);
@@ -1215,6 +1394,8 @@ test.describe('Browser smoke tests', () => {
     await expect
       .poll(async () => (await mobileControlFlags(page)) & mobileFlag.canDigits)
       .toBe(mobileFlag.canDigits);
+    await expect(page.locator('[data-control="page"]')).toBeEnabled();
+    await expect(page.locator('[data-control="sell"]')).toBeEnabled();
     const tradeSlots = await stationPanelDigitSlots(page);
     expect(tradeSlots).toBeGreaterThanOrEqual(0);
     expect(tradeSlots).toBeLessThanOrEqual(5);
@@ -1246,7 +1427,9 @@ test.describe('Browser smoke tests', () => {
     await expect(page.locator('[data-control="boost"]')).toBeVisible();
     await expect(page.locator('[data-control="thrust"]')).toBeVisible();
     await expect(page.locator('[data-control="brake"]')).toBeVisible();
+    await expect(page.locator('[data-control="thrust"]')).toBeEnabled();
     await expect(page.locator('[data-control="tab"]')).toBeHidden();
+    expectTouchControlsKeepSlots(dockedPrimarySlots, await touchControlRects(page, primaryControls), primaryControls);
     await expectTouchControlsFit(page);
 
     await page.locator('[data-control="plan"]').click();
@@ -1255,7 +1438,9 @@ test.describe('Browser smoke tests', () => {
       .toBe(mobileFlag.planActive);
     await expect(page.locator('[data-control="plan"]')).toHaveText('Exit');
     await expect(page.locator('[data-control="cycle"]')).toBeVisible();
-    await expect(page.locator('[data-control="fire"]')).toBeHidden();
+    await expect(page.locator('[data-control="cycle"]')).toBeEnabled();
+    await expect(page.locator('[data-control="fire"]')).toBeVisible();
+    await expect(page.locator('[data-control="fire"]')).toBeDisabled();
     await expectTouchControlsFit(page);
 
     await page.setViewportSize({ width: 844, height: 390 });

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -893,6 +893,76 @@ test.describe('Browser smoke tests', () => {
     expectNoFatalErrors(logs, { allowExpectedLiveClose: true });
   });
 
+  test('touch controls stay synced when canvas focus moves to overlay', async ({ page }) => {
+    test.skip(usesLiveSmokeUrl(), 'requires the local play.html build with debug input exports');
+
+    const logs = installFatalCollectors(page);
+    await page.setViewportSize({ width: 390, height: 760 });
+    await page.goto(addQueryParam(smokeUrl({ singleplayer: true }), 'touch', '1'));
+    await waitForRenderedGame(page, page.locator('canvas'), false);
+
+    await page.locator('[data-control="use"]').click();
+    await expect
+      .poll(async () => {
+        const flags = await mobileControlFlags(page);
+        return (flags & mobileFlag.docked) === 0 &&
+          (flags & mobileFlag.canFlight) !== 0;
+      }, {
+        timeout: 8_000,
+        message: 'touch launch should enter flight mode',
+      })
+      .toBeTruthy();
+
+    const thrust = page.locator('[data-control="thrust"]');
+    await expect(thrust).toBeVisible();
+    const box = await thrust.boundingBox();
+    expect(box).toBeTruthy();
+
+    await page.mouse.move(box!.x + box!.width * 0.5, box!.y + box!.height * 0.5);
+    await page.mouse.down();
+    try {
+      await expect
+        .poll(async () => heldControlMask(page), {
+          timeout: 2_000,
+          message: 'touch Accel should register as held thrust',
+        })
+        .toBe(1);
+
+      await page.evaluate(() => {
+        const canvas = document.querySelector('canvas');
+        const thrustButton = document.querySelector('[data-control="thrust"]');
+        canvas?.dispatchEvent(new FocusEvent('blur', {
+          bubbles: false,
+          relatedTarget: thrustButton,
+        }));
+      });
+      expect(await heldControlMask(page)).toBe(1);
+
+      await page.evaluate(() => {
+        const mod = (window as unknown as {
+          SignalGameModule?: { ccall?: (name: string, returnType: string | null, argTypes: unknown[], args: unknown[]) => void };
+        }).SignalGameModule;
+        mod?.ccall?.('signal_mobile_clear', null, [], []);
+      });
+      await expect
+        .poll(async () => heldControlMask(page), {
+          timeout: 1_000,
+          message: 'visually held touch controls should reassert into WASM',
+        })
+        .toBe(1);
+    } finally {
+      await page.mouse.up();
+    }
+
+    await expect
+      .poll(async () => heldControlMask(page), {
+        timeout: 1_000,
+        message: 'releasing touch Accel should clear thrust',
+      })
+      .toBe(0);
+    expectNoFatalErrors(logs);
+  });
+
   test('play page clears held flight controls when browser focus leaves', async ({ page }) => {
     test.skip(usesLiveSmokeUrl(), 'requires the local play.html build with debug input exports');
 

--- a/tests/c/test_bug_regression.c
+++ b/tests/c/test_bug_regression.c
@@ -878,6 +878,32 @@ TEST(test_movement_queue_rejects_late_older_sequence) {
     ASSERT_EQ_INT(sp->last_input_seq, 2);
 }
 
+TEST(test_reset_input_stream_accepts_reconnected_low_sequence) {
+    WORLD_DECL;
+    world_reset(&w);
+    server_player_t *sp = &w.players[0];
+    player_init_ship(sp, &w);
+    sp->connected = true;
+    sp->docked = false;
+    sp->in_dock_range = false;
+    sp->ship.pos = v2(0.0f, -2400.0f);
+    sp->ship.vel = v2(0.0f, 0.0f);
+    sp->ship.angle = 0.0f;
+    sp->last_input_seq = 77;
+    sp->last_input_tick = 9001;
+
+    server_player_reset_input_stream(sp);
+    input_intent_t turn = { .turn = 1.0f };
+    server_player_queue_movement_input(sp, &turn, 1, w.tick + 1u);
+
+    ASSERT_EQ_INT(sp->movement_queue_count, 1);
+    world_sim_step(&w, SIM_DT);
+
+    ASSERT_EQ_INT(sp->last_input_seq, 1);
+    ASSERT_EQ_FLOAT(sp->input.turn, 1.0f, 0.001f);
+    ASSERT(sp->ship.angle > 0.001f);
+}
+
 TEST(test_bug40_no_player_player_collision) {
     WORLD_DECL;
     world_reset(&w);
@@ -1878,6 +1904,7 @@ void register_bug_regression_batch4_tests(void) {
     RUN(test_launch_applies_queued_thrust_through_physics);
     RUN(test_launch_from_freeport_retains_control_authority);
     RUN(test_movement_queue_rejects_late_older_sequence);
+    RUN(test_reset_input_stream_accepts_reconnected_low_sequence);
     RUN(test_bug40_no_player_player_collision);
 }
 

--- a/tests/c/test_bug_regression.c
+++ b/tests/c/test_bug_regression.c
@@ -878,6 +878,148 @@ TEST(test_movement_queue_rejects_late_older_sequence) {
     ASSERT_EQ_INT(sp->last_input_seq, 2);
 }
 
+TEST(test_same_tick_movement_inputs_apply_on_separate_ticks) {
+    WORLD_DECL;
+    world_reset(&w);
+    server_player_t *sp = &w.players[0];
+    player_init_ship(sp, &w);
+    sp->connected = true;
+    sp->docked = false;
+    sp->in_dock_range = false;
+    sp->ship.pos = v2(0.0f, -2400.0f);
+    sp->ship.vel = v2(0.0f, 0.0f);
+    sp->ship.angle = 0.0f;
+
+    input_intent_t thrust = { .thrust = 1.0f };
+    input_intent_t release = { 0 };
+    server_player_queue_movement_input(sp, &thrust, 1, w.tick + 2u);
+    server_player_queue_movement_input(sp, &release, 2, w.tick + 2u);
+
+    ASSERT_EQ_INT(sp->movement_queue_count, 2);
+    ASSERT_EQ_INT((int)sp->movement_queue[0].apply_tick, 2);
+    ASSERT_EQ_INT((int)sp->movement_queue[1].apply_tick, 3);
+
+    world_sim_step(&w, SIM_DT);
+    ASSERT_EQ_INT((int)w.tick, 1);
+    ASSERT_EQ_FLOAT(sp->input.thrust, 0.0f, 0.001f);
+
+    world_sim_step(&w, SIM_DT);
+    ASSERT_EQ_INT((int)w.tick, 2);
+    ASSERT_EQ_FLOAT(sp->input.thrust, 1.0f, 0.001f);
+    ASSERT_EQ_INT((int)sp->last_input_seq, 1);
+    ASSERT(sp->actual_thrusting);
+
+    world_sim_step(&w, SIM_DT);
+    ASSERT_EQ_INT((int)w.tick, 3);
+    ASSERT_EQ_FLOAT(sp->input.thrust, 0.0f, 0.001f);
+    ASSERT_EQ_INT((int)sp->last_input_seq, 2);
+    ASSERT(!sp->actual_thrusting);
+}
+
+TEST(test_ticked_same_tick_movement_inputs_preserve_apply_tick) {
+    WORLD_DECL;
+    world_reset(&w);
+    server_player_t *sp = &w.players[0];
+    player_init_ship(sp, &w);
+    sp->connected = true;
+    sp->docked = false;
+    sp->in_dock_range = false;
+    sp->ship.pos = v2(0.0f, -2400.0f);
+    sp->ship.vel = v2(0.0f, 0.0f);
+    sp->ship.angle = 0.0f;
+
+    input_intent_t thrust = { .thrust = 1.0f };
+    input_intent_t release = { 0 };
+    server_player_queue_ticked_movement_input(sp, &thrust, 1, w.tick + 2u);
+    server_player_queue_ticked_movement_input(sp, &release, 2, w.tick + 2u);
+
+    ASSERT_EQ_INT(sp->movement_queue_count, 2);
+    ASSERT_EQ_INT((int)sp->movement_queue[0].apply_tick, 2);
+    ASSERT_EQ_INT((int)sp->movement_queue[1].apply_tick, 2);
+
+    world_sim_step(&w, SIM_DT);
+    ASSERT_EQ_INT((int)w.tick, 1);
+    ASSERT_EQ_FLOAT(sp->input.thrust, 0.0f, 0.001f);
+
+    world_sim_step(&w, SIM_DT);
+    ASSERT_EQ_INT((int)w.tick, 2);
+    ASSERT_EQ_FLOAT(sp->input.thrust, 0.0f, 0.001f);
+    ASSERT_EQ_INT((int)sp->last_input_seq, 2);
+    ASSERT_EQ_INT((int)sp->last_input_tick, 2);
+    ASSERT(!sp->actual_thrusting);
+}
+
+TEST(test_ticked_turn_release_preserves_authoritative_heading) {
+    WORLD_DECL;
+    world_reset(&w);
+    server_player_t *sp = &w.players[0];
+    player_init_ship(sp, &w);
+    sp->connected = true;
+    sp->docked = false;
+    sp->in_dock_range = false;
+    sp->ship.pos = v2(0.0f, -2400.0f);
+    sp->ship.vel = v2(0.0f, 0.0f);
+    sp->ship.angle = 0.0f;
+
+    input_intent_t turn = { .turn = 1.0f };
+    server_player_queue_ticked_movement_input(sp, &turn, 1, w.tick + 1u);
+
+    for (int i = 0; i < 20; i++)
+        world_sim_step(&w, SIM_DT);
+
+    float turned_angle = sp->ship.angle;
+    ASSERT(turned_angle > 0.01f);
+    ASSERT_EQ_FLOAT(sp->input.turn, 1.0f, 0.001f);
+
+    input_intent_t release = { 0 };
+    server_player_queue_ticked_movement_input(sp, &release, 2, w.tick + 1u);
+    world_sim_step(&w, SIM_DT);
+
+    ASSERT_EQ_FLOAT(sp->input.turn, 0.0f, 0.001f);
+    ASSERT_EQ_INT((int)sp->last_input_seq, 2);
+    ASSERT_EQ_INT((int)sp->last_input_tick, (int)w.tick);
+    ASSERT_EQ_FLOAT(sp->ship.angle, turned_angle, 0.001f);
+}
+
+TEST(test_dispatch_ticked_left_input_rotates_authoritative_ship) {
+    WORLD_DECL;
+    world_reset(&w);
+    server_player_t *sp = &w.players[0];
+    player_init_ship(sp, &w);
+    sp->connected = true;
+    sp->docked = false;
+    sp->in_dock_range = false;
+    sp->ship.pos = v2(0.0f, -2400.0f);
+    sp->ship.vel = v2(0.0f, 0.0f);
+    sp->ship.angle = 0.0f;
+
+    uint8_t input[NET_INPUT_MSG_SIZE] = {0};
+    input[0] = NET_MSG_INPUT;
+    input[1] = NET_INPUT_LEFT;
+    input[3] = 0xFFu;
+    input[4] = MINING_GRADE_COUNT;
+    input[5] = 0xFFu;
+    input[6] = 0xFFu;
+    input[7] = 0xFFu;
+    input[8] = 1u;
+    input[10] = 0xFFu;
+    input[11] = 0xFFu;
+    write_u32_le(&input[14], w.tick + 1u);
+
+    server_input_dispatch_result_t result;
+    ASSERT(server_dispatch_input_message(&w, 0, input, NET_INPUT_MSG_SIZE,
+                                         &result));
+    ASSERT_EQ_INT((int)result.input_seq, 1);
+    ASSERT_EQ_INT((int)result.apply_tick, (int)(w.tick + 1u));
+
+    for (int i = 0; i < 20; i++)
+        world_sim_step(&w, SIM_DT);
+
+    ASSERT_EQ_FLOAT(sp->input.turn, 1.0f, 0.001f);
+    ASSERT(sp->ship.angle > 0.01f);
+    ASSERT_EQ_INT((int)sp->last_input_seq, 1);
+}
+
 TEST(test_reset_input_stream_accepts_reconnected_low_sequence) {
     WORLD_DECL;
     world_reset(&w);
@@ -1904,6 +2046,10 @@ void register_bug_regression_batch4_tests(void) {
     RUN(test_launch_applies_queued_thrust_through_physics);
     RUN(test_launch_from_freeport_retains_control_authority);
     RUN(test_movement_queue_rejects_late_older_sequence);
+    RUN(test_same_tick_movement_inputs_apply_on_separate_ticks);
+    RUN(test_ticked_same_tick_movement_inputs_preserve_apply_tick);
+    RUN(test_ticked_turn_release_preserves_authoritative_heading);
+    RUN(test_dispatch_ticked_left_input_rotates_authoritative_ship);
     RUN(test_reset_input_stream_accepts_reconnected_low_sequence);
     RUN(test_bug40_no_player_player_collision);
 }

--- a/tests/c/test_bug_regression.c
+++ b/tests/c/test_bug_regression.c
@@ -751,6 +751,33 @@ TEST(test_launch_preserves_flight_controls) {
     ASSERT(v2_dot(sp->ship.vel, away) > 50.0f);
 }
 
+TEST(test_launch_does_not_reanchor_docked_position) {
+    WORLD_DECL;
+    world_reset(&w);
+    server_player_t *sp = &w.players[0];
+    player_init_ship(sp, &w);
+    sp->connected = true;
+    ASSERT(sp->docked);
+
+    station_t *st = &w.stations[sp->current_station];
+    vec2 berth_pos = sp->ship.pos;
+    vec2 docked_pos = v2_add(st->pos, v2(180.0f, -240.0f));
+    ASSERT(v2_dist_sq(docked_pos, berth_pos) > 100.0f * 100.0f);
+
+    sp->ship.pos = docked_pos;
+    sp->ship.vel = v2(0.0f, 0.0f);
+    sp->docked = true;
+    sp->in_dock_range = true;
+    sp->nearby_station = sp->current_station;
+    sp->input.launch = true;
+
+    world_sim_step(&w, SIM_DT);
+
+    ASSERT(!sp->docked);
+    ASSERT(v2_len(v2_sub(sp->ship.pos, docked_pos)) < 0.01f);
+    ASSERT(v2_len(sp->ship.vel) > 50.0f);
+}
+
 TEST(test_launch_applies_queued_thrust_through_physics) {
     WORLD_DECL;
     world_reset(&w);
@@ -790,6 +817,36 @@ TEST(test_launch_applies_queued_thrust_through_physics) {
     ASSERT(v2_dot(sp->ship.vel, away) > 20.0f);
 }
 
+TEST(test_launch_from_freeport_retains_control_authority) {
+    WORLD_DECL;
+    world_reset(&w);
+    server_player_t *sp = &w.players[0];
+    player_init_ship(sp, &w);
+    sp->connected = true;
+    sp->current_station = SIGNAL_FREEPORT_STATION_INDEX;
+    sp->nearby_station = SIGNAL_FREEPORT_STATION_INDEX;
+    sp->docked = true;
+    sp->dock_berth = -1;
+    anchor_ship_in_station(sp, &w);
+
+    vec2 start = sp->ship.pos;
+    float launch_control =
+        signal_control_scale(signal_strength_at(&w, sp->ship.pos));
+    ASSERT(launch_control > 0.35f);
+
+    sp->input.launch = true;
+    world_sim_step(&w, SIM_DT);
+    ASSERT(!sp->docked);
+
+    sp->input.thrust = 1.0f;
+    for (int i = 0; i < 90; i++) {
+        world_sim_step(&w, SIM_DT);
+        ASSERT(!sp->docked);
+    }
+
+    ASSERT(v2_len(v2_sub(sp->ship.pos, start)) > 60.0f);
+}
+
 TEST(test_movement_queue_rejects_late_older_sequence) {
     WORLD_DECL;
     world_reset(&w);
@@ -806,6 +863,7 @@ TEST(test_movement_queue_rejects_late_older_sequence) {
     input_intent_t stale_zero = { 0 };
     server_player_queue_movement_input(sp, &thrust, 2, 2);
     server_player_queue_movement_input(sp, &stale_zero, 1, 3);
+    ASSERT_EQ_INT(sp->movement_queue_count, 1);
 
     world_sim_step(&w, SIM_DT);
     ASSERT_EQ_FLOAT(sp->input.thrust, 0.0f, 0.001f);
@@ -1816,7 +1874,9 @@ void register_bug_regression_batch4_tests(void) {
     RUN(test_launch_stays_at_docked_berth_when_actor_blocks_exit);
     RUN(test_launch_carries_towed_pod_to_docked_berth);
     RUN(test_launch_preserves_flight_controls);
+    RUN(test_launch_does_not_reanchor_docked_position);
     RUN(test_launch_applies_queued_thrust_through_physics);
+    RUN(test_launch_from_freeport_retains_control_authority);
     RUN(test_movement_queue_rejects_late_older_sequence);
     RUN(test_bug40_no_player_player_collision);
 }

--- a/tests/c/test_crypto.c
+++ b/tests/c/test_crypto.c
@@ -2,6 +2,7 @@
  * and rejects the obvious tamper cases. */
 #include "test_harness.h"
 
+#include "base64.h"
 #include "signal_crypto.h"
 
 TEST(test_crypto_keypair_distinct) {
@@ -88,6 +89,19 @@ TEST(test_crypto_verify_rejects_pub_tamper) {
     ASSERT(!signal_crypto_verify(sig, msg, sizeof(msg), pub));
 }
 
+TEST(test_base64_decode_rejects_short_output_buffer) {
+    const uint8_t raw[3] = {1, 2, 3};
+    char encoded[8];
+    uint8_t decoded[3] = {0};
+    uint8_t short_decoded[2] = {0};
+
+    ASSERT_EQ_INT(base64_encode(raw, sizeof(raw), encoded, sizeof(encoded)), 4);
+    ASSERT(strcmp(encoded, "AQID") == 0);
+    ASSERT_EQ_INT(base64_decode(encoded, decoded, sizeof(decoded)), 3);
+    ASSERT(memcmp(decoded, raw, sizeof(raw)) == 0);
+    ASSERT_EQ_INT(base64_decode(encoded, short_decoded, sizeof(short_decoded)), -1);
+}
+
 void register_crypto_tests(void);
 void register_crypto_tests(void) {
     TEST_SECTION("\nCrypto (Ed25519) tests:\n");
@@ -97,4 +111,5 @@ void register_crypto_tests(void) {
     RUN(test_crypto_verify_rejects_msg_tamper);
     RUN(test_crypto_verify_rejects_sig_tamper);
     RUN(test_crypto_verify_rejects_pub_tamper);
+    RUN(test_base64_decode_rejects_short_output_buffer);
 }

--- a/tests/c/test_econ_sim.c
+++ b/tests/c/test_econ_sim.c
@@ -923,10 +923,18 @@ TEST(test_e2e_kit_chain_converges) {
      * without first bootstrapping the entire upstream chain (smelting,
      * pressing, etc — not what this test is about). 5 sim-minutes is
      * 10 fab cycles at REPAIR_KIT_FAB_PERIOD = 30s; should produce
-     * many full batches if the gate works. */
+     * many full batches if the gate works. Keep unrelated NPC and
+     * asteroid churn disabled so this remains a repair-kit fab gate
+     * instead of a broad world-performance soak. */
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     ASSERT(w != NULL);
     world_reset(w);
+    for (int i = 0; i < MAX_NPC_SHIPS; i++)
+        w->npc_ships[i].active = false;
+    for (int i = 0; i < MAX_ASTEROIDS; i++)
+        w->asteroids[i].active = false;
+    w->npc_respawn_timer = 1e6f;
+    w->field_spawn_timer = 1e6f;
     /* Find the shipyard station. */
     int shipyard = -1;
     for (int s = 0; s < MAX_STATIONS; s++) {

--- a/tests/c/test_protocol.c
+++ b/tests/c/test_protocol.c
@@ -2161,6 +2161,18 @@ TEST(test_action_result_roundtrip) {
     ASSERT_EQ_INT((int)read_u32_le(&buf[7]), (int)0xAABBCCDDu);
 }
 
+TEST(test_input_applied_roundtrip) {
+    uint8_t buf[NET_INPUT_APPLIED_SIZE];
+    int len = serialize_input_applied(buf, 0x1234, 0xAABBCCDDu,
+                                      0x01020304u);
+
+    ASSERT_EQ_INT(len, NET_INPUT_APPLIED_SIZE);
+    ASSERT_EQ_INT(buf[0], NET_MSG_INPUT_APPLIED);
+    ASSERT_EQ_INT((int)read_u16_le(&buf[1]), 0x1234);
+    ASSERT_EQ_INT((int)read_u32_le(&buf[3]), (int)0xAABBCCDDu);
+    ASSERT_EQ_INT((int)read_u32_le(&buf[7]), (int)0x01020304u);
+}
+
 TEST(test_cargo_receipt_bundle_roundtrip) {
     cargo_receipt_chain_t chain;
     memset(&chain, 0, sizeof(chain));
@@ -2215,6 +2227,7 @@ TEST(test_protocol_info_serializes_stream_map) {
     ASSERT(read_u32_le(&buf[3]) & SIGNAL_PROTOCOL_CAP_STATION_DIAG);
     ASSERT(read_u32_le(&buf[3]) & SIGNAL_PROTOCOL_CAP_HANDOFF_TICKETS);
     ASSERT(read_u32_le(&buf[3]) & SIGNAL_PROTOCOL_CAP_DELIVERY_SHIPMENTS);
+    ASSERT(read_u32_le(&buf[3]) & SIGNAL_PROTOCOL_CAP_INPUT_APPLIED_ACK);
     ASSERT_EQ_INT(buf[7], (len - PROTOCOL_INFO_HEADER_SIZE) /
                           PROTOCOL_INFO_STREAM_RECORD_SIZE);
     ASSERT(buf[7] <= PROTOCOL_INFO_STREAM_CAPACITY);
@@ -2252,7 +2265,16 @@ TEST(test_protocol_info_serializes_stream_map) {
     const uint8_t *input = find_protocol_stream(buf, NET_MSG_INPUT);
     ASSERT(input != NULL);
     ASSERT_EQ_INT(read_u16_le(&input[4]), NET_INPUT_MSG_SIZE);
-    ASSERT_EQ_INT(read_u16_le(&input[10]), 8);
+    ASSERT_EQ_INT(read_u16_le(&input[10]), NET_INPUT_ACTIVE_HEARTBEAT_MS);
+
+    const uint8_t *input_applied = find_protocol_stream(buf, NET_MSG_INPUT_APPLIED);
+    ASSERT(input_applied != NULL);
+    ASSERT_EQ_INT(input_applied[1], PROTOCOL_STREAM_CLASS_LIVE);
+    ASSERT(read_u16_le(&input_applied[2]) & PROTOCOL_STREAM_FLAG_SERVER_TO_CLIENT);
+    ASSERT(read_u16_le(&input_applied[2]) & PROTOCOL_STREAM_FLAG_PER_PLAYER);
+    ASSERT(read_u16_le(&input_applied[2]) & PROTOCOL_STREAM_FLAG_FIXED_SIZE);
+    ASSERT_EQ_INT(read_u16_le(&input_applied[4]), NET_INPUT_APPLIED_SIZE);
+    ASSERT_EQ_INT(read_u16_le(&input_applied[10]), 8);
 
     const uint8_t *contracts = find_protocol_stream(buf, NET_MSG_CONTRACTS);
     ASSERT(contracts != NULL);
@@ -2405,6 +2427,7 @@ void register_protocol_main_tests(void) {
     RUN(test_latency_pong_can_arrive_before_authoritative_input_ack);
     RUN(test_action_ack_roundtrip);
     RUN(test_action_result_roundtrip);
+    RUN(test_input_applied_roundtrip);
     RUN(test_cargo_receipt_bundle_roundtrip);
     RUN(test_latency_pong_roundtrip);
     RUN(test_protocol_info_serializes_stream_map);

--- a/tests/c/test_registry.c
+++ b/tests/c/test_registry.c
@@ -173,6 +173,55 @@ TEST(test_registry_lookup_skips_disconnected_stale_session) {
     ASSERT_EQ_INT(registry_lookup_by_pubkey(w, pk), 5);
 }
 
+TEST(test_registry_same_token_takeover_moves_live_ship) {
+    WORLD_HEAP w = calloc(1, sizeof(world_t));
+    ASSERT(w != NULL);
+    world_reset(w);
+
+    uint8_t pk[32];  fill_pubkey(pk, 44);
+    uint8_t tok[8];  fill_token(tok, 45);
+
+    server_player_t *old = &w->players[0];
+    player_init_ship(old, w);
+    setup_registered_player(w, 0, pk, tok);
+    old->docked = false;
+    old->ship.pos = v2(1234.0f, 5678.0f);
+    old->ship.vel = v2(11.0f, -3.0f);
+    old->ship.angle = 0.75f;
+    old->ship.stat_credits_earned = 91.0f;
+    uint32_t old_asset_id = old->ship_asset_id;
+    ASSERT(old_asset_id != SHIP_ASSET_ID_NONE);
+
+    server_player_t *new_slot = &w->players[5];
+    player_init_ship(new_slot, w);
+    new_slot->connected = true;
+    new_slot->id = 5;
+    memcpy(new_slot->session_token, tok, 8);
+    new_slot->session_ready = true;
+    memcpy(new_slot->pubkey, pk, 32);
+    new_slot->pubkey_set = true;
+    new_slot->pubkey_proof_ok = true;
+
+    ASSERT_EQ_INT(registry_lookup_by_pubkey(w, pk), 0);
+    ASSERT(world_player_transfer_ship_state(w, 5, 0));
+    old->connected = false;
+    old->grace_period = false;
+    server_player_clear_live_session_identity(old);
+    server_player_clear_transient_input(old);
+    ASSERT(registry_register_pubkey(w, pk, tok));
+
+    ASSERT_EQ_INT(registry_lookup_by_pubkey(w, pk), 5);
+    ASSERT_EQ_INT(old->ship_asset_id, SHIP_ASSET_ID_NONE);
+    ASSERT_EQ_INT(new_slot->ship_asset_id, old_asset_id);
+    ASSERT(!new_slot->docked);
+    ASSERT_EQ_FLOAT(new_slot->ship.pos.x, 1234.0f, 0.001f);
+    ASSERT_EQ_FLOAT(new_slot->ship.pos.y, 5678.0f, 0.001f);
+    ASSERT_EQ_FLOAT(new_slot->ship.vel.x, 11.0f, 0.001f);
+    ASSERT_EQ_FLOAT(new_slot->ship.vel.y, -3.0f, 0.001f);
+    ASSERT_EQ_FLOAT(new_slot->ship.angle, 0.75f, 0.001f);
+    ASSERT_EQ_FLOAT(new_slot->ship.stat_credits_earned, 91.0f, 0.001f);
+}
+
 TEST(test_player_clear_live_session_identity) {
     server_player_t sp;
     memset(&sp, 0, sizeof(sp));
@@ -378,6 +427,7 @@ void register_registry_tests(void) {
     RUN(test_registry_idempotent_reregistration);
     RUN(test_registry_reconnect_with_new_token);
     RUN(test_registry_lookup_skips_disconnected_stale_session);
+    RUN(test_registry_same_token_takeover_moves_live_ship);
     RUN(test_player_clear_live_session_identity);
     RUN(test_registry_two_pubkeys_one_machine);
     RUN(test_registry_save_load_roundtrip);

--- a/tests/c/test_registry.c
+++ b/tests/c/test_registry.c
@@ -182,6 +182,7 @@ TEST(test_player_clear_live_session_identity) {
     sp.pubkey_set = true;
     sp.pubkey_proof_ok = true;
     sp.pubkey_identity_finalized = true;
+    sp.preserve_live_state_on_pubkey_finalize = true;
     sp.last_signed_nonce = 99;
 
     server_player_clear_live_session_identity(&sp);
@@ -194,6 +195,7 @@ TEST(test_player_clear_live_session_identity) {
     ASSERT(!sp.pubkey_set);
     ASSERT(!sp.pubkey_proof_ok);
     ASSERT(!sp.pubkey_identity_finalized);
+    ASSERT(!sp.preserve_live_state_on_pubkey_finalize);
     ASSERT_EQ_INT((int)sp.last_signed_nonce, 0);
 }
 
@@ -309,6 +311,7 @@ TEST(test_identity_dispatch_session_register_and_proof) {
     ASSERT(server_finalize_pubkey_identity(w, 0));
     ASSERT(sp->pubkey_identity_finalized);
     ASSERT_EQ_INT(registry_lookup_by_pubkey(w, pk), 0);
+    sp->preserve_live_state_on_pubkey_finalize = true;
 
     server_pubkey_register_result_t same;
     ASSERT(server_dispatch_register_pubkey_message(
@@ -317,6 +320,19 @@ TEST(test_identity_dispatch_session_register_and_proof) {
     ASSERT(same.same_pubkey);
     ASSERT(sp->pubkey_proof_ok);
     ASSERT(sp->pubkey_identity_finalized);
+    ASSERT(sp->preserve_live_state_on_pubkey_finalize);
+
+    uint8_t other_pk[32], other_sk[SIGNAL_CRYPTO_SECRET_BYTES];
+    signal_crypto_keypair(other_pk, other_sk);
+    uint8_t other_register_msg[REGISTER_PUBKEY_MSG_SIZE] =
+        { NET_MSG_REGISTER_PUBKEY };
+    memcpy(&other_register_msg[1], other_pk, 32);
+    server_pubkey_register_result_t other;
+    ASSERT(server_dispatch_register_pubkey_message(
+        w, 0, other_register_msg, sizeof(other_register_msg), &other));
+    ASSERT(other.accepted);
+    ASSERT(!other.same_pubkey);
+    ASSERT(!sp->preserve_live_state_on_pubkey_finalize);
 }
 
 TEST(test_identity_dispatch_rejects_wrong_session_proof) {

--- a/tests/c/test_save.c
+++ b/tests/c/test_save.c
@@ -1146,6 +1146,56 @@ TEST(test_player_load_invalid_station_falls_back) {
     remove(TMP("player_94.sav"));
 }
 
+TEST(test_player_load_repairs_degenerate_dock_berth) {
+    WORLD_DECL;
+    world_reset(&w);
+    SERVER_PLAYER_DECL(saved);
+    player_init_ship(&saved, &w);
+    saved.id = 0;
+    saved.connected = true;
+    saved.current_station = 0;
+    saved.docked = true;
+    saved.ship.pos = w.stations[0].pos;
+    ASSERT(player_save(&saved, test_tmp_dir(), 87));
+
+    station_t *prospect = &w.stations[0];
+    bool corrupted = false;
+    for (int i = 0; i < prospect->module_count; i++) {
+        station_module_t *mod = &prospect->modules[i];
+        if (mod->type != MODULE_DOCK || mod->scaffold) continue;
+        mod->ring = 0;
+        mod->slot = 0;
+        corrupted = true;
+        break;
+    }
+    ASSERT(corrupted);
+
+    server_player_t *loaded = &w.players[0];
+    loaded->id = 0;
+    loaded->connected = true;
+    loaded->session_ready = true;
+    memset(loaded->session_token, 0x87, sizeof(loaded->session_token));
+    ASSERT(player_load(loaded, &w, test_tmp_dir(), 87));
+    ASSERT(loaded->docked);
+    vec2 berth_pos = loaded->ship.pos;
+    ASSERT(v2_len(v2_sub(berth_pos, prospect->pos)) > prospect->radius + 1.0f);
+
+    world_sim_step(&w, SIM_DT);
+    ASSERT(loaded->docked);
+    ASSERT(v2_len(v2_sub(loaded->ship.pos, prospect->pos)) > prospect->radius + 1.0f);
+    ASSERT(v2_len(v2_sub(loaded->ship.pos, berth_pos)) < 0.01f);
+
+    loaded->input.launch = true;
+    world_sim_step(&w, SIM_DT);
+    ASSERT(!loaded->docked);
+    ASSERT(v2_len(v2_sub(loaded->ship.pos, berth_pos)) < 2.0f);
+    ASSERT(v2_len(loaded->ship.vel) > 50.0f);
+
+    char path[256];
+    if (player_save_path(path, sizeof(path), test_tmp_dir(), &saved, 87))
+        remove(path);
+}
+
 TEST(test_player_load_bad_magic_fails) {
     /* Write garbage with wrong magic */
     FILE *f = fopen(TMP("player_93.sav"), "wb");
@@ -2024,6 +2074,7 @@ void register_save_persistence_tests(void) {
     RUN(test_player_load_clamps_hull_hp);
     RUN(test_player_load_clamps_upgrade_levels);
     RUN(test_player_load_invalid_station_falls_back);
+    RUN(test_player_load_repairs_degenerate_dock_berth);
     RUN(test_player_load_bad_magic_fails);
     RUN(test_world_load_rejects_stale_version);
     RUN(test_world_save_load_preserves_module_ring_slot);

--- a/tests/c/test_save.c
+++ b/tests/c/test_save.c
@@ -274,6 +274,35 @@ TEST(test_v3_station_catalog_repairs_helios_smelter_layout) {
     remove(path);
 }
 
+TEST(test_station_catalog_bad_file_preserves_seeded_fallback) {
+    WORLD_HEAP seeded = calloc(1, sizeof(world_t));
+    ASSERT(seeded != NULL);
+    world_reset(seeded);
+
+    const char *dir = TMP("test_bad_station_catalog");
+    ASSERT(station_catalog_save(&seeded->stations[3], 3, dir));
+
+    char bad_path[256];
+    snprintf(bad_path, sizeof(bad_path), "%s/0.cat", dir);
+    FILE *f = fopen(bad_path, "wb");
+    ASSERT(f != NULL);
+    ASSERT(fwrite("bad", 1, 3, f) == 3);
+    fclose(f);
+
+    WORLD_HEAP loaded = calloc(1, sizeof(world_t));
+    ASSERT(loaded != NULL);
+    world_reset(loaded);
+    float expected_range = loaded->stations[0].signal_range;
+    ASSERT(expected_range > 0.0f);
+
+    ASSERT_EQ_INT(station_catalog_load_all(loaded->stations, MAX_STATIONS, dir), 1);
+    ASSERT(station_exists(&loaded->stations[0]));
+    ASSERT_EQ_FLOAT(loaded->stations[0].signal_range, expected_range, 0.01f);
+    ASSERT(station_exists(&loaded->stations[3]));
+
+    remove(bad_path);
+}
+
 TEST(test_world_save_load_preserves_stations) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
     world_reset(w);
@@ -2079,6 +2108,7 @@ void register_save_persistence_tests(void) {
     RUN(test_world_load_rejects_stale_version);
     RUN(test_world_save_load_preserves_module_ring_slot);
     RUN(test_v3_station_catalog_repairs_helios_smelter_layout);
+    RUN(test_station_catalog_bad_file_preserves_seeded_fallback);
     RUN(test_v51_migration_tags_untagged_furnaces_and_fills_hoppers);
     RUN(test_v51_migration_furnace_count_heuristic);
     RUN(test_world_save_load_preserves_smelted_ingot_pod);

--- a/tests/c/test_world_sim.c
+++ b/tests/c/test_world_sim.c
@@ -8003,6 +8003,28 @@ TEST(test_sector_one_broken_helios_corridor) {
     ASSERT(signal_strength_at(&w, w.stations[2].pos) > 0.95f);
 }
 
+TEST(test_freeport_dock_beacon_restores_local_control) {
+    WORLD_DECL;
+    world_reset(&w);
+
+    station_t *freeport = &w.stations[SIGNAL_FREEPORT_STATION_INDEX];
+    ASSERT(station_exists(freeport));
+    ASSERT(!station_provides_signal(freeport));
+    ASSERT(signal_strength_at(&w, freeport->pos) < 0.25f);
+
+    server_player_t *sp = &w.players[0];
+    player_init_ship(sp, &w);
+    sp->current_station = SIGNAL_FREEPORT_STATION_INDEX;
+    sp->nearby_station = SIGNAL_FREEPORT_STATION_INDEX;
+    sp->docked = true;
+    sp->dock_berth = -1;
+    anchor_ship_in_station(sp, &w);
+
+    float berth_signal = signal_strength_at(&w, sp->ship.pos);
+    ASSERT(berth_signal > 0.35f);
+    ASSERT(signal_control_scale(berth_signal) > 0.35f);
+}
+
 TEST(test_signal_zero_outside_range) {
     /* Far from all stations, signal should be 0.0 */
     WORLD_DECL;
@@ -8699,6 +8721,7 @@ void register_world_sim_signal_tests(void) {
     RUN(test_signal_strength_falls_off);
     RUN(test_signal_overlap_boosts_strength);
     RUN(test_sector_one_broken_helios_corridor);
+    RUN(test_freeport_dock_beacon_restores_local_control);
     RUN(test_signal_zero_outside_range);
     RUN(test_signal_max_of_stations);
     RUN(test_ship_thrust_scales_with_signal);

--- a/tests/c/test_world_sim.c
+++ b/tests/c/test_world_sim.c
@@ -8068,6 +8068,27 @@ TEST(test_ship_thrust_scales_with_signal) {
     ASSERT(vel_low_signal < vel_full_signal * 0.7f);
 }
 
+TEST(test_zero_signal_preserves_ship_momentum_without_boundary_pull) {
+    WORLD_DECL;
+    world_reset(&w);
+    server_player_t *sp = &w.players[0];
+    player_init_ship(sp, &w);
+    sp->connected = true;
+    sp->docked = false;
+    sp->ship.pos = v2(40000.0f, 0.0f);
+    sp->ship.vel = v2(120.0f, 0.0f);
+    sp->ship.angle = 0.0f;
+    ASSERT(signal_strength_at(&w, sp->ship.pos) < 0.01f);
+
+    vec2 start = sp->ship.pos;
+    world_sim_step_player_only(&w, 0, SIM_DT);
+
+    ASSERT(sp->ship.pos.x > start.x);
+    ASSERT(sp->ship.vel.x > 0.0f);
+    ASSERT(sp->ship.vel.x < 120.0f);
+    ASSERT_EQ_FLOAT(sp->ship.vel.y, 0.0f, 0.001f);
+}
+
 TEST(test_asteroid_outside_signal_despawns) {
     WORLD_DECL;
     world_reset(&w);
@@ -8725,6 +8746,7 @@ void register_world_sim_signal_tests(void) {
     RUN(test_signal_zero_outside_range);
     RUN(test_signal_max_of_stations);
     RUN(test_ship_thrust_scales_with_signal);
+    RUN(test_zero_signal_preserves_ship_momentum_without_boundary_pull);
     RUN(test_asteroid_outside_signal_despawns);
     RUN(test_npc_miners_avoid_zero_signal_asteroids);
     RUN(test_npc_miner_prefers_starved_ore_over_nearest_compatible_rock);

--- a/tools/signal_replay.c
+++ b/tools/signal_replay.c
@@ -24,6 +24,7 @@
 #include "sim_ai.h"
 #include "sim_asteroid.h"
 #include "sim_physics.h"
+#include "station_util.h"
 
 #define SR_SCHEMA "signal.replay_counterfactual.v1"
 #define SR_ACTION_COUNT 9
@@ -508,6 +509,52 @@ static void sr_reset_player(world_t *w, server_player_t *sp)
     memset(&sp->input, 0, sizeof(sp->input));
 }
 
+static int sr_first_station_module(const station_t *st, module_type_t type)
+{
+    if (!st) return -1;
+    for (int i = 0; i < st->module_count && i < MAX_MODULES_PER_STATION; i++) {
+        const station_module_t *module = &st->modules[i];
+        if (!module->scaffold && module->type == type)
+            return i;
+    }
+    return -1;
+}
+
+static int sr_spawn_station_market_pod(world_t *w,
+                                       int station_idx,
+                                       commodity_t commodity,
+                                       uint16_t count,
+                                       const uint8_t origin[8])
+{
+    if (!w || station_idx < 0 || station_idx >= MAX_STATIONS ||
+        commodity >= COMMODITY_COUNT || count == 0 ||
+        count > CARGO_POD_MANIFEST_CAP) {
+        return -1;
+    }
+
+    station_t *st = &w->stations[station_idx];
+    int dock_idx = sr_first_station_module(st, MODULE_DOCK);
+    if (dock_idx < 0) return -1;
+
+    cargo_unit_t units[CARGO_POD_MANIFEST_CAP];
+    memset(units, 0, sizeof(units));
+    for (uint16_t i = 0; i < count; i++) {
+        if (!hash_legacy_migrate_unit(origin, commodity, i, &units[i]))
+            return -1;
+    }
+
+    vec2 pos = module_world_pos_ring(st, st->modules[dock_idx].ring,
+                                     st->modules[dock_idx].slot);
+    int pod_idx = spawn_cargo_pod_with_manifest_deterministic(
+        w, pos, v2(0.0f, 0.0f), commodity, units, count,
+        CARGO_POD_CARGO, 0.0f, 0.0f);
+    if (pod_idx < 0) return -1;
+    w->cargo_pods[pod_idx].towed_by = -1;
+    cargo_pod_set_module_tractor(&w->cargo_pods[pod_idx],
+                                 station_idx, dock_idx);
+    return pod_idx;
+}
+
 static bool sr_setup_world(const sr_config_t *config,
                            world_t *w,
                            server_player_t **out_sp,
@@ -568,10 +615,15 @@ static bool sr_setup_provenance_script(const sr_config_t *config,
     case SR_PROVENANCE_SCRIPT_BUY_SELL: {
         const int station_index = 1; /* Kepler: seeded frame producer. */
         station_t *st;
+        const uint8_t origin[8] = { 'R','E','P','L','A','Y','0','1' };
         if (station_index >= w->station_count) return false;
         st = &w->stations[station_index];
         if (!station_manifest_bootstrap(st)) return false;
         if (station_finished_mint(st, COMMODITY_FRAME, 4, NULL) < 4) {
+            return false;
+        }
+        if (sr_spawn_station_market_pod(
+                w, station_index, COMMODITY_FRAME, 1, origin) < 0) {
             return false;
         }
         ledger_earn_by_pubkey(st, sp->pubkey, 10000.0f);
@@ -597,14 +649,17 @@ static bool sr_setup_provenance_script(const sr_config_t *config,
         return true;
     }
     case SR_PROVENANCE_SCRIPT_POD_TOW_SELL: {
-        const int station_index = 0;
+        const int station_index = 1; /* Kepler consumes ferrite ingots. */
+        const commodity_t pod_commodity = COMMODITY_FERRITE_INGOT;
         station_t *st;
         int pod_idx;
+        cargo_unit_t units[7];
+        const uint8_t origin[8] = { 'R','E','P','L','A','Y','0','2' };
         if (station_index >= w->station_count) return false;
         st = &w->stations[station_index];
         memset(w->cargo_pods, 0, sizeof(w->cargo_pods));
-        if (st->base_price[COMMODITY_FERRITE_ORE] <= FLOAT_EPSILON) {
-            st->base_price[COMMODITY_FERRITE_ORE] = 10.0f;
+        if (st->base_price[pod_commodity] <= FLOAT_EPSILON) {
+            st->base_price[pod_commodity] = 10.0f;
         }
 
         sp->docked = false;
@@ -613,16 +668,21 @@ static bool sr_setup_provenance_script(const sr_config_t *config,
         sp->in_dock_range = false;
         sp->docking_approach = false;
         sp->dock_berth = 0;
-        sp->ship.pos = v2_add(st->pos, v2(220.0f, 0.0f));
+        sp->ship.pos = v2_add(st->pos, v2(800.0f, 0.0f));
         sp->ship.vel = v2(0.0f, 0.0f);
         sp->ship.angle = PI_F;
 
-        pod_idx = spawn_cargo_pod(w,
-                                  v2_add(sp->ship.pos, v2(28.0f, 0.0f)),
-                                  v2(0.0f, 0.0f),
-                                  COMMODITY_FERRITE_ORE,
-                                  7,
-                                  CARGO_POD_CARGO);
+        memset(units, 0, sizeof(units));
+        for (uint16_t i = 0; i < 7; i++) {
+            if (!hash_legacy_migrate_unit(origin, pod_commodity,
+                                          i, &units[i])) {
+                return false;
+            }
+        }
+        pod_idx = spawn_cargo_pod_with_manifest_deterministic(
+            w, v2_add(sp->ship.pos, v2(28.0f, 0.0f)),
+            v2(0.0f, 0.0f), pod_commodity,
+            units, 7, CARGO_POD_CARGO, 0.0f, 0.0f);
         return pod_idx >= 0;
     }
     case SR_PROVENANCE_SCRIPT_MINE_FRACTURE: {
@@ -1517,36 +1577,53 @@ static bool sr_run_provenance_script(const sr_config_t *config,
 
     switch (config->provenance_script) {
     case SR_PROVENANCE_SCRIPT_BUY_SELL: {
-        uint16_t start_station_manifest = w->stations[sp->current_station].manifest.count;
-        uint16_t start_ship_manifest = sp->ship.manifest.count;
+        int buy_before = counts->buy_events;
+        int sell_before = counts->sell_events;
+        int start_towed_pods = sp->ship.towed_pod_count;
+        int pod_idx = -1;
 
         sp->input.buy_product = true;
         sp->input.buy_commodity = COMMODITY_FRAME;
         sp->input.buy_grade = MINING_GRADE_COMMON;
         world_sim_step(w, SIM_DT);
         sr_accumulate_events(w, counts, event_hash);
-        if (counts->buy_events <= 0 ||
-            sp->ship.manifest.count <= start_ship_manifest ||
-            w->stations[sp->current_station].manifest.count >= start_station_manifest) {
+        if (counts->buy_events <= buy_before ||
+            sp->ship.towed_pod_count <= start_towed_pods) {
+            return false;
+        }
+        pod_idx = sp->ship.towed_pods[start_towed_pods];
+        if (pod_idx < 0 || pod_idx >= MAX_CARGO_PODS ||
+            !w->cargo_pods[pod_idx].active ||
+            w->cargo_pods[pod_idx].towed_by != (int8_t)sp->id ||
+            w->cargo_pods[pod_idx].commodity != COMMODITY_FRAME ||
+            w->cargo_pods[pod_idx].manifest_count == 0) {
             return false;
         }
 
-        sp->input.service_sell = true;
-        sp->input.service_sell_only = COMMODITY_FRAME;
-        sp->input.service_sell_grade = MINING_GRADE_COUNT;
+        int hopper_idx = station_find_hopper_for(
+            &w->stations[sp->current_station], COMMODITY_FRAME);
+        if (hopper_idx < 0) return false;
+        w->cargo_pods[pod_idx].pos = module_world_pos_ring(
+            &w->stations[sp->current_station],
+            w->stations[sp->current_station].modules[hopper_idx].ring,
+            w->stations[sp->current_station].modules[hopper_idx].slot);
+        w->cargo_pods[pod_idx].vel = v2(0.0f, 0.0f);
         world_sim_step(w, SIM_DT);
         sr_accumulate_events(w, counts, event_hash);
-        if (counts->sell_events <= 0 ||
-            sp->ship.manifest.count != start_ship_manifest) {
+        if (counts->sell_events <= sell_before ||
+            sp->ship.towed_pod_count != start_towed_pods ||
+            !w->cargo_pods[pod_idx].active ||
+            w->cargo_pods[pod_idx].towed_by != -1) {
             return false;
         }
         return true;
     }
     case SR_PROVENANCE_SCRIPT_POD_TOW_SELL: {
         int pickup_before = counts->pickup_events;
-        int dock_before = counts->dock_events;
         int sell_before = counts->sell_events;
         int station_index = sp->current_station;
+        const commodity_t pod_commodity = COMMODITY_FERRITE_INGOT;
+        int pod_idx = -1;
 
         sp->input.tractor_hold = true;
         world_sim_step(w, SIM_DT);
@@ -1556,33 +1633,29 @@ static bool sr_run_provenance_script(const sr_config_t *config,
             return false;
         }
 
-        sp->input.tractor_hold = true;
-        sp->input.dock = true;
-        world_sim_step(w, SIM_DT);
-        sr_accumulate_events(w, counts, event_hash);
-
-        for (int i = 0; i < 240 && !sp->docked; i++) {
-            sp->input.tractor_hold = true;
-            world_sim_step(w, SIM_DT);
-            sr_accumulate_events(w, counts, event_hash);
-        }
-        if (!sp->docked || sp->current_station != station_index ||
-            counts->dock_events <= dock_before ||
-            sp->ship.towed_pod_count <= 0) {
+        pod_idx = sp->ship.towed_pods[0];
+        if (pod_idx < 0 || pod_idx >= MAX_CARGO_PODS ||
+            !w->cargo_pods[pod_idx].active ||
+            w->cargo_pods[pod_idx].towed_by != (int8_t)sp->id) {
             return false;
         }
-
-        sp->input.service_sell = true;
-        sp->input.service_sell_only = COMMODITY_COUNT;
-        sp->input.service_sell_grade = MINING_GRADE_COUNT;
-        world_sim_step(w, SIM_DT);
+        int hopper_idx = station_find_hopper_for(
+            &w->stations[station_index], pod_commodity);
+        if (hopper_idx < 0) return false;
+        w->cargo_pods[pod_idx].pos = module_world_pos_ring(
+            &w->stations[station_index],
+            w->stations[station_index].modules[hopper_idx].ring,
+            w->stations[station_index].modules[hopper_idx].slot);
+        w->cargo_pods[pod_idx].vel = v2(0.0f, 0.0f);
+        w->events.count = 0;
+        step_station_cargo_pod_tractors(w, SIM_DT);
         sr_accumulate_events(w, counts, event_hash);
         if (counts->sell_events <= sell_before ||
-            sp->ship.towed_pod_count != 0) {
+            sp->ship.towed_pod_count != 0 ||
+            !w->cargo_pods[pod_idx].active ||
+            w->cargo_pods[pod_idx].towed_by != -1 ||
+            !cargo_pod_has_module_tractor(&w->cargo_pods[pod_idx])) {
             return false;
-        }
-        for (int i = 0; i < MAX_CARGO_PODS; i++) {
-            if (w->cargo_pods[i].active) return false;
         }
         return true;
     }

--- a/web/play.html
+++ b/web/play.html
@@ -157,6 +157,15 @@
           !target.isContentEditable;
       }
 
+      function signalFocusInsideTouchControls(target) {
+        return !!(target && target.closest &&
+          target.closest('.signal-touch-controls'));
+      }
+
+      function signalTouchControlHeld() {
+        return !!document.querySelector('.signal-touch-button.is-held');
+      }
+
       function signalKeyboardFallback(e, down) {
         if (!signalKeyboardTargetIsGame(e)) return;
         var action = signalKeyActions[e.code] || signalKeyActions[e.key];
@@ -196,7 +205,11 @@
         if (document.hidden) signalClearHeldControls();
         else signalFocusCanvas();
       });
-      canvas.addEventListener('blur', signalClearHeldControls);
+      canvas.addEventListener('blur', function(e) {
+        if (signalFocusInsideTouchControls(e.relatedTarget) ||
+            signalTouchControlHeld()) return;
+        signalClearHeldControls();
+      });
     </script>
     <script>
 

--- a/web/signal-touch-controls.js
+++ b/web/signal-touch-controls.js
@@ -307,6 +307,14 @@
     el.hidden = !visible;
   }
 
+  function reassertHeldControls() {
+    Object.keys(controls).forEach(function (name) {
+      var el = controls[name];
+      if (!el || el.hidden || !el.classList.contains("is-held")) return;
+      send(Number(el.dataset.action), true);
+    });
+  }
+
   function syncGroups() {
     groups.forEach(function (group) {
       var visible = Array.prototype.some.call(
@@ -381,6 +389,7 @@
     setButton("four", (digitMask & 8) !== 0, "4");
     setButton("five", (digitMask & 16) !== 0, "5");
 
+    reassertHeldControls();
     syncGroups();
   }
 

--- a/web/signal-touch-controls.js
+++ b/web/signal-touch-controls.js
@@ -88,8 +88,8 @@
   };
 
   var controls = {};
-  var groups = [];
   var controlsRoot = null;
+  var stationGroup = null;
 
   function gameModule() {
     return window.SignalGameModule || window.Module;
@@ -198,34 +198,37 @@
   function installStyles() {
     var style = document.createElement("style");
     style.textContent = [
-      ".signal-touch-controls{position:fixed;inset:0;z-index:12;pointer-events:none;font-family:\"IBM Plex Mono\",\"SFMono-Regular\",ui-monospace,monospace;-webkit-user-select:none;user-select:none}",
+      ".signal-touch-controls{position:fixed;inset:0;z-index:12;pointer-events:none;font-family:\"IBM Plex Mono\",\"SFMono-Regular\",ui-monospace,monospace;-webkit-user-select:none;user-select:none;--edge:max(12px,env(safe-area-inset-bottom));--side:max(12px,env(safe-area-inset-right));--left-side:max(12px,env(safe-area-inset-left));--top-edge:max(12px,env(safe-area-inset-top))}",
       ".signal-touch-controls *{box-sizing:border-box;-webkit-tap-highlight-color:transparent}",
-      ".signal-touch-button{pointer-events:auto;min-width:48px;min-height:44px;padding:0 7px;border:1px solid rgba(245,239,223,.22);border-radius:7px;background:rgba(8,7,6,.44);color:#f5efdf;font:700 10px/1.05 \"IBM Plex Mono\",\"SFMono-Regular\",ui-monospace,monospace;letter-spacing:0;text-transform:uppercase;box-shadow:0 6px 16px rgba(0,0,0,.24);backdrop-filter:blur(8px);touch-action:none;white-space:normal;overflow:hidden;word-break:break-word}",
-      ".signal-touch-button[hidden],.signal-touch-stack[hidden]{display:none!important}",
+      ".signal-touch-button{pointer-events:auto;min-width:48px;min-height:44px;padding:0 7px;border:1px solid rgba(245,239,223,.22);border-radius:7px;background:rgba(8,7,6,.50);color:#f5efdf;font:700 10px/1.05 \"IBM Plex Mono\",\"SFMono-Regular\",ui-monospace,monospace;letter-spacing:0;text-transform:uppercase;box-shadow:0 6px 16px rgba(0,0,0,.24);backdrop-filter:blur(8px);touch-action:none;white-space:normal;overflow:hidden;word-break:break-word;transition:opacity .12s,border-color .12s,background .12s,color .12s}",
+      ".signal-touch-stack[hidden]{display:none!important}",
+      ".signal-touch-button:disabled,.signal-touch-button.is-disabled{opacity:.34;background:rgba(8,7,6,.28);border-color:rgba(245,239,223,.12);box-shadow:none;color:rgba(245,239,223,.52)}",
       ".signal-touch-button:active,.signal-touch-button.is-held{background:rgba(128,255,213,.18);border-color:rgba(128,255,213,.72);color:#dffff4}",
+      ".signal-touch-button:disabled:active,.signal-touch-button.is-disabled:active{background:rgba(8,7,6,.28);border-color:rgba(245,239,223,.12);color:rgba(245,239,223,.52)}",
       ".signal-touch-stack{position:absolute;display:grid;gap:7px;pointer-events:none}",
-      ".signal-touch-left{left:max(12px,env(safe-area-inset-left));bottom:max(12px,env(safe-area-inset-bottom));grid-template-columns:repeat(2,58px);grid-template-rows:46px 58px}",
-      ".signal-touch-left .boost{grid-column:1/span 2;color:#91bcff}",
+      ".signal-touch-left{left:var(--left-side);bottom:var(--edge);grid-template-columns:repeat(2,58px);grid-template-rows:46px 58px}",
+      ".signal-touch-left .boost{grid-column:1/span 2;grid-row:1;color:#91bcff}",
+      ".signal-touch-left .left{grid-column:1;grid-row:2}.signal-touch-left .right{grid-column:2;grid-row:2}",
       ".signal-touch-left .left,.signal-touch-left .right{min-height:58px;color:#80ffd5;font-size:18px}",
-      ".signal-touch-right{right:max(12px,env(safe-area-inset-right));bottom:max(12px,env(safe-area-inset-bottom));grid-template-columns:60px 72px;grid-template-rows:52px 58px 58px 40px}",
-      ".signal-touch-right .use{grid-column:1/span 2;min-height:52px;color:#f7d389;border-color:rgba(247,211,137,.44);font-size:11px}",
-      ".signal-touch-right .thrust,.signal-touch-right .brake{grid-column:2;min-height:58px;color:#f5efdf}",
-      ".signal-touch-right .fire,.signal-touch-right .tractor{grid-column:1;min-height:58px}",
+      ".signal-touch-right{right:var(--side);bottom:var(--edge);grid-template-columns:60px 72px;grid-template-rows:52px 58px 58px 40px}",
+      ".signal-touch-right .use{grid-column:1/span 2;grid-row:1;min-height:52px;color:#f7d389;border-color:rgba(247,211,137,.44);font-size:11px}",
+      ".signal-touch-right .fire{grid-column:1;grid-row:2}.signal-touch-right .thrust{grid-column:2;grid-row:2}.signal-touch-right .tractor{grid-column:1;grid-row:3}.signal-touch-right .brake{grid-column:2;grid-row:3}.signal-touch-right .scan{grid-column:1;grid-row:4}.signal-touch-right .auto{grid-column:2;grid-row:4}",
+      ".signal-touch-right .thrust,.signal-touch-right .brake{min-height:58px;color:#f5efdf}",
+      ".signal-touch-right .fire,.signal-touch-right .tractor{min-height:58px}",
       ".signal-touch-right .fire{color:#f1b566}.signal-touch-right .tractor{color:#80ffd5}",
       ".signal-touch-right .scan,.signal-touch-right .auto{min-height:40px;font-size:9px;background:rgba(8,7,6,.36)}",
-      ".signal-touch-secondary{right:max(12px,env(safe-area-inset-right));bottom:calc(max(12px,env(safe-area-inset-bottom)) + 232px);grid-template-columns:repeat(2,62px);grid-auto-rows:38px}",
+      ".signal-touch-secondary{right:var(--side);bottom:calc(var(--edge) + 232px);grid-template-columns:repeat(2,62px);grid-template-rows:38px}",
+      ".signal-touch-secondary .plan{grid-column:1;grid-row:1}.signal-touch-secondary .cycle{grid-column:2;grid-row:1}",
       ".signal-touch-secondary .signal-touch-button{min-height:38px;font-size:9px;background:rgba(8,7,6,.36)}",
-      ".signal-touch-station{left:50%;bottom:max(10px,env(safe-area-inset-bottom));transform:translateX(-50%);width:min(380px,calc(100vw - 20px));grid-template-columns:repeat(8,minmax(0,1fr));grid-auto-rows:38px;justify-content:center}",
+      ".signal-touch-station{left:50%;top:var(--top-edge);transform:translateX(-50%);width:min(380px,calc(100vw - 20px));grid-template-columns:repeat(7,minmax(0,1fr));grid-auto-rows:36px;justify-content:center;gap:5px}",
       ".signal-touch-station .signal-touch-button{min-width:0;min-height:38px;padding:0 5px;font-size:9px;background:rgba(8,7,6,.36)}",
       ".signal-touch-station .wide{grid-column:span 2;min-width:0}",
-      ".signal-touch-controls.is-docked .signal-touch-right{top:max(10px,env(safe-area-inset-top));right:max(10px,env(safe-area-inset-right));bottom:auto;grid-template-columns:repeat(3,58px);grid-template-rows:38px;gap:6px}",
-      ".signal-touch-controls.is-docked .signal-touch-right .use{grid-column:auto;min-height:38px;font-size:9px}",
-      ".signal-touch-controls.is-docked .signal-touch-right .scan,.signal-touch-controls.is-docked .signal-touch-right .auto{min-height:38px;font-size:9px}",
-      ".signal-touch-controls.is-docked .signal-touch-station{bottom:max(8px,env(safe-area-inset-bottom));width:min(360px,calc(100vw - 20px));grid-template-columns:repeat(6,minmax(0,1fr));grid-auto-rows:36px;gap:5px}",
-      ".signal-touch-controls.is-docked .signal-touch-station .signal-touch-button{min-height:36px;font-size:9px}",
+      ".signal-touch-station .tab{grid-column:1/span 2;grid-row:1}.signal-touch-station .page{grid-column:3/span 2;grid-row:1}.signal-touch-station .sell{grid-column:5/span 3;grid-row:1}",
+      ".signal-touch-station .repair{grid-column:1/span 2;grid-row:2}.signal-touch-station .laser{grid-column:3/span 2;grid-row:2}.signal-touch-station .cargo{grid-column:5/span 3;grid-row:2}",
+      ".signal-touch-station .tractorUpgrade{grid-column:1/span 2;grid-row:3}.signal-touch-station .one{grid-column:3;grid-row:3}.signal-touch-station .two{grid-column:4;grid-row:3}.signal-touch-station .three{grid-column:5;grid-row:3}.signal-touch-station .four{grid-column:6;grid-row:3}.signal-touch-station .five{grid-column:7;grid-row:3}",
       "@media (min-width:860px) and (pointer:fine){.signal-touch-controls{display:none}}",
-      "@media (max-width:560px){.signal-touch-button{min-width:44px;min-height:42px;font-size:9px}.signal-touch-left{left:max(10px,env(safe-area-inset-left));grid-template-columns:repeat(2,54px);grid-template-rows:42px 54px;gap:6px}.signal-touch-left .left,.signal-touch-left .right{min-height:54px;font-size:17px}.signal-touch-right{right:max(10px,env(safe-area-inset-right));grid-template-columns:56px 66px;grid-template-rows:48px 54px 54px 38px;gap:6px}.signal-touch-right .use{min-height:48px}.signal-touch-right .thrust,.signal-touch-right .brake,.signal-touch-right .fire,.signal-touch-right .tractor{min-height:54px}.signal-touch-secondary{right:max(10px,env(safe-area-inset-right));bottom:calc(max(12px,env(safe-area-inset-bottom)) + 218px);grid-template-columns:repeat(2,58px);gap:6px}.signal-touch-station{width:calc(100vw - 20px);grid-template-columns:repeat(5,minmax(0,1fr));gap:5px}}",
-      "@media (max-height:520px){.signal-touch-left,.signal-touch-right,.signal-touch-station{bottom:max(8px,env(safe-area-inset-bottom))}.signal-touch-left{grid-template-columns:repeat(2,52px);grid-template-rows:40px 50px}.signal-touch-right{grid-template-columns:52px 62px;grid-template-rows:44px 50px 50px 36px}.signal-touch-left .left,.signal-touch-left .right,.signal-touch-right .thrust,.signal-touch-right .brake,.signal-touch-right .fire,.signal-touch-right .tractor{min-height:50px}.signal-touch-secondary{right:max(8px,env(safe-area-inset-right));bottom:calc(max(8px,env(safe-area-inset-bottom)) + 224px);grid-template-columns:repeat(2,54px)}.signal-touch-station .signal-touch-button{min-height:34px}.signal-touch-controls.is-docked .signal-touch-right{top:max(8px,env(safe-area-inset-top));grid-template-columns:repeat(3,54px);grid-template-rows:34px}.signal-touch-controls.is-docked .signal-touch-right .use,.signal-touch-controls.is-docked .signal-touch-right .scan,.signal-touch-controls.is-docked .signal-touch-right .auto{min-height:34px}.signal-touch-controls.is-docked .signal-touch-station{bottom:max(6px,env(safe-area-inset-bottom));grid-auto-rows:34px}}"
+      "@media (max-width:560px){.signal-touch-controls{--edge:max(12px,env(safe-area-inset-bottom));--side:max(10px,env(safe-area-inset-right));--left-side:max(10px,env(safe-area-inset-left));--top-edge:max(10px,env(safe-area-inset-top))}.signal-touch-button{min-width:44px;min-height:42px;font-size:9px}.signal-touch-left{grid-template-columns:repeat(2,54px);grid-template-rows:42px 54px;gap:6px}.signal-touch-left .left,.signal-touch-left .right{min-height:54px;font-size:17px}.signal-touch-right{grid-template-columns:56px 66px;grid-template-rows:48px 54px 54px 38px;gap:6px}.signal-touch-right .use{min-height:48px}.signal-touch-right .thrust,.signal-touch-right .brake,.signal-touch-right .fire,.signal-touch-right .tractor{min-height:54px}.signal-touch-secondary{bottom:calc(var(--edge) + 218px);grid-template-columns:repeat(2,58px);gap:6px}.signal-touch-station{width:calc(100vw - 20px);grid-auto-rows:34px}}",
+      "@media (max-height:520px){.signal-touch-controls{--edge:max(8px,env(safe-area-inset-bottom));--side:max(8px,env(safe-area-inset-right));--left-side:max(8px,env(safe-area-inset-left));--top-edge:max(8px,env(safe-area-inset-top))}.signal-touch-left{grid-template-columns:repeat(2,52px);grid-template-rows:40px 50px}.signal-touch-right{grid-template-columns:52px 62px;grid-template-rows:44px 50px 50px 36px}.signal-touch-left .left,.signal-touch-left .right,.signal-touch-right .thrust,.signal-touch-right .brake,.signal-touch-right .fire,.signal-touch-right .tractor{min-height:50px}.signal-touch-secondary{bottom:calc(var(--edge) + 224px);grid-template-columns:repeat(2,54px)}.signal-touch-station{grid-auto-rows:32px}.signal-touch-station .signal-touch-button{min-height:32px}}"
     ].join("");
     document.head.appendChild(style);
   }
@@ -250,7 +253,7 @@
     el.addEventListener("pointerdown", function (ev) {
       ev.preventDefault();
       ev.stopPropagation();
-      if (el.hidden) return;
+      if (el.hidden || el.disabled) return;
       focusGame();
       pointerId = ev.pointerId;
       if (el.setPointerCapture) el.setPointerCapture(pointerId);
@@ -294,34 +297,42 @@
     });
   }
 
-  function setButton(name, visible, label) {
+  function setButton(name, enabled, label) {
     var el = controls[name];
     if (!el) return;
     if (label && el.textContent !== label) {
       el.textContent = label;
       el.setAttribute("aria-label", label);
     }
-    if (!visible && !el.hidden && el.signalTouchRelease) {
+    if (!enabled && !el.disabled && el.signalTouchRelease) {
       el.signalTouchRelease();
     }
-    el.hidden = !visible;
+    el.disabled = !enabled;
+    el.classList.toggle("is-disabled", !enabled);
+    el.setAttribute("aria-disabled", enabled ? "false" : "true");
   }
 
   function reassertHeldControls() {
     Object.keys(controls).forEach(function (name) {
       var el = controls[name];
-      if (!el || el.hidden || !el.classList.contains("is-held")) return;
+      if (!el || el.hidden || el.disabled || !el.classList.contains("is-held")) return;
       send(Number(el.dataset.action), true);
     });
   }
 
-  function syncGroups() {
-    groups.forEach(function (group) {
-      var visible = Array.prototype.some.call(
-        group.querySelectorAll(".signal-touch-button"),
-        function (el) { return !el.hidden; }
-      );
-      group.hidden = !visible;
+  function setGroupVisible(group, visible) {
+    if (!group) return;
+    if (!visible && !group.hidden) {
+      Array.prototype.forEach.call(group.querySelectorAll(".signal-touch-button"), function (el) {
+        if (el.signalTouchRelease) el.signalTouchRelease();
+      });
+    }
+    group.hidden = !visible;
+  }
+
+  function setDigits(enabled, digitMask) {
+    ["one", "two", "three", "four", "five"].forEach(function (name, index) {
+      setButton(name, enabled && ((digitMask & (1 << index)) !== 0), String(index + 1));
     });
   }
 
@@ -375,22 +386,18 @@
     setButton("cycle", has(flags, FLAG.canCycle), "Type");
 
     setButton("tab", docked, "Panel");
-    setButton("page", has(flags, FLAG.canPage), "More");
-    setButton("sell", has(flags, FLAG.canSell), workView ? "Deliver" : "Sell");
-    setButton("repair", dockView && has(flags, FLAG.canRepair), "Repair");
-    setButton("laser", dockView && has(flags, FLAG.canUpgradeMine), "Laser+");
-    setButton("cargo", dockView && has(flags, FLAG.canUpgradeHold), "Hold+");
-    setButton("tractorUpgrade", dockView && has(flags, FLAG.canUpgradeTractor), "Tow+");
+    setButton("page", docked && has(flags, FLAG.canPage), "More");
+    setButton("sell", docked && has(flags, FLAG.canSell), workView ? "Deliver" : "Sell");
+    setButton("repair", docked && dockView && has(flags, FLAG.canRepair), "Repair");
+    setButton("laser", docked && dockView && has(flags, FLAG.canUpgradeMine), "Laser+");
+    setButton("cargo", docked && dockView && has(flags, FLAG.canUpgradeHold), "Hold+");
+    setButton("tractorUpgrade", docked && dockView && has(flags, FLAG.canUpgradeTractor), "Tow+");
 
     var digitMask = (tradeView || workView || yardView) ? mobileDigitMask(flags) : 0;
-    setButton("one", (digitMask & 1) !== 0, "1");
-    setButton("two", (digitMask & 2) !== 0, "2");
-    setButton("three", (digitMask & 4) !== 0, "3");
-    setButton("four", (digitMask & 8) !== 0, "4");
-    setButton("five", (digitMask & 16) !== 0, "5");
+    setDigits(docked, digitMask);
 
     reassertHeldControls();
-    syncGroups();
+    setGroupVisible(stationGroup, docked);
   }
 
   function installControls() {
@@ -444,7 +451,7 @@
     root.appendChild(station);
     document.body.appendChild(root);
 
-    groups = [left, right, secondary, station];
+    stationGroup = station;
     Array.prototype.forEach.call(root.querySelectorAll(".signal-touch-button"), bindButton);
     refreshControls();
     window.setInterval(refreshControls, 120);


### PR DESCRIPTION
## Summary

- Documents the multiplayer local prediction and reconciliation contract.
- Finishes the tick-addressed input/ack prediction path, replay reset behavior, and browser smoke coverage for reconnect/flight controls.
- Updates replay provenance fixtures to match physical manifest-backed cargo pod buy/sell flows.
- Fixes follow-on bugs found during verification: idle neural NPC assignment cooldown, repair-kit soak isolation, base64 short-buffer decode rejection, and route-history tail buffer initialization.

## Root Cause

The branch had the runtime behavior mostly in place, but the contract was not documented, replay fixtures still assumed older manifest-only cargo behavior, and broader verification exposed a slow idle NPC reassignment path plus small helper/static-analysis issues.

## Validation

- `make test-all` passed: 998 tests
- `make cppcheck` passed
- `make replay-native-wasm` passed: 15 fast scenarios
- `make smoke` passed: 10 passed, 4 skipped
