### PR TITLE
Replicate towing as one atomic relation snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-web build-server build-test build-san test-san test-tsan build-flight-trace flight-trace build-signal-replay build-signal-replay-wasm signal-replay replay-repeatability replay-repeatability-long signal-no-omniscience-soak replay-cross-build replay-cross-build-long replay-native-wasm replay-native-wasm-long build-chain-assets chain-assets build-rati-receipt rati-receipt rati-anchor-batch test-rati-anchor-batch rati-anchor-stamp test-rati-anchor-stamp neural-gap-ab signal-client-brain-shadow signal-hnn-shadow assets protocol-check test test-serial test-fast test-soak test-all smoke smoke-latency smoke-ack-lag smoke-latency-suite relay-traffic-probe banned-apis deterministic-libm deterministic-build-flags doc-freshness fuzz-receipts fuzz-receipts-standalone cppcheck crap profile-machine latency-proxy latency-proxy-high latency-proxy-ack-lag rtc-gateway deploy-fly site clean install-hooks
+.PHONY: all build build-web build-server build-test build-san test-san test-tsan build-flight-trace flight-trace build-signal-replay build-signal-replay-wasm signal-replay replay-repeatability replay-repeatability-long signal-no-omniscience-soak replay-cross-build replay-cross-build-long replay-native-wasm replay-native-wasm-long build-chain-assets chain-assets build-rati-receipt rati-receipt rati-anchor-batch test-rati-anchor-batch rati-anchor-stamp test-rati-anchor-stamp neural-gap-ab signal-client-brain-shadow signal-hnn-shadow assets protocol-check test test-serial test-fast test-soak test-all smoke smoke-latency smoke-ack-lag smoke-latency-suite test-latency-proxy relay-traffic-probe banned-apis deterministic-libm deterministic-build-flags doc-freshness fuzz-receipts fuzz-receipts-standalone cppcheck crap profile-machine latency-proxy latency-proxy-high latency-proxy-ack-lag rtc-gateway deploy-fly site clean install-hooks
 
 all: build build-web build-server
 
@@ -532,7 +532,10 @@ smoke-latency:
 smoke-ack-lag:
 	SMOKE_URL="$(SMOKE_LATENCY_URL)" SMOKE_ACK_LAG_ASSERT=1 npx playwright test tests/browser-smoke.spec.ts --project=chromium --grep "low-ping high-ack"
 
-smoke-latency-suite: build-web build-server
+test-latency-proxy:
+	node scripts/test-ws-frame-impairment.mjs
+
+smoke-latency-suite: build-web build-server test-latency-proxy
 	node scripts/smoke-latency-suite.mjs
 
 RELAY_PROBE_URL ?= ws://127.0.0.1:9091/ws

--- a/client/client.h
+++ b/client/client.h
@@ -765,14 +765,16 @@ typedef struct {
     struct {
         client_npc_render_state_t prev[MAX_NPC_SHIPS];
         client_npc_render_state_t curr[MAX_NPC_SHIPS];
-        float t;
-        float interval;
+        /* Sparse NPC identity, pose, and linear packets arrive on separate
+         * schedules. One clock per slot prevents traffic for NPC B from
+         * restarting NPC A's correction baseline. */
+        float elapsed[MAX_NPC_SHIPS];
     } npc_interp;
     struct {
         scaffold_t prev[MAX_SCAFFOLDS];
         scaffold_t curr[MAX_SCAFFOLDS];
-        float t;
-        float interval;
+        /* Scaffold metadata and motion are sparse independent streams. */
+        float elapsed[MAX_SCAFFOLDS];
     } scaffold_interp;
     struct {
         cargo_pod_t prev[MAX_CARGO_PODS];

--- a/client/client.h
+++ b/client/client.h
@@ -449,6 +449,9 @@ typedef struct {
     char identity_pub_b58[48];   /* base58 of pubkey, null-terminated */
     /* --- Network authority (remote WebSocket or local loopback) --- */
     bool net_authority_enabled;
+    bool tow_snapshot_received;
+    uint32_t tow_snapshot_revision;
+    uint32_t tow_snapshot_server_tick;
     float net_send_timer;
     bool scanned_players[NET_MAX_PLAYERS];
     uint8_t pending_net_action;

--- a/client/hud.c
+++ b/client/hud.c
@@ -4807,8 +4807,7 @@ static int smoke_apply_loop_state(int state) {
                sizeof(g.asteroid_interp.elapsed));
         memset(g.npc_interp.curr, 0, sizeof(g.npc_interp.curr));
         memset(g.npc_interp.prev, 0, sizeof(g.npc_interp.prev));
-        g.npc_interp.t = 0.0f;
-        g.npc_interp.interval = 0.1f;
+        memset(g.npc_interp.elapsed, 0, sizeof(g.npc_interp.elapsed));
         return 1;
     }
     case SMOKE_LOOP_STATE_CUPRITE_GATE:

--- a/client/main.c
+++ b/client/main.c
@@ -3431,6 +3431,108 @@ int signal_smoke_tow_lifecycle_state(void) {
 }
 
 EMSCRIPTEN_KEEPALIVE
+const char *signal_smoke_live_tow_summary(void) {
+    static char summary[768];
+    const int target_idx = MAX_ASTEROIDS - 1;
+    const asteroid_t *target = &g.world.asteroids[target_idx];
+    const asteroid_t *target_interp = &g.asteroid_interp.curr[target_idx];
+    int player_idx = g.local_player_slot;
+    const server_player_t *sp =
+        (player_idx >= 0 && player_idx < MAX_PLAYERS)
+            ? &g.world.players[player_idx]
+            : NULL;
+
+    int compat_occurrences = 0;
+    int compat_count = 0;
+    int target_links = 0;
+    int local_target_links = 0;
+    int link_state = 0;
+    int link_slot = -1;
+    uint32_t link_revision = 0;
+    bool tractor_active = false;
+    bool docked = true;
+    bool local_ready = false;
+    float player_x = 0.0f;
+    float player_y = 0.0f;
+
+    if (sp && sp->ship) {
+        local_ready = sp->connected;
+        docked = sp->docked;
+        tractor_active = sp->ship->tractor_active;
+        compat_count = sp->ship->towed_count;
+        player_x = sp->ship->pos.x;
+        player_y = sp->ship->pos.y;
+        for (int i = 0; i < 10; i++) {
+            if (sp->ship->towed_fragments[i] == target_idx)
+                compat_occurrences++;
+        }
+    }
+
+    for (int i = 0; i < MAX_TOW_LINKS; i++) {
+        const tow_link_t *link = &g.world.tow_links[i];
+        if (!link->active ||
+            link->target.kind != ENTITY_KIND_ASTEROID ||
+            link->target.index != target_idx ||
+            link->target.part != -1) {
+            continue;
+        }
+        target_links++;
+        if (sp &&
+            link->source.kind == ENTITY_KIND_SHIP &&
+            link->source.index == WORLD_PLAYER_SHIP_BASE + player_idx &&
+            link->source.part == -1 &&
+            link->profile == TOW_PROFILE_SHIP_FRAGMENT) {
+            local_target_links++;
+            link_state = link->state;
+            link_slot = link->slot;
+            link_revision = link->revision;
+        }
+    }
+
+    snprintf(
+        summary, sizeof(summary),
+        "{\"localPlayer\":%d,\"localReady\":%d,"
+        "\"netAuthority\":%d,\"loopback\":%d,"
+        "\"docked\":%d,\"targetActive\":%d,\"targetInterpActive\":%d,"
+        "\"towSnapshotReceived\":%d,\"tractorActive\":%d,"
+        "\"compatCount\":%d,\"compatOccurrences\":%d,"
+        "\"targetLinks\":%d,\"localTargetLinks\":%d,"
+        "\"targetTractor\":%d,\"interpTargetTractor\":%d,"
+        "\"towRevision\":%u,\"snapshotRevision\":%u,"
+        "\"linkRevision\":%u,\"linkState\":%d,\"linkSlot\":%d,"
+        "\"x\":%.6f,\"y\":%.6f,\"vx\":%.6f,\"vy\":%.6f,"
+        "\"elapsed\":%.6f,\"playerX\":%.6f,\"playerY\":%.6f}",
+        player_idx,
+        local_ready ? 1 : 0,
+        g.net_authority_enabled ? 1 : 0,
+        net_is_loopback() ? 1 : 0,
+        docked ? 1 : 0,
+        target->active ? 1 : 0,
+        target_interp->active ? 1 : 0,
+        g.tow_snapshot_received ? 1 : 0,
+        tractor_active ? 1 : 0,
+        compat_count,
+        compat_occurrences,
+        target_links,
+        local_target_links,
+        asteroid_tractor_player(target),
+        asteroid_tractor_player(target_interp),
+        g.world.tow_revision,
+        g.tow_snapshot_revision,
+        link_revision,
+        link_state,
+        link_slot,
+        target->pos.x,
+        target->pos.y,
+        target->vel.x,
+        target->vel.y,
+        g.asteroid_interp.elapsed[target_idx],
+        player_x,
+        player_y);
+    return summary;
+}
+
+EMSCRIPTEN_KEEPALIVE
 int signal_smoke_remote_towable_interp_check(void) {
     bool saved_local_server_active = g.local_server.active;
     bool saved_net_authority_enabled = g.net_authority_enabled;

--- a/client/main.c
+++ b/client/main.c
@@ -3533,6 +3533,91 @@ const char *signal_smoke_live_tow_summary(void) {
 }
 
 EMSCRIPTEN_KEEPALIVE
+const char *signal_smoke_live_station_tow_summary(void) {
+    static char summary[640];
+    const int target_idx = MAX_CARGO_PODS - 1;
+    const cargo_pod_t *target = &g.world.cargo_pods[target_idx];
+    const cargo_pod_t *target_interp = &g.cargo_pod_interp.curr[target_idx];
+    int station_idx = -1;
+    int module_idx = -1;
+    int interp_station_idx = -1;
+    int interp_module_idx = -1;
+    (void)cargo_pod_module_tractor_indices(
+        target, &station_idx, &module_idx);
+    (void)cargo_pod_module_tractor_indices(
+        target_interp, &interp_station_idx, &interp_module_idx);
+
+    int target_links = 0;
+    int module_target_links = 0;
+    int interaction_matches = 0;
+    uint32_t link_revision = 0;
+    for (int i = 0; i < MAX_TOW_LINKS; i++) {
+        const tow_link_t *link = &g.world.tow_links[i];
+        if (!link->active ||
+            link->target.kind != ENTITY_KIND_CARGO_POD ||
+            link->target.index != target_idx ||
+            link->target.part != -1) {
+            continue;
+        }
+        target_links++;
+        if (link->source.kind == ENTITY_KIND_STATION_MODULE &&
+            link->source.index == station_idx &&
+            link->source.part == module_idx &&
+            link->profile == TOW_PROFILE_MODULE_POD &&
+            link->state == TOW_LINK_HELD &&
+            link->slot == 0) {
+            module_target_links++;
+            link_revision = link->revision;
+        }
+    }
+    for (int i = 0; i < g.world.interactions.count; i++) {
+        const sim_interaction_t *interaction =
+            &g.world.interactions.items[i];
+        if (interaction->type == SIM_INTERACTION_TRACTOR_BEAM &&
+            interaction->visual ==
+                SIM_INTERACTION_VISUAL_CARGO_POD_MODULE_TRACTOR &&
+            interaction->source.type ==
+                SIM_INTERACTION_ENTITY_STATION_MODULE &&
+            interaction->source.index == station_idx &&
+            interaction->source.aux == module_idx &&
+            interaction->target.type == SIM_INTERACTION_ENTITY_CARGO_POD &&
+            interaction->target.index == target_idx) {
+            interaction_matches++;
+        }
+    }
+
+    snprintf(
+        summary, sizeof(summary),
+        "{\"targetActive\":%d,\"targetInterpActive\":%d,"
+        "\"towSnapshotReceived\":%d,\"station\":%d,\"module\":%d,"
+        "\"interpStation\":%d,\"interpModule\":%d,"
+        "\"targetLinks\":%d,\"moduleTargetLinks\":%d,"
+        "\"interactionMatches\":%d,\"towRevision\":%u,"
+        "\"snapshotRevision\":%u,\"linkRevision\":%u,"
+        "\"x\":%.6f,\"y\":%.6f,\"vx\":%.6f,\"vy\":%.6f,"
+        "\"elapsed\":%.6f}",
+        target->active ? 1 : 0,
+        target_interp->active ? 1 : 0,
+        g.tow_snapshot_received ? 1 : 0,
+        station_idx,
+        module_idx,
+        interp_station_idx,
+        interp_module_idx,
+        target_links,
+        module_target_links,
+        interaction_matches,
+        g.world.tow_revision,
+        g.tow_snapshot_revision,
+        link_revision,
+        target->pos.x,
+        target->pos.y,
+        target->vel.x,
+        target->vel.y,
+        g.cargo_pod_interp.elapsed[target_idx]);
+    return summary;
+}
+
+EMSCRIPTEN_KEEPALIVE
 int signal_smoke_remote_towable_interp_check(void) {
     bool saved_local_server_active = g.local_server.active;
     bool saved_net_authority_enabled = g.net_authority_enabled;

--- a/client/main.c
+++ b/client/main.c
@@ -228,6 +228,7 @@ static void configure_net_callbacks(NetCallbacks *cbs) {
     cbs->on_cargo_pod_linear = apply_remote_cargo_pod_linear;
     cbs->on_interactions = apply_remote_interactions;
     cbs->on_interaction_drift = apply_remote_interaction_drift;
+    cbs->on_tow_links = apply_remote_tow_links;
     cbs->on_hail_response = apply_remote_hail_response;
     cbs->on_player_ship = apply_remote_player_ship;
     cbs->on_contracts = apply_remote_contracts;
@@ -3434,6 +3435,11 @@ int signal_smoke_remote_towable_interp_check(void) {
     bool saved_local_server_active = g.local_server.active;
     bool saved_net_authority_enabled = g.net_authority_enabled;
     bool saved_net_input_tick_protocol = g.net_input_tick_protocol;
+    bool saved_tow_snapshot_received = g.tow_snapshot_received;
+    uint32_t saved_tow_snapshot_revision = g.tow_snapshot_revision;
+    uint32_t saved_tow_snapshot_server_tick = g.tow_snapshot_server_tick;
+    uint32_t saved_world_tow_revision = g.world.tow_revision;
+    tow_link_t saved_world_tow_links[MAX_TOW_LINKS];
     int saved_local_player_slot = g.local_player_slot;
     bool saved_player0_connected = g.world.players[0].connected;
     bool saved_player0_docked = g.world.players[0].docked;
@@ -3464,6 +3470,8 @@ int signal_smoke_remote_towable_interp_check(void) {
     memcpy(saved_player0_towed_pods,
            g.world.players[0].ship->towed_pods,
            sizeof(saved_player0_towed_pods));
+    memcpy(saved_world_tow_links, g.world.tow_links,
+           sizeof(saved_world_tow_links));
     memcpy(saved_world_asteroids, g.world.asteroids, sizeof(saved_world_asteroids));
     memcpy(saved_local_server_asteroids, g.local_server.world.asteroids,
            sizeof(saved_local_server_asteroids));
@@ -3481,6 +3489,9 @@ int signal_smoke_remote_towable_interp_check(void) {
            sizeof(saved_cargo_pod_elapsed));
 
     g.local_server.active = false;
+    /* This smoke exercises the compatibility packet paths directly. The
+     * atomic tow snapshot is covered by the real loopback lifecycle smoke. */
+    g.tow_snapshot_received = false;
     g.world.players[0].ship->towed_count = 0;
     g.world.players[0].ship->towed_pod_count = 0;
     for (int i = 0; i < 10; i++) {
@@ -3613,6 +3624,43 @@ int signal_smoke_remote_towable_interp_check(void) {
     net_advance_cargo_pod_interpolation(0.05f);
     interpolate_world_for_render();
     float local_towed_pod_predicted_x = g.world.cargo_pods[11].pos.x;
+
+    tow_link_t atomic_link = {
+        .active = true,
+        .source = g.world.players[0].ship_ref,
+        .target = {
+            .kind = ENTITY_KIND_CARGO_POD,
+            .index = 11,
+            .part = -1,
+            .generation = 1,
+        },
+        .profile = TOW_PROFILE_SHIP_POD,
+        .slot = 0,
+        .state = TOW_LINK_HELD,
+        .attached_tick = 400,
+        .revision = 40,
+    };
+    apply_remote_tow_links(&atomic_link, 1, 40, 400);
+    bool atomic_attach_ok =
+        g.tow_snapshot_received &&
+        g.tow_snapshot_revision == 40 &&
+        g.world.tow_links[0].active &&
+        cargo_pod_player_tractor(&g.cargo_pod_interp.curr[11]) == 0;
+    apply_remote_tow_links(NULL, 0, 39, 401);
+    bool stale_release_rejected =
+        g.world.tow_links[0].active &&
+        cargo_pod_player_tractor(&g.cargo_pod_interp.curr[11]) == 0;
+    apply_remote_tow_links(NULL, 0, 40, 402);
+    bool conflicting_duplicate_idempotent =
+        g.world.tow_links[0].active &&
+        cargo_pod_player_tractor(&g.cargo_pod_interp.curr[11]) == 0;
+    apply_remote_tow_links(NULL, 0, 41, 403);
+    bool newer_release_applied =
+        !g.world.tow_links[0].active &&
+        !cargo_pod_has_player_tractor(&g.cargo_pod_interp.curr[11]);
+    bool atomic_tow_snapshot_ok =
+        atomic_attach_ok && stale_release_rejected &&
+        conflicting_duplicate_idempotent && newer_release_applied;
 
     NetAsteroidState asteroid = {
         .index = 7,
@@ -3891,6 +3939,7 @@ int signal_smoke_remote_towable_interp_check(void) {
              local_towed_pod_binding_preserved &&
              local_towed_pod_predicted_x > 299.9f &&
              local_towed_pod_predicted_x < 300.1f &&
+             atomic_tow_snapshot_ok &&
              asteroid_first_x > 9.0f && asteroid_first_x < 11.5f &&
              asteroid_blended_x > asteroid_first_x &&
              asteroid_blended_x < 95.0f &&
@@ -3942,6 +3991,12 @@ int signal_smoke_remote_towable_interp_check(void) {
     g.local_server.active = saved_local_server_active;
     g.net_authority_enabled = saved_net_authority_enabled;
     g.net_input_tick_protocol = saved_net_input_tick_protocol;
+    g.tow_snapshot_received = saved_tow_snapshot_received;
+    g.tow_snapshot_revision = saved_tow_snapshot_revision;
+    g.tow_snapshot_server_tick = saved_tow_snapshot_server_tick;
+    g.world.tow_revision = saved_world_tow_revision;
+    memcpy(g.world.tow_links, saved_world_tow_links,
+           sizeof(saved_world_tow_links));
     g.local_player_slot = saved_local_player_slot;
     g.world.players[0].connected = saved_player0_connected;
     g.world.players[0].docked = saved_player0_docked;

--- a/client/main.c
+++ b/client/main.c
@@ -417,9 +417,7 @@ static void reset_world(void) {
     g.inspect_was_active = false;
     memset(&g.asteroid_interp, 0, sizeof(g.asteroid_interp));
     memset(&g.npc_interp, 0, sizeof(g.npc_interp));
-    g.npc_interp.interval = 0.1f;
     memset(&g.scaffold_interp, 0, sizeof(g.scaffold_interp));
-    g.scaffold_interp.interval = 0.1f;
     memset(&g.cargo_pod_interp, 0, sizeof(g.cargo_pod_interp));
     memset(&g.player_interp, 0, sizeof(g.player_interp));
     g.player_interp.interval = 0.1f;
@@ -1551,9 +1549,9 @@ static void sim_step(float dt) {
 
     /* Advance interpolation timers (both modes) */
     net_advance_asteroid_interpolation(dt);
+    net_advance_npc_interpolation(dt);
+    net_advance_scaffold_interpolation(dt);
     net_advance_cargo_pod_interpolation(dt);
-    g.npc_interp.t += dt / fmaxf(g.npc_interp.interval, 0.01f);
-    g.scaffold_interp.t += dt / fmaxf(g.scaffold_interp.interval, 0.01f);
     g.player_interp.t += dt / fmaxf(g.player_interp.interval, 0.01f);
 
     /* Thrust flame: local input for manual, server input for autopilot.
@@ -3618,6 +3616,90 @@ const char *signal_smoke_live_station_tow_summary(void) {
 }
 
 EMSCRIPTEN_KEEPALIVE
+const char *signal_smoke_live_npc_scaffold_tow_summary(void) {
+    static char summary[768];
+    const int target_idx = MAX_SCAFFOLDS - 1;
+    const scaffold_t *target = &g.world.scaffolds[target_idx];
+    const scaffold_t *target_interp = &g.scaffold_interp.curr[target_idx];
+    int npc_idx = scaffold_tractor_npc(target);
+    int interp_npc_idx = scaffold_tractor_npc(target_interp);
+    int target_links = 0;
+    int npc_target_links = 0;
+    uint32_t link_revision = 0;
+    for (int i = 0; i < MAX_TOW_LINKS; i++) {
+        const tow_link_t *link = &g.world.tow_links[i];
+        if (!link->active ||
+            link->target.kind != ENTITY_KIND_SCAFFOLD ||
+            link->target.index != target_idx ||
+            link->target.part != -1) {
+            continue;
+        }
+        target_links++;
+        if (npc_idx >= 0 &&
+            link->source.kind == ENTITY_KIND_SHIP &&
+            link->source.index == WORLD_NPC_SHIP_BASE + npc_idx &&
+            link->source.part == -1 &&
+            link->profile == TOW_PROFILE_SHIP_SCAFFOLD &&
+            link->state == TOW_LINK_HELD &&
+            link->slot == 0) {
+            npc_target_links++;
+            link_revision = link->revision;
+        }
+    }
+
+    bool npc_active = npc_idx >= 0 && npc_idx < MAX_NPC_SHIPS &&
+                      g.world.npc_ships[npc_idx].active &&
+                      g.world.npc_ships[npc_idx].ship;
+    bool interp_npc_active =
+        interp_npc_idx >= 0 && interp_npc_idx < MAX_NPC_SHIPS &&
+        g.npc_interp.curr[interp_npc_idx].active;
+    const ship_t *npc_ship =
+        npc_active ? g.world.npc_ships[npc_idx].ship : NULL;
+    int npc_towed_scaffold =
+        npc_ship ? npc_ship->towed_scaffold : -1;
+    int interp_npc_towed_scaffold = interp_npc_active
+        ? g.npc_interp.curr[interp_npc_idx].towed_scaffold : -1;
+    vec2 npc_pos = npc_ship ? npc_ship->pos : v2(0.0f, 0.0f);
+
+    snprintf(
+        summary, sizeof(summary),
+        "{\"targetActive\":%d,\"targetInterpActive\":%d,"
+        "\"towSnapshotReceived\":%d,\"npc\":%d,\"interpNpc\":%d,"
+        "\"npcActive\":%d,\"interpNpcActive\":%d,"
+        "\"targetLinks\":%d,\"npcTargetLinks\":%d,"
+        "\"npcTowedScaffold\":%d,\"interpNpcTowedScaffold\":%d,"
+        "\"towRevision\":%u,\"snapshotRevision\":%u,"
+        "\"linkRevision\":%u,"
+        "\"x\":%.6f,\"y\":%.6f,\"vx\":%.6f,\"vy\":%.6f,"
+        "\"npcX\":%.6f,\"npcY\":%.6f,"
+        "\"elapsed\":%.6f,\"npcElapsed\":%.6f}",
+        target->active ? 1 : 0,
+        target_interp->active ? 1 : 0,
+        g.tow_snapshot_received ? 1 : 0,
+        npc_idx,
+        interp_npc_idx,
+        npc_active ? 1 : 0,
+        interp_npc_active ? 1 : 0,
+        target_links,
+        npc_target_links,
+        npc_towed_scaffold,
+        interp_npc_towed_scaffold,
+        g.world.tow_revision,
+        g.tow_snapshot_revision,
+        link_revision,
+        target->pos.x,
+        target->pos.y,
+        target->vel.x,
+        target->vel.y,
+        npc_pos.x,
+        npc_pos.y,
+        g.scaffold_interp.elapsed[target_idx],
+        npc_idx >= 0 && npc_idx < MAX_NPC_SHIPS
+            ? g.npc_interp.elapsed[npc_idx] : 0.0f);
+    return summary;
+}
+
+EMSCRIPTEN_KEEPALIVE
 int signal_smoke_remote_towable_interp_check(void) {
     bool saved_local_server_active = g.local_server.active;
     bool saved_net_authority_enabled = g.net_authority_enabled;
@@ -3648,8 +3730,7 @@ int signal_smoke_remote_towable_interp_check(void) {
     cargo_pod_t saved_cargo_pod_prev[MAX_CARGO_PODS];
     cargo_pod_t saved_cargo_pod_curr[MAX_CARGO_PODS];
     float saved_cargo_pod_elapsed[MAX_CARGO_PODS];
-    float saved_scaffold_t = g.scaffold_interp.t;
-    float saved_scaffold_interval = g.scaffold_interp.interval;
+    float saved_scaffold_elapsed[MAX_SCAFFOLDS];
 
     memcpy(saved_player0_towed_fragments,
            g.world.players[0].ship->towed_fragments,
@@ -3669,6 +3750,8 @@ int signal_smoke_remote_towable_interp_check(void) {
     memcpy(saved_world_scaffolds, g.world.scaffolds, sizeof(saved_world_scaffolds));
     memcpy(saved_scaffold_prev, g.scaffold_interp.prev, sizeof(saved_scaffold_prev));
     memcpy(saved_scaffold_curr, g.scaffold_interp.curr, sizeof(saved_scaffold_curr));
+    memcpy(saved_scaffold_elapsed, g.scaffold_interp.elapsed,
+           sizeof(saved_scaffold_elapsed));
     memcpy(saved_world_cargo_pods, g.world.cargo_pods, sizeof(saved_world_cargo_pods));
     memcpy(saved_cargo_pod_prev, g.cargo_pod_interp.prev, sizeof(saved_cargo_pod_prev));
     memcpy(saved_cargo_pod_curr, g.cargo_pod_interp.curr, sizeof(saved_cargo_pod_curr));
@@ -3689,7 +3772,6 @@ int signal_smoke_remote_towable_interp_check(void) {
     memset(&g.world.interactions, 0, sizeof(g.world.interactions));
     memset(g.world.scaffolds, 0, sizeof(g.world.scaffolds));
     memset(&g.scaffold_interp, 0, sizeof(g.scaffold_interp));
-    g.scaffold_interp.interval = 0.1f;
     memset(g.world.cargo_pods, 0, sizeof(g.world.cargo_pods));
     memset(&g.cargo_pod_interp, 0, sizeof(g.cargo_pod_interp));
 
@@ -3709,15 +3791,41 @@ int signal_smoke_remote_towable_interp_check(void) {
     apply_remote_scaffolds(&scaffold, 1);
     bool scaffold_station_authoritative =
         g.scaffold_interp.curr[3].built_at_station == 2;
-    g.scaffold_interp.t = 0.1f / fmaxf(g.scaffold_interp.interval, 0.001f);
+    g.scaffold_interp.elapsed[3] = 0.1f;
     interpolate_world_for_render();
     float scaffold_first_x = g.world.scaffolds[3].pos.x;
     scaffold.pos_x = 100.0f;
     scaffold.vel_x = 0.0f;
     apply_remote_scaffolds(&scaffold, 1);
-    g.scaffold_interp.t = 0.05f / fmaxf(g.scaffold_interp.interval, 0.001f);
+    g.scaffold_interp.elapsed[3] = 0.05f;
     interpolate_world_for_render();
     float scaffold_blended_x = g.world.scaffolds[3].pos.x;
+
+    memset(g.world.scaffolds, 0, sizeof(g.world.scaffolds));
+    memset(&g.scaffold_interp, 0, sizeof(g.scaffold_interp));
+    scaffold.pos_x = 0.0f;
+    scaffold.pos_y = 0.0f;
+    scaffold.vel_x = 100.0f;
+    NetScaffoldState unrelated_scaffold = scaffold;
+    unrelated_scaffold.index = 4;
+    unrelated_scaffold.pos_y = 90.0f;
+    unrelated_scaffold.vel_x = 0.0f;
+    NetScaffoldState scaffold_pair[2] = {scaffold, unrelated_scaffold};
+    apply_remote_scaffolds(scaffold_pair, 2);
+    g.scaffold_interp.elapsed[3] = 0.1f;
+    interpolate_world_for_render();
+    float scaffold_before_unrelated_x = g.world.scaffolds[3].pos.x;
+    NetScaffoldMotionState unrelated_scaffold_motion = {
+        .index = 4,
+        .pos_x = 5.0f,
+        .pos_y = 90.0f,
+        .vel_x = 0.0f,
+        .vel_y = 0.0f,
+    };
+    apply_remote_scaffold_motion(&unrelated_scaffold_motion, 1);
+    net_advance_scaffold_interpolation(0.05f);
+    interpolate_world_for_render();
+    float scaffold_after_unrelated_x = g.world.scaffolds[3].pos.x;
 
     NetCargoPodState pod = {
         .index = 5,
@@ -4114,6 +4222,10 @@ int signal_smoke_remote_towable_interp_check(void) {
              scaffold_blended_x > scaffold_first_x &&
              scaffold_blended_x < 95.0f &&
              scaffold_station_authoritative &&
+             scaffold_before_unrelated_x > 9.0f &&
+             scaffold_before_unrelated_x < 11.5f &&
+             scaffold_after_unrelated_x > 14.0f &&
+             scaffold_after_unrelated_x < 16.0f &&
              pod_first_x > 9.0f && pod_first_x < 11.5f &&
              pod_blended_x > pod_first_x &&
              pod_blended_x < 95.0f &&
@@ -4168,13 +4280,13 @@ int signal_smoke_remote_towable_interp_check(void) {
     memcpy(g.world.scaffolds, saved_world_scaffolds, sizeof(saved_world_scaffolds));
     memcpy(g.scaffold_interp.prev, saved_scaffold_prev, sizeof(saved_scaffold_prev));
     memcpy(g.scaffold_interp.curr, saved_scaffold_curr, sizeof(saved_scaffold_curr));
+    memcpy(g.scaffold_interp.elapsed, saved_scaffold_elapsed,
+           sizeof(saved_scaffold_elapsed));
     memcpy(g.world.cargo_pods, saved_world_cargo_pods, sizeof(saved_world_cargo_pods));
     memcpy(g.cargo_pod_interp.prev, saved_cargo_pod_prev, sizeof(saved_cargo_pod_prev));
     memcpy(g.cargo_pod_interp.curr, saved_cargo_pod_curr, sizeof(saved_cargo_pod_curr));
     memcpy(g.cargo_pod_interp.elapsed, saved_cargo_pod_elapsed,
            sizeof(saved_cargo_pod_elapsed));
-    g.scaffold_interp.t = saved_scaffold_t;
-    g.scaffold_interp.interval = saved_scaffold_interval;
     g.local_server.active = saved_local_server_active;
     g.net_authority_enabled = saved_net_authority_enabled;
     g.net_input_tick_protocol = saved_net_input_tick_protocol;

--- a/client/net.c
+++ b/client/net.c
@@ -2559,6 +2559,58 @@ static void handle_message(const uint8_t* data, int len) {
         }
         break;
 
+    case NET_MSG_WORLD_TOW_LINKS:
+        if (len >= TOW_LINKS_MSG_HEADER_SIZE &&
+            net_state.callbacks.on_tow_links) {
+            int count = (int)read_u16_le(&data[1]);
+            if (count > MAX_TOW_LINKS) break;
+            int expected = TOW_LINKS_MSG_HEADER_SIZE +
+                count * TOW_LINK_RECORD_SIZE;
+            if (len < expected) break;
+            tow_link_t links[MAX_TOW_LINKS];
+            memset(links, 0, sizeof(links));
+            bool valid = true;
+            for (int i = 0; i < count; i++) {
+                const uint8_t *p =
+                    &data[TOW_LINKS_MSG_HEADER_SIZE +
+                          i * TOW_LINK_RECORD_SIZE];
+                tow_link_t *link = &links[i];
+                link->active = true;
+                link->source = (entity_ref_t){
+                    .kind = p[0],
+                    .index = (int16_t)read_u16_le(&p[1]),
+                    .part = (int16_t)read_u16_le(&p[3]),
+                    .generation = read_u16_le(&p[5]),
+                };
+                link->target = (entity_ref_t){
+                    .kind = p[7],
+                    .index = (int16_t)read_u16_le(&p[8]),
+                    .part = (int16_t)read_u16_le(&p[10]),
+                    .generation = read_u16_le(&p[12]),
+                };
+                link->profile = p[14];
+                link->slot = p[15];
+                link->state = p[16];
+                link->attached_tick = read_u32_le(&p[18]);
+                link->revision = read_u32_le(&p[22]);
+                if (entity_ref_is_none(link->source) ||
+                    entity_ref_is_none(link->target) ||
+                    link->profile <= TOW_PROFILE_NONE ||
+                    link->profile > TOW_PROFILE_MODULE_POD ||
+                    link->state <= TOW_LINK_INACTIVE ||
+                    link->state > TOW_LINK_RELEASING) {
+                    valid = false;
+                    break;
+                }
+            }
+            if (valid) {
+                net_state.callbacks.on_tow_links(
+                    links, count, read_u32_le(&data[3]),
+                    read_u32_le(&data[7]));
+            }
+        }
+        break;
+
     case NET_MSG_HAIL_RESPONSE:
         if (len >= 6 && net_state.callbacks.on_hail_response) {
             uint8_t station = data[1];

--- a/client/net.h
+++ b/client/net.h
@@ -363,6 +363,8 @@ typedef struct {
 typedef void (*net_on_interactions_fn)(const sim_interaction_t *items, int count);
 typedef void (*net_on_interaction_drift_fn)(const NetInteractionDriftState *items,
                                             int count);
+typedef void (*net_on_tow_links_fn)(const tow_link_t *links, int count,
+                                    uint32_t revision, uint32_t server_tick);
 
 typedef struct {
     uint32_t flags;
@@ -522,6 +524,7 @@ typedef struct {
     net_on_cargo_pod_linear_fn on_cargo_pod_linear;
     net_on_interactions_fn on_interactions;
     net_on_interaction_drift_fn on_interaction_drift;
+    net_on_tow_links_fn on_tow_links;
     net_on_hail_response_fn on_hail_response;
     net_on_player_ship_fn on_player_ship;
     net_on_contracts_fn on_contracts;

--- a/client/net_sync.c
+++ b/client/net_sync.c
@@ -28,8 +28,10 @@
 #define ASTEROID_AMBIENT_DRAG 0.42f
 #define ASTEROID_RENDER_CORRECTION_CUTOFF_SEC \
     (ASTEROID_RENDER_CORRECTION_SEC * 4.0f)
-#define NPC_RENDER_CORRECTION_SEC 0.18f
+#define NPC_RENDER_CORRECTION_SEC 0.50f
 #define NPC_RENDER_EXTRAPOLATE_MAX_SEC 2.20f
+#define NPC_RENDER_CORRECTION_CUTOFF_SEC \
+    (NPC_RENDER_CORRECTION_SEC * 4.0f)
 #define REMOTE_PLAYER_RENDER_CORRECTION_SEC 0.18f
 #define REMOTE_PLAYER_RENDER_EXTRAPOLATE_MAX_SEC 2.25f
 #define SCAFFOLD_RENDER_CORRECTION_SEC 0.18f
@@ -711,12 +713,32 @@ static client_npc_render_state_t npc_render_state_at(int slot, float elapsed) {
     out.pos.y += curr->vel.y * elapsed;
 
     if (prev->active) {
+        /* Preserve both position and velocity across a late sparse update,
+         * then critically damp the visual offset. A position-only lerp
+         * visibly kicks tractor emitters after a long extrapolation gap. */
+        float omega = 4.0f / NPC_RENDER_CORRECTION_SEC;
+        float decay = expf(-omega * elapsed);
+        vec2 pos_error = v2_sub(prev->pos, curr->pos);
+        vec2 vel_error = v2_sub(prev->vel, curr->vel);
+        vec2 c = v2_add(vel_error, v2_scale(pos_error, omega));
+        vec2 offset = v2_scale(
+            v2_add(pos_error, v2_scale(c, elapsed)), decay);
+        vec2 offset_vel = v2_scale(
+            v2_sub(vel_error, v2_scale(c, omega * elapsed)), decay);
+        out.pos = v2_add(out.pos, offset);
+        out.vel = v2_add(out.vel, offset_vel);
         float blend = clampf(elapsed / NPC_RENDER_CORRECTION_SEC, 0.0f, 1.0f);
-        out.pos.x = lerpf(prev->pos.x, out.pos.x, blend);
-        out.pos.y = lerpf(prev->pos.y, out.pos.y, blend);
         out.angle = lerp_angle(prev->angle, out.angle, blend);
     }
     return out;
+}
+
+static void npc_interp_begin_update(int slot) {
+    if (slot < 0 || slot >= MAX_NPC_SHIPS) return;
+    float elapsed = clampf(g.npc_interp.elapsed[slot], 0.0f,
+                           NPC_RENDER_EXTRAPOLATE_MAX_SEC);
+    g.npc_interp.prev[slot] = npc_render_state_at(slot, elapsed);
+    g.npc_interp.elapsed[slot] = 0.0f;
 }
 
 static scaffold_t scaffold_render_state_at(int slot, float elapsed) {
@@ -736,6 +758,15 @@ static scaffold_t scaffold_render_state_at(int slot, float elapsed) {
         out.pos.y = lerpf(prev->pos.y, out.pos.y, blend);
     }
     return out;
+}
+
+static void scaffold_interp_begin_update(int slot) {
+    if (slot < 0 || slot >= MAX_SCAFFOLDS) return;
+    float elapsed = clampf(g.scaffold_interp.elapsed[slot], 0.0f,
+                           SCAFFOLD_RENDER_EXTRAPOLATE_MAX_SEC);
+    g.scaffold_interp.prev[slot] =
+        scaffold_render_state_at(slot, elapsed);
+    g.scaffold_interp.elapsed[slot] = 0.0f;
 }
 
 static cargo_pod_t cargo_pod_render_state_at(int slot, float elapsed) {
@@ -809,14 +840,6 @@ static bool net_local_player_towing_asteroid(int idx) {
         if (sp->ship->towed_fragments[t] == idx) return true;
     }
     return false;
-}
-
-static float net_prediction_future_elapsed(float t, float interval,
-                                           float dt, float max_elapsed) {
-    if (!isfinite(interval) || interval <= 0.0f) interval = 0.01f;
-    float elapsed = (isfinite(t) && t > 0.0f) ? t * interval : 0.0f;
-    if (isfinite(dt) && dt > 0.0f) elapsed += dt;
-    return clampf(elapsed, 0.0f, max_elapsed);
 }
 
 static void net_adopt_local_asteroid_prediction_base(int idx, float elapsed,
@@ -931,11 +954,14 @@ void net_adopt_local_tow_prediction(float dt) {
         net_adopt_local_cargo_pod_prediction(idx, elapsed);
     }
 
-    float scaffold_elapsed = net_prediction_future_elapsed(
-        g.scaffold_interp.t, g.scaffold_interp.interval, dt,
-        SCAFFOLD_RENDER_EXTRAPOLATE_MAX_SEC);
-    net_adopt_local_scaffold_prediction(sp->ship->towed_scaffold,
-                                        scaffold_elapsed);
+    int scaffold_idx = sp->ship->towed_scaffold;
+    if (scaffold_idx >= 0 && scaffold_idx < MAX_SCAFFOLDS) {
+        float elapsed = g.scaffold_interp.elapsed[scaffold_idx];
+        if (isfinite(dt) && dt > 0.0f) elapsed += dt;
+        elapsed = clampf(elapsed, 0.0f,
+                         SCAFFOLD_RENDER_EXTRAPOLATE_MAX_SEC);
+        net_adopt_local_scaffold_prediction(scaffold_idx, elapsed);
+    }
 }
 
 void net_advance_asteroid_interpolation(float dt) {
@@ -960,6 +986,43 @@ void net_advance_asteroid_interpolation(float dt) {
         if (prev->active &&
             elapsed >= ASTEROID_RENDER_CORRECTION_CUTOFF_SEC)
             prev->active = false;
+    }
+}
+
+void net_advance_npc_interpolation(float dt) {
+    if (!isfinite(dt) || dt <= 0.0f) return;
+    for (int i = 0; i < MAX_NPC_SHIPS; i++) {
+        client_npc_render_state_t *curr = &g.npc_interp.curr[i];
+        client_npc_render_state_t *prev = &g.npc_interp.prev[i];
+        if (!curr->active) {
+            g.npc_interp.elapsed[i] = 0.0f;
+            prev->active = false;
+            continue;
+        }
+        float elapsed = g.npc_interp.elapsed[i] + dt;
+        g.npc_interp.elapsed[i] = clampf(
+            elapsed, 0.0f, NPC_RENDER_EXTRAPOLATE_MAX_SEC);
+        if (prev->active &&
+            g.npc_interp.elapsed[i] >=
+                NPC_RENDER_CORRECTION_CUTOFF_SEC) {
+            prev->active = false;
+        }
+    }
+}
+
+void net_advance_scaffold_interpolation(float dt) {
+    if (!isfinite(dt) || dt <= 0.0f) return;
+    for (int i = 0; i < MAX_SCAFFOLDS; i++) {
+        scaffold_t *curr = &g.scaffold_interp.curr[i];
+        scaffold_t *prev = &g.scaffold_interp.prev[i];
+        if (!curr->active) {
+            g.scaffold_interp.elapsed[i] = 0.0f;
+            prev->active = false;
+            continue;
+        }
+        float elapsed = g.scaffold_interp.elapsed[i] + dt;
+        g.scaffold_interp.elapsed[i] = clampf(
+            elapsed, 0.0f, SCAFFOLD_RENDER_EXTRAPOLATE_MAX_SEC);
     }
 }
 
@@ -1055,11 +1118,9 @@ void reset_remote_dynamic_sync(void) {
         memset(&g.world.npc_ships[i], 0, sizeof(g.world.npc_ships[i]));
     }
     memset(&g.npc_interp, 0, sizeof(g.npc_interp));
-    g.npc_interp.interval = 0.1f;
 
     memset(g.world.scaffolds, 0, sizeof(g.world.scaffolds));
     memset(&g.scaffold_interp, 0, sizeof(g.scaffold_interp));
-    g.scaffold_interp.interval = 0.1f;
 
     memset(g.world.cargo_pods, 0, sizeof(g.world.cargo_pods));
     memset(&g.cargo_pod_interp, 0, sizeof(g.cargo_pod_interp));
@@ -1259,15 +1320,6 @@ static int16_t remote_npc_asteroid_index(int value) {
 }
 
 void apply_remote_npcs(const NetNpcState* npcs, int count) {
-    float npc_elapsed = g.npc_interp.t * g.npc_interp.interval;
-    npc_elapsed = clampf(npc_elapsed, 0.0f, NPC_RENDER_EXTRAPOLATE_MAX_SEC);
-    for (int i = 0; i < MAX_NPC_SHIPS; i++)
-        g.npc_interp.prev[i] = npc_render_state_at(i, npc_elapsed);
-
-    float packet_interval = clampf(npc_elapsed, 0.05f, 0.2f);
-    g.npc_interp.interval = lerpf(g.npc_interp.interval, packet_interval, 0.3f);
-    g.npc_interp.t = 0.0f;
-
     bool received[MAX_NPC_SHIPS];
     memset(received, 0, sizeof(received));
 
@@ -1276,6 +1328,7 @@ void apply_remote_npcs(const NetNpcState* npcs, int count) {
         if (idx >= MAX_NPC_SHIPS) continue;
         received[idx] = true;
 
+        npc_interp_begin_update(idx);
         client_npc_render_state_t* n = &g.npc_interp.curr[idx];
         n->active = (npcs[i].flags & 1) != 0;
         n->role = (npc_role_t)((npcs[i].flags >> 1) & 0x3);
@@ -1303,7 +1356,8 @@ void apply_remote_npcs(const NetNpcState* npcs, int count) {
     }
 
     for (int i = 0; i < MAX_NPC_SHIPS; i++) {
-        if (!received[i]) {
+        if (!received[i] && g.npc_interp.curr[i].active) {
+            npc_interp_begin_update(i);
             g.npc_interp.curr[i].active = false;
         }
     }
@@ -1312,21 +1366,13 @@ void apply_remote_npcs(const NetNpcState* npcs, int count) {
 }
 
 void apply_remote_npc_motion(const NetNpcMotionState* npcs, int count) {
-    float npc_elapsed = g.npc_interp.t * g.npc_interp.interval;
-    npc_elapsed = clampf(npc_elapsed, 0.0f, NPC_RENDER_EXTRAPOLATE_MAX_SEC);
-    for (int i = 0; i < MAX_NPC_SHIPS; i++)
-        g.npc_interp.prev[i] = npc_render_state_at(i, npc_elapsed);
-
-    float packet_interval = clampf(npc_elapsed, 0.05f, 0.2f);
-    g.npc_interp.interval = lerpf(g.npc_interp.interval, packet_interval, 0.3f);
-    g.npc_interp.t = 0.0f;
-
     for (int i = 0; i < count; i++) {
         uint8_t idx = npcs[i].index;
         if (idx >= MAX_NPC_SHIPS) continue;
 
         client_npc_render_state_t* n = &g.npc_interp.curr[idx];
         if (!n->active) continue;
+        npc_interp_begin_update(idx);
         n->thrusting = (npcs[i].flags & (1 << 6)) != 0;
         n->pos.x = npcs[i].x;
         n->pos.y = npcs[i].y;
@@ -1341,21 +1387,13 @@ void apply_remote_npc_motion(const NetNpcMotionState* npcs, int count) {
 void apply_remote_npc_pos(const NetNpcPosState* npcs, int count) {
     if (!npcs || count <= 0) return;
 
-    float npc_elapsed = g.npc_interp.t * g.npc_interp.interval;
-    npc_elapsed = clampf(npc_elapsed, 0.0f, NPC_RENDER_EXTRAPOLATE_MAX_SEC);
-    for (int i = 0; i < MAX_NPC_SHIPS; i++)
-        g.npc_interp.prev[i] = npc_render_state_at(i, npc_elapsed);
-
-    float packet_interval = clampf(npc_elapsed, 0.05f, 0.2f);
-    g.npc_interp.interval = lerpf(g.npc_interp.interval, packet_interval, 0.3f);
-    g.npc_interp.t = 0.0f;
-
     for (int i = 0; i < count; i++) {
         uint8_t idx = npcs[i].index;
         if (idx >= MAX_NPC_SHIPS) continue;
 
         client_npc_render_state_t* n = &g.npc_interp.curr[idx];
         if (!n->active) continue;
+        npc_interp_begin_update(idx);
         n->pos.x = npcs[i].x;
         n->pos.y = npcs[i].y;
     }
@@ -1364,21 +1402,13 @@ void apply_remote_npc_pos(const NetNpcPosState* npcs, int count) {
 void apply_remote_npc_pose(const NetNpcPoseState* npcs, int count) {
     if (!npcs || count <= 0) return;
 
-    float npc_elapsed = g.npc_interp.t * g.npc_interp.interval;
-    npc_elapsed = clampf(npc_elapsed, 0.0f, NPC_RENDER_EXTRAPOLATE_MAX_SEC);
-    for (int i = 0; i < MAX_NPC_SHIPS; i++)
-        g.npc_interp.prev[i] = npc_render_state_at(i, npc_elapsed);
-
-    float packet_interval = clampf(npc_elapsed, 0.05f, 0.2f);
-    g.npc_interp.interval = lerpf(g.npc_interp.interval, packet_interval, 0.3f);
-    g.npc_interp.t = 0.0f;
-
     for (int i = 0; i < count; i++) {
         uint8_t idx = npcs[i].index;
         if (idx >= MAX_NPC_SHIPS) continue;
 
         client_npc_render_state_t* n = &g.npc_interp.curr[idx];
         if (!n->active) continue;
+        npc_interp_begin_update(idx);
         n->pos.x = npcs[i].x;
         n->pos.y = npcs[i].y;
         n->angle = npcs[i].angle;
@@ -1388,21 +1418,13 @@ void apply_remote_npc_pose(const NetNpcPoseState* npcs, int count) {
 void apply_remote_npc_linear(const NetNpcLinearState* npcs, int count) {
     if (!npcs || count <= 0) return;
 
-    float npc_elapsed = g.npc_interp.t * g.npc_interp.interval;
-    npc_elapsed = clampf(npc_elapsed, 0.0f, NPC_RENDER_EXTRAPOLATE_MAX_SEC);
-    for (int i = 0; i < MAX_NPC_SHIPS; i++)
-        g.npc_interp.prev[i] = npc_render_state_at(i, npc_elapsed);
-
-    float packet_interval = clampf(npc_elapsed, 0.05f, 0.2f);
-    g.npc_interp.interval = lerpf(g.npc_interp.interval, packet_interval, 0.3f);
-    g.npc_interp.t = 0.0f;
-
     for (int i = 0; i < count; i++) {
         uint8_t idx = npcs[i].index;
         if (idx >= MAX_NPC_SHIPS) continue;
 
         client_npc_render_state_t* n = &g.npc_interp.curr[idx];
         if (!n->active) continue;
+        npc_interp_begin_update(idx);
         n->pos.x = npcs[i].x;
         n->pos.y = npcs[i].y;
         n->vel.x = npcs[i].vx;
@@ -1915,15 +1937,6 @@ void apply_remote_station_diag(uint8_t station_id, const uint8_t *diag,
 }
 
 void apply_remote_scaffolds(const NetScaffoldState* received, int count) {
-    float elapsed = g.scaffold_interp.t * g.scaffold_interp.interval;
-    elapsed = clampf(elapsed, 0.0f, SCAFFOLD_RENDER_EXTRAPOLATE_MAX_SEC);
-    for (int i = 0; i < MAX_SCAFFOLDS; i++)
-        g.scaffold_interp.prev[i] = scaffold_render_state_at(i, elapsed);
-
-    float packet_interval = clampf(elapsed, 0.05f, 0.2f);
-    g.scaffold_interp.interval = lerpf(g.scaffold_interp.interval, packet_interval, 0.3f);
-    g.scaffold_interp.t = 0.0f;
-
     bool seen[MAX_SCAFFOLDS] = { false };
     const NetProtocolInfo *info = net_protocol_info();
     bool replacement_snapshot = !info ||
@@ -1931,6 +1944,7 @@ void apply_remote_scaffolds(const NetScaffoldState* received, int count) {
     for (int i = 0; i < count; i++) {
         uint8_t idx = received[i].index;
         if (idx >= MAX_SCAFFOLDS) continue;
+        scaffold_interp_begin_update(idx);
         scaffold_t *sc = &g.scaffold_interp.curr[idx];
         sc->active = true;
         sc->state = (scaffold_state_t)received[i].state;
@@ -1949,7 +1963,10 @@ void apply_remote_scaffolds(const NetScaffoldState* received, int count) {
     }
     if (replacement_snapshot) {
         for (int i = 0; i < MAX_SCAFFOLDS; i++) {
-            if (!seen[i]) g.scaffold_interp.curr[i].active = false;
+            if (!seen[i] && g.scaffold_interp.curr[i].active) {
+                scaffold_interp_begin_update(i);
+                g.scaffold_interp.curr[i].active = false;
+            }
         }
     }
 }
@@ -1957,19 +1974,10 @@ void apply_remote_scaffolds(const NetScaffoldState* received, int count) {
 void apply_remote_scaffold_remove(const uint8_t* indices, int count) {
     if (!indices || count <= 0) return;
 
-    float elapsed = g.scaffold_interp.t * g.scaffold_interp.interval;
-    elapsed = clampf(elapsed, 0.0f, SCAFFOLD_RENDER_EXTRAPOLATE_MAX_SEC);
-    for (int i = 0; i < MAX_SCAFFOLDS; i++)
-        g.scaffold_interp.prev[i] = scaffold_render_state_at(i, elapsed);
-
-    float packet_interval = clampf(elapsed, 0.05f, 0.2f);
-    g.scaffold_interp.interval = lerpf(g.scaffold_interp.interval,
-                                       packet_interval, 0.3f);
-    g.scaffold_interp.t = 0.0f;
-
     for (int i = 0; i < count; i++) {
         uint8_t idx = indices[i];
         if (idx >= MAX_SCAFFOLDS) continue;
+        scaffold_interp_begin_update(idx);
         g.scaffold_interp.curr[idx].active = false;
     }
 }
@@ -1978,21 +1986,12 @@ void apply_remote_scaffold_motion(const NetScaffoldMotionState* received,
                                   int count) {
     if (!received || count <= 0) return;
 
-    float elapsed = g.scaffold_interp.t * g.scaffold_interp.interval;
-    elapsed = clampf(elapsed, 0.0f, SCAFFOLD_RENDER_EXTRAPOLATE_MAX_SEC);
-    for (int i = 0; i < MAX_SCAFFOLDS; i++)
-        g.scaffold_interp.prev[i] = scaffold_render_state_at(i, elapsed);
-
-    float packet_interval = clampf(elapsed, 0.05f, 0.3f);
-    g.scaffold_interp.interval = lerpf(g.scaffold_interp.interval,
-                                       packet_interval, 0.3f);
-    g.scaffold_interp.t = 0.0f;
-
     for (int i = 0; i < count; i++) {
         uint8_t idx = received[i].index;
         if (idx >= MAX_SCAFFOLDS) continue;
         scaffold_t *sc = &g.scaffold_interp.curr[idx];
         if (!sc->active) continue;
+        scaffold_interp_begin_update(idx);
         sc->pos = v2(received[i].pos_x, received[i].pos_y);
         sc->vel = v2(received[i].vel_x, received[i].vel_y);
     }
@@ -3008,8 +3007,6 @@ void interpolate_world_for_render(void) {
             i, g.asteroid_interp.elapsed[i], asteroid_towed[i]);
     }
 
-    float npc_elapsed = clampf(g.npc_interp.t * g.npc_interp.interval,
-                               0.0f, NPC_RENDER_EXTRAPOLATE_MAX_SEC);
     for (int i = 0; i < MAX_NPC_SHIPS; i++) {
         const client_npc_render_state_t *curr = &g.npc_interp.curr[i];
         const client_npc_render_state_t *prev = &g.npc_interp.prev[i];
@@ -3021,7 +3018,8 @@ void interpolate_world_for_render(void) {
             }
             continue;
         }
-        client_npc_render_state_t render = npc_render_state_at(i, npc_elapsed);
+        client_npc_render_state_t render = npc_render_state_at(
+            i, g.npc_interp.elapsed[i]);
         if (!g.world.npc_ships[i].ship &&
             !world_npc_ship_slot_activate(&g.world, i)) {
             continue;
@@ -3046,8 +3044,6 @@ void interpolate_world_for_render(void) {
         dst->ship->towed_scaffold = render.towed_scaffold;
     }
 
-    float scaffold_elapsed = clampf(g.scaffold_interp.t * g.scaffold_interp.interval,
-                                    0.0f, SCAFFOLD_RENDER_EXTRAPOLATE_MAX_SEC);
     for (int i = 0; i < MAX_SCAFFOLDS; i++) {
         const scaffold_t *curr = &g.scaffold_interp.curr[i];
         const scaffold_t *prev = &g.scaffold_interp.prev[i];
@@ -3056,7 +3052,8 @@ void interpolate_world_for_render(void) {
             continue;
         }
         scaffold_t *dst = &g.world.scaffolds[i];
-        *dst = scaffold_render_state_at(i, scaffold_elapsed);
+        *dst = scaffold_render_state_at(
+            i, g.scaffold_interp.elapsed[i]);
     }
 
     for (int i = 0; i < MAX_CARGO_PODS; i++) {

--- a/client/net_sync.c
+++ b/client/net_sync.c
@@ -486,6 +486,133 @@ static void accept_authoritative_local_launch_state(const NetPlayerState *state,
     frame_camera_on_authoritative_baseline(sp);
 }
 
+typedef struct {
+    int index;
+    vec2 pos;
+    vec2 vel;
+    float rotation;
+    float spin;
+    float age;
+} net_replay_tow_pose_t;
+
+typedef struct {
+    int asteroid_count;
+    net_replay_tow_pose_t asteroids[10];
+    int cargo_pod_count;
+    net_replay_tow_pose_t cargo_pods[10];
+    bool scaffold_active;
+    net_replay_tow_pose_t scaffold;
+} net_replay_tow_snapshot_t;
+
+static void net_replay_capture_local_tow_poses(
+    const server_player_t *sp, net_replay_tow_snapshot_t *snapshot) {
+    if (!sp || !sp->ship || !snapshot) return;
+    memset(snapshot, 0, sizeof(*snapshot));
+
+    int asteroid_cap =
+        (int)(sizeof(sp->ship->towed_fragments) /
+              sizeof(sp->ship->towed_fragments[0]));
+    int asteroid_count = sp->ship->towed_count;
+    if (asteroid_count > asteroid_cap) asteroid_count = asteroid_cap;
+    for (int i = 0; i < asteroid_count; i++) {
+        if (snapshot->asteroid_count >=
+            (int)(sizeof(snapshot->asteroids) /
+                  sizeof(snapshot->asteroids[0]))) {
+            break;
+        }
+        int idx = sp->ship->towed_fragments[i];
+        if (idx < 0 || idx >= MAX_ASTEROIDS) continue;
+        const asteroid_t *a = &g.world.asteroids[idx];
+        if (!a->active) continue;
+        snapshot->asteroids[snapshot->asteroid_count++] =
+            (net_replay_tow_pose_t){
+                .index = idx,
+                .pos = a->pos,
+                .vel = a->vel,
+                .rotation = a->rotation,
+                .spin = a->spin,
+                .age = a->age,
+            };
+    }
+
+    int pod_cap =
+        (int)(sizeof(sp->ship->towed_pods) /
+              sizeof(sp->ship->towed_pods[0]));
+    int pod_count = sp->ship->towed_pod_count;
+    if (pod_count > pod_cap) pod_count = pod_cap;
+    for (int i = 0; i < pod_count; i++) {
+        if (snapshot->cargo_pod_count >=
+            (int)(sizeof(snapshot->cargo_pods) /
+                  sizeof(snapshot->cargo_pods[0]))) {
+            break;
+        }
+        int idx = sp->ship->towed_pods[i];
+        if (idx < 0 || idx >= MAX_CARGO_PODS) continue;
+        const cargo_pod_t *pod = &g.world.cargo_pods[idx];
+        if (!pod->active) continue;
+        snapshot->cargo_pods[snapshot->cargo_pod_count++] =
+            (net_replay_tow_pose_t){
+                .index = idx,
+                .pos = pod->pos,
+                .vel = pod->vel,
+                .rotation = pod->rotation,
+                .spin = pod->spin,
+                .age = pod->age,
+            };
+    }
+
+    int scaffold_idx = sp->ship->towed_scaffold;
+    if (scaffold_idx >= 0 && scaffold_idx < MAX_SCAFFOLDS &&
+        g.world.scaffolds[scaffold_idx].active) {
+        const scaffold_t *scaffold = &g.world.scaffolds[scaffold_idx];
+        snapshot->scaffold_active = true;
+        snapshot->scaffold = (net_replay_tow_pose_t){
+            .index = scaffold_idx,
+            .pos = scaffold->pos,
+            .vel = scaffold->vel,
+            .rotation = scaffold->rotation,
+            .spin = scaffold->spin,
+            .age = scaffold->age,
+        };
+    }
+}
+
+static void net_replay_restore_local_tow_poses(
+    const net_replay_tow_snapshot_t *snapshot) {
+    if (!snapshot) return;
+    for (int i = 0; i < snapshot->asteroid_count; i++) {
+        const net_replay_tow_pose_t *pose = &snapshot->asteroids[i];
+        asteroid_t *a = &g.world.asteroids[pose->index];
+        if (!a->active) continue;
+        a->pos = pose->pos;
+        a->vel = pose->vel;
+        a->rotation = pose->rotation;
+        a->spin = pose->spin;
+        a->age = pose->age;
+    }
+    for (int i = 0; i < snapshot->cargo_pod_count; i++) {
+        const net_replay_tow_pose_t *pose = &snapshot->cargo_pods[i];
+        cargo_pod_t *pod = &g.world.cargo_pods[pose->index];
+        if (!pod->active) continue;
+        pod->pos = pose->pos;
+        pod->vel = pose->vel;
+        pod->rotation = pose->rotation;
+        pod->spin = pose->spin;
+        pod->age = pose->age;
+    }
+    if (snapshot->scaffold_active) {
+        const net_replay_tow_pose_t *pose = &snapshot->scaffold;
+        scaffold_t *scaffold = &g.world.scaffolds[pose->index];
+        if (scaffold->active) {
+            scaffold->pos = pose->pos;
+            scaffold->vel = pose->vel;
+            scaffold->rotation = pose->rotation;
+            scaffold->spin = pose->spin;
+            scaffold->age = pose->age;
+        }
+    }
+}
+
 static bool net_replay_reconcile_local_player(const NetPlayerState *state,
                                               server_player_t *sp,
                                               int *out_replayed) {
@@ -509,6 +636,15 @@ static bool net_replay_reconcile_local_player(const NetPlayerState *state,
         return false;
     if (net_replay_missing_prefix(server_tick, first_after)) return false;
 
+    /*
+     * Player snapshots rewind only the owner. Towed bodies are already at
+     * the client's current predicted time, so replaying the same unacked
+     * frames on them again creates a forward jump on every reconciliation.
+     * Preserve their current pose while replay reconstructs the ship, then
+     * let subsequent live prediction frames resume tow physics normally.
+     */
+    net_replay_tow_snapshot_t tow_snapshot;
+    net_replay_capture_local_tow_poses(sp, &tow_snapshot);
     sim_events_t saved_events = g.world.events;
     apply_authoritative_local_motion(state, sp);
     uint32_t last_tick = server_tick;
@@ -520,6 +656,7 @@ static bool net_replay_reconcile_local_player(const NetPlayerState *state,
         last_tick = frame->tick;
         (*out_replayed)++;
     }
+    net_replay_restore_local_tow_poses(&tow_snapshot);
     net_adopt_local_tow_prediction(0.0f);
     g.world.events = saved_events;
 

--- a/client/net_sync.c
+++ b/client/net_sync.c
@@ -360,6 +360,7 @@ static void sync_local_tow_state_from_authority(const NetPlayerState *state,
                                                 server_player_t *sp) {
     if (!state || !sp) return;
     sp->ship->tractor_level = (int)state->tractor_level;
+    if (g.tow_snapshot_received) return;
 
     int tow_cap = (int)(sizeof(sp->ship->towed_fragments) /
                         sizeof(sp->ship->towed_fragments[0]));
@@ -1029,6 +1030,11 @@ void net_reset_local_input_stream(void) {
 
 void reset_remote_dynamic_sync(void) {
     net_reset_local_input_stream();
+    g.tow_snapshot_received = false;
+    g.tow_snapshot_revision = 0;
+    g.tow_snapshot_server_tick = 0;
+    memset(g.world.tow_links, 0, sizeof(g.world.tow_links));
+    g.world.tow_revision = 0;
     g.net_last_ping_raw_rtt = 0.0f;
     g.net_last_ping_rtt = 0.0f;
     g.net_last_ping_server_turnaround_ms = 0.0f;
@@ -1283,9 +1289,11 @@ void apply_remote_npcs(const NetNpcState* npcs, int count) {
         n->angle = npcs[i].angle;
         n->target_asteroid =
             remote_npc_asteroid_index(npcs[i].target_asteroid);
-        n->towed_fragment =
-            remote_npc_asteroid_index(npcs[i].towed_fragment);
-        n->towed_scaffold = -1;
+        if (!g.tow_snapshot_received) {
+            n->towed_fragment =
+                remote_npc_asteroid_index(npcs[i].towed_fragment);
+            n->towed_scaffold = -1;
+        }
         n->tint_r = (float)npcs[i].tint_r / 255.0f;
         n->tint_g = (float)npcs[i].tint_g / 255.0f;
         n->tint_b = (float)npcs[i].tint_b / 255.0f;
@@ -1414,9 +1422,11 @@ void apply_remote_npc_status(const NetNpcStatusState* npcs, int count) {
         n->hull_class = npc_default_hull_class_for_role(n->role);
         n->target_asteroid =
             remote_npc_asteroid_index(npcs[i].target_asteroid);
-        n->towed_fragment =
-            remote_npc_asteroid_index(npcs[i].towed_fragment);
-        n->towed_scaffold = -1;
+        if (!g.tow_snapshot_received) {
+            n->towed_fragment =
+                remote_npc_asteroid_index(npcs[i].towed_fragment);
+            n->towed_scaffold = -1;
+        }
     }
 }
 
@@ -2001,7 +2011,7 @@ void apply_remote_cargo_pods(const NetCargoPodState* received, int count) {
         pod->active = true;
         pod->kind = (cargo_pod_kind_t)received[i].kind;
         pod->commodity = (commodity_t)received[i].commodity;
-        cargo_pod_clear_tractor(pod);
+        if (!g.tow_snapshot_received) cargo_pod_clear_tractor(pod);
         pod->pos = v2(received[i].pos_x, received[i].pos_y);
         pod->vel = v2(received[i].vel_x, received[i].vel_y);
         pod->radius = received[i].radius;
@@ -2012,13 +2022,15 @@ void apply_remote_cargo_pods(const NetCargoPodState* received, int count) {
         pod->shipment_id = received[i].shipment_id;
         pod->summary_flags = received[i].summary_flags;
         pod->summary_grade = received[i].summary_grade;
-        if (received[i].tractor_player >= 0) {
-            cargo_pod_set_player_tractor(pod, received[i].tractor_player);
-        } else if (received[i].tractor_station > 0 &&
-                   received[i].tractor_module > 0) {
-            cargo_pod_set_module_tractor(
-                pod, (int)received[i].tractor_station - 1,
-                (int)received[i].tractor_module - 1);
+        if (!g.tow_snapshot_received) {
+            if (received[i].tractor_player >= 0) {
+                cargo_pod_set_player_tractor(pod, received[i].tractor_player);
+            } else if (received[i].tractor_station > 0 &&
+                       received[i].tractor_module > 0) {
+                cargo_pod_set_module_tractor(
+                    pod, (int)received[i].tractor_station - 1,
+                    (int)received[i].tractor_module - 1);
+            }
         }
         pod->tow_hardpoint_tag = received[i].tow_hardpoint_tag <=
                 CARGO_POD_HARDPOINT_COUNT
@@ -2032,7 +2044,8 @@ void apply_remote_cargo_pods(const NetCargoPodState* received, int count) {
             g.cargo_pod_interp.curr[i].active = false;
         }
     }
-    sync_local_towed_pods_from_cargo_authority();
+    if (!g.tow_snapshot_received)
+        sync_local_towed_pods_from_cargo_authority();
 }
 
 void apply_remote_cargo_pod_remove(const uint8_t* indices, int count) {
@@ -2044,7 +2057,8 @@ void apply_remote_cargo_pod_remove(const uint8_t* indices, int count) {
         cargo_pod_interp_begin_update(idx);
         g.cargo_pod_interp.curr[idx].active = false;
     }
-    sync_local_towed_pods_from_cargo_authority();
+    if (!g.tow_snapshot_received)
+        sync_local_towed_pods_from_cargo_authority();
 }
 
 void apply_remote_cargo_pod_motion(const NetCargoPodMotionState* received,
@@ -2105,6 +2119,229 @@ void apply_remote_interaction_drift(const NetInteractionDriftState *items,
         it->range = items[i].range;
         it->intensity = items[i].intensity;
     }
+}
+
+static bool net_tow_revision_before(uint32_t a, uint32_t b) {
+    return (int32_t)(a - b) < 0;
+}
+
+static bool net_tow_link_shape_valid(const tow_link_t *link) {
+    if (!link || !link->active || entity_ref_is_none(link->source) ||
+        entity_ref_is_none(link->target) || link->target.part != -1) {
+        return false;
+    }
+    bool target_valid =
+        (link->target.kind == ENTITY_KIND_ASTEROID &&
+         link->target.index >= 0 && link->target.index < MAX_ASTEROIDS) ||
+        (link->target.kind == ENTITY_KIND_CARGO_POD &&
+         link->target.index >= 0 && link->target.index < MAX_CARGO_PODS) ||
+        (link->target.kind == ENTITY_KIND_SCAFFOLD &&
+         link->target.index >= 0 && link->target.index < MAX_SCAFFOLDS);
+    if (!target_valid) return false;
+    if (link->source.kind == ENTITY_KIND_SHIP) {
+        if (link->source.index < WORLD_PLAYER_SHIP_BASE ||
+            link->source.index >= WORLD_SHIP_CAP ||
+            link->source.part != -1) {
+            return false;
+        }
+        if (link->profile == TOW_PROFILE_SHIP_FRAGMENT)
+            return link->target.kind == ENTITY_KIND_ASTEROID &&
+                   link->slot < 10;
+        if (link->profile == TOW_PROFILE_SHIP_POD)
+            return link->target.kind == ENTITY_KIND_CARGO_POD &&
+                   link->source.index < WORLD_NPC_SHIP_BASE &&
+                   link->slot < 10;
+        if (link->profile == TOW_PROFILE_SHIP_SCAFFOLD)
+            return link->target.kind == ENTITY_KIND_SCAFFOLD &&
+                   link->slot == 0;
+        return false;
+    }
+    return link->source.kind == ENTITY_KIND_STATION_MODULE &&
+           link->source.index >= 0 &&
+           link->source.index < MAX_STATIONS &&
+           link->source.part >= 0 &&
+           link->source.part < MAX_MODULES_PER_STATION &&
+           link->profile == TOW_PROFILE_MODULE_POD &&
+           link->target.kind == ENTITY_KIND_CARGO_POD &&
+           link->slot == 0;
+}
+
+static tractor_binding_t net_tow_binding_for_source(entity_ref_t source) {
+    tractor_binding_t binding;
+    tractor_binding_clear(&binding);
+    if (source.kind == ENTITY_KIND_SHIP &&
+        source.index >= WORLD_PLAYER_SHIP_BASE &&
+        source.index < WORLD_NPC_SHIP_BASE) {
+        binding.kind = TRACTOR_SOURCE_PLAYER;
+        binding.source_index =
+            (int16_t)(source.index - WORLD_PLAYER_SHIP_BASE);
+    } else if (source.kind == ENTITY_KIND_SHIP &&
+               source.index >= WORLD_NPC_SHIP_BASE &&
+               source.index < WORLD_SHIP_CAP) {
+        binding.kind = TRACTOR_SOURCE_NPC;
+        binding.source_index =
+            (int16_t)(source.index - WORLD_NPC_SHIP_BASE);
+    } else if (source.kind == ENTITY_KIND_STATION_MODULE) {
+        binding.kind = TRACTOR_SOURCE_STATION_MODULE;
+        binding.source_index = source.index;
+        binding.source_part = source.part;
+    }
+    binding.source_generation = source.generation;
+    return binding;
+}
+
+static void net_clear_tow_projections(void) {
+    for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        tractor_binding_clear(&g.world.asteroids[i].tractor);
+        tractor_binding_clear(&g.asteroid_interp.prev[i].tractor);
+        tractor_binding_clear(&g.asteroid_interp.curr[i].tractor);
+    }
+    for (int i = 0; i < MAX_CARGO_PODS; i++) {
+        tractor_binding_clear(&g.world.cargo_pods[i].tractor);
+        tractor_binding_clear(&g.cargo_pod_interp.prev[i].tractor);
+        tractor_binding_clear(&g.cargo_pod_interp.curr[i].tractor);
+    }
+    for (int i = 0; i < MAX_SCAFFOLDS; i++) {
+        tractor_binding_clear(&g.world.scaffolds[i].tractor);
+        tractor_binding_clear(&g.scaffold_interp.prev[i].tractor);
+        tractor_binding_clear(&g.scaffold_interp.curr[i].tractor);
+    }
+    for (int i = 0; i < WORLD_SHIP_CAP; i++) {
+        if (!g.world.ships[i].active) continue;
+        ship_t *ship = &g.world.ships[i].component;
+        ship->towed_count = 0;
+        ship->towed_pod_count = 0;
+        ship->towed_scaffold = -1;
+        memset(ship->towed_fragments, -1, sizeof(ship->towed_fragments));
+        memset(ship->towed_pods, -1, sizeof(ship->towed_pods));
+    }
+    for (int i = 0; i < NET_MAX_PLAYERS; i++) {
+        g.player_interp.prev[i].towed_count = 0;
+        g.player_interp.curr[i].towed_count = 0;
+        for (int slot = 0; slot < 10; slot++) {
+            g.player_interp.prev[i].towed_fragments[slot] = 0xFFFFu;
+            g.player_interp.curr[i].towed_fragments[slot] = 0xFFFFu;
+        }
+    }
+    for (int i = 0; i < MAX_NPC_SHIPS; i++) {
+        g.npc_interp.prev[i].towed_fragment = -1;
+        g.npc_interp.curr[i].towed_fragment = -1;
+        g.npc_interp.prev[i].towed_scaffold = -1;
+        g.npc_interp.curr[i].towed_scaffold = -1;
+    }
+}
+
+static void net_project_tow_target(entity_ref_t target,
+                                   tractor_binding_t binding) {
+    if (target.kind == ENTITY_KIND_ASTEROID &&
+        target.index >= 0 && target.index < MAX_ASTEROIDS) {
+        g.world.asteroids[target.index].tractor = binding;
+        g.asteroid_interp.prev[target.index].tractor = binding;
+        g.asteroid_interp.curr[target.index].tractor = binding;
+    } else if (target.kind == ENTITY_KIND_CARGO_POD &&
+               target.index >= 0 && target.index < MAX_CARGO_PODS) {
+        g.world.cargo_pods[target.index].tractor = binding;
+        g.cargo_pod_interp.prev[target.index].tractor = binding;
+        g.cargo_pod_interp.curr[target.index].tractor = binding;
+    } else if (target.kind == ENTITY_KIND_SCAFFOLD &&
+               target.index >= 0 && target.index < MAX_SCAFFOLDS) {
+        g.world.scaffolds[target.index].tractor = binding;
+        g.scaffold_interp.prev[target.index].tractor = binding;
+        g.scaffold_interp.curr[target.index].tractor = binding;
+    }
+}
+
+static void net_project_tow_source(const tow_link_t *link) {
+    if (!link || link->source.kind != ENTITY_KIND_SHIP) return;
+    int ship_slot = link->source.index;
+    ship_t *ship = g.world.ships[ship_slot].active
+        ? &g.world.ships[ship_slot].component : NULL;
+    if (link->profile == TOW_PROFILE_SHIP_FRAGMENT) {
+        if (ship) {
+            ship->towed_fragments[link->slot] = link->target.index;
+            if (ship->towed_count <= link->slot)
+                ship->towed_count = (uint8_t)(link->slot + 1);
+        }
+        if (ship_slot < WORLD_NPC_SHIP_BASE) {
+            int player = ship_slot - WORLD_PLAYER_SHIP_BASE;
+            g.player_interp.prev[player].towed_fragments[link->slot] =
+                (uint16_t)link->target.index;
+            g.player_interp.curr[player].towed_fragments[link->slot] =
+                (uint16_t)link->target.index;
+            if (g.player_interp.prev[player].towed_count <= link->slot)
+                g.player_interp.prev[player].towed_count =
+                    (uint8_t)(link->slot + 1);
+            if (g.player_interp.curr[player].towed_count <= link->slot)
+                g.player_interp.curr[player].towed_count =
+                    (uint8_t)(link->slot + 1);
+        } else {
+            int npc = ship_slot - WORLD_NPC_SHIP_BASE;
+            g.npc_interp.prev[npc].towed_fragment = link->target.index;
+            g.npc_interp.curr[npc].towed_fragment = link->target.index;
+        }
+    } else if (link->profile == TOW_PROFILE_SHIP_POD && ship) {
+        ship->towed_pods[link->slot] = link->target.index;
+        if (ship->towed_pod_count <= link->slot)
+            ship->towed_pod_count = (uint8_t)(link->slot + 1);
+    } else if (link->profile == TOW_PROFILE_SHIP_SCAFFOLD) {
+        if (ship) ship->towed_scaffold = link->target.index;
+        if (ship_slot >= WORLD_NPC_SHIP_BASE) {
+            int npc = ship_slot - WORLD_NPC_SHIP_BASE;
+            g.npc_interp.prev[npc].towed_scaffold = link->target.index;
+            g.npc_interp.curr[npc].towed_scaffold = link->target.index;
+        }
+    }
+}
+
+void apply_remote_tow_links(const tow_link_t *links, int count,
+                            uint32_t revision, uint32_t server_tick) {
+    if (count < 0 || count > MAX_TOW_LINKS || (count > 0 && !links)) return;
+    if (g.tow_snapshot_received &&
+        revision != g.tow_snapshot_revision &&
+        net_tow_revision_before(revision, g.tow_snapshot_revision)) {
+        return;
+    }
+
+    tow_link_t accepted[MAX_TOW_LINKS];
+    int accepted_count = 0;
+    if (g.tow_snapshot_received && revision == g.tow_snapshot_revision) {
+        /* Equal revisions are duplicate delivery, not a new command. Reuse
+         * the accepted relation set so a same-version packet with different
+         * bytes cannot mutate authority, while still re-projecting after a
+         * target identity enters relevance. */
+        for (int i = 0; i < MAX_TOW_LINKS; i++) {
+            if (g.world.tow_links[i].active)
+                accepted[accepted_count++] = g.world.tow_links[i];
+        }
+    } else {
+        for (int i = 0; i < count; i++) {
+            if (!net_tow_link_shape_valid(&links[i])) continue;
+            bool duplicate_target = false;
+            for (int j = 0; j < accepted_count; j++) {
+                if (accepted[j].target.kind == links[i].target.kind &&
+                    accepted[j].target.index == links[i].target.index &&
+                    accepted[j].target.part == links[i].target.part) {
+                    duplicate_target = true;
+                    break;
+                }
+            }
+            if (!duplicate_target) accepted[accepted_count++] = links[i];
+        }
+    }
+
+    net_clear_tow_projections();
+    memset(g.world.tow_links, 0, sizeof(g.world.tow_links));
+    for (int i = 0; i < accepted_count; i++) {
+        g.world.tow_links[i] = accepted[i];
+        net_project_tow_source(&accepted[i]);
+        net_project_tow_target(
+            accepted[i].target,
+            net_tow_binding_for_source(accepted[i].source));
+    }
+    g.world.tow_revision = revision;
+    g.tow_snapshot_received = true;
+    g.tow_snapshot_revision = revision;
+    g.tow_snapshot_server_tick = server_tick;
 }
 
 /* Defined in main.c — process events for audio + UI */
@@ -2657,6 +2894,13 @@ void apply_remote_player_state(const NetPlayerState* state) {
                 }
             }
         }
+        if (g.tow_snapshot_received) {
+            const NetPlayerState *tow =
+                &g.player_interp.curr[state->player_id];
+            next.towed_count = tow->towed_count;
+            memcpy(next.towed_fragments, tow->towed_fragments,
+                   sizeof(next.towed_fragments));
+        }
         g.player_interp.curr[state->player_id] = next;
         /* First time we see this player with a callsign — show join notice */
         if (!was_active && next.active && next.callsign[0])
@@ -2689,10 +2933,14 @@ void apply_remote_player_ship(const NetPlayerShipState* state) {
             sp->ship->cargo[c] = state->cargo[c];
         sp->nearby_fragments = (int)state->nearby_fragments;
         sp->tractor_fragments = (int)state->tractor_fragments;
-        sp->ship->towed_count = state->towed_count;
-        for (int t = 0; t < 10; t++)
-            sp->ship->towed_fragments[t] = (state->towed_fragments[t] == 0xFFFFu)
-                ? -1 : (int16_t)state->towed_fragments[t];
+        if (!g.tow_snapshot_received) {
+            sp->ship->towed_count = state->towed_count;
+            for (int t = 0; t < 10; t++) {
+                sp->ship->towed_fragments[t] =
+                    (state->towed_fragments[t] == 0xFFFFu)
+                        ? -1 : (int16_t)state->towed_fragments[t];
+            }
+        }
         /* Autopilot is also predict-protected: the [O] press triggers an
          * optimistic local toggle, and stale PLAYER_SHIP messages can
          * arrive carrying the pre-toggle value before the server has
@@ -2823,7 +3071,8 @@ void interpolate_world_for_render(void) {
             i, clampf(g.cargo_pod_interp.elapsed[i], 0.0f,
                       CARGO_POD_RENDER_EXTRAPOLATE_MAX_SEC));
     }
-    sync_local_towed_pods_from_cargo_authority();
+    if (!g.tow_snapshot_received)
+        sync_local_towed_pods_from_cargo_authority();
 }
 
 const NetPlayerState* net_get_interpolated_players(void) {

--- a/client/net_sync.h
+++ b/client/net_sync.h
@@ -52,6 +52,8 @@ void net_observe_transport_latency_sample(float rtt_ms,
                                           bool from_input_ack);
 void net_adopt_local_tow_prediction(float dt);
 void net_advance_asteroid_interpolation(float dt);
+void net_advance_npc_interpolation(float dt);
+void net_advance_scaffold_interpolation(float dt);
 void net_advance_cargo_pod_interpolation(float dt);
 
 /* Apply server-authoritative world state. */

--- a/client/net_sync.h
+++ b/client/net_sync.h
@@ -92,6 +92,8 @@ void apply_remote_cargo_pod_linear(const NetCargoPodLinearState* pods,
 void apply_remote_interactions(const sim_interaction_t *items, int count);
 void apply_remote_interaction_drift(const NetInteractionDriftState *items,
                                     int count);
+void apply_remote_tow_links(const tow_link_t *links, int count,
+                            uint32_t revision, uint32_t server_tick);
 void apply_remote_hail_response(uint8_t station,
                                 float credits,
                                 int contract_index,

--- a/client/world_draw.c
+++ b/client/world_draw.c
@@ -3246,6 +3246,28 @@ void draw_npc_ships(void) {
                                          1.0f);
             }
         }
+        int towed_scaffold = tnpc->ship->towed_scaffold;
+        if (towed_scaffold >= 0 && towed_scaffold < MAX_SCAFFOLDS) {
+            const scaffold_t *sc = &g.world.scaffolds[towed_scaffold];
+            if (sc->active && sc->state == SCAFFOLD_TOWING &&
+                scaffold_tractor_npc(sc) == i) {
+                float tr = ship_tractor_range(tnpc->ship);
+                tractor_beam_t beam = tractor_tow_beam(
+                    tr, TRACTOR_TOW_BAND_REST_LENGTH);
+                float stretch = tractor_beam_tautness(
+                    tnpc->ship->pos, sc->pos, &beam);
+                float pulse = 0.5f + 0.2f *
+                    sinf(g.world.time * 3.0f + (float)i * 1.5f);
+                draw_tractor_tether_wave(
+                    tnpc->ship->pos, sc->pos,
+                    0.5f, 0.85f, 0.75f, pulse,
+                    stretch, (float)i * 2.3f,
+                    SIM_INTERACTION_ENTITY_PLAYER_SHIP,
+                    SIM_INTERACTION_ENTITY_SCAFFOLD,
+                    SIM_INTERACTION_VISUAL_DEFAULT_TRACTOR,
+                    1.0f);
+            }
+        }
         if (i == scan_npc) {
             /* Hug the visible ship: ship_radius is the collision radius
              * and the rendered triangle sits within it, so a tight

--- a/scripts/smoke-latency-suite.mjs
+++ b/scripts/smoke-latency-suite.mjs
@@ -368,6 +368,27 @@ await withCleanup(async () => {
   });
 
   await runLatencyCase({
+    name: 'station tractor relevance exit and re-entry smoke',
+    grep: 'station beam exits and re-enters relevance',
+    envFlag: 'SMOKE_STATION_RELEVANCE_ADVERSE_ASSERT',
+    httpPort,
+    serverEnv: {
+      SIGNAL_STATION_TOW_SMOKE_FIXTURE: '1',
+      SIGNAL_STATION_RELEVANCE_SMOKE_FIXTURE: '1',
+    },
+    proxyArgs: [
+      '--client-ms=160',
+      '--server-ms=160',
+      '--jitter-ms=90',
+      '--seed=2037',
+      '--server-drop-every=11',
+      '--server-duplicate-every=7',
+      '--server-reorder-every=5',
+      '--server-interaction-faults',
+    ],
+  });
+
+  await runLatencyCase({
     name: 'NPC scaffold tow adverse-network smoke',
     grep: 'NPC scaffold tow stays visible',
     envFlag: 'SMOKE_NPC_SCAFFOLD_TOW_ADVERSE_ASSERT',

--- a/scripts/smoke-latency-suite.mjs
+++ b/scripts/smoke-latency-suite.mjs
@@ -348,6 +348,26 @@ await withCleanup(async () => {
   });
 
   await runLatencyCase({
+    name: 'authoritative tow target retirement adverse-network smoke',
+    grep: 'authoritative target retirement clears tow',
+    envFlag: 'SMOKE_TOW_RETIRE_ADVERSE_ASSERT',
+    httpPort,
+    serverEnv: {
+      SIGNAL_TOW_SMOKE_FIXTURE: '1',
+      SIGNAL_TOW_RETIRE_SMOKE_FIXTURE: '1',
+    },
+    proxyArgs: [
+      '--client-ms=160',
+      '--server-ms=160',
+      '--jitter-ms=90',
+      '--seed=2037',
+      '--server-drop-every=11',
+      '--server-duplicate-every=7',
+      '--server-reorder-every=5',
+    ],
+  });
+
+  await runLatencyCase({
     name: 'NPC scaffold tow adverse-network smoke',
     grep: 'NPC scaffold tow stays visible',
     envFlag: 'SMOKE_NPC_SCAFFOLD_TOW_ADVERSE_ASSERT',

--- a/scripts/smoke-latency-suite.mjs
+++ b/scripts/smoke-latency-suite.mjs
@@ -11,6 +11,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const isWindows = process.platform === 'win32';
 const signalServerBin = path.join(repoRoot, 'build', isWindows ? 'signal_server.exe' : 'signal_server');
 const npxBin = isWindows ? 'npx.cmd' : 'npx';
+const configuredPlaywrightBin = process.env.SIGNAL_PLAYWRIGHT_BIN || '';
 
 const children = [];
 const tempDirs = [];
@@ -214,8 +215,10 @@ async function runLatencyCase({
     `http://127.0.0.1:${httpPort}/play.html?server=ws://127.0.0.1:${proxyPort}/ws`;
 
   try {
-    await runForeground(`running ${name}`, npxBin, [
-      'playwright',
+    const command = configuredPlaywrightBin || npxBin;
+    const commandPrefix = configuredPlaywrightBin ? [] : ['playwright'];
+    await runForeground(`running ${name}`, command, [
+      ...commandPrefix,
       'test',
       'tests/browser-smoke.spec.ts',
       '--project=chromium',
@@ -270,6 +273,23 @@ await withCleanup(async () => {
       '--client-ms=450',
       '--server-ms=450',
       '--jitter-ms=150',
+    ],
+  });
+
+  await runLatencyCase({
+    name: 'loss, duplication, and reordering proxy smoke',
+    grep: 'high-latency',
+    envFlag: 'SMOKE_LATENCY_ASSERT',
+    httpPort,
+    serverPort,
+    proxyArgs: [
+      '--client-ms=160',
+      '--server-ms=160',
+      '--jitter-ms=90',
+      '--seed=2037',
+      '--server-drop-every=11',
+      '--server-duplicate-every=7',
+      '--server-reorder-every=5',
     ],
   });
 

--- a/scripts/smoke-latency-suite.mjs
+++ b/scripts/smoke-latency-suite.mjs
@@ -328,6 +328,26 @@ await withCleanup(async () => {
   });
 
   await runLatencyCase({
+    name: 'station tractor adverse-network smoke',
+    grep: 'station tractor beam stays visible',
+    envFlag: 'SMOKE_STATION_TOW_ADVERSE_ASSERT',
+    httpPort,
+    serverEnv: {
+      SIGNAL_STATION_TOW_SMOKE_FIXTURE: '1',
+    },
+    proxyArgs: [
+      '--client-ms=160',
+      '--server-ms=160',
+      '--jitter-ms=90',
+      '--seed=2037',
+      '--server-drop-every=11',
+      '--server-duplicate-every=7',
+      '--server-reorder-every=5',
+      '--server-interaction-faults',
+    ],
+  });
+
+  await runLatencyCase({
     name: 'low-ping high-ack proxy smoke',
     grep: 'low-ping high-ack',
     envFlag: 'SMOKE_ACK_LAG_ASSERT',

--- a/scripts/smoke-latency-suite.mjs
+++ b/scripts/smoke-latency-suite.mjs
@@ -12,6 +12,7 @@ const isWindows = process.platform === 'win32';
 const signalServerBin = path.join(repoRoot, 'build', isWindows ? 'signal_server.exe' : 'signal_server');
 const npxBin = isWindows ? 'npx.cmd' : 'npx';
 const configuredPlaywrightBin = process.env.SIGNAL_PLAYWRIGHT_BIN || '';
+const requestedCase = process.env.SIGNAL_LATENCY_SUITE_CASE || '';
 
 const children = [];
 const tempDirs = [];
@@ -201,20 +202,45 @@ async function runLatencyCase({
   grep,
   envFlag,
   httpPort,
-  serverPort,
   proxyArgs,
+  serverEnv = {},
 }) {
-  const proxy = startBackground(name, process.execPath, [
-    'scripts/ws-latency-proxy.mjs',
-    '--listen=127.0.0.1:0',
-    `--upstream=ws://127.0.0.1:${serverPort}/ws`,
-    ...proxyArgs,
-  ]);
-  const proxyPort = await waitForProxy(proxy);
-  const smokeUrl =
-    `http://127.0.0.1:${httpPort}/play.html?server=ws://127.0.0.1:${proxyPort}/ws`;
+  if (requestedCase && !name.includes(requestedCase)) {
+    log(`skipping ${name} (SIGNAL_LATENCY_SUITE_CASE=${requestedCase})`);
+    return;
+  }
+  const serverPort = await freePort();
+  const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'signal-latency-smoke-'));
+  tempDirs.push(dataDir);
+  log(`starting ${name} signal_server on :${serverPort}`);
+  const server = startBackground(`${name} signal_server`, signalServerBin, [], {
+    env: {
+      PORT: String(serverPort),
+      SIGNAL_DATA_DIR: dataDir,
+      SIGNAL_WORLD_SEED: '2037',
+      SIGNAL_WORLD_SEQ: '1',
+      SIGNAL_ALLOW_DEV_STATION_AUTH_SECRET: '1',
+      ...serverEnv,
+    },
+  });
+  await waitForHttp(
+    `http://127.0.0.1:${serverPort}/health`,
+    `${name} signal_server`,
+    [server],
+    30000,
+  );
 
+  let proxy;
   try {
+    proxy = startBackground(name, process.execPath, [
+      'scripts/ws-latency-proxy.mjs',
+      '--listen=127.0.0.1:0',
+      `--upstream=ws://127.0.0.1:${serverPort}/ws`,
+      ...proxyArgs,
+    ]);
+    const proxyPort = await waitForProxy(proxy);
+    const smokeUrl =
+      `http://127.0.0.1:${httpPort}/play.html?server=ws://127.0.0.1:${proxyPort}/ws`;
     const command = configuredPlaywrightBin || npxBin;
     const commandPrefix = configuredPlaywrightBin ? [] : ['playwright'];
     await runForeground(`running ${name}`, command, [
@@ -230,26 +256,12 @@ async function runLatencyCase({
     });
   } finally {
     await stopProcess(proxy);
+    await stopProcess(server);
   }
 }
 
 await withCleanup(async () => {
-  const serverPort = await freePort();
   const httpPort = await freePort();
-  const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'signal-latency-smoke-'));
-  tempDirs.push(dataDir);
-
-  log(`starting signal_server on :${serverPort}`);
-  const server = startBackground('signal_server', signalServerBin, [], {
-    env: {
-      PORT: String(serverPort),
-      SIGNAL_DATA_DIR: dataDir,
-      SIGNAL_WORLD_SEED: '2037',
-      SIGNAL_WORLD_SEQ: '1',
-      SIGNAL_ALLOW_DEV_STATION_AUTH_SECRET: '1',
-    },
-  });
-  await waitForHttp(`http://127.0.0.1:${serverPort}/health`, 'signal_server', [server], 30000);
 
   log(`starting static build-web server on :${httpPort}`);
   const staticServer = startBackground('static-http', 'python3', [
@@ -261,14 +273,18 @@ await withCleanup(async () => {
     '--directory',
     path.join(repoRoot, 'build-web'),
   ]);
-  await waitForHttp(`http://127.0.0.1:${httpPort}/play.html`, 'static server', [server, staticServer], 10000);
+  await waitForHttp(
+    `http://127.0.0.1:${httpPort}/play.html`,
+    'static server',
+    [staticServer],
+    10000,
+  );
 
   await runLatencyCase({
     name: 'high-latency proxy smoke',
     grep: 'high-latency',
     envFlag: 'SMOKE_LATENCY_ASSERT',
     httpPort,
-    serverPort,
     proxyArgs: [
       '--client-ms=450',
       '--server-ms=450',
@@ -281,7 +297,25 @@ await withCleanup(async () => {
     grep: 'high-latency',
     envFlag: 'SMOKE_LATENCY_ASSERT',
     httpPort,
-    serverPort,
+    proxyArgs: [
+      '--client-ms=160',
+      '--server-ms=160',
+      '--jitter-ms=90',
+      '--seed=2037',
+      '--server-drop-every=11',
+      '--server-duplicate-every=7',
+      '--server-reorder-every=5',
+    ],
+  });
+
+  await runLatencyCase({
+    name: 'authoritative tow adverse-network smoke',
+    grep: 'authoritative tow stays atomic',
+    envFlag: 'SMOKE_TOW_ADVERSE_ASSERT',
+    httpPort,
+    serverEnv: {
+      SIGNAL_TOW_SMOKE_FIXTURE: '1',
+    },
     proxyArgs: [
       '--client-ms=160',
       '--server-ms=160',
@@ -298,7 +332,6 @@ await withCleanup(async () => {
     grep: 'low-ping high-ack',
     envFlag: 'SMOKE_ACK_LAG_ASSERT',
     httpPort,
-    serverPort,
     proxyArgs: [
       '--client-ms=20',
       '--server-ms=20',

--- a/scripts/smoke-latency-suite.mjs
+++ b/scripts/smoke-latency-suite.mjs
@@ -348,6 +348,25 @@ await withCleanup(async () => {
   });
 
   await runLatencyCase({
+    name: 'NPC scaffold tow adverse-network smoke',
+    grep: 'NPC scaffold tow stays visible',
+    envFlag: 'SMOKE_NPC_SCAFFOLD_TOW_ADVERSE_ASSERT',
+    httpPort,
+    serverEnv: {
+      SIGNAL_NPC_SCAFFOLD_TOW_SMOKE_FIXTURE: '1',
+    },
+    proxyArgs: [
+      '--client-ms=160',
+      '--server-ms=160',
+      '--jitter-ms=90',
+      '--seed=2037',
+      '--server-drop-every=11',
+      '--server-duplicate-every=7',
+      '--server-reorder-every=5',
+    ],
+  });
+
+  await runLatencyCase({
     name: 'low-ping high-ack proxy smoke',
     grep: 'low-ping high-ack',
     envFlag: 'SMOKE_ACK_LAG_ASSERT',

--- a/scripts/test-ws-frame-impairment.mjs
+++ b/scripts/test-ws-frame-impairment.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+
+import {
+  createDeterministicUnitRandom,
+  createFrameImpairment,
+} from './ws-frame-impairment.mjs';
+
+function byte(value) {
+  return Buffer.from([value]);
+}
+
+function values(frames) {
+  return frames.map((frame) => frame[0]);
+}
+
+{
+  const first = createDeterministicUnitRandom(2037);
+  const second = createDeterministicUnitRandom(2037);
+  const third = createDeterministicUnitRandom(2038);
+  const firstSequence = Array.from({ length: 8 }, () => first());
+  assert.deepEqual(
+    firstSequence,
+    Array.from({ length: 8 }, () => second()),
+    'equal seeds must reproduce the same jitter sequence'
+  );
+  assert.notDeepEqual(
+    firstSequence,
+    Array.from({ length: 8 }, () => third()),
+    'different seeds must produce a different jitter sequence'
+  );
+}
+
+{
+  const impairment = createFrameImpairment({ dropEvery: 2 });
+  assert.deepEqual(values(impairment.push(byte(1))), [1]);
+  assert.deepEqual(values(impairment.push(byte(2))), []);
+  assert.deepEqual(values(impairment.push(byte(3))), [3]);
+  assert.equal(impairment.selectedCount(), 3);
+}
+
+{
+  const impairment = createFrameImpairment({ duplicateEvery: 2 });
+  assert.deepEqual(values(impairment.push(byte(1))), [1]);
+  assert.deepEqual(values(impairment.push(byte(2))), [2, 2]);
+}
+
+{
+  const impairment = createFrameImpairment({ reorderEvery: 2 });
+  assert.deepEqual(values(impairment.push(byte(1))), [1]);
+  assert.deepEqual(values(impairment.push(byte(2))), []);
+  assert.deepEqual(values(impairment.push(byte(3))), [3, 2]);
+  assert.deepEqual(values(impairment.push(byte(4))), []);
+  assert.deepEqual(values(impairment.flush()), [4]);
+}
+
+{
+  const impairment = createFrameImpairment({
+    reorderEvery: 2,
+    isSelected: (frame) => frame[0] < 10,
+  });
+  assert.deepEqual(values(impairment.push(byte(1))), [1]);
+  assert.deepEqual(values(impairment.push(byte(2))), []);
+  assert.deepEqual(
+    values(impairment.push(byte(99))),
+    [99],
+    'unselected control frames must bypass world-stream impairment'
+  );
+  assert.deepEqual(values(impairment.push(byte(3))), [3, 2]);
+  assert.equal(impairment.selectedCount(), 3);
+}
+
+console.log('deterministic websocket frame impairment checks passed');

--- a/scripts/ws-frame-impairment.mjs
+++ b/scripts/ws-frame-impairment.mjs
@@ -1,0 +1,86 @@
+function requireNonNegativeInteger(name, value) {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+}
+
+export function createDeterministicUnitRandom(seed) {
+  requireNonNegativeInteger('seed', seed);
+  let state = (seed >>> 0) || 0x9e3779b9;
+  return () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    return (state >>> 0) / 0x100000000;
+  };
+}
+
+export function createFrameImpairment({
+  dropEvery = 0,
+  duplicateEvery = 0,
+  reorderEvery = 0,
+  isSelected = () => true,
+  onEvent = () => {},
+} = {}) {
+  requireNonNegativeInteger('dropEvery', dropEvery);
+  requireNonNegativeInteger('duplicateEvery', duplicateEvery);
+  requireNonNegativeInteger('reorderEvery', reorderEvery);
+
+  let selectedOrdinal = 0;
+  let held = null;
+
+  function deliveriesFor(frame, ordinal) {
+    const deliveries = [frame];
+    if (duplicateEvery > 0 && ordinal % duplicateEvery === 0) {
+      deliveries.push(Buffer.from(frame));
+      onEvent('duplicate', ordinal);
+    }
+    return deliveries;
+  }
+
+  return {
+    push(frame) {
+      if (!isSelected(frame)) return [frame];
+
+      selectedOrdinal++;
+      const ordinal = selectedOrdinal;
+      if (dropEvery > 0 && ordinal % dropEvery === 0) {
+        onEvent('drop', ordinal);
+        return [];
+      }
+
+      if (held) {
+        const previous = held;
+        held = null;
+        onEvent('reorder', previous.ordinal);
+        return [
+          ...deliveriesFor(frame, ordinal),
+          ...deliveriesFor(previous.frame, previous.ordinal),
+        ];
+      }
+
+      if (reorderEvery > 0 && ordinal % reorderEvery === 0) {
+        held = {
+          frame: Buffer.from(frame),
+          ordinal,
+        };
+        onEvent('hold', ordinal);
+        return [];
+      }
+
+      return deliveriesFor(frame, ordinal);
+    },
+
+    flush() {
+      if (!held) return [];
+      const previous = held;
+      held = null;
+      onEvent('flush', previous.ordinal);
+      return deliveriesFor(previous.frame, previous.ordinal);
+    },
+
+    selectedCount() {
+      return selectedOrdinal;
+    },
+  };
+}

--- a/scripts/ws-latency-proxy.mjs
+++ b/scripts/ws-latency-proxy.mjs
@@ -30,6 +30,8 @@ Options:
   --server-duplicate-every=N  duplicate every Nth selected server world frame (default: 0)
   --server-reorder-every=N    swap every Nth selected server world frame with
                               the next selected frame (default: 0)
+  --server-interaction-faults include interaction identity/drift frames in the
+                              selected server world fault schedule (default: off)
   --log-frames                log forwarded frame sizes
 `);
 }
@@ -74,6 +76,11 @@ const SERVER_ADVERSE_WORLD_TYPES = new Set([
   0x6E, // WORLD_PLAYER_MOTIONM_Q
   0x70, // WORLD_TOW_LINKS
 ]);
+const SERVER_ADVERSE_INTERACTION_TYPES = new Set([
+  0x49, // WORLD_INTERACTIONS
+  0x50, // WORLD_INTERACTION_DRIFT
+  0x61, // WORLD_INTERACTIONS_Q
+]);
 
 function parseArgs(argv) {
   const out = {
@@ -88,6 +95,7 @@ function parseArgs(argv) {
     serverDropEvery: 0,
     serverDuplicateEvery: 0,
     serverReorderEvery: 0,
+    serverInteractionFaults: false,
     logFrames: false,
   };
 
@@ -117,6 +125,8 @@ function parseArgs(argv) {
       out.serverDuplicateEvery = Number(arg.slice('--server-duplicate-every='.length));
     } else if (arg.startsWith('--server-reorder-every=')) {
       out.serverReorderEvery = Number(arg.slice('--server-reorder-every='.length));
+    } else if (arg === '--server-interaction-faults') {
+      out.serverInteractionFaults = true;
     } else if (arg === '--log-frames') {
       out.logFrames = true;
     } else {
@@ -385,8 +395,12 @@ async function handleClient(client, opts) {
         dropEvery: opts.serverDropEvery,
         duplicateEvery: opts.serverDuplicateEvery,
         reorderEvery: opts.serverReorderEvery,
-        isSelected: (frame) =>
-          SERVER_ADVERSE_WORLD_TYPES.has(websocketPayloadInfo(frame).type),
+        isSelected: (frame) => {
+          const type = websocketPayloadInfo(frame).type;
+          return SERVER_ADVERSE_WORLD_TYPES.has(type) ||
+            (opts.serverInteractionFaults &&
+              SERVER_ADVERSE_INTERACTION_TYPES.has(type));
+        },
         onEvent: (action, ordinal) => {
           if (opts.logFrames) {
             console.error(

--- a/scripts/ws-latency-proxy.mjs
+++ b/scripts/ws-latency-proxy.mjs
@@ -2,6 +2,10 @@
 import crypto from 'node:crypto';
 import net from 'node:net';
 import tls from 'node:tls';
+import {
+  createDeterministicUnitRandom,
+  createFrameImpairment,
+} from './ws-frame-impairment.mjs';
 
 const GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 
@@ -21,6 +25,11 @@ Options:
                               with WORLD_PLAYERS delay to model high
                               authoritative ack age without delaying pings.
   --jitter-ms=N               additive per-frame jitter, preserving order (default: 0)
+  --seed=N                    deterministic jitter/impairment seed (default: 2037)
+  --server-drop-every=N       drop every Nth selected server world frame (default: 0)
+  --server-duplicate-every=N  duplicate every Nth selected server world frame (default: 0)
+  --server-reorder-every=N    swap every Nth selected server world frame with
+                              the next selected frame (default: 0)
   --log-frames                log forwarded frame sizes
 `);
 }
@@ -29,6 +38,42 @@ const NET_MSG_STATE = 0x03;
 const NET_STATE_AUTH_SIZE = 55;
 const NET_MSG_WORLD_PLAYERS = 0x18;
 const NET_MSG_INPUT_APPLIED = 0x48;
+const SERVER_ADVERSE_WORLD_TYPES = new Set([
+  NET_MSG_STATE,
+  0x10, // WORLD_ASTEROIDS
+  0x11, // WORLD_NPCS
+  NET_MSG_WORLD_PLAYERS,
+  0x24, // WORLD_SCAFFOLDS
+  0x46, // WORLD_CARGO_PODS
+  0x4B, // WORLD_ASTEROID_MOTION
+  0x4C, // WORLD_ASTEROID_MOTION_Q
+  0x4D, // WORLD_PLAYER_MOTION
+  0x4E, // WORLD_NPC_MOTION
+  0x4F, // WORLD_CARGO_POD_MOTION
+  0x52, // WORLD_NPC_MOTION_Q
+  0x54, // WORLD_CARGO_POD_MOTION_Q
+  0x55, // WORLD_ASTEROID_POS_Q
+  0x56, // WORLD_ASTEROID_REMOVE
+  0x57, // WORLD_CARGO_POD_REMOVE
+  0x58, // WORLD_SCAFFOLD_REMOVE
+  0x59, // WORLD_SCAFFOLD_MOTION_Q
+  0x5A, // WORLD_NPC_POS_Q
+  0x5B, // WORLD_NPC_POSE_Q
+  0x5C, // WORLD_ASTEROID_POS8_Q
+  0x5D, // WORLD_NPC_LINEAR_Q
+  0x5F, // WORLD_CARGO_POD_LINEAR_Q
+  0x62, // WORLD_CARGO_PODS_Q
+  0x66, // WORLD_ASTEROID_POSD_Q
+  0x67, // WORLD_ASTEROID_POSD8_Q
+  0x68, // WORLD_ASTEROIDS_Q
+  0x69, // WORLD_ASTEROIDS8_Q
+  0x6A, // WORLD_PLAYER_MOTION_Q
+  0x6B, // WORLD_PLAYER_DOCK_Q
+  0x6C, // WORLD_PLAYER_MOTIOND_Q
+  0x6D, // WORLD_PLAYER_POSED_Q
+  0x6E, // WORLD_PLAYER_MOTIONM_Q
+  0x70, // WORLD_TOW_LINKS
+]);
 
 function parseArgs(argv) {
   const out = {
@@ -39,6 +84,10 @@ function parseArgs(argv) {
     serverWorldPlayersMs: 0,
     serverInputAppliedMs: 0,
     jitterMs: 0,
+    seed: 2037,
+    serverDropEvery: 0,
+    serverDuplicateEvery: 0,
+    serverReorderEvery: 0,
     logFrames: false,
   };
 
@@ -60,6 +109,14 @@ function parseArgs(argv) {
       out.serverInputAppliedMs = Number(arg.slice('--server-input-applied-ms='.length));
     } else if (arg.startsWith('--jitter-ms=')) {
       out.jitterMs = Number(arg.slice('--jitter-ms='.length));
+    } else if (arg.startsWith('--seed=')) {
+      out.seed = Number(arg.slice('--seed='.length));
+    } else if (arg.startsWith('--server-drop-every=')) {
+      out.serverDropEvery = Number(arg.slice('--server-drop-every='.length));
+    } else if (arg.startsWith('--server-duplicate-every=')) {
+      out.serverDuplicateEvery = Number(arg.slice('--server-duplicate-every='.length));
+    } else if (arg.startsWith('--server-reorder-every=')) {
+      out.serverReorderEvery = Number(arg.slice('--server-reorder-every='.length));
     } else if (arg === '--log-frames') {
       out.logFrames = true;
     } else {
@@ -77,6 +134,17 @@ function parseArgs(argv) {
     ['jitter-ms', out.jitterMs],
   ]) {
     if (!Number.isFinite(value) || value < 0) {
+      console.error(`invalid --${name}: ${value}`);
+      process.exit(2);
+    }
+  }
+  for (const [name, value] of [
+    ['seed', out.seed],
+    ['server-drop-every', out.serverDropEvery],
+    ['server-duplicate-every', out.serverDuplicateEvery],
+    ['server-reorder-every', out.serverReorderEvery],
+  ]) {
+    if (!Number.isInteger(value) || value < 0) {
       console.error(`invalid --${name}: ${value}`);
       process.exit(2);
     }
@@ -141,14 +209,25 @@ function wsAccept(key) {
   return crypto.createHash('sha1').update(key + GUID).digest('base64');
 }
 
-function makeForwarder({ from, to, label, delayMs, extraDelayForFrame, jitterMs, logFrames }) {
+function makeForwarder({
+  from,
+  to,
+  label,
+  delayMs,
+  extraDelayForFrame,
+  jitterMs,
+  seed,
+  impairment,
+  logFrames,
+}) {
   let buffer = Buffer.alloc(0);
   let nextWriteAt = 0;
   let nextExtraWriteAt = 0;
+  const random = createDeterministicUnitRandom(seed);
 
-  function schedule(frame) {
+  function scheduleOne(frame) {
     const extraDelayMs = extraDelayForFrame ? extraDelayForFrame(frame) : 0;
-    const jitter = jitterMs > 0 ? Math.floor(Math.random() * (jitterMs + 1)) : 0;
+    const jitter = jitterMs > 0 ? Math.floor(random() * (jitterMs + 1)) : 0;
     let due = Date.now() + delayMs + extraDelayMs + jitter;
     /* Model fixed path latency, not a bandwidth bottleneck. If frames arrive
      * faster than the delay, they should still emerge at roughly that same
@@ -169,6 +248,11 @@ function makeForwarder({ from, to, label, delayMs, extraDelayForFrame, jitterMs,
     setTimeout(() => {
       if (!to.destroyed) to.write(frame);
     }, Math.max(0, due - Date.now()));
+  }
+
+  function schedule(frame) {
+    const deliveries = impairment ? impairment.push(frame) : [frame];
+    for (const delivery of deliveries) scheduleOne(delivery);
   }
 
   from.on('data', (chunk) => {
@@ -294,7 +378,22 @@ async function handleClient(client, opts) {
         label: 'client->server',
         delayMs: opts.clientMs,
         jitterMs: opts.jitterMs,
+        seed: opts.seed ^ 0x51a7,
         logFrames: opts.logFrames,
+      });
+      const serverImpairment = createFrameImpairment({
+        dropEvery: opts.serverDropEvery,
+        duplicateEvery: opts.serverDuplicateEvery,
+        reorderEvery: opts.serverReorderEvery,
+        isSelected: (frame) =>
+          SERVER_ADVERSE_WORLD_TYPES.has(websocketPayloadInfo(frame).type),
+        onEvent: (action, ordinal) => {
+          if (opts.logFrames) {
+            console.error(
+              `[ws-latency] server->client ${action} selected=${ordinal}`
+            );
+          }
+        },
       });
       makeForwarder({
         from: upstream,
@@ -311,6 +410,8 @@ async function handleClient(client, opts) {
           return 0;
         },
         jitterMs: opts.jitterMs,
+        seed: opts.seed ^ 0xa735,
+        impairment: serverImpairment,
         logFrames: opts.logFrames,
       });
 
@@ -338,7 +439,10 @@ server.listen(listen.port, listen.host, () => {
     `[ws-latency] listening ws://${host}:${port}/ -> ${opts.upstream} ` +
     `(client=${opts.clientMs}ms server=${opts.serverMs}ms ` +
     `world_players=${opts.serverWorldPlayersMs}ms ` +
-    `input_applied=${opts.serverInputAppliedMs}ms jitter=${opts.jitterMs}ms)`
+    `input_applied=${opts.serverInputAppliedMs}ms jitter=${opts.jitterMs}ms ` +
+    `seed=${opts.seed} drop_every=${opts.serverDropEvery} ` +
+    `duplicate_every=${opts.serverDuplicateEvery} ` +
+    `reorder_every=${opts.serverReorderEvery})`
   );
 });
 

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -1497,6 +1497,26 @@ static bool world_tow_link_capacity_allows(const world_t *w,
     return fragments + pods < ship_tow_body_capacity(ship);
 }
 
+static uint32_t world_tow_next_revision(world_t *w) {
+    if (!w) return 0;
+    w->tow_revision++;
+    if (w->tow_revision == 0) w->tow_revision++;
+    return w->tow_revision;
+}
+
+static void world_tow_link_retire(world_t *w, tow_link_t *link) {
+    if (!w || !link || !link->active) return;
+    (void)world_tow_next_revision(w);
+    memset(link, 0, sizeof(*link));
+}
+
+static void world_tow_link_set_slot(world_t *w, tow_link_t *link,
+                                    uint8_t slot) {
+    if (!w || !link || link->slot == slot) return;
+    link->slot = slot;
+    link->revision = world_tow_next_revision(w);
+}
+
 static bool world_tow_link_store(world_t *w, entity_ref_t source,
                                  entity_ref_t target, tow_profile_t profile,
                                  int slot, tow_link_state_t state) {
@@ -1517,6 +1537,16 @@ static bool world_tow_link_store(world_t *w, entity_ref_t source,
         }
     }
     if (!link) return false;
+    bool same_attachment = link->active &&
+        entity_ref_equal(link->source, source) &&
+        entity_ref_equal(link->target, target);
+    if (same_attachment && link->profile == (uint8_t)profile &&
+        link->slot == (uint8_t)slot && link->state == (uint8_t)state) {
+        return true;
+    }
+    uint32_t attached_tick =
+        same_attachment ? link->attached_tick : w->tick;
+    uint32_t revision = world_tow_next_revision(w);
     *link = (tow_link_t){
         .active = true,
         .source = source,
@@ -1524,6 +1554,8 @@ static bool world_tow_link_store(world_t *w, entity_ref_t source,
         .profile = (uint8_t)profile,
         .slot = (uint8_t)slot,
         .state = (uint8_t)state,
+        .attached_tick = attached_tick,
+        .revision = revision,
     };
     return true;
 }
@@ -1543,7 +1575,7 @@ bool world_tow_link_clear_target(world_t *w, entity_ref_t target) {
     if (!w || entity_ref_is_none(target)) return false;
     tow_link_t *link = world_tow_link_for_target(w, target);
     bool found = link != NULL;
-    if (link) memset(link, 0, sizeof(*link));
+    world_tow_link_retire(w, link);
     world_tow_rebuild_projections(w);
     return found;
 }
@@ -1554,7 +1586,7 @@ void world_tow_links_clear_source(world_t *w, entity_ref_t source) {
     for (int i = 0; i < MAX_TOW_LINKS; i++) {
         tow_link_t *link = &w->tow_links[i];
         if (link->active && entity_ref_equal(link->source, source)) {
-            memset(link, 0, sizeof(*link));
+            world_tow_link_retire(w, link);
             cleared = true;
         }
     }
@@ -1570,7 +1602,7 @@ static void world_tow_links_clear_target_slot(world_t *w,
         tow_link_t *link = &w->tow_links[i];
         if (link->active && link->target.kind == (uint8_t)kind &&
             link->target.index == index && link->target.part == part) {
-            memset(link, 0, sizeof(*link));
+            world_tow_link_retire(w, link);
         }
     }
     world_tow_rebuild_projections(w);
@@ -2115,8 +2147,10 @@ bool world_player_transfer_ship_state(world_t *w, int dst_slot, int src_slot) {
 
     for (int i = 0; i < MAX_TOW_LINKS; i++) {
         tow_link_t *link = &w->tow_links[i];
-        if (link->active && entity_ref_equal(link->source, src_ship_ref))
+        if (link->active && entity_ref_equal(link->source, src_ship_ref)) {
             link->source = dst_ship_ref;
+            link->revision = world_tow_next_revision(w);
+        }
     }
 
     src->ship_asset_id = SHIP_ASSET_ID_NONE;
@@ -2867,13 +2901,13 @@ static void world_tow_import_target_projection(world_t *w,
     if (!binding) return;
     tow_link_t *existing = world_tow_link_for_target(w, target);
     if (binding->kind == TRACTOR_SOURCE_NONE) {
-        if (existing) memset(existing, 0, sizeof(*existing));
+        world_tow_link_retire(w, existing);
         return;
     }
     entity_ref_t source = world_tow_source_ref_from_binding(w, *binding);
     tow_profile_t profile = world_tow_profile_for(source, target);
     if (entity_ref_is_none(source) || profile == TOW_PROFILE_NONE) {
-        if (existing) memset(existing, 0, sizeof(*existing));
+        world_tow_link_retire(w, existing);
         tractor_binding_clear(binding);
         return;
     }
@@ -2899,13 +2933,13 @@ static bool world_tow_project_link(world_t *w, tow_link_t *link) {
         if (!ship) return false;
         if (link->source.index >= WORLD_NPC_SHIP_BASE) {
             if (ship->towed_count > 0) return false;
-            link->slot = 0;
+            world_tow_link_set_slot(w, link, 0);
         } else {
             int cap = (int)(sizeof(ship->towed_fragments) /
                             sizeof(ship->towed_fragments[0]));
             if (ship->towed_count >= cap || ship_tow_body_space(ship) <= 0)
                 return false;
-            link->slot = ship->towed_count;
+            world_tow_link_set_slot(w, link, ship->towed_count);
         }
         ship->towed_fragments[ship->towed_count++] = link->target.index;
         break;
@@ -2915,17 +2949,17 @@ static bool world_tow_project_link(world_t *w, tow_link_t *link) {
                         sizeof(ship->towed_pods[0]));
         if (ship->towed_pod_count >= cap || ship_tow_body_space(ship) <= 0)
             return false;
-        link->slot = ship->towed_pod_count;
+        world_tow_link_set_slot(w, link, ship->towed_pod_count);
         ship->towed_pods[ship->towed_pod_count++] = link->target.index;
         break;
     }
     case TOW_PROFILE_SHIP_SCAFFOLD:
         if (!ship || ship->towed_scaffold >= 0) return false;
-        link->slot = 0;
+        world_tow_link_set_slot(w, link, 0);
         ship->towed_scaffold = link->target.index;
         break;
     case TOW_PROFILE_MODULE_POD:
-        link->slot = 0;
+        world_tow_link_set_slot(w, link, 0);
         break;
     default:
         return false;
@@ -2970,7 +3004,7 @@ static void world_tow_rebuild_projections(world_t *w) {
     for (int i = 0; i < count; i++) {
         tow_link_t *link = ordered[i];
         if (!world_tow_project_link(w, link))
-            memset(link, 0, sizeof(*link));
+            world_tow_link_retire(w, link);
     }
 }
 
@@ -2983,7 +3017,7 @@ void world_tow_links_refresh(world_t *w) {
         if (!link->active) continue;
         if (!world_tow_source_is_live(w, link->source) ||
             !world_entity_ref_is_live(w, link->target)) {
-            memset(link, 0, sizeof(*link));
+            world_tow_link_retire(w, link);
         }
     }
 

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -327,6 +327,7 @@ typedef struct {
     bool scaffold_sent[MAX_SCAFFOLDS];
     uint64_t scaffold_sent_sig[MAX_SCAFFOLDS];
     uint64_t scaffold_motion_sent_sig[MAX_SCAFFOLDS];
+    uint32_t scaffold_remove_heartbeat_tick;
     net_payload_cache_t world_cargo_pods_cache;
     net_payload_cache_t world_cargo_pod_motion_cache;
     uint64_t world_cargo_pods_semantic_hash;
@@ -335,6 +336,7 @@ typedef struct {
     uint32_t world_cargo_pod_motion_last_sent_tick;
     bool cargo_pod_sent[MAX_CARGO_PODS];
     uint64_t cargo_pod_sent_sig[MAX_CARGO_PODS];
+    uint32_t cargo_pod_remove_heartbeat_tick;
     uint32_t cargo_pod_motion_sent_tick[MAX_CARGO_PODS];
     vec2 cargo_pod_motion_sent_pos[MAX_CARGO_PODS];
     vec2 cargo_pod_motion_sent_vel[MAX_CARGO_PODS];

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -275,6 +275,9 @@ typedef struct {
     uint32_t asteroid_state_sent_tick[MAX_ASTEROIDS];
     uint32_t asteroid_state_sent_sig[MAX_ASTEROIDS];
     uint32_t asteroid_state_sent_semantic_sig[MAX_ASTEROIDS];
+    /* Tombstone heartbeat keeps relevance exits and retirements convergent
+     * even when an application-level world frame is lost. */
+    uint32_t asteroid_remove_heartbeat_tick;
     uint32_t fracture_challenge_sent_id[MAX_ASTEROIDS];
     uint32_t fracture_resolved_sent_ids[MAX_PENDING_RESOLVES];
     uint8_t fracture_resolved_sent_cursor;

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -489,10 +489,6 @@ typedef struct {
     uint64_t last_signed_nonce;
 } server_player_t;
 
-enum {
-    MAX_TOW_LINKS = 512,
-};
-
 typedef struct {
     bool active;
     uint16_t shipment_id;
@@ -666,6 +662,7 @@ typedef struct {
     /* Live tractor ownership. Target bindings and ship tow arrays are
      * compatibility projections rebuilt from this relationship pool. */
     tow_link_t tow_links[MAX_TOW_LINKS];
+    uint32_t tow_revision;
     uint16_t asteroid_generation[MAX_ASTEROIDS];
     uint16_t cargo_pod_generation[MAX_CARGO_PODS];
     uint16_t scaffold_generation[MAX_SCAFFOLDS];

--- a/server/main.c
+++ b/server/main.c
@@ -1298,6 +1298,104 @@ static void server_apply_tow_smoke_fixture(server_player_t *sp) {
            sp->id);
 }
 
+/*
+ * Keep the station-beam regression independent from player towing.  A
+ * station-owned market pod on a real dock exercises the normal module tow
+ * relation, rotating hold anchor, interaction publication, relevance filter,
+ * compact cargo motion stream, and browser beam renderer.
+ */
+static void server_apply_station_tow_smoke_fixture(server_player_t *sp) {
+    const char *enabled = getenv("SIGNAL_STATION_TOW_SMOKE_FIXTURE");
+    if (!enabled || strcmp(enabled, "1") != 0 || !sp || !sp->ship)
+        return;
+
+    const int station_idx = 0;
+    const int target_idx = MAX_CARGO_PODS - 1;
+    station_t *st = &world.stations[station_idx];
+    int module_idx = -1;
+    for (int i = 0; i < st->module_count &&
+                    i < MAX_MODULES_PER_STATION; i++) {
+        if (!st->modules[i].scaffold &&
+            st->modules[i].type == MODULE_DOCK) {
+            module_idx = i;
+            break;
+        }
+    }
+    if (module_idx < 0) return;
+
+    for (int i = 0; i < MAX_CARGO_PODS; i++) {
+        if (world.cargo_pods[i].active)
+            world_cargo_pod_clear_tractor(&world, i);
+        memset(&world.cargo_pods[i], 0, sizeof(world.cargo_pods[i]));
+        world.cargo_pod_generation_live[i] = false;
+    }
+
+    station_module_t *module = &st->modules[module_idx];
+    vec2 module_pos =
+        module_world_pos_ring(st, module->ring, module->slot);
+    vec2 outward = v2_sub(module_pos, st->pos);
+    float outward_len = v2_len(outward);
+    if (outward_len > 0.001f) {
+        outward = v2_scale(outward, 1.0f / outward_len);
+    } else {
+        outward = v2(1.0f, 0.0f);
+    }
+    const vec2 pod_pos =
+        v2_add(module_pos, v2_scale(outward, 260.0f));
+    const vec2 ship_pos =
+        v2_add(module_pos, v2_scale(outward, 360.0f));
+
+    cargo_pod_t *pod = &world.cargo_pods[target_idx];
+    *pod = (cargo_pod_t){
+        .active = true,
+        .kind = CARGO_POD_CARGO,
+        .commodity = COMMODITY_LASER_MODULE,
+        .quantity = 32,
+        .manifest_count = 32,
+        .pos = pod_pos,
+        .vel = { 0.0f, 0.0f },
+        .radius = 18.0f,
+    };
+    for (uint16_t i = 0; i < pod->manifest_count; i++) {
+        pod->manifest_units[i] = (cargo_unit_t){
+            .kind = CARGO_KIND_LASER,
+            .commodity = COMMODITY_LASER_MODULE,
+            .grade = MINING_GRADE_COMMON,
+            .prefix_class = INGOT_PREFIX_ANONYMOUS,
+            .origin_station = station_idx,
+            .quantity = 1,
+        };
+        pod->manifest_units[i].pub[0] = (uint8_t)(i + 1u);
+    }
+    cargo_pod_set_station_custody(pod, station_idx);
+    (void)world_entity_ref_for_slot(
+        &world, ENTITY_KIND_CARGO_POD, target_idx, -1);
+    if (!world_cargo_pod_set_module_tractor(
+            &world, target_idx, station_idx, module_idx)) {
+        memset(pod, 0, sizeof(*pod));
+        world.cargo_pod_generation_live[target_idx] = false;
+        return;
+    }
+
+    server_player_clear_transient_input(sp);
+    sp->session_ready = true;
+    sp->docked = false;
+    sp->docking_approach = false;
+    sp->in_dock_range = false;
+    sp->nearby_station = -1;
+    sp->dock_berth = -1;
+    sp->ship->pos = ship_pos;
+    sp->ship->vel = v2(0.0f, 0.0f);
+    sp->ship->angle = 0.0f;
+    sp->ship->hull = ship_max_hull(sp->ship);
+    sp->ship->tractor_active = false;
+    sp->replication->force_authoritative_resync = true;
+    module->active_pulse = 1.0f;
+
+    printf("[server] seeded adverse-network station tow fixture for player %d\n",
+           sp->id);
+}
+
 static void force_player_authoritative_resync(server_player_t *sp) {
     if (sp) sp->replication->force_authoritative_resync = true;
 }
@@ -3080,6 +3178,7 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
                                               reattached_live_state);
             server_player_t *ready_sp = &world.players[pid];
             server_apply_tow_smoke_fixture(ready_sp);
+            server_apply_station_tow_smoke_fixture(ready_sp);
             server_player_reset_input_stream(ready_sp);
             invalidate_player_authoritative_caches(ready_sp);
             (void)server_emit_authoritative_player_state_snapshot(

--- a/server/main.c
+++ b/server/main.c
@@ -1190,6 +1190,7 @@ static void invalidate_player_authoritative_caches(server_player_t *sp) {
            sizeof(sp->replication->scaffold_sent_sig));
     memset(sp->replication->scaffold_motion_sent_sig, 0,
            sizeof(sp->replication->scaffold_motion_sent_sig));
+    sp->replication->scaffold_remove_heartbeat_tick = 0u;
     sp->replication->world_cargo_pods_cache.valid = false;
     sp->replication->world_cargo_pod_motion_cache.valid = false;
     sp->replication->world_cargo_pods_semantic_hash = 0;
@@ -1199,6 +1200,7 @@ static void invalidate_player_authoritative_caches(server_player_t *sp) {
     memset(sp->replication->cargo_pod_sent, 0, sizeof(sp->replication->cargo_pod_sent));
     memset(sp->replication->cargo_pod_sent_sig, 0,
            sizeof(sp->replication->cargo_pod_sent_sig));
+    sp->replication->cargo_pod_remove_heartbeat_tick = 0u;
     sp->replication->world_interactions_cache.valid = false;
     sp->replication->world_interaction_drift_cache.valid = false;
     sp->replication->world_interactions_semantic_hash = 0;
@@ -1449,6 +1451,70 @@ static void server_apply_station_tow_smoke_fixture(server_player_t *sp) {
 
     printf("[server] seeded adverse-network station tow fixture for player %d\n",
            sp->id);
+}
+
+/*
+ * Move the station-fixture recipient across the normal 3000-unit relevance
+ * boundary, hold it outside long enough to lose and retry removal frames,
+ * then return it to the original observation point.  Authority and the tow
+ * relation never change; only recipient relevance does.
+ */
+static void server_tick_station_relevance_smoke_fixture(void) {
+    static bool initialized = false;
+    static bool enabled = false;
+    static bool started = false;
+    static uint32_t start_tick = 0;
+    static vec2 near_pos;
+    static vec2 far_pos;
+    static int stage = -1;
+    if (!initialized) {
+        const char *value =
+            getenv("SIGNAL_STATION_RELEVANCE_SMOKE_FIXTURE");
+        enabled = value && strcmp(value, "1") == 0;
+        initialized = true;
+    }
+    if (!enabled) return;
+
+    server_player_t *sp = NULL;
+    for (int i = 0; i < MAX_PLAYERS; i++) {
+        if (server_player_is_gameplay_ready(&world.players[i]) &&
+            world.players[i].ship && world.players[i].replication) {
+            sp = &world.players[i];
+            break;
+        }
+    }
+    if (!sp) return;
+
+    const int target_idx = MAX_CARGO_PODS - 1;
+    int station_idx = -1;
+    int module_idx = -1;
+    if (!world.cargo_pods[target_idx].active ||
+        !cargo_pod_module_tractor_indices(
+            &world.cargo_pods[target_idx], &station_idx, &module_idx)) {
+        return;
+    }
+
+    if (!started) {
+        near_pos = sp->ship->pos;
+        far_pos = v2_add(near_pos, v2(4200.0f, 0.0f));
+        start_tick = world.tick;
+        started = true;
+    }
+
+    uint32_t elapsed = world.tick - start_tick;
+    const uint32_t near_ticks = (uint32_t)(8.0f / SIM_DT);
+    const uint32_t return_ticks = (uint32_t)(18.0f / SIM_DT);
+    int next_stage = elapsed < near_ticks ? 0 :
+        (elapsed < return_ticks ? 1 : 2);
+    if (next_stage != stage) {
+        stage = next_stage;
+        server_player_clear_transient_input(sp);
+        sp->ship->vel = v2(0.0f, 0.0f);
+        printf("[server] station relevance smoke entered stage %d at tick %u\n",
+               stage, (unsigned)world.tick);
+    }
+    sp->ship->pos = stage == 1 ? far_pos : near_pos;
+    sp->ship->vel = v2(0.0f, 0.0f);
 }
 
 /*
@@ -6586,6 +6652,7 @@ static bool run_sim_ticks(float *sim_accum, float elapsed, uint64_t now) {
     while (*sim_accum >= SIM_DT && steps < MAX_SIM_STEPS) {
         world_sim_step(&world, SIM_DT);
         server_tick_tow_retirement_smoke_fixture();
+        server_tick_station_relevance_smoke_fixture();
         mark_station_identity_dirty_for_hull_inventory_changes();
         for (int p = 0; p < MAX_PLAYERS; p++) {
             const server_player_t *sp = &world.players[p];

--- a/server/main.c
+++ b/server/main.c
@@ -1396,6 +1396,113 @@ static void server_apply_station_tow_smoke_fixture(server_player_t *sp) {
            sp->id);
 }
 
+/*
+ * Exercise the NPC owner and scaffold target paths together.  The fixture
+ * starts one live NPC in its normal scaffold delivery state, so the same AI
+ * tow physics, canonical relation, compact NPC/scaffold streams, client
+ * interpolation, and remote tether renderer used by production all run.
+ */
+static void server_apply_npc_scaffold_tow_smoke_fixture(
+    server_player_t *sp) {
+    const char *enabled =
+        getenv("SIGNAL_NPC_SCAFFOLD_TOW_SMOKE_FIXTURE");
+    if (!enabled || strcmp(enabled, "1") != 0 || !sp || !sp->ship)
+        return;
+
+    int npc_idx = -1;
+    for (int i = 0; i < MAX_NPC_SHIPS; i++) {
+        if (world.npc_ships[i].active && world.npc_ships[i].ship) {
+            npc_idx = i;
+            break;
+        }
+    }
+    if (npc_idx < 0) return;
+
+    for (int i = 0; i < MAX_NPC_SHIPS; i++) {
+        if (world.npc_ships[i].active && world.npc_ships[i].ship)
+            world_tow_links_clear_source(
+                &world, world.npc_ships[i].ship_ref);
+    }
+    world_tow_links_clear_source(&world, sp->ship_ref);
+    for (int i = 0; i < MAX_SCAFFOLDS; i++) {
+        if (world.scaffolds[i].active)
+            world_scaffold_clear_tractor(&world, i);
+        memset(&world.scaffolds[i], 0, sizeof(world.scaffolds[i]));
+        world.scaffold_generation_live[i] = false;
+    }
+
+    const int station_idx = 0;
+    const int target_idx = MAX_SCAFFOLDS - 1;
+    const vec2 npc_pos =
+        v2_add(world.stations[station_idx].pos, v2(2400.0f, -1400.0f));
+    const vec2 scaffold_pos = v2_add(npc_pos, v2(110.0f, 0.0f));
+    const vec2 player_pos = v2_add(npc_pos, v2(0.0f, 180.0f));
+    const float clear_radius_sq = 450.0f * 450.0f;
+    for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        asteroid_t *a = &world.asteroids[i];
+        if (!a->active || v2_dist_sq(a->pos, npc_pos) > clear_radius_sq)
+            continue;
+        world_asteroid_clear_tractor(&world, i);
+        memset(a, 0, sizeof(*a));
+        world.asteroid_generation_live[i] = false;
+    }
+
+    scaffold_t *scaffold = &world.scaffolds[target_idx];
+    *scaffold = (scaffold_t){
+        .active = true,
+        .module_type = MODULE_FRAME_PRESS,
+        .state = SCAFFOLD_TOWING,
+        .owner = -1,
+        .pos = scaffold_pos,
+        .vel = { 0.0f, 0.0f },
+        .radius = 32.0f,
+        .spin = 0.3f,
+        .placed_station = -1,
+        .placed_ring = -1,
+        .placed_slot = -1,
+        .built_at_station = -1,
+    };
+    (void)world_entity_ref_for_slot(
+        &world, ENTITY_KIND_SCAFFOLD, target_idx, -1);
+
+    npc_ship_t *npc = &world.npc_ships[npc_idx];
+    npc->state = NPC_STATE_TRAVEL_TO_DEST;
+    npc->state_timer = 0.0f;
+    npc->home_station = station_idx;
+    npc->dest_station = station_idx;
+    npc->target_asteroid = -1;
+    npc->pickup_station = -1;
+    npc->pickup_commodity = COMMODITY_COUNT;
+    npc->brain_mode = SERVER_BRAIN_MODE_NEURAL_FLIGHT;
+    npc->ship->pos = npc_pos;
+    npc->ship->vel = v2(0.0f, 0.0f);
+    npc->ship->angle = PI_F;
+    npc->ship->hull = npc_max_hull(npc);
+    if (!world_scaffold_set_npc_tractor(
+            &world, target_idx, npc_idx)) {
+        memset(scaffold, 0, sizeof(*scaffold));
+        world.scaffold_generation_live[target_idx] = false;
+        return;
+    }
+
+    server_player_clear_transient_input(sp);
+    sp->session_ready = true;
+    sp->docked = false;
+    sp->docking_approach = false;
+    sp->in_dock_range = false;
+    sp->nearby_station = -1;
+    sp->dock_berth = -1;
+    sp->ship->pos = player_pos;
+    sp->ship->vel = v2(0.0f, 0.0f);
+    sp->ship->angle = 0.0f;
+    sp->ship->hull = ship_max_hull(sp->ship);
+    sp->ship->tractor_active = false;
+    sp->replication->force_authoritative_resync = true;
+
+    printf("[server] seeded adverse-network NPC scaffold tow fixture "
+           "for player %d with NPC %d\n", sp->id, npc_idx);
+}
+
 static void force_player_authoritative_resync(server_player_t *sp) {
     if (sp) sp->replication->force_authoritative_resync = true;
 }
@@ -3179,6 +3286,7 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
             server_player_t *ready_sp = &world.players[pid];
             server_apply_tow_smoke_fixture(ready_sp);
             server_apply_station_tow_smoke_fixture(ready_sp);
+            server_apply_npc_scaffold_tow_smoke_fixture(ready_sp);
             server_player_reset_input_stream(ready_sp);
             invalidate_player_authoritative_caches(ready_sp);
             (void)server_emit_authoritative_player_state_snapshot(

--- a/server/main.c
+++ b/server/main.c
@@ -1255,6 +1255,8 @@ static void server_apply_tow_smoke_fixture(server_player_t *sp) {
     world_asteroid_clear_tractor(&world, target_idx);
     memset(&world.asteroids[target_idx], 0,
            sizeof(world.asteroids[target_idx]));
+    memset(&world.asteroid_origin[target_idx], 0,
+           sizeof(world.asteroid_origin[target_idx]));
     world.asteroid_generation_live[target_idx] = false;
     world.asteroids[target_idx] = (asteroid_t){
         .active = true,
@@ -1296,6 +1298,59 @@ static void server_apply_tow_smoke_fixture(server_player_t *sp) {
 
     printf("[server] seeded adverse-network tow fixture for player %d\n",
            sp->id);
+}
+
+/*
+ * Retire the live tow fixture through the same authoritative target cleanup
+ * used by production consumption/despawn paths.  Waiting two simulated
+ * seconds after the canonical attach gives the adverse client enough time to
+ * observe the held relation before the target, relation, projections, and
+ * beam must disappear.
+ */
+static void server_tick_tow_retirement_smoke_fixture(void) {
+    static bool initialized = false;
+    static bool enabled = false;
+    static bool retired = false;
+    static uint32_t attached_tick = 0;
+    if (!initialized) {
+        const char *value = getenv("SIGNAL_TOW_RETIRE_SMOKE_FIXTURE");
+        enabled = value && strcmp(value, "1") == 0;
+        initialized = true;
+    }
+    if (!enabled || retired) return;
+
+    const int target_idx = MAX_ASTEROIDS - 1;
+    asteroid_t *target = &world.asteroids[target_idx];
+    if (!target->active) return;
+
+    bool attached = false;
+    for (int i = 0; i < MAX_TOW_LINKS; i++) {
+        const tow_link_t *link = &world.tow_links[i];
+        if (link->active &&
+            link->target.kind == ENTITY_KIND_ASTEROID &&
+            link->target.index == target_idx &&
+            link->target.part == -1 &&
+            link->state == TOW_LINK_HELD) {
+            attached = true;
+            break;
+        }
+    }
+    if (!attached) {
+        attached_tick = 0;
+        return;
+    }
+    if (attached_tick == 0) attached_tick = world.tick;
+    const uint32_t retire_delay_ticks = (uint32_t)(2.0f / SIM_DT);
+    if (world.tick - attached_tick < retire_delay_ticks) return;
+
+    world_asteroid_clear_tractor(&world, target_idx);
+    memset(target, 0, sizeof(*target));
+    memset(&world.asteroid_origin[target_idx], 0,
+           sizeof(world.asteroid_origin[target_idx]));
+    world.asteroid_generation_live[target_idx] = false;
+    retired = true;
+    printf("[server] retired attached adverse-network tow target at tick %u\n",
+           (unsigned)world.tick);
 }
 
 /*
@@ -1755,6 +1810,7 @@ static void send_initial_world_bundle_to_player(struct mg_connection *c,
             sp->replication->asteroid_motion_sent_vel, sp->replication->asteroid_identity_sent_sig,
             NULL, NULL, NULL,
             world.tick,
+            false,
             asteroid_net_background_identity_budget_at_tick(world.tick));
         if (sync_len > ASTEROID_MSG_HEADER)
             ws_send(c, world_snapshot_scratch.asteroids, (size_t)sync_len);
@@ -6529,6 +6585,7 @@ static bool run_sim_ticks(float *sim_accum, float elapsed, uint64_t now) {
     int steps = 0;
     while (*sim_accum >= SIM_DT && steps < MAX_SIM_STEPS) {
         world_sim_step(&world, SIM_DT);
+        server_tick_tow_retirement_smoke_fixture();
         mark_station_identity_dirty_for_hull_inventory_changes();
         for (int p = 0; p < MAX_PLAYERS; p++) {
             const server_player_t *sp = &world.players[p];

--- a/server/main.c
+++ b/server/main.c
@@ -1222,6 +1222,82 @@ static void invalidate_player_authoritative_caches(server_player_t *sp) {
     sp->replication->fracture_resolved_sent_cursor = 0;
 }
 
+/*
+ * Browser-only adverse-network fixture for #617.  The latency suite gives
+ * each run an isolated data directory and opts in explicitly, so production
+ * sessions never enter this path.  Seed the target before the first
+ * authoritative bundle: that makes attach, motion, release, and reattach use
+ * the real WebSocket/session/replication path rather than a client-side
+ * loopback mutation.
+ */
+static void server_apply_tow_smoke_fixture(server_player_t *sp) {
+    const char *enabled = getenv("SIGNAL_TOW_SMOKE_FIXTURE");
+    if (!enabled || strcmp(enabled, "1") != 0 || !sp || !sp->ship)
+        return;
+
+    const int target_idx = MAX_ASTEROIDS - 1;
+    const vec2 ship_pos = { 2400.0f, -2400.0f };
+    const vec2 target_pos = { ship_pos.x - 90.0f, ship_pos.y };
+    const float clear_radius_sq = 400.0f * 400.0f;
+
+    world_tow_links_clear_source(&world, sp->ship_ref);
+    for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        asteroid_t *a = &world.asteroids[i];
+        if (!a->active || i == target_idx ||
+            v2_dist_sq(a->pos, ship_pos) > clear_radius_sq) {
+            continue;
+        }
+        world_asteroid_clear_tractor(&world, i);
+        memset(a, 0, sizeof(*a));
+        world.asteroid_generation_live[i] = false;
+    }
+
+    world_asteroid_clear_tractor(&world, target_idx);
+    memset(&world.asteroids[target_idx], 0,
+           sizeof(world.asteroids[target_idx]));
+    world.asteroid_generation_live[target_idx] = false;
+    world.asteroids[target_idx] = (asteroid_t){
+        .active = true,
+        .fracture_child = true,
+        .tier = ASTEROID_TIER_S,
+        .commodity = COMMODITY_FERRITE_ORE,
+        .pos = target_pos,
+        .vel = { 0.0f, 0.0f },
+        .hp = 8.0f,
+        .max_hp = 8.0f,
+        .ore = 3.0f,
+        .max_ore = 3.0f,
+        .radius = 14.0f,
+        .grade = MINING_GRADE_COMMON,
+        .net_dirty = true,
+    };
+    (void)world_entity_ref_for_slot(
+        &world, ENTITY_KIND_ASTEROID, target_idx, -1);
+
+    server_player_clear_transient_input(sp);
+    sp->session_ready = true;
+    sp->docked = false;
+    sp->docking_approach = false;
+    sp->in_dock_range = false;
+    sp->nearby_station = -1;
+    sp->dock_berth = -1;
+    sp->ship->pos = ship_pos;
+    sp->ship->vel = v2(0.0f, 0.0f);
+    sp->ship->angle = 0.0f;
+    sp->ship->hull = ship_max_hull(sp->ship);
+    sp->ship->tractor_active = false;
+    sp->ship->towed_count = 0;
+    sp->ship->towed_pod_count = 0;
+    sp->ship->towed_scaffold = -1;
+    memset(sp->ship->towed_fragments, -1,
+           sizeof(sp->ship->towed_fragments));
+    memset(sp->ship->towed_pods, -1, sizeof(sp->ship->towed_pods));
+    sp->replication->force_authoritative_resync = true;
+
+    printf("[server] seeded adverse-network tow fixture for player %d\n",
+           sp->id);
+}
+
 static void force_player_authoritative_resync(server_player_t *sp) {
     if (sp) sp->replication->force_authoritative_resync = true;
 }
@@ -3003,6 +3079,7 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
             finalize_verified_pubkey_identity(c, pid, now,
                                               reattached_live_state);
             server_player_t *ready_sp = &world.players[pid];
+            server_apply_tow_smoke_fixture(ready_sp);
             server_player_reset_input_stream(ready_sp);
             invalidate_player_authoritative_caches(ready_sp);
             (void)server_emit_authoritative_player_state_snapshot(

--- a/server/net_protocol.h
+++ b/server/net_protocol.h
@@ -1585,6 +1585,7 @@ static inline bool world_players_semantic_heartbeat_due(uint64_t last_sent_ms,
 #define ASTEROID_NET_VERY_FAR_MOVING_REPEAT_TICKS 360u /* 0.33 Hz for fast edge-of-view drift */
 #define ASTEROID_NET_VERY_FAR_SLOW_MOVING_REPEAT_TICKS 1200u /* 0.1 Hz ordinary edge drift */
 #define ASTEROID_NET_MOTION_HEARTBEAT_TICKS 240u /* 0.5 Hz safety refresh */
+#define ASTEROID_REMOVE_HEARTBEAT_TICKS 120u /* 1 Hz tombstone reconciliation */
 #define ASTEROID_NET_CRAWL_MOTION_HEARTBEAT_TICKS 4800u /* 0.025 Hz crawl safety refresh */
 #define ASTEROID_NET_SLOW_MOTION_HEARTBEAT_TICKS 720u /* 0.17 Hz slow near safety refresh */
 #define ASTEROID_NET_FAR_MOTION_HEARTBEAT_TICKS 720u /* 0.17 Hz far-field safety refresh */
@@ -1985,6 +1986,7 @@ static inline void server_player_invalidate_asteroid_stream_caches(
            sizeof(sp->replication->asteroid_state_sent_sig));
     memset(sp->replication->asteroid_state_sent_semantic_sig, 0,
            sizeof(sp->replication->asteroid_state_sent_semantic_sig));
+    sp->replication->asteroid_remove_heartbeat_tick = 0u;
 }
 
 static inline bool asteroid_net_motion_should_send(
@@ -2084,6 +2086,7 @@ static inline int serialize_asteroids_for_player_split_ext_state_budget_at_tick(
     uint32_t *state_sent_tick,
     uint32_t *state_sent_sig, uint32_t *state_sent_semantic_sig,
     uint32_t server_tick,
+    bool removal_heartbeat,
     int background_identity_budget) {
     int count = 0;
     int asteroids_q_count = 0;
@@ -2331,21 +2334,31 @@ static inline int serialize_asteroids_for_player_split_ext_state_budget_at_tick(
                 a, i, state_sent_tick, state_sent_sig,
                 state_sent_semantic_sig, server_tick);
         } else if (sent[i] && !in_view) {
-            if (remove_buf) {
-                uint8_t *p = &remove_buf[
-                    ASTEROID_REMOVE_MSG_HEADER +
-                    remove_count * ASTEROID_REMOVE_RECORD_SIZE];
-                write_u16_le(p, (uint16_t)i);
-                remove_count++;
-            } else {
-                uint8_t *p = &buf[
-                    ASTEROID_MSG_HEADER + count * ASTEROID_RECORD_SIZE];
-                memset(p, 0, ASTEROID_RECORD_SIZE);
-                write_u16_le(&p[0], (uint16_t)i);
-                p[2] = 0; /* active = false */
-                count++;
+            bool durable_tombstone = identity_sent_sig != NULL;
+            bool first_removal = !durable_tombstone ||
+                identity_sent_sig[i] != 0u;
+            if (first_removal || removal_heartbeat) {
+                if (remove_buf) {
+                    uint8_t *p = &remove_buf[
+                        ASTEROID_REMOVE_MSG_HEADER +
+                        remove_count * ASTEROID_REMOVE_RECORD_SIZE];
+                    write_u16_le(p, (uint16_t)i);
+                    remove_count++;
+                } else {
+                    uint8_t *p = &buf[
+                        ASTEROID_MSG_HEADER + count * ASTEROID_RECORD_SIZE];
+                    memset(p, 0, ASTEROID_RECORD_SIZE);
+                    write_u16_le(&p[0], (uint16_t)i);
+                    p[2] = 0; /* active = false */
+                    count++;
+                }
             }
-            sent[i] = false;
+            /* With identity signatures, retain knowledge that this client
+             * may still own the slot and periodically reconcile the
+             * tombstone. A zero signature forces a full identity upsert if
+             * the slot becomes relevant again. Compatibility callers without
+             * signatures keep the historical one-shot sent bit behavior. */
+            sent[i] = durable_tombstone;
             if (motion_sent_tick) {
                 motion_sent_tick[i] = 0u;
                 if (motion_sent_pos) motion_sent_pos[i] = v2(0.0f, 0.0f);
@@ -2469,7 +2482,7 @@ static inline int serialize_asteroids_for_player_split_ext_state_at_tick(
         state_q_buf, state_q_len_out, remove_buf, remove_len_out,
         asteroids, player_pos, sent, motion_sent_tick, motion_sent_pos,
         motion_sent_vel, NULL, state_sent_tick, state_sent_sig,
-        state_sent_semantic_sig, server_tick, -1);
+        state_sent_semantic_sig, server_tick, false, -1);
 }
 
 static inline int serialize_asteroids_for_player_split_ext_at_tick(
@@ -5900,6 +5913,11 @@ static inline void server_emit_world_snapshot_for_player(
         int background_identity_budget =
             asteroid_net_background_identity_budget_at_tick_for_players(
                 w->tick, server_live_asteroid_recipient_count(w));
+        uint32_t last_remove_heartbeat =
+            sp->replication->asteroid_remove_heartbeat_tick;
+        bool removal_heartbeat = last_remove_heartbeat == 0u ||
+            (uint32_t)(w->tick - last_remove_heartbeat) >=
+                ASTEROID_REMOVE_HEARTBEAT_TICKS;
         server_prioritize_towed_asteroid_streams(sp, w->asteroids, w->tick);
         int alen = serialize_asteroids_for_player_split_ext_state_budget_at_tick(
             scratch->asteroids,
@@ -5918,7 +5936,10 @@ static inline void server_emit_world_snapshot_for_player(
             sp->replication->asteroid_motion_sent_vel, sp->replication->asteroid_identity_sent_sig,
             sp->replication->asteroid_state_sent_tick,
             sp->replication->asteroid_state_sent_sig, sp->replication->asteroid_state_sent_semantic_sig,
-            w->tick, background_identity_budget);
+            w->tick, removal_heartbeat, background_identity_budget);
+        if (removal_heartbeat)
+            sp->replication->asteroid_remove_heartbeat_tick =
+                w->tick != 0u ? w->tick : 1u;
         if (alen > ASTEROID_MSG_HEADER)
             send(send_user, scratch->asteroids, alen);
         if (asteroids8_q_len > ASTEROID8_Q_MSG_HEADER)

--- a/server/net_protocol.h
+++ b/server/net_protocol.h
@@ -153,6 +153,7 @@ static inline bool net_msg_is_deferable_snapshot(uint8_t msg) {
     case NET_MSG_WORLD_INTERACTIONS:
     case NET_MSG_WORLD_INTERACTIONS_Q:
     case NET_MSG_WORLD_INTERACTION_DRIFT:
+    case NET_MSG_WORLD_TOW_LINKS:
         return true;
     default:
         return false;
@@ -660,6 +661,10 @@ static inline int serialize_protocol_info(uint8_t *buf,
                         INTERACTION_DRIFT_MSG_HEADER,
                         INTERACTION_DRIFT_RECORD_SIZE, SIM_MAX_INTERACTIONS,
                         world_tick_ms);
+    ADD_PROTOCOL_STREAM(NET_MSG_WORLD_TOW_LINKS, PROTOCOL_STREAM_CLASS_AUTH,
+                        PROTOCOL_STREAM_FLAG_SERVER_TO_CLIENT,
+                        TOW_LINKS_MSG_HEADER_SIZE, TOW_LINK_RECORD_SIZE,
+                        MAX_TOW_LINKS, world_tick_ms);
     ADD_PROTOCOL_STREAM(NET_MSG_PLAYER_SHIP, PROTOCOL_STREAM_CLASS_PLAYER,
                         PROTOCOL_STREAM_FLAG_SERVER_TO_CLIENT |
                         PROTOCOL_STREAM_FLAG_PER_PLAYER,
@@ -5497,6 +5502,38 @@ static inline int serialize_interaction_drift_for_player(
            count * INTERACTION_DRIFT_RECORD_SIZE;
 }
 
+static inline void serialize_entity_ref(uint8_t *buf, entity_ref_t ref) {
+    buf[0] = ref.kind;
+    write_u16_le(&buf[1], (uint16_t)ref.index);
+    write_u16_le(&buf[3], (uint16_t)ref.part);
+    write_u16_le(&buf[5], ref.generation);
+}
+
+static inline int serialize_tow_links(uint8_t *buf, const world_t *w) {
+    if (!buf || !w) return 0;
+    int count = 0;
+    for (int i = 0; i < MAX_TOW_LINKS; i++) {
+        const tow_link_t *link = &w->tow_links[i];
+        if (!link->active) continue;
+        uint8_t *record = &buf[TOW_LINKS_MSG_HEADER_SIZE +
+                               count * TOW_LINK_RECORD_SIZE];
+        serialize_entity_ref(&record[0], link->source);
+        serialize_entity_ref(&record[7], link->target);
+        record[14] = link->profile;
+        record[15] = link->slot;
+        record[16] = link->state;
+        record[17] = 0;
+        write_u32_le(&record[18], link->attached_tick);
+        write_u32_le(&record[22], link->revision);
+        count++;
+    }
+    buf[0] = NET_MSG_WORLD_TOW_LINKS;
+    write_u16_le(&buf[1], (uint16_t)count);
+    write_u32_le(&buf[3], w->tow_revision);
+    write_u32_le(&buf[7], w->tick);
+    return TOW_LINKS_MSG_HEADER_SIZE + count * TOW_LINK_RECORD_SIZE;
+}
+
 static inline uint64_t net_world_interactions_semantic_hash(const uint8_t *data,
                                                             int len) {
     if (!data || len <= 0) return 0;
@@ -5820,6 +5857,7 @@ typedef struct {
     uint8_t interactions_q[2 + SIM_MAX_INTERACTIONS * INTERACTION_Q_RECORD_SIZE];
     uint8_t interaction_drift[INTERACTION_DRIFT_MSG_HEADER +
                               SIM_MAX_INTERACTIONS * INTERACTION_DRIFT_RECORD_SIZE];
+    uint8_t tow_links[TOW_LINKS_MAX_SIZE];
     uint8_t world_time[5];
 } server_world_snapshot_scratch_t;
 
@@ -5976,6 +6014,10 @@ static inline void server_emit_world_snapshot_for_player(
         if (idrift_len > INTERACTION_DRIFT_MSG_HEADER)
             send(send_user, scratch->interaction_drift, idrift_len);
     }
+
+    int tow_len = serialize_tow_links(scratch->tow_links, w);
+    if (tow_len >= TOW_LINKS_MSG_HEADER_SIZE)
+        send(send_user, scratch->tow_links, tow_len);
 
     if (!sp->replication->world_time_sent ||
         (uint32_t)(w->tick - sp->replication->world_time_last_sent_tick) >=

--- a/server/net_protocol.h
+++ b/server/net_protocol.h
@@ -1585,7 +1585,7 @@ static inline bool world_players_semantic_heartbeat_due(uint64_t last_sent_ms,
 #define ASTEROID_NET_VERY_FAR_MOVING_REPEAT_TICKS 360u /* 0.33 Hz for fast edge-of-view drift */
 #define ASTEROID_NET_VERY_FAR_SLOW_MOVING_REPEAT_TICKS 1200u /* 0.1 Hz ordinary edge drift */
 #define ASTEROID_NET_MOTION_HEARTBEAT_TICKS 240u /* 0.5 Hz safety refresh */
-#define ASTEROID_REMOVE_HEARTBEAT_TICKS 120u /* 1 Hz tombstone reconciliation */
+#define WORLD_REMOVE_TOMBSTONE_HEARTBEAT_TICKS 120u /* 1 Hz reconciliation */
 #define ASTEROID_NET_CRAWL_MOTION_HEARTBEAT_TICKS 4800u /* 0.025 Hz crawl safety refresh */
 #define ASTEROID_NET_SLOW_MOTION_HEARTBEAT_TICKS 720u /* 0.17 Hz slow near safety refresh */
 #define ASTEROID_NET_FAR_MOTION_HEARTBEAT_TICKS 720u /* 0.17 Hz far-field safety refresh */
@@ -4674,7 +4674,8 @@ static inline int serialize_scaffolds_for_player_delta(
     vec2 player_pos,
     bool *sent,
     uint64_t *sent_sig,
-    uint64_t *motion_sent_sig) {
+    uint64_t *motion_sent_sig,
+    bool removal_heartbeat) {
     int count = 0;
     int remove_count = 0;
     if (remove_len_out) *remove_len_out = 0;
@@ -4696,13 +4697,14 @@ static inline int serialize_scaffolds_for_player_delta(
                     motion_sent_sig[i] = scaffold_motion_q_sig(i, sc);
             }
         } else if (sent[i]) {
-            if (remove_buf) {
+            if ((sent_sig[i] != 0u || removal_heartbeat) && remove_buf) {
                 remove_buf[SCAFFOLD_REMOVE_MSG_HEADER +
                            remove_count * SCAFFOLD_REMOVE_RECORD_SIZE] =
                     (uint8_t)i;
                 remove_count++;
             }
-            sent[i] = false;
+            /* Retain a tombstone until a full relevance re-entry upsert. */
+            sent[i] = true;
             sent_sig[i] = 0;
             if (motion_sent_sig) motion_sent_sig[i] = 0;
         }
@@ -4930,7 +4932,8 @@ static inline int serialize_cargo_pods_for_player_delta(
     vec2 player_pos,
     bool *sent,
     uint64_t *sent_sig,
-    bool refresh_all_known) {
+    bool refresh_all_known,
+    bool removal_heartbeat) {
     int count = 0;
     int remove_count = 0;
     if (remove_len_out) *remove_len_out = 0;
@@ -4950,13 +4953,14 @@ static inline int serialize_cargo_pods_for_player_delta(
                 sent_sig[i] = sig;
             }
         } else if (sent[i]) {
-            if (remove_buf) {
+            if ((sent_sig[i] != 0u || removal_heartbeat) && remove_buf) {
                 remove_buf[CARGO_POD_REMOVE_MSG_HEADER +
                            remove_count * CARGO_POD_REMOVE_RECORD_SIZE] =
                     (uint8_t)i;
                 remove_count++;
             }
-            sent[i] = false;
+            /* Retain a tombstone until a full relevance re-entry upsert. */
+            sent[i] = true;
             sent_sig[i] = 0;
         }
     }
@@ -4982,7 +4986,8 @@ static inline int serialize_cargo_pods_q_for_player_delta(
     vec2 player_pos,
     bool *sent,
     uint64_t *sent_sig,
-    bool refresh_all_known) {
+    bool refresh_all_known,
+    bool removal_heartbeat) {
     int count = 0;
     int remove_count = 0;
     if (remove_len_out) *remove_len_out = 0;
@@ -5002,13 +5007,14 @@ static inline int serialize_cargo_pods_q_for_player_delta(
                 sent_sig[i] = sig;
             }
         } else if (sent[i]) {
-            if (remove_buf) {
+            if ((sent_sig[i] != 0u || removal_heartbeat) && remove_buf) {
                 remove_buf[CARGO_POD_REMOVE_MSG_HEADER +
                            remove_count * CARGO_POD_REMOVE_RECORD_SIZE] =
                     (uint8_t)i;
                 remove_count++;
             }
-            sent[i] = false;
+            /* Retain a tombstone until a full relevance re-entry upsert. */
+            sent[i] = true;
             sent_sig[i] = 0;
         }
     }
@@ -5917,7 +5923,7 @@ static inline void server_emit_world_snapshot_for_player(
             sp->replication->asteroid_remove_heartbeat_tick;
         bool removal_heartbeat = last_remove_heartbeat == 0u ||
             (uint32_t)(w->tick - last_remove_heartbeat) >=
-                ASTEROID_REMOVE_HEARTBEAT_TICKS;
+                WORLD_REMOVE_TOMBSTONE_HEARTBEAT_TICKS;
         server_prioritize_towed_asteroid_streams(sp, w->asteroids, w->tick);
         int alen = serialize_asteroids_for_player_split_ext_state_budget_at_tick(
             scratch->asteroids,
@@ -5991,11 +5997,21 @@ static inline void server_emit_world_snapshot_for_player(
     }
 
     int scaffold_remove_len = 0;
+    uint32_t last_scaffold_remove_heartbeat =
+        sp->replication->scaffold_remove_heartbeat_tick;
+    bool scaffold_remove_heartbeat =
+        last_scaffold_remove_heartbeat == 0u ||
+        (uint32_t)(w->tick - last_scaffold_remove_heartbeat) >=
+            WORLD_REMOVE_TOMBSTONE_HEARTBEAT_TICKS;
     int slen = serialize_scaffolds_for_player_delta(
         scratch->scaffolds, scratch->scaffold_remove, &scaffold_remove_len,
         w->scaffolds, sp->ship->pos, sp->replication->scaffold_sent,
         sp->replication->scaffold_sent_sig,
-        sp->replication->scaffold_motion_sent_sig);
+        sp->replication->scaffold_motion_sent_sig,
+        scaffold_remove_heartbeat);
+    if (scaffold_remove_heartbeat)
+        sp->replication->scaffold_remove_heartbeat_tick =
+            w->tick != 0u ? w->tick : 1u;
     if (slen > 2)
         send(send_user, scratch->scaffolds, slen);
     if (scaffold_remove_len > SCAFFOLD_REMOVE_MSG_HEADER)
@@ -6009,12 +6025,22 @@ static inline void server_emit_world_snapshot_for_player(
     }
 
     int cargo_remove_len = 0;
+    uint32_t last_cargo_remove_heartbeat =
+        sp->replication->cargo_pod_remove_heartbeat_tick;
+    bool cargo_remove_heartbeat =
+        last_cargo_remove_heartbeat == 0u ||
+        (uint32_t)(w->tick - last_cargo_remove_heartbeat) >=
+            WORLD_REMOVE_TOMBSTONE_HEARTBEAT_TICKS;
     bool cargo_refresh_due = cargo_pod_net_metadata_refresh_due(
         sp->replication->world_cargo_pods_last_sent_tick, w->tick);
     int clen = serialize_cargo_pods_q_for_player_delta(
         scratch->cargo_pods_q, scratch->cargo_pod_remove, &cargo_remove_len,
         w->cargo_pods, sp->ship->pos, sp->replication->cargo_pod_sent,
-        sp->replication->cargo_pod_sent_sig, cargo_refresh_due);
+        sp->replication->cargo_pod_sent_sig, cargo_refresh_due,
+        cargo_remove_heartbeat);
+    if (cargo_remove_heartbeat)
+        sp->replication->cargo_pod_remove_heartbeat_tick =
+            w->tick != 0u ? w->tick : 1u;
     if (clen > 2)
         send(send_user, scratch->cargo_pods_q, clen);
     if (cargo_remove_len > CARGO_POD_REMOVE_MSG_HEADER)

--- a/shared/protocol.h
+++ b/shared/protocol.h
@@ -363,6 +363,18 @@ enum {
                                             * This is the private wire mirror of
                                             * KNOW_MARKET items only; authoritative
                                             * contracts retain their visibility mask. */
+    NET_MSG_WORLD_TOW_LINKS        = 0x70, /* server -> client. Atomic replacement
+                                            * snapshot of canonical live towing
+                                            * relationships.
+                                            *
+                                            *   [type:1][count:u16]
+                                            *   [revision:u32][server_tick:u32]
+                                            *     count x TOW_LINK_RECORD_SIZE
+                                            *
+                                            * Legacy ship/target tow fields remain
+                                            * compatibility projections. Clients that
+                                            * understand this stream rebuild those
+                                            * projections only from this snapshot. */
     NET_MSG_WORLD_ASTEROID_MOTION  = 0x4B, /* server -> client. Compact live asteroid
                                             * motion correction for already-known clean
                                             * rocks.
@@ -1501,6 +1513,15 @@ _Static_assert(NET_ACTION_COMMISSION_SHIP + HULL_CLASS_COUNT <= 256,
 #define PLAYER_DOCK_MSG_HEADER 2  /* type + count */
 #define PLAYER_DOCK_RECORD_SIZE 2 /* id + compact status flags byte */
 #define PLAYER_DOCK_STATUS_FLAGS_MASK 0x05u /* thrusting + docked */
+
+/* Canonical tow relationship snapshot. Each entity reference is encoded as
+ * [kind:u8][index:i16][part:i16][generation:u16]. The record then carries
+ * [profile:u8][slot:u8][state:u8][reserved:u8]
+ * [attached_tick:u32][revision:u32]. */
+#define TOW_LINKS_MSG_HEADER_SIZE 11
+#define TOW_LINK_RECORD_SIZE 26
+#define TOW_LINKS_MAX_SIZE \
+    (TOW_LINKS_MSG_HEADER_SIZE + MAX_TOW_LINKS * TOW_LINK_RECORD_SIZE)
 
 /* Asteroid record: [index:2][flags:1][pos:2xf32][vel:2xf32][hp:f32][ore:f32][radius:f32]
  * [smelt:u8][grade:u8][crystal_stage:u8][phase:u8] */

--- a/shared/types.h
+++ b/shared/types.h
@@ -38,6 +38,7 @@ enum {
     MAX_NPC_SHIPS = 100,  /* uint8 index — see banner above (#285 to lift) */
     MAX_SCAFFOLDS = 16,  /* uint8 index — see banner above (#285 to lift) */
     MAX_CARGO_PODS = 64, /* uint8 wire index; towable engine-less cargo bodies */
+    MAX_TOW_LINKS = 512, /* canonical live source -> towable relationships */
     CARGO_POD_MANIFEST_CAP = 200, /* one rich ore fragment can become one full smelt pod */
     CARGO_POD_UNIT_CAPACITY = CELL_HEX_PAYLOAD_CAPACITY,
     AUDIO_VOICE_COUNT = 24,
@@ -86,6 +87,8 @@ typedef struct {
     uint8_t slot;       /* source-local formation/hold slot */
     uint8_t state;      /* tow_link_state_t */
     uint8_t _pad;
+    uint32_t attached_tick;
+    uint32_t revision;
 } tow_link_t;
 
 static inline entity_ref_t entity_ref_none(void) {

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -134,6 +134,32 @@ type LiveStationTowSnapshot = {
   elapsed: number;
 };
 
+type LiveNpcScaffoldTowSnapshot = {
+  sampledAt: number;
+  targetActive: number;
+  targetInterpActive: number;
+  towSnapshotReceived: number;
+  npc: number;
+  interpNpc: number;
+  npcActive: number;
+  interpNpcActive: number;
+  targetLinks: number;
+  npcTargetLinks: number;
+  npcTowedScaffold: number;
+  interpNpcTowedScaffold: number;
+  towRevision: number;
+  snapshotRevision: number;
+  linkRevision: number;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  npcX: number;
+  npcY: number;
+  elapsed: number;
+  npcElapsed: number;
+};
+
 function addQueryParam(rawUrl: string, key: string, value: string): string {
   const hashAt = rawUrl.indexOf('#');
   const beforeHash = hashAt >= 0 ? rawUrl.slice(0, hashAt) : rawUrl;
@@ -634,6 +660,36 @@ async function liveStationTowSnapshot(page: Page): Promise<LiveStationTowSnapsho
   });
 }
 
+async function liveNpcScaffoldTowSnapshot(
+  page: Page,
+): Promise<LiveNpcScaffoldTowSnapshot> {
+  return page.evaluate(() => {
+    const mod = (window as unknown as {
+      Module?: {
+        ccall?: (
+          name: string,
+          returnType: string,
+          argTypes: unknown[],
+          args: unknown[],
+        ) => string;
+      };
+    }).Module;
+    if (!mod || typeof mod.ccall !== 'function') {
+      throw new Error('WASM ccall unavailable for live NPC scaffold telemetry');
+    }
+    const raw = mod.ccall(
+      'signal_smoke_live_npc_scaffold_tow_summary',
+      'string',
+      [],
+      [],
+    );
+    return {
+      ...(JSON.parse(raw) as Omit<LiveNpcScaffoldTowSnapshot, 'sampledAt'>),
+      sampledAt: performance.now(),
+    };
+  });
+}
+
 function liveTowIsAttached(snapshot: LiveTowSnapshot): boolean {
   return snapshot.targetLinks === 1 &&
     snapshot.localTargetLinks === 1 &&
@@ -656,6 +712,22 @@ function liveStationTowIsBound(snapshot: LiveStationTowSnapshot): boolean {
     snapshot.targetLinks === 1 &&
     snapshot.moduleTargetLinks === 1 &&
     snapshot.interactionMatches === 1;
+}
+
+function liveNpcScaffoldTowIsBound(
+  snapshot: LiveNpcScaffoldTowSnapshot,
+): boolean {
+  return snapshot.targetActive === 1 &&
+    snapshot.targetInterpActive === 1 &&
+    snapshot.towSnapshotReceived === 1 &&
+    snapshot.npc >= 0 &&
+    snapshot.interpNpc === snapshot.npc &&
+    snapshot.npcActive === 1 &&
+    snapshot.interpNpcActive === 1 &&
+    snapshot.targetLinks === 1 &&
+    snapshot.npcTargetLinks === 1 &&
+    snapshot.npcTowedScaffold >= 0 &&
+    snapshot.interpNpcTowedScaffold === snapshot.npcTowedScaffold;
 }
 
 function liveTowIsReleased(snapshot: LiveTowSnapshot): boolean {
@@ -2610,6 +2682,164 @@ test.describe('Browser smoke tests', () => {
     expect(maxElapsed).toBeLessThanOrEqual(0.5);
     expect(maxBeamSourceStep).toBeLessThanOrEqual(4);
     expect(maxSpanJump).toBeLessThanOrEqual(15);
+
+    expectNoFatalErrors(logs, { allowExpectedLiveClose: true });
+  });
+
+  test('NPC scaffold tow stays visible and smooth through adverse network faults', async ({ page }) => {
+    test.skip(
+      !process.env.SMOKE_NPC_SCAFFOLD_TOW_ADVERSE_ASSERT,
+      'set SMOKE_NPC_SCAFFOLD_TOW_ADVERSE_ASSERT=1 with the NPC scaffold fixture and adverse proxy',
+    );
+    test.setTimeout(80_000);
+
+    const logs = installFatalCollectors(page);
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await loadGame(page, true);
+
+    await expect
+      .poll(async () => liveNpcScaffoldTowIsBound(
+        await liveNpcScaffoldTowSnapshot(page),
+      ), {
+        timeout: 15_000,
+        message: 'the NPC-owned scaffold should converge on one canonical relation and both source/target projections',
+      })
+      .toBe(true);
+    await expect
+      .poll(async () => (await tractorDrawTelemetry(page, 0)).count, {
+        timeout: 5_000,
+        message: 'the authoritative NPC-scaffold relation should render one tether',
+      })
+      .toBe(1);
+    const initialBeam = await tractorDrawTelemetry(page, 0);
+    expect(initialBeam.sourceType).toBe(3);
+    expect(initialBeam.targetType).toBe(5);
+    expect(initialBeam.span).toBeGreaterThan(20);
+    expect(initialBeam.intensity).toBeGreaterThan(0);
+
+    const samples: LiveNpcScaffoldTowSnapshot[] = [];
+    const beams: TractorDrawTelemetry[] = [];
+    for (let i = 0; i < 60; i++) {
+      samples.push(await liveNpcScaffoldTowSnapshot(page));
+      beams.push(await tractorDrawTelemetry(page, 0));
+      await page.waitForTimeout(50);
+    }
+
+    const nonAtomic = samples.find(
+      (sample) => !liveNpcScaffoldTowIsBound(sample),
+    );
+    expect(
+      nonAtomic,
+      `NPC-scaffold tow relation or projection disappeared: ${JSON.stringify(nonAtomic)}`,
+    ).toBeUndefined();
+    const missingBeam = beams.find(
+      (beam) => beam.count !== 1 || beam.sourceType !== 3 ||
+        beam.targetType !== 5 || beam.intensity <= 0,
+    );
+    expect(
+      missingBeam,
+      `NPC-scaffold tether disappeared or changed identity: ${JSON.stringify(missingBeam)}`,
+    ).toBeUndefined();
+
+    let pathLength = 0;
+    let npcPathLength = 0;
+    let maxStep = 0;
+    let maxResidual = 0;
+    let maxVelocityJump = 0;
+    let maxJerk = 0;
+    let maxElapsed = 0;
+    let maxNpcElapsed = 0;
+    let maxNpcStep = 0;
+    let maxBeamSourceStep = 0;
+    let maxSpanJump = 0;
+    let maxTowDistance = 0;
+    let maxBeamSourceError = 0;
+    let maxBeamTargetError = 0;
+    for (let i = 0; i < samples.length; i++) {
+      const sample = samples[i];
+      const beam = beams[i];
+      maxElapsed = Math.max(maxElapsed, sample.elapsed);
+      maxNpcElapsed = Math.max(maxNpcElapsed, sample.npcElapsed);
+      maxTowDistance = Math.max(
+        maxTowDistance,
+        Math.hypot(sample.x - sample.npcX, sample.y - sample.npcY),
+      );
+      maxBeamSourceError = Math.max(
+        maxBeamSourceError,
+        Math.hypot(beam.sourceX - sample.npcX, beam.sourceY - sample.npcY),
+      );
+      maxBeamTargetError = Math.max(
+        maxBeamTargetError,
+        Math.hypot(beam.targetX - sample.x, beam.targetY - sample.y),
+      );
+      if (i === 0) continue;
+      const previous = samples[i - 1];
+      const previousBeam = beams[i - 1];
+      const dt = Math.max(0.001, (sample.sampledAt - previous.sampledAt) / 1000);
+      const step = Math.hypot(sample.x - previous.x, sample.y - previous.y);
+      const npcStep = Math.hypot(
+        sample.npcX - previous.npcX,
+        sample.npcY - previous.npcY,
+      );
+      const speed = Math.hypot(sample.vx, sample.vy);
+      const previousSpeed = Math.hypot(previous.vx, previous.vy);
+      const residual = Math.abs(step - (previousSpeed + speed) * 0.5 * dt);
+      const velocityJump = Math.hypot(sample.vx - previous.vx, sample.vy - previous.vy);
+      const sourceStep = Math.hypot(
+        beam.sourceX - previousBeam.sourceX,
+        beam.sourceY - previousBeam.sourceY,
+      );
+      pathLength += step;
+      npcPathLength += npcStep;
+      maxStep = Math.max(maxStep, step);
+      maxResidual = Math.max(maxResidual, residual);
+      maxVelocityJump = Math.max(maxVelocityJump, velocityJump);
+      maxJerk = Math.max(maxJerk, velocityJump / dt);
+      maxNpcStep = Math.max(maxNpcStep, npcStep);
+      maxBeamSourceStep = Math.max(maxBeamSourceStep, sourceStep);
+      maxSpanJump = Math.max(maxSpanJump, Math.abs(beam.span - previousBeam.span));
+    }
+    const firstSample = samples[0];
+    const lastSample = samples[samples.length - 1];
+    const displacement = Math.hypot(
+      lastSample.x - firstSample.x,
+      lastSample.y - firstSample.y,
+    );
+    const motion = {
+      samples: samples.length,
+      pathLength,
+      displacement,
+      npcPathLength,
+      maxStep,
+      maxResidual,
+      maxVelocityJump,
+      maxJerk,
+      maxElapsed,
+      maxNpcElapsed,
+      maxNpcStep,
+      maxBeamSourceStep,
+      maxSpanJump,
+      maxTowDistance,
+      maxBeamSourceError,
+      maxBeamTargetError,
+    };
+    console.log(`[npc-scaffold-tow-adverse] ${JSON.stringify(motion)}`);
+
+    expect(pathLength).toBeGreaterThan(25);
+    expect(displacement).toBeGreaterThan(20);
+    expect(npcPathLength).toBeGreaterThan(40);
+    expect(maxStep).toBeLessThanOrEqual(12);
+    expect(maxResidual).toBeLessThanOrEqual(6);
+    expect(maxVelocityJump).toBeLessThanOrEqual(30);
+    expect(maxJerk).toBeLessThanOrEqual(500);
+    expect(maxElapsed).toBeLessThanOrEqual(0.6);
+    expect(maxNpcElapsed).toBeLessThanOrEqual(2.2);
+    expect(maxNpcStep).toBeLessThanOrEqual(18);
+    expect(maxBeamSourceStep).toBeLessThanOrEqual(18);
+    expect(maxSpanJump).toBeLessThanOrEqual(18);
+    expect(maxTowDistance).toBeLessThan(150);
+    expect(maxBeamSourceError).toBeLessThanOrEqual(6);
+    expect(maxBeamTargetError).toBeLessThanOrEqual(4);
 
     expectNoFatalErrors(logs, { allowExpectedLiveClose: true });
   });

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -714,6 +714,21 @@ function liveStationTowIsBound(snapshot: LiveStationTowSnapshot): boolean {
     snapshot.interactionMatches === 1;
 }
 
+function liveStationTowIsOutOfRelevance(
+  snapshot: LiveStationTowSnapshot,
+): boolean {
+  return snapshot.targetActive === 0 &&
+    snapshot.targetInterpActive === 0 &&
+    snapshot.towSnapshotReceived === 1 &&
+    snapshot.station >= 0 &&
+    snapshot.module >= 0 &&
+    snapshot.interpStation === snapshot.station &&
+    snapshot.interpModule === snapshot.module &&
+    snapshot.targetLinks === 1 &&
+    snapshot.moduleTargetLinks === 1 &&
+    snapshot.interactionMatches === 0;
+}
+
 function liveNpcScaffoldTowIsBound(
   snapshot: LiveNpcScaffoldTowSnapshot,
 ): boolean {
@@ -762,6 +777,22 @@ async function waitForLiveTowState(
   let last: LiveTowSnapshot | null = null;
   while (Date.now() < deadline) {
     last = await liveTowSnapshot(page);
+    if (predicate(last)) return last;
+    await page.waitForTimeout(100);
+  }
+  throw new Error(`${message}; last state: ${JSON.stringify(last)}`);
+}
+
+async function waitForLiveStationTowState(
+  page: Page,
+  predicate: (snapshot: LiveStationTowSnapshot) => boolean,
+  timeoutMs: number,
+  message: string,
+): Promise<LiveStationTowSnapshot> {
+  const deadline = Date.now() + timeoutMs;
+  let last: LiveStationTowSnapshot | null = null;
+  while (Date.now() < deadline) {
+    last = await liveStationTowSnapshot(page);
     if (predicate(last)) return last;
     await page.waitForTimeout(100);
   }
@@ -2460,11 +2491,15 @@ test.describe('Browser smoke tests', () => {
 
     let pathLength = 0;
     let maxStep = 0;
+    let maxStep50ms = 0;
     let maxResidual = 0;
+    let maxResidual50ms = 0;
     let maxVelocityJump = 0;
     let maxJerk = 0;
     let maxElapsed = 0;
     let maxTowDistance = 0;
+    let maxSampleInterval = 0;
+    let maxStepIndex = 0;
     for (let i = 0; i < samples.length; i++) {
       const sample = samples[i];
       maxElapsed = Math.max(maxElapsed, sample.elapsed);
@@ -2480,11 +2515,21 @@ test.describe('Browser smoke tests', () => {
       const speed = Math.hypot(sample.vx, sample.vy);
       const residual = Math.abs(step - (previousSpeed + speed) * 0.5 * dt);
       const velocityJump = Math.hypot(sample.vx - previous.vx, sample.vy - previous.vy);
+      const frameScale = 0.05 / dt;
       pathLength += step;
-      maxStep = Math.max(maxStep, step);
+      if (step > maxStep) {
+        maxStep = step;
+        maxStepIndex = i;
+      }
+      maxStep50ms = Math.max(maxStep50ms, step * frameScale);
       maxResidual = Math.max(maxResidual, residual);
+      maxResidual50ms = Math.max(
+        maxResidual50ms,
+        residual * frameScale,
+      );
       maxVelocityJump = Math.max(maxVelocityJump, velocityJump);
       maxJerk = Math.max(maxJerk, velocityJump / dt);
+      maxSampleInterval = Math.max(maxSampleInterval, dt);
     }
     const lastSample = samples[samples.length - 1];
     const displacement = Math.hypot(
@@ -2496,18 +2541,26 @@ test.describe('Browser smoke tests', () => {
       pathLength,
       displacement,
       maxStep,
+      maxStep50ms,
       maxResidual,
+      maxResidual50ms,
       maxVelocityJump,
       maxJerk,
       maxElapsed,
       maxTowDistance,
+      maxSampleInterval,
+      maxStepIndex,
+      maxStepWindow: samples.slice(
+        Math.max(0, maxStepIndex - 2),
+        Math.min(samples.length, maxStepIndex + 3),
+      ),
     };
     console.log(`[tow-adverse] ${JSON.stringify(motion)}`);
 
     expect(pathLength).toBeGreaterThan(250);
     expect(displacement).toBeGreaterThan(200);
-    expect(maxStep).toBeLessThanOrEqual(35);
-    expect(maxResidual).toBeLessThanOrEqual(18);
+    expect(maxStep50ms).toBeLessThanOrEqual(35);
+    expect(maxResidual50ms).toBeLessThanOrEqual(18);
     expect(maxVelocityJump).toBeLessThanOrEqual(100);
     expect(maxJerk).toBeLessThanOrEqual(2_500);
     expect(maxElapsed).toBeLessThanOrEqual(0.5);
@@ -2787,6 +2840,108 @@ test.describe('Browser smoke tests', () => {
         message: 'key-up should reach authority after the retirement cleanup',
       })
       .toBe(0);
+    expectNoFatalErrors(logs, { allowExpectedLiveClose: true });
+  });
+
+  test('station beam exits and re-enters relevance without changing authority', async ({ page }) => {
+    test.skip(
+      !process.env.SMOKE_STATION_RELEVANCE_ADVERSE_ASSERT,
+      'set SMOKE_STATION_RELEVANCE_ADVERSE_ASSERT=1 with the station relevance fixture and adverse proxy',
+    );
+    test.setTimeout(60_000);
+
+    const logs = installFatalCollectors(page);
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await loadGame(page, true);
+
+    await expect
+      .poll(async () => liveStationTowIsBound(
+        await liveStationTowSnapshot(page),
+      ), {
+        timeout: 15_000,
+        message: 'the station-owned pod should begin relevant and fully bound',
+      })
+      .toBe(true);
+    await expect
+      .poll(async () => (await tractorDrawTelemetry(page, 1)).count, {
+        timeout: 5_000,
+        message: 'the initially relevant station tow should render one beam',
+      })
+      .toBe(1);
+    const initial = await liveStationTowSnapshot(page);
+
+    await waitForLiveStationTowState(
+      page,
+      liveStationTowIsOutOfRelevance,
+      15_000,
+      'leaving relevance should remove the pod identity and interaction while retaining canonical and projected ownership',
+    );
+    const outside = await liveStationTowSnapshot(page);
+    expect(outside.linkRevision).toBe(initial.linkRevision);
+    expect(outside.towRevision).toBeGreaterThanOrEqual(initial.towRevision);
+    expect(outside.snapshotRevision).toBeGreaterThanOrEqual(
+      initial.snapshotRevision,
+    );
+    await expect
+      .poll(async () => (await tractorDrawTelemetry(page, 1)).count, {
+        timeout: 5_000,
+        message: 'leaving relevance should remove the station beam',
+      })
+      .toBe(0);
+
+    const outsideStates: LiveStationTowSnapshot[] = [];
+    const outsideBeams: TractorDrawTelemetry[] = [];
+    for (let i = 0; i < 20; i++) {
+      outsideStates.push(await liveStationTowSnapshot(page));
+      outsideBeams.push(await tractorDrawTelemetry(page, 1));
+      await page.waitForTimeout(50);
+    }
+    expect(
+      outsideStates.find((state) => !liveStationTowIsOutOfRelevance(state)),
+      'the irrelevant target or interaction should not reappear before re-entry',
+    ).toBeUndefined();
+    expect(
+      outsideBeams.find((beam) => beam.count !== 0),
+      'the irrelevant station beam should remain absent',
+    ).toBeUndefined();
+
+    await expect
+      .poll(async () => liveStationTowIsBound(
+        await liveStationTowSnapshot(page),
+      ), {
+        timeout: 15_000,
+        message: 're-entering relevance should restore target identity, projected binding, interaction, and beam ownership',
+      })
+      .toBe(true);
+    const reentered = await liveStationTowSnapshot(page);
+    expect(reentered.linkRevision).toBe(initial.linkRevision);
+    expect(reentered.towRevision).toBeGreaterThanOrEqual(outside.towRevision);
+    expect(reentered.snapshotRevision).toBeGreaterThanOrEqual(
+      outside.snapshotRevision,
+    );
+    await expect
+      .poll(async () => (await tractorDrawTelemetry(page, 1)).count, {
+        timeout: 5_000,
+        message: 're-entering relevance should restore exactly one station beam',
+      })
+      .toBe(1);
+
+    const reboundStates: LiveStationTowSnapshot[] = [];
+    const reboundBeams: TractorDrawTelemetry[] = [];
+    for (let i = 0; i < 30; i++) {
+      reboundStates.push(await liveStationTowSnapshot(page));
+      reboundBeams.push(await tractorDrawTelemetry(page, 1));
+      await page.waitForTimeout(50);
+    }
+    expect(
+      reboundStates.find((state) => !liveStationTowIsBound(state)),
+      'the rebound station relation/projections should remain singular',
+    ).toBeUndefined();
+    expect(
+      reboundBeams.find((beam) => beam.count !== 1),
+      'the rebound station beam should remain singular',
+    ).toBeUndefined();
+
     expectNoFatalErrors(logs, { allowExpectedLiveClose: true });
   });
 

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -740,6 +740,18 @@ function liveTowIsReleased(snapshot: LiveTowSnapshot): boolean {
     snapshot.tractorActive === 0;
 }
 
+function liveTowTargetIsRetired(snapshot: LiveTowSnapshot): boolean {
+  return snapshot.targetActive === 0 &&
+    snapshot.targetInterpActive === 0 &&
+    snapshot.towSnapshotReceived === 1 &&
+    snapshot.targetLinks === 0 &&
+    snapshot.localTargetLinks === 0 &&
+    snapshot.compatCount === 0 &&
+    snapshot.compatOccurrences === 0 &&
+    snapshot.targetTractor === -1 &&
+    snapshot.interpTargetTractor === -1;
+}
+
 async function waitForLiveTowState(
   page: Page,
   predicate: (snapshot: LiveTowSnapshot) => boolean,
@@ -2683,6 +2695,98 @@ test.describe('Browser smoke tests', () => {
     expect(maxBeamSourceStep).toBeLessThanOrEqual(4);
     expect(maxSpanJump).toBeLessThanOrEqual(15);
 
+    expectNoFatalErrors(logs, { allowExpectedLiveClose: true });
+  });
+
+  test('authoritative target retirement clears tow and beam through adverse network faults', async ({ page }) => {
+    test.skip(
+      !process.env.SMOKE_TOW_RETIRE_ADVERSE_ASSERT,
+      'set SMOKE_TOW_RETIRE_ADVERSE_ASSERT=1 with the tow retirement fixture and adverse proxy',
+    );
+    test.setTimeout(60_000);
+
+    const logs = installFatalCollectors(page);
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const canvas = await loadGame(page, true);
+    await canvas.click();
+
+    await expect
+      .poll(async () => {
+        const state = await liveTowSnapshot(page);
+        return state.localReady === 1 &&
+          state.netAuthority === 1 &&
+          state.loopback === 0 &&
+          state.docked === 0 &&
+          state.targetActive === 1 &&
+          state.targetInterpActive === 1 &&
+          liveTowIsReleased(state);
+      }, {
+        timeout: 15_000,
+        message: 'the retirement fixture should begin with one released live target',
+      })
+      .toBe(true);
+
+    let attached: LiveTowSnapshot;
+    await page.keyboard.down('Space');
+    try {
+      attached = await waitForLiveTowState(
+        page,
+        liveTowIsAttached,
+        15_000,
+        'the live target should attach exactly once before retirement',
+      );
+      await expect
+        .poll(async () => (await tractorDrawTelemetry(page, 0)).count, {
+          timeout: 5_000,
+          message: 'the attached target should render exactly one beam before retirement',
+        })
+        .toBe(1);
+
+      await waitForLiveTowState(
+        page,
+        liveTowTargetIsRetired,
+        15_000,
+        'target retirement should clear the target, canonical relation, both compatibility projections, and target binding',
+      );
+    } finally {
+      await page.keyboard.up('Space');
+    }
+
+    const retired = await liveTowSnapshot(page);
+    expect(retired.snapshotRevision).toBeGreaterThan(attached.snapshotRevision);
+    await expect
+      .poll(async () => (await tractorDrawTelemetry(page, 0)).count, {
+        timeout: 5_000,
+        message: 'target retirement should remove the visible beam',
+      })
+      .toBe(0);
+
+    const cleanSamples: LiveTowSnapshot[] = [];
+    const cleanBeams: TractorDrawTelemetry[] = [];
+    for (let i = 0; i < 30; i++) {
+      cleanSamples.push(await liveTowSnapshot(page));
+      cleanBeams.push(await tractorDrawTelemetry(page, 0));
+      await page.waitForTimeout(50);
+    }
+    const staleState = cleanSamples.find(
+      (sample) => !liveTowTargetIsRetired(sample),
+    );
+    expect(
+      staleState,
+      `retired target or tow state reappeared: ${JSON.stringify(staleState)}`,
+    ).toBeUndefined();
+    const staleBeam = cleanBeams.find((beam) => beam.count !== 0);
+    expect(
+      staleBeam,
+      `retired target left or resurrected a beam: ${JSON.stringify(staleBeam)}`,
+    ).toBeUndefined();
+
+    await expect
+      .poll(async () => (await liveTowSnapshot(page)).tractorActive, {
+        timeout: 10_000,
+        message: 'key-up should reach authority after the retirement cleanup',
+      })
+      .toBe(0);
     expectNoFatalErrors(logs, { allowExpectedLiveClose: true });
   });
 

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -81,6 +81,37 @@ type PlayerStateSnapshot = {
   docked: number;
 };
 
+type LiveTowSnapshot = {
+  sampledAt: number;
+  localPlayer: number;
+  localReady: number;
+  netAuthority: number;
+  loopback: number;
+  docked: number;
+  targetActive: number;
+  targetInterpActive: number;
+  towSnapshotReceived: number;
+  tractorActive: number;
+  compatCount: number;
+  compatOccurrences: number;
+  targetLinks: number;
+  localTargetLinks: number;
+  targetTractor: number;
+  interpTargetTractor: number;
+  towRevision: number;
+  snapshotRevision: number;
+  linkRevision: number;
+  linkState: number;
+  linkSlot: number;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  elapsed: number;
+  playerX: number;
+  playerY: number;
+};
+
 function addQueryParam(rawUrl: string, key: string, value: string): string {
   const hashAt = rawUrl.indexOf('#');
   const beforeHash = hashAt >= 0 ? rawUrl.slice(0, hashAt) : rawUrl;
@@ -528,6 +559,66 @@ async function towLifecycleState(page: Page): Promise<number> {
     if (!mod || typeof mod.ccall !== 'function') return 0;
     return mod.ccall('signal_smoke_tow_lifecycle_state', 'number', [], []);
   });
+}
+
+async function liveTowSnapshot(page: Page): Promise<LiveTowSnapshot> {
+  return page.evaluate(() => {
+    const mod = (window as unknown as {
+      Module?: {
+        ccall?: (
+          name: string,
+          returnType: string,
+          argTypes: unknown[],
+          args: unknown[],
+        ) => string;
+      };
+    }).Module;
+    if (!mod || typeof mod.ccall !== 'function') {
+      throw new Error('WASM ccall unavailable for live tow telemetry');
+    }
+    const raw = mod.ccall('signal_smoke_live_tow_summary', 'string', [], []);
+    return {
+      ...(JSON.parse(raw) as Omit<LiveTowSnapshot, 'sampledAt'>),
+      sampledAt: performance.now(),
+    };
+  });
+}
+
+function liveTowIsAttached(snapshot: LiveTowSnapshot): boolean {
+  return snapshot.targetLinks === 1 &&
+    snapshot.localTargetLinks === 1 &&
+    snapshot.compatCount === 1 &&
+    snapshot.compatOccurrences === 1 &&
+    snapshot.targetTractor === snapshot.localPlayer &&
+    snapshot.interpTargetTractor === snapshot.localPlayer &&
+    snapshot.linkState === 2 &&
+    snapshot.linkSlot === 0;
+}
+
+function liveTowIsReleased(snapshot: LiveTowSnapshot): boolean {
+  return snapshot.targetLinks === 0 &&
+    snapshot.localTargetLinks === 0 &&
+    snapshot.compatCount === 0 &&
+    snapshot.compatOccurrences === 0 &&
+    snapshot.targetTractor === -1 &&
+    snapshot.interpTargetTractor === -1 &&
+    snapshot.tractorActive === 0;
+}
+
+async function waitForLiveTowState(
+  page: Page,
+  predicate: (snapshot: LiveTowSnapshot) => boolean,
+  timeoutMs: number,
+  message: string,
+): Promise<LiveTowSnapshot> {
+  const deadline = Date.now() + timeoutMs;
+  let last: LiveTowSnapshot | null = null;
+  while (Date.now() < deadline) {
+    last = await liveTowSnapshot(page);
+    if (predicate(last)) return last;
+    await page.waitForTimeout(100);
+  }
+  throw new Error(`${message}; last state: ${JSON.stringify(last)}`);
 }
 
 async function tapTowOnNextSample(page: Page): Promise<number> {
@@ -2130,6 +2221,213 @@ test.describe('Browser smoke tests', () => {
     await expectTouchControlsFit(page);
 
     expectNoFatalErrors(logs);
+  });
+
+  test('authoritative tow stays atomic and smooth through adverse network faults', async ({ page }) => {
+    test.skip(
+      !process.env.SMOKE_TOW_ADVERSE_ASSERT,
+      'set SMOKE_TOW_ADVERSE_ASSERT=1 with the server tow fixture and adverse proxy',
+    );
+    test.setTimeout(100_000);
+
+    const logs = installFatalCollectors(page);
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const canvas = await loadGame(page, true);
+    await canvas.click();
+
+    await expect
+      .poll(async () => {
+        const state = await liveTowSnapshot(page);
+        return state.localReady === 1 &&
+          state.netAuthority === 1 &&
+          state.loopback === 0 &&
+          state.docked === 0 &&
+          state.targetActive === 1 &&
+          state.targetInterpActive === 1 &&
+          state.towSnapshotReceived === 1 &&
+          liveTowIsReleased(state);
+      }, {
+        timeout: 15_000,
+        message: 'the isolated live fixture should arrive with one released tow target',
+      })
+      .toBe(true);
+
+    await page.keyboard.down('Space');
+    try {
+      await waitForLiveTowState(
+        page,
+        liveTowIsAttached,
+        15_000,
+        'Space hold should converge on exactly one canonical live tow link',
+      );
+      await page.waitForTimeout(500);
+    } finally {
+      await page.keyboard.up('Space');
+    }
+
+    await expect
+      .poll(async () => {
+        const state = await liveTowSnapshot(page);
+        return state.tractorActive === 0 && liveTowIsAttached(state);
+      }, {
+        timeout: 10_000,
+        message: 'key-up should stop reaching while keeping the authoritative tow latched',
+      })
+      .toBe(true);
+
+    await expect
+      .poll(async () => (await tractorDrawTelemetry(page, 0)).count, {
+        timeout: 5_000,
+        message: 'the latched authoritative relation should render one tractor beam',
+      })
+      .toBe(1);
+    const initialBeam = await tractorDrawTelemetry(page, 0);
+    expect(initialBeam.sourceType).toBe(3);
+    expect(initialBeam.targetType).toBe(4);
+    expect(initialBeam.span).toBeGreaterThan(20);
+
+    const samples: LiveTowSnapshot[] = [];
+    await page.keyboard.down('W');
+    await page.keyboard.down('A');
+    await page.keyboard.down('Shift');
+    try {
+      for (let i = 0; i < 60; i++) {
+        if (i === 5) await page.keyboard.up('Shift');
+        if (i === 20) {
+          await page.keyboard.up('A');
+          await page.keyboard.down('D');
+        }
+        if (i === 42) await page.keyboard.up('D');
+        samples.push(await liveTowSnapshot(page));
+        await page.waitForTimeout(50);
+      }
+    } finally {
+      await page.keyboard.up('Shift');
+      await page.keyboard.up('D');
+      await page.keyboard.up('A');
+      await page.keyboard.up('W');
+    }
+
+    const nonAtomic = samples.find((sample) => !liveTowIsAttached(sample));
+    expect(nonAtomic, `tow relation changed atomically: ${JSON.stringify(nonAtomic)}`).toBeUndefined();
+
+    let pathLength = 0;
+    let maxStep = 0;
+    let maxResidual = 0;
+    let maxVelocityJump = 0;
+    let maxJerk = 0;
+    let maxElapsed = 0;
+    let maxTowDistance = 0;
+    for (let i = 0; i < samples.length; i++) {
+      const sample = samples[i];
+      maxElapsed = Math.max(maxElapsed, sample.elapsed);
+      maxTowDistance = Math.max(
+        maxTowDistance,
+        Math.hypot(sample.x - sample.playerX, sample.y - sample.playerY),
+      );
+      if (i === 0) continue;
+      const previous = samples[i - 1];
+      const dt = Math.max(0.001, (sample.sampledAt - previous.sampledAt) / 1000);
+      const step = Math.hypot(sample.x - previous.x, sample.y - previous.y);
+      const previousSpeed = Math.hypot(previous.vx, previous.vy);
+      const speed = Math.hypot(sample.vx, sample.vy);
+      const residual = Math.abs(step - (previousSpeed + speed) * 0.5 * dt);
+      const velocityJump = Math.hypot(sample.vx - previous.vx, sample.vy - previous.vy);
+      pathLength += step;
+      maxStep = Math.max(maxStep, step);
+      maxResidual = Math.max(maxResidual, residual);
+      maxVelocityJump = Math.max(maxVelocityJump, velocityJump);
+      maxJerk = Math.max(maxJerk, velocityJump / dt);
+    }
+    const lastSample = samples[samples.length - 1];
+    const displacement = Math.hypot(
+      lastSample.x - samples[0].x,
+      lastSample.y - samples[0].y,
+    );
+    const motion = {
+      samples: samples.length,
+      pathLength,
+      displacement,
+      maxStep,
+      maxResidual,
+      maxVelocityJump,
+      maxJerk,
+      maxElapsed,
+      maxTowDistance,
+    };
+    console.log(`[tow-adverse] ${JSON.stringify(motion)}`);
+
+    expect(pathLength).toBeGreaterThan(250);
+    expect(displacement).toBeGreaterThan(200);
+    expect(maxStep).toBeLessThanOrEqual(35);
+    expect(maxResidual).toBeLessThanOrEqual(18);
+    expect(maxVelocityJump).toBeLessThanOrEqual(100);
+    expect(maxJerk).toBeLessThanOrEqual(2_500);
+    expect(maxElapsed).toBeLessThanOrEqual(0.5);
+    expect(maxTowDistance).toBeLessThan(180);
+
+    await page.waitForTimeout(800);
+    await page.keyboard.down('Space');
+    await page.waitForTimeout(100);
+    await page.keyboard.up('Space');
+    await expect
+      .poll(async () => liveTowIsReleased(await liveTowSnapshot(page)), {
+        timeout: 15_000,
+        message: 'a distinct tap should clear canonical, projected, and rendered tow state',
+      })
+      .toBe(true);
+    await expect
+      .poll(async () => (await tractorDrawTelemetry(page, 0)).count, {
+        timeout: 5_000,
+        message: 'the tractor beam should disappear after authoritative release',
+      })
+      .toBe(0);
+
+    await page.keyboard.down('Space');
+    try {
+      await expect
+        .poll(async () => liveTowIsAttached(await liveTowSnapshot(page)), {
+          timeout: 15_000,
+          message: 'the just-released target should immediately reattach exactly once',
+        })
+        .toBe(true);
+      await page.waitForTimeout(350);
+    } finally {
+      await page.keyboard.up('Space');
+    }
+    await expect
+      .poll(async () => (await tractorDrawTelemetry(page, 0)).count, {
+        timeout: 5_000,
+        message: 'the reattached target should restore exactly one visible beam',
+      })
+      .toBe(1);
+
+    await expect
+      .poll(async () => {
+        const state = await liveTowSnapshot(page);
+        return state.tractorActive === 0 && liveTowIsAttached(state);
+      }, {
+        timeout: 10_000,
+        message: 'reattach key-up should latch one relation before final release',
+      })
+      .toBe(true);
+    await page.keyboard.down('Space');
+    await page.waitForTimeout(100);
+    await page.keyboard.up('Space');
+    await expect
+      .poll(async () => liveTowIsReleased(await liveTowSnapshot(page)), {
+        timeout: 15_000,
+        message: 'final release should leave no stale canonical link, compatibility entry, or target binding',
+      })
+      .toBe(true);
+    await expect
+      .poll(async () => (await tractorDrawTelemetry(page, 0)).count, {
+        timeout: 5_000,
+        message: 'final release should leave no stale tractor beam',
+      })
+      .toBe(0);
+
+    expectNoFatalErrors(logs, { allowExpectedLiveClose: true });
   });
 
   test('high-latency multiplayer correction telemetry stays bounded', async ({ page }) => {

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -112,6 +112,28 @@ type LiveTowSnapshot = {
   playerY: number;
 };
 
+type LiveStationTowSnapshot = {
+  sampledAt: number;
+  targetActive: number;
+  targetInterpActive: number;
+  towSnapshotReceived: number;
+  station: number;
+  module: number;
+  interpStation: number;
+  interpModule: number;
+  targetLinks: number;
+  moduleTargetLinks: number;
+  interactionMatches: number;
+  towRevision: number;
+  snapshotRevision: number;
+  linkRevision: number;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  elapsed: number;
+};
+
 function addQueryParam(rawUrl: string, key: string, value: string): string {
   const hashAt = rawUrl.indexOf('#');
   const beforeHash = hashAt >= 0 ? rawUrl.slice(0, hashAt) : rawUrl;
@@ -584,6 +606,34 @@ async function liveTowSnapshot(page: Page): Promise<LiveTowSnapshot> {
   });
 }
 
+async function liveStationTowSnapshot(page: Page): Promise<LiveStationTowSnapshot> {
+  return page.evaluate(() => {
+    const mod = (window as unknown as {
+      Module?: {
+        ccall?: (
+          name: string,
+          returnType: string,
+          argTypes: unknown[],
+          args: unknown[],
+        ) => string;
+      };
+    }).Module;
+    if (!mod || typeof mod.ccall !== 'function') {
+      throw new Error('WASM ccall unavailable for live station tow telemetry');
+    }
+    const raw = mod.ccall(
+      'signal_smoke_live_station_tow_summary',
+      'string',
+      [],
+      [],
+    );
+    return {
+      ...(JSON.parse(raw) as Omit<LiveStationTowSnapshot, 'sampledAt'>),
+      sampledAt: performance.now(),
+    };
+  });
+}
+
 function liveTowIsAttached(snapshot: LiveTowSnapshot): boolean {
   return snapshot.targetLinks === 1 &&
     snapshot.localTargetLinks === 1 &&
@@ -593,6 +643,19 @@ function liveTowIsAttached(snapshot: LiveTowSnapshot): boolean {
     snapshot.interpTargetTractor === snapshot.localPlayer &&
     snapshot.linkState === 2 &&
     snapshot.linkSlot === 0;
+}
+
+function liveStationTowIsBound(snapshot: LiveStationTowSnapshot): boolean {
+  return snapshot.targetActive === 1 &&
+    snapshot.targetInterpActive === 1 &&
+    snapshot.towSnapshotReceived === 1 &&
+    snapshot.station === 0 &&
+    snapshot.module >= 0 &&
+    snapshot.interpStation === snapshot.station &&
+    snapshot.interpModule === snapshot.module &&
+    snapshot.targetLinks === 1 &&
+    snapshot.moduleTargetLinks === 1 &&
+    snapshot.interactionMatches === 1;
 }
 
 function liveTowIsReleased(snapshot: LiveTowSnapshot): boolean {
@@ -2430,6 +2493,127 @@ test.describe('Browser smoke tests', () => {
     expectNoFatalErrors(logs, { allowExpectedLiveClose: true });
   });
 
+  test('station tractor beam stays visible and smooth through adverse network faults', async ({ page }) => {
+    test.skip(
+      !process.env.SMOKE_STATION_TOW_ADVERSE_ASSERT,
+      'set SMOKE_STATION_TOW_ADVERSE_ASSERT=1 with the station tow fixture and adverse proxy',
+    );
+    test.setTimeout(80_000);
+
+    const logs = installFatalCollectors(page);
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await loadGame(page, true);
+
+    await expect
+      .poll(async () => liveStationTowIsBound(await liveStationTowSnapshot(page)), {
+        timeout: 15_000,
+        message: 'the station-owned pod should converge on one canonical module relation and one published interaction',
+      })
+      .toBe(true);
+    await expect
+      .poll(async () => (await tractorDrawTelemetry(page, 1)).count, {
+        timeout: 5_000,
+        message: 'the authoritative station-module relation should render one cargo beam',
+      })
+      .toBe(1);
+    const initialBeam = await tractorDrawTelemetry(page, 1);
+    expect(initialBeam.sourceType).toBe(1);
+    expect(initialBeam.targetType).toBe(2);
+    expect(initialBeam.span).toBeGreaterThan(20);
+    expect(initialBeam.intensity).toBeGreaterThan(0);
+
+    const samples: LiveStationTowSnapshot[] = [];
+    const beams: TractorDrawTelemetry[] = [];
+    for (let i = 0; i < 60; i++) {
+      samples.push(await liveStationTowSnapshot(page));
+      beams.push(await tractorDrawTelemetry(page, 1));
+      await page.waitForTimeout(50);
+    }
+
+    const nonAtomic = samples.find((sample) => !liveStationTowIsBound(sample));
+    expect(
+      nonAtomic,
+      `station tow relation or interaction disappeared: ${JSON.stringify(nonAtomic)}`,
+    ).toBeUndefined();
+    const missingBeam = beams.find(
+      (beam) => beam.count !== 1 || beam.sourceType !== 1 ||
+        beam.targetType !== 2 || beam.intensity <= 0,
+    );
+    expect(
+      missingBeam,
+      `station tractor beam disappeared or changed identity: ${JSON.stringify(missingBeam)}`,
+    ).toBeUndefined();
+
+    let pathLength = 0;
+    let sourcePathLength = 0;
+    let maxStep = 0;
+    let maxResidual = 0;
+    let maxVelocityJump = 0;
+    let maxJerk = 0;
+    let maxElapsed = 0;
+    let maxBeamSourceStep = 0;
+    let maxSpanJump = 0;
+    for (let i = 0; i < samples.length; i++) {
+      maxElapsed = Math.max(maxElapsed, samples[i].elapsed);
+      if (i === 0) continue;
+      const sample = samples[i];
+      const previous = samples[i - 1];
+      const beam = beams[i];
+      const previousBeam = beams[i - 1];
+      const dt = Math.max(0.001, (sample.sampledAt - previous.sampledAt) / 1000);
+      const step = Math.hypot(sample.x - previous.x, sample.y - previous.y);
+      const speed = Math.hypot(sample.vx, sample.vy);
+      const previousSpeed = Math.hypot(previous.vx, previous.vy);
+      const residual = Math.abs(step - (previousSpeed + speed) * 0.5 * dt);
+      const velocityJump = Math.hypot(sample.vx - previous.vx, sample.vy - previous.vy);
+      const sourceStep = Math.hypot(
+        beam.sourceX - previousBeam.sourceX,
+        beam.sourceY - previousBeam.sourceY,
+      );
+      pathLength += step;
+      sourcePathLength += sourceStep;
+      maxStep = Math.max(maxStep, step);
+      maxResidual = Math.max(maxResidual, residual);
+      maxVelocityJump = Math.max(maxVelocityJump, velocityJump);
+      maxJerk = Math.max(maxJerk, velocityJump / dt);
+      maxBeamSourceStep = Math.max(maxBeamSourceStep, sourceStep);
+      maxSpanJump = Math.max(maxSpanJump, Math.abs(beam.span - previousBeam.span));
+    }
+    const firstSample = samples[0];
+    const lastSample = samples[samples.length - 1];
+    const displacement = Math.hypot(
+      lastSample.x - firstSample.x,
+      lastSample.y - firstSample.y,
+    );
+    const motion = {
+      samples: samples.length,
+      pathLength,
+      displacement,
+      sourcePathLength,
+      maxStep,
+      maxResidual,
+      maxVelocityJump,
+      maxJerk,
+      maxElapsed,
+      maxBeamSourceStep,
+      maxSpanJump,
+    };
+    console.log(`[station-tow-adverse] ${JSON.stringify(motion)}`);
+
+    expect(pathLength).toBeGreaterThan(80);
+    expect(displacement).toBeGreaterThan(70);
+    expect(sourcePathLength).toBeGreaterThan(15);
+    expect(maxStep).toBeLessThanOrEqual(15);
+    expect(maxResidual).toBeLessThanOrEqual(8);
+    expect(maxVelocityJump).toBeLessThanOrEqual(20);
+    expect(maxJerk).toBeLessThanOrEqual(400);
+    expect(maxElapsed).toBeLessThanOrEqual(0.5);
+    expect(maxBeamSourceStep).toBeLessThanOrEqual(4);
+    expect(maxSpanJump).toBeLessThanOrEqual(15);
+
+    expectNoFatalErrors(logs, { allowExpectedLiveClose: true });
+  });
+
   test('high-latency multiplayer correction telemetry stays bounded', async ({ page }) => {
     test.skip(
       !process.env.SMOKE_LATENCY_ASSERT,
@@ -2464,7 +2648,6 @@ test.describe('Browser smoke tests', () => {
     // A one-client authority can suppress unchanged recipient-excluded player
     // batches after the initial baseline. Local correction samples below are
     // the meaningful repeated-authority signal for this case.
-    expect(motion.playerBatches).toBeGreaterThan(0);
     expect(motion.inputAcks).toBeGreaterThan(0);
     expect(motion.pingSamples).toBeGreaterThan(0);
     expect(motion.lastPingRttMs).toBeGreaterThan(250);
@@ -2473,7 +2656,9 @@ test.describe('Browser smoke tests', () => {
     expect(motion.maxAckRttMs).toBeGreaterThan(250);
     expect(motion.lastAckGapMs).toBeGreaterThanOrEqual(0);
     expect(motion.pingServerTurnaroundMs).toBeGreaterThanOrEqual(0);
-    expect(motion.maxPlayerIntervalMs).toBeGreaterThan(0);
+    if (motion.playerBatches > 0) {
+      expect(motion.maxPlayerIntervalMs).toBeGreaterThan(0);
+    }
     expect(motion.maxPlayerIntervalMs).toBeLessThanOrEqual(150);
     expect(motion.maxTickSkewAbs).toBeLessThan(720);
     expect(motion.actionQueueDepth).toBeLessThanOrEqual(1);

--- a/tests/c/test_protocol.c
+++ b/tests/c/test_protocol.c
@@ -3097,7 +3097,7 @@ TEST(test_cargo_pod_delta_uses_compact_removal_stream_when_available) {
 
     int len = serialize_cargo_pods_for_player_delta(
         buf, remove, &remove_len, pods, v2(0.0f, 0.0f),
-        sent, sent_sig, false);
+        sent, sent_sig, false, false);
     ASSERT_EQ_INT(buf[0], NET_MSG_WORLD_CARGO_PODS);
     ASSERT_EQ_INT(buf[1], 2);
     ASSERT_EQ_INT(len, 2 + 2 * CARGO_POD_RECORD_SIZE);
@@ -3107,7 +3107,7 @@ TEST(test_cargo_pod_delta_uses_compact_removal_stream_when_available) {
 
     len = serialize_cargo_pods_for_player_delta(
         buf, remove, &remove_len, pods, v2(0.0f, 0.0f),
-        sent, sent_sig, false);
+        sent, sent_sig, false, false);
     ASSERT_EQ_INT(buf[1], 0);
     ASSERT_EQ_INT(len, 2);
     ASSERT_EQ_INT(remove[1], 0);
@@ -3115,7 +3115,7 @@ TEST(test_cargo_pod_delta_uses_compact_removal_stream_when_available) {
     pods[5].active = false;
     len = serialize_cargo_pods_for_player_delta(
         buf, remove, &remove_len, pods, v2(0.0f, 0.0f),
-        sent, sent_sig, false);
+        sent, sent_sig, false, false);
     ASSERT_EQ_INT(buf[1], 0);
     ASSERT_EQ_INT(len, 2);
     ASSERT_EQ_INT(remove[0], NET_MSG_WORLD_CARGO_POD_REMOVE);
@@ -3123,12 +3123,12 @@ TEST(test_cargo_pod_delta_uses_compact_removal_stream_when_available) {
     ASSERT_EQ_INT(remove_len, CARGO_POD_REMOVE_MSG_HEADER +
                             CARGO_POD_REMOVE_RECORD_SIZE);
     ASSERT_EQ_INT(remove[CARGO_POD_REMOVE_MSG_HEADER], 5);
-    ASSERT(!sent[5]);
+    ASSERT(sent[5]);
 
     pods[6].quantity = 6;
     len = serialize_cargo_pods_for_player_delta(
         buf, remove, &remove_len, pods, v2(0.0f, 0.0f),
-        sent, sent_sig, false);
+        sent, sent_sig, false, false);
     ASSERT_EQ_INT(buf[1], 1);
     ASSERT_EQ_INT(len, 2 + CARGO_POD_RECORD_SIZE);
     ASSERT_EQ_INT(buf[2], 6);
@@ -3160,7 +3160,7 @@ TEST(test_cargo_pod_q_delta_uses_compact_identity_and_removal) {
 
     int len = serialize_cargo_pods_q_for_player_delta(
         buf, remove, &remove_len, pods, v2(0.0f, 0.0f),
-        sent, sent_sig, false);
+        sent, sent_sig, false, false);
     ASSERT_EQ_INT(buf[0], NET_MSG_WORLD_CARGO_PODS_Q);
     ASSERT_EQ_INT(buf[1], 2);
     ASSERT_EQ_INT(len, 2 + 2 * CARGO_POD_Q_RECORD_SIZE);
@@ -3170,7 +3170,7 @@ TEST(test_cargo_pod_q_delta_uses_compact_identity_and_removal) {
 
     len = serialize_cargo_pods_q_for_player_delta(
         buf, remove, &remove_len, pods, v2(0.0f, 0.0f),
-        sent, sent_sig, false);
+        sent, sent_sig, false, false);
     ASSERT_EQ_INT(buf[1], 0);
     ASSERT_EQ_INT(len, 2);
     ASSERT_EQ_INT(remove[1], 0);
@@ -3178,7 +3178,7 @@ TEST(test_cargo_pod_q_delta_uses_compact_identity_and_removal) {
     cargo_pod_set_player_tractor(&pods[5], 0);
     len = serialize_cargo_pods_q_for_player_delta(
         buf, remove, &remove_len, pods, v2(0.0f, 0.0f),
-        sent, sent_sig, false);
+        sent, sent_sig, false, false);
     ASSERT_EQ_INT(buf[0], NET_MSG_WORLD_CARGO_PODS_Q);
     ASSERT_EQ_INT(buf[1], 1);
     ASSERT_EQ_INT(len, 2 + CARGO_POD_Q_RECORD_SIZE);
@@ -3189,7 +3189,7 @@ TEST(test_cargo_pod_q_delta_uses_compact_identity_and_removal) {
     pods[5].active = false;
     len = serialize_cargo_pods_q_for_player_delta(
         buf, remove, &remove_len, pods, v2(0.0f, 0.0f),
-        sent, sent_sig, false);
+        sent, sent_sig, false, false);
     ASSERT_EQ_INT(buf[1], 0);
     ASSERT_EQ_INT(len, 2);
     ASSERT_EQ_INT(remove[0], NET_MSG_WORLD_CARGO_POD_REMOVE);
@@ -3197,18 +3197,36 @@ TEST(test_cargo_pod_q_delta_uses_compact_identity_and_removal) {
     ASSERT_EQ_INT(remove_len, CARGO_POD_REMOVE_MSG_HEADER +
                             CARGO_POD_REMOVE_RECORD_SIZE);
     ASSERT_EQ_INT(remove[CARGO_POD_REMOVE_MSG_HEADER], 5);
-    ASSERT(!sent[5]);
+    ASSERT(sent[5]);
 
     pods[6].quantity = 6;
     len = serialize_cargo_pods_q_for_player_delta(
         buf, remove, &remove_len, pods, v2(0.0f, 0.0f),
-        sent, sent_sig, false);
+        sent, sent_sig, false, false);
     ASSERT_EQ_INT(buf[0], NET_MSG_WORLD_CARGO_PODS_Q);
     ASSERT_EQ_INT(buf[1], 1);
     ASSERT_EQ_INT(len, 2 + CARGO_POD_Q_RECORD_SIZE);
     ASSERT_EQ_INT(buf[2], 6);
     ASSERT_EQ_INT(read_u16_le(&buf[2 + 18]), 6);
     ASSERT_EQ_INT(remove[1], 0);
+
+    len = serialize_cargo_pods_q_for_player_delta(
+        buf, remove, &remove_len, pods, v2(0.0f, 0.0f),
+        sent, sent_sig, false, true);
+    ASSERT_EQ_INT(buf[1], 0);
+    ASSERT_EQ_INT(remove[1], 1);
+    ASSERT_EQ_INT(remove[CARGO_POD_REMOVE_MSG_HEADER], 5);
+    ASSERT(sent[5]);
+
+    pods[5].active = true;
+    cargo_pod_clear_tractor(&pods[5]);
+    len = serialize_cargo_pods_q_for_player_delta(
+        buf, remove, &remove_len, pods, v2(0.0f, 0.0f),
+        sent, sent_sig, false, false);
+    ASSERT_EQ_INT(buf[1], 1);
+    ASSERT_EQ_INT(buf[2], 5);
+    ASSERT_EQ_INT(remove[1], 0);
+    ASSERT(sent_sig[5] != 0u);
 }
 
 TEST(test_scaffold_delta_uses_compact_removal_stream_when_available) {
@@ -3237,7 +3255,7 @@ TEST(test_scaffold_delta_uses_compact_removal_stream_when_available) {
 
     int len = serialize_scaffolds_for_player_delta(
         buf, remove, &remove_len, scaffolds, v2(0.0f, 0.0f),
-        sent, sent_sig, motion_sig);
+        sent, sent_sig, motion_sig, false);
     ASSERT_EQ_INT(buf[0], NET_MSG_WORLD_SCAFFOLDS);
     ASSERT_EQ_INT(buf[1], 2);
     ASSERT_EQ_INT(len, 2 + 2 * SCAFFOLD_RECORD_SIZE);
@@ -3253,7 +3271,7 @@ TEST(test_scaffold_delta_uses_compact_removal_stream_when_available) {
 
     len = serialize_scaffolds_for_player_delta(
         buf, remove, &remove_len, scaffolds, v2(0.0f, 0.0f),
-        sent, sent_sig, motion_sig);
+        sent, sent_sig, motion_sig, false);
     ASSERT_EQ_INT(buf[1], 0);
     ASSERT_EQ_INT(len, 2);
     ASSERT_EQ_INT(remove[1], 0);
@@ -3261,7 +3279,7 @@ TEST(test_scaffold_delta_uses_compact_removal_stream_when_available) {
     scaffolds[4].built_at_station = 1;
     len = serialize_scaffolds_for_player_delta(
         buf, remove, &remove_len, scaffolds, v2(0.0f, 0.0f),
-        sent, sent_sig, motion_sig);
+        sent, sent_sig, motion_sig, false);
     ASSERT_EQ_INT(buf[1], 1);
     ASSERT_EQ_INT(len, 2 + SCAFFOLD_RECORD_SIZE);
     ASSERT_EQ_INT(buf[2], 4);
@@ -3271,7 +3289,7 @@ TEST(test_scaffold_delta_uses_compact_removal_stream_when_available) {
     scaffolds[3].active = false;
     len = serialize_scaffolds_for_player_delta(
         buf, remove, &remove_len, scaffolds, v2(0.0f, 0.0f),
-        sent, sent_sig, motion_sig);
+        sent, sent_sig, motion_sig, false);
     ASSERT_EQ_INT(buf[1], 0);
     ASSERT_EQ_INT(len, 2);
     ASSERT_EQ_INT(remove[0], NET_MSG_WORLD_SCAFFOLD_REMOVE);
@@ -3279,13 +3297,13 @@ TEST(test_scaffold_delta_uses_compact_removal_stream_when_available) {
     ASSERT_EQ_INT(remove_len, SCAFFOLD_REMOVE_MSG_HEADER +
                             SCAFFOLD_REMOVE_RECORD_SIZE);
     ASSERT_EQ_INT(remove[SCAFFOLD_REMOVE_MSG_HEADER], 3);
-    ASSERT(!sent[3]);
+    ASSERT(sent[3]);
 
     scaffolds[4].pos.x = -25.0f;
     scaffolds[4].vel = v2(2.0f, -1.0f);
     len = serialize_scaffolds_for_player_delta(
         buf, remove, &remove_len, scaffolds, v2(0.0f, 0.0f),
-        sent, sent_sig, motion_sig);
+        sent, sent_sig, motion_sig, false);
     ASSERT_EQ_INT(buf[1], 0);
     ASSERT_EQ_INT(len, 2);
     ASSERT_EQ_INT(remove[1], 0);
@@ -3303,6 +3321,23 @@ TEST(test_scaffold_delta_uses_compact_removal_stream_when_available) {
     ASSERT_EQ_FLOAT((float)(int16_t)read_u16_le(&p[5]) *
                     SCAFFOLD_MOTION_Q_VEL_SCALE,
                     2.0f, SCAFFOLD_MOTION_Q_VEL_SCALE);
+
+    len = serialize_scaffolds_for_player_delta(
+        buf, remove, &remove_len, scaffolds, v2(0.0f, 0.0f),
+        sent, sent_sig, motion_sig, true);
+    ASSERT_EQ_INT(buf[1], 0);
+    ASSERT_EQ_INT(remove[1], 1);
+    ASSERT_EQ_INT(remove[SCAFFOLD_REMOVE_MSG_HEADER], 3);
+    ASSERT(sent[3]);
+
+    scaffolds[3].active = true;
+    len = serialize_scaffolds_for_player_delta(
+        buf, remove, &remove_len, scaffolds, v2(0.0f, 0.0f),
+        sent, sent_sig, motion_sig, false);
+    ASSERT_EQ_INT(buf[1], 1);
+    ASSERT_EQ_INT(buf[2], 3);
+    ASSERT_EQ_INT(remove[1], 0);
+    ASSERT(sent_sig[3] != 0u);
 }
 
 TEST(test_cargo_pod_motion_stream_uses_relevance_filter) {

--- a/tests/c/test_protocol.c
+++ b/tests/c/test_protocol.c
@@ -838,7 +838,7 @@ TEST(test_asteroid_identity_budget_trickles_background_first_visible) {
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
         asteroids, v2(0.0f, 0.0f), sent, NULL, NULL, NULL,
-        NULL, NULL, NULL, NULL, 10u, 1);
+        NULL, NULL, NULL, NULL, 10u, false, 1);
 
     ASSERT_EQ_INT(len, ASTEROID_MSG_HEADER);
     ASSERT_EQ_INT(asteroids8_q[0], NET_MSG_WORLD_ASTEROIDS8_Q);
@@ -856,7 +856,7 @@ TEST(test_asteroid_identity_budget_trickles_background_first_visible) {
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
         asteroids, v2(0.0f, 0.0f), sent, NULL, NULL, NULL,
-        NULL, NULL, NULL, NULL, 11u, 1);
+        NULL, NULL, NULL, NULL, 11u, false, 1);
 
     ASSERT_EQ_INT(len, ASTEROID_MSG_HEADER);
     ASSERT_EQ_INT(asteroids8_q[1], 1);
@@ -2414,7 +2414,7 @@ TEST(test_asteroid_identity_change_forces_full_upsert) {
         asteroids, v2(0.0f, 0.0f), sent,
         NULL, NULL, NULL, identity_sent_sig,
         state_sent_tick, state_sent_sig, state_sent_semantic_sig,
-        101u, -1);
+        101u, false, -1);
 
     ASSERT_EQ_INT(full_len, ASTEROID_MSG_HEADER + ASTEROID_RECORD_SIZE);
     ASSERT_EQ_INT(full[1] | (full[2] << 8), 1);
@@ -2433,7 +2433,7 @@ TEST(test_asteroid_identity_change_forces_full_upsert) {
     ASSERT_EQ_INT((int)state_sent_tick[7], 101);
 }
 
-TEST(test_asteroid_cache_invalidation_preserves_pending_removal) {
+TEST(test_asteroid_removal_tombstone_repeats_after_frame_loss) {
     static server_player_t sp;
     static server_replication_t replication;
     static asteroid_t asteroids[MAX_ASTEROIDS];
@@ -2472,7 +2472,8 @@ TEST(test_asteroid_cache_invalidation_preserves_pending_removal) {
         sp.replication->asteroid_motion_sent_tick, sp.replication->asteroid_motion_sent_pos,
         sp.replication->asteroid_motion_sent_vel, sp.replication->asteroid_identity_sent_sig,
         sp.replication->asteroid_state_sent_tick, sp.replication->asteroid_state_sent_sig,
-        sp.replication->asteroid_state_sent_semantic_sig, 100u, -1);
+        sp.replication->asteroid_state_sent_semantic_sig,
+        100u, true, -1);
 
     ASSERT_EQ_INT(full_len, ASTEROID_MSG_HEADER);
     ASSERT_EQ_INT(remove_len,
@@ -2480,7 +2481,81 @@ TEST(test_asteroid_cache_invalidation_preserves_pending_removal) {
     ASSERT_EQ_INT(remove_buf[0], NET_MSG_WORLD_ASTEROID_REMOVE);
     ASSERT_EQ_INT(remove_buf[1] | (remove_buf[2] << 8), 1);
     ASSERT_EQ_INT(remove_buf[3] | (remove_buf[4] << 8), 7);
-    ASSERT(!sp.replication->asteroid_sent[7]);
+    ASSERT(sp.replication->asteroid_sent[7]);
+
+    remove_len = 0;
+    full_len = serialize_asteroids_for_player_split_ext_state_budget_at_tick(
+        full, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, remove_buf, &remove_len,
+        asteroids, v2(0.0f, 0.0f), sp.replication->asteroid_sent,
+        sp.replication->asteroid_motion_sent_tick,
+        sp.replication->asteroid_motion_sent_pos,
+        sp.replication->asteroid_motion_sent_vel,
+        sp.replication->asteroid_identity_sent_sig,
+        sp.replication->asteroid_state_sent_tick,
+        sp.replication->asteroid_state_sent_sig,
+        sp.replication->asteroid_state_sent_semantic_sig,
+        101u, false, -1);
+    ASSERT_EQ_INT(full_len, ASTEROID_MSG_HEADER);
+    ASSERT_EQ_INT(remove_len, ASTEROID_REMOVE_MSG_HEADER);
+    ASSERT(sp.replication->asteroid_sent[7]);
+
+    remove_len = 0;
+    full_len = serialize_asteroids_for_player_split_ext_state_budget_at_tick(
+        full, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, remove_buf, &remove_len,
+        asteroids, v2(0.0f, 0.0f), sp.replication->asteroid_sent,
+        sp.replication->asteroid_motion_sent_tick,
+        sp.replication->asteroid_motion_sent_pos,
+        sp.replication->asteroid_motion_sent_vel,
+        sp.replication->asteroid_identity_sent_sig,
+        sp.replication->asteroid_state_sent_tick,
+        sp.replication->asteroid_state_sent_sig,
+        sp.replication->asteroid_state_sent_semantic_sig,
+        220u, true, -1);
+    ASSERT_EQ_INT(full_len, ASTEROID_MSG_HEADER);
+    ASSERT_EQ_INT(remove_len,
+                  ASTEROID_REMOVE_MSG_HEADER + ASTEROID_REMOVE_RECORD_SIZE);
+    ASSERT_EQ_INT(remove_buf[3] | (remove_buf[4] << 8), 7);
+    ASSERT(sp.replication->asteroid_sent[7]);
+
+    asteroids[7] = (asteroid_t){
+        .active = true,
+        .tier = ASTEROID_TIER_S,
+        .commodity = COMMODITY_FERRITE_ORE,
+        .pos = { 20.0f, 30.0f },
+        .radius = 14.0f,
+        .hp = 8.0f,
+        .max_hp = 8.0f,
+        .ore = 3.0f,
+        .max_ore = 3.0f,
+    };
+    remove_len = 0;
+    full_len = serialize_asteroids_for_player_split_ext_state_budget_at_tick(
+        full, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, remove_buf, &remove_len,
+        asteroids, v2(0.0f, 0.0f), sp.replication->asteroid_sent,
+        sp.replication->asteroid_motion_sent_tick,
+        sp.replication->asteroid_motion_sent_pos,
+        sp.replication->asteroid_motion_sent_vel,
+        sp.replication->asteroid_identity_sent_sig,
+        sp.replication->asteroid_state_sent_tick,
+        sp.replication->asteroid_state_sent_sig,
+        sp.replication->asteroid_state_sent_semantic_sig,
+        221u, false, -1);
+    ASSERT_EQ_INT(full_len,
+                  ASTEROID_MSG_HEADER + ASTEROID_RECORD_SIZE);
+    ASSERT_EQ_INT(full[1] | (full[2] << 8), 1);
+    ASSERT_EQ_INT(full[3] | (full[4] << 8), 7);
+    ASSERT(full[5] & 1);
+    ASSERT_EQ_INT(remove_len, ASTEROID_REMOVE_MSG_HEADER);
+    ASSERT(sp.replication->asteroid_identity_sent_sig[7] != 0u);
 }
 
 TEST(test_asteroid_delta_coalesces_dirty_state_stream_per_player) {
@@ -8882,7 +8957,7 @@ void register_protocol_main_tests(void) {
     RUN(test_asteroid_delta_uses_quantized_motion_stream_for_settling);
     RUN(test_asteroid_delta_uses_compact_state_stream_for_known_dirty);
     RUN(test_asteroid_identity_change_forces_full_upsert);
-    RUN(test_asteroid_cache_invalidation_preserves_pending_removal);
+    RUN(test_asteroid_removal_tombstone_repeats_after_frame_loss);
     RUN(test_asteroid_delta_coalesces_dirty_state_stream_per_player);
     RUN(test_asteroid_delta_sends_inactive_removal);
     RUN(test_asteroid_delta_uses_compact_removal_stream_when_available);

--- a/tests/c/test_protocol.c
+++ b/tests/c/test_protocol.c
@@ -4844,18 +4844,20 @@ TEST(test_world_snapshot_emitter_sequence_shared) {
                                           packet_capture_sink, &cap,
                                           &scratch);
 
-    ASSERT_EQ_INT(cap.count, 5);
+    ASSERT_EQ_INT(cap.count, 6);
     ASSERT_EQ_INT(cap.type[0], NET_MSG_WORLD_ASTEROIDS8_Q);
     ASSERT_EQ_INT(cap.type[1], NET_MSG_WORLD_PLAYERS);
     ASSERT_EQ_INT(cap.type[2], NET_MSG_WORLD_NPCS);
     ASSERT_EQ_INT(cap.type[3], NET_MSG_WORLD_INTERACTIONS_Q);
-    ASSERT_EQ_INT(cap.type[4], NET_MSG_WORLD_TIME);
+    ASSERT_EQ_INT(cap.type[4], NET_MSG_WORLD_TOW_LINKS);
+    ASSERT_EQ_INT(cap.type[5], NET_MSG_WORLD_TIME);
     ASSERT_EQ_INT(cap.len[0],
                   ASTEROID8_Q_MSG_HEADER + ASTEROID8_Q_RECORD_SIZE);
     ASSERT_EQ_INT(cap.len[1], 2);
     ASSERT_EQ_INT(cap.len[2], 2);
     ASSERT_EQ_INT(cap.len[3], 2);
-    ASSERT_EQ_INT(cap.len[4], 5);
+    ASSERT_EQ_INT(cap.len[4], TOW_LINKS_MSG_HEADER_SIZE);
+    ASSERT_EQ_INT(cap.len[5], 5);
 
     ASSERT(w.asteroids[2].net_dirty);
     server_clear_asteroid_net_dirty(&w);
@@ -4890,14 +4892,15 @@ TEST(test_world_snapshot_emits_compact_asteroid_motion_stream) {
                                           packet_capture_sink, &cap,
                                           &scratch);
 
-    ASSERT_EQ_INT(cap.count, 4);
+    ASSERT_EQ_INT(cap.count, 5);
     ASSERT_EQ_INT(cap.type[0], NET_MSG_WORLD_ASTEROID_POSD8_Q);
     ASSERT_EQ_INT(cap.len[0],
                   ASTEROID_POSD8_Q_MSG_HEADER + ASTEROID_POSD8_Q_RECORD_SIZE);
     ASSERT_EQ_INT((int)w.players[0].replication->asteroid_motion_sent_tick[2],
                   100 + ASTEROID_NET_MOVING_REPEAT_TICKS);
     ASSERT_EQ_INT(cap.type[1], NET_MSG_WORLD_NPCS);
-    ASSERT_EQ_INT(cap.type[3], NET_MSG_WORLD_TIME);
+    ASSERT_EQ_INT(cap.type[3], NET_MSG_WORLD_TOW_LINKS);
+    ASSERT_EQ_INT(cap.type[4], NET_MSG_WORLD_TIME);
 }
 
 TEST(test_world_snapshot_prioritizes_local_towed_asteroid_identity) {
@@ -4931,7 +4934,7 @@ TEST(test_world_snapshot_prioritizes_local_towed_asteroid_identity) {
                                           packet_capture_sink, &cap,
                                           &scratch);
 
-    ASSERT_EQ_INT(cap.count, 4);
+    ASSERT_EQ_INT(cap.count, 5);
     ASSERT_EQ_INT(cap.type[0], NET_MSG_WORLD_ASTEROIDS8_Q);
     ASSERT_EQ_INT(cap.len[0],
                   ASTEROID8_Q_MSG_HEADER + ASTEROID8_Q_RECORD_SIZE);
@@ -5100,8 +5103,9 @@ TEST(test_world_time_snapshot_reconciles_at_low_cadence) {
     server_emit_world_snapshot_for_player(&w, 0, false,
                                           packet_capture_sink, &cap,
                                           &scratch);
-    ASSERT_EQ_INT(cap.count, 3);
-    ASSERT_EQ_INT(cap.type[2], NET_MSG_WORLD_TIME);
+    ASSERT_EQ_INT(cap.count, 4);
+    ASSERT_EQ_INT(cap.type[2], NET_MSG_WORLD_TOW_LINKS);
+    ASSERT_EQ_INT(cap.type[3], NET_MSG_WORLD_TIME);
     ASSERT(w.players[0].replication->world_time_sent);
     ASSERT_EQ_INT((int)w.players[0].replication->world_time_last_sent_tick, 100);
 
@@ -5111,7 +5115,7 @@ TEST(test_world_time_snapshot_reconciles_at_low_cadence) {
     server_emit_world_snapshot_for_player(&w, 0, false,
                                           packet_capture_sink, &cap,
                                           &scratch);
-    ASSERT_EQ_INT(cap.count, 2);
+    ASSERT_EQ_INT(cap.count, 3);
     for (int i = 0; i < cap.count; i++)
         ASSERT(cap.type[i] != NET_MSG_WORLD_TIME);
     ASSERT_EQ_INT((int)w.players[0].replication->world_time_last_sent_tick, 100);
@@ -5122,8 +5126,9 @@ TEST(test_world_time_snapshot_reconciles_at_low_cadence) {
     server_emit_world_snapshot_for_player(&w, 0, false,
                                           packet_capture_sink, &cap,
                                           &scratch);
-    ASSERT_EQ_INT(cap.count, 3);
-    ASSERT_EQ_INT(cap.type[2], NET_MSG_WORLD_TIME);
+    ASSERT_EQ_INT(cap.count, 4);
+    ASSERT_EQ_INT(cap.type[2], NET_MSG_WORLD_TOW_LINKS);
+    ASSERT_EQ_INT(cap.type[3], NET_MSG_WORLD_TIME);
     ASSERT_EQ_INT((int)w.players[0].replication->world_time_last_sent_tick,
                   100 + WORLD_TIME_REPEAT_TICKS);
 }
@@ -7977,6 +7982,56 @@ TEST(test_latency_pong_roundtrip) {
     ASSERT_EQ_INT((int)read_u32_le(&buf[17]), (int)0x01020304u);
 }
 
+TEST(test_atomic_tow_link_snapshot_roundtrip) {
+    WORLD_DECL;
+    memset(&w, 0, sizeof(w));
+    w.tick = 0x11223344u;
+    w.tow_revision = 0x55667788u;
+    w.tow_links[3] = (tow_link_t){
+        .active = true,
+        .source = {
+            .kind = ENTITY_KIND_SHIP,
+            .index = 2,
+            .part = -1,
+            .generation = 9,
+        },
+        .target = {
+            .kind = ENTITY_KIND_CARGO_POD,
+            .index = 17,
+            .part = -1,
+            .generation = 12,
+        },
+        .profile = TOW_PROFILE_SHIP_POD,
+        .slot = 4,
+        .state = TOW_LINK_HELD,
+        .attached_tick = 0x01020304u,
+        .revision = 0x05060708u,
+    };
+
+    uint8_t buf[TOW_LINKS_MAX_SIZE];
+    int len = serialize_tow_links(buf, &w);
+    ASSERT_EQ_INT(len, TOW_LINKS_MSG_HEADER_SIZE + TOW_LINK_RECORD_SIZE);
+    ASSERT_EQ_INT(buf[0], NET_MSG_WORLD_TOW_LINKS);
+    ASSERT_EQ_INT(read_u16_le(&buf[1]), 1);
+    ASSERT(read_u32_le(&buf[3]) == w.tow_revision);
+    ASSERT(read_u32_le(&buf[7]) == w.tick);
+
+    const uint8_t *p = &buf[TOW_LINKS_MSG_HEADER_SIZE];
+    ASSERT_EQ_INT(p[0], ENTITY_KIND_SHIP);
+    ASSERT_EQ_INT((int16_t)read_u16_le(&p[1]), 2);
+    ASSERT_EQ_INT((int16_t)read_u16_le(&p[3]), -1);
+    ASSERT_EQ_INT(read_u16_le(&p[5]), 9);
+    ASSERT_EQ_INT(p[7], ENTITY_KIND_CARGO_POD);
+    ASSERT_EQ_INT((int16_t)read_u16_le(&p[8]), 17);
+    ASSERT_EQ_INT((int16_t)read_u16_le(&p[10]), -1);
+    ASSERT_EQ_INT(read_u16_le(&p[12]), 12);
+    ASSERT_EQ_INT(p[14], TOW_PROFILE_SHIP_POD);
+    ASSERT_EQ_INT(p[15], 4);
+    ASSERT_EQ_INT(p[16], TOW_LINK_HELD);
+    ASSERT(read_u32_le(&p[18]) == 0x01020304u);
+    ASSERT(read_u32_le(&p[22]) == 0x05060708u);
+}
+
 static const uint8_t *find_protocol_stream(const uint8_t *buf, uint8_t msg) {
     int count = buf[7];
     for (int i = 0; i < count; i++) {
@@ -8036,6 +8091,17 @@ TEST(test_protocol_info_serializes_stream_map) {
     ASSERT_EQ_INT(read_u16_le(&diag[6]), 1);
     ASSERT_EQ_INT(read_u16_le(&diag[8]), MAX_MODULES_PER_STATION);
     ASSERT_EQ_INT(read_u16_le(&diag[10]), 300);
+
+    const uint8_t *tow_links = find_protocol_stream(
+        buf, NET_MSG_WORLD_TOW_LINKS);
+    ASSERT(tow_links != NULL);
+    ASSERT_EQ_INT(tow_links[1], PROTOCOL_STREAM_CLASS_AUTH);
+    ASSERT(read_u16_le(&tow_links[2]) &
+           PROTOCOL_STREAM_FLAG_SERVER_TO_CLIENT);
+    ASSERT_EQ_INT(read_u16_le(&tow_links[4]), TOW_LINKS_MSG_HEADER_SIZE);
+    ASSERT_EQ_INT(read_u16_le(&tow_links[6]), TOW_LINK_RECORD_SIZE);
+    ASSERT_EQ_INT(read_u16_le(&tow_links[8]), MAX_TOW_LINKS);
+    ASSERT_EQ_INT(read_u16_le(&tow_links[10]), 100);
 
     const uint8_t *latency_pong = find_protocol_stream(
         buf, NET_MSG_LATENCY_PONG);
@@ -8935,6 +9001,7 @@ void register_protocol_main_tests(void) {
     RUN(test_input_applied_roundtrip);
     RUN(test_cargo_receipt_bundle_roundtrip);
     RUN(test_latency_pong_roundtrip);
+    RUN(test_atomic_tow_link_snapshot_roundtrip);
     RUN(test_protocol_info_serializes_stream_map);
     RUN(test_buy_event_serializes_cost_and_quantity);
     RUN(test_events_for_recipient_filters_local_only_damage);

--- a/tests/c/test_tractor.c
+++ b/tests/c/test_tractor.c
@@ -156,6 +156,55 @@ TEST(test_tow_target_generation_changes_after_recycle) {
     ASSERT(second.generation != first.generation);
 }
 
+TEST(test_tow_link_revision_is_monotonic_and_idempotent) {
+    WORLD_DECL;
+    world_reset(&w);
+    server_player_t *sp = &w.players[0];
+    sp->connected = true;
+    sp->session_ready = true;
+    sp->id = 0;
+    player_init_ship(sp, &w);
+
+    int pod = MAX_CARGO_PODS - 2;
+    w.cargo_pods[pod].active = true;
+    w.cargo_pods[pod].kind = CARGO_POD_CARGO;
+    w.tick = 1234;
+    entity_ref_t target = world_entity_ref_for_slot(
+        &w, ENTITY_KIND_CARGO_POD, pod, -1);
+    ASSERT(world_tow_link_set(
+        &w, sp->ship_ref, target, TOW_PROFILE_SHIP_POD, 0, TOW_LINK_HELD));
+    const tow_link_t *link = world_tow_link_for_target_const(&w, target);
+    ASSERT(link != NULL);
+    uint32_t first_world_revision = w.tow_revision;
+    uint32_t first_link_revision = link->revision;
+    ASSERT(first_world_revision != 0);
+    ASSERT(first_link_revision == first_world_revision);
+    ASSERT(link->attached_tick == 1234u);
+
+    w.tick = 1235;
+    ASSERT(world_tow_link_set(
+        &w, sp->ship_ref, target, TOW_PROFILE_SHIP_POD, 0, TOW_LINK_HELD));
+    link = world_tow_link_for_target_const(&w, target);
+    ASSERT(link != NULL);
+    ASSERT(w.tow_revision == first_world_revision);
+    ASSERT(link->revision == first_link_revision);
+    ASSERT(link->attached_tick == 1234u);
+
+    ASSERT(world_tow_link_set(
+        &w, sp->ship_ref, target, TOW_PROFILE_SHIP_POD, 0,
+        TOW_LINK_RELEASING));
+    link = world_tow_link_for_target_const(&w, target);
+    ASSERT(link != NULL);
+    ASSERT(w.tow_revision > first_world_revision);
+    ASSERT(link->revision == w.tow_revision);
+    ASSERT(link->attached_tick == 1234u);
+
+    uint32_t release_revision = w.tow_revision;
+    ASSERT(world_tow_link_clear_target(&w, target));
+    ASSERT(world_tow_link_for_target_const(&w, target) == NULL);
+    ASSERT(w.tow_revision > release_revision);
+}
+
 TEST(test_tow_links_ignore_stale_projection_capacity_and_collect_stably) {
     WORLD_DECL;
     world_reset(&w);
@@ -490,6 +539,7 @@ void register_tractor_tests(void) {
     RUN(test_tractor_binding_has_one_source_at_a_time);
     RUN(test_tow_link_pool_is_authority_for_ship_projections);
     RUN(test_tow_target_generation_changes_after_recycle);
+    RUN(test_tow_link_revision_is_monotonic_and_idempotent);
     RUN(test_tow_links_ignore_stale_projection_capacity_and_collect_stably);
     RUN(test_ship_pointer_cache_rebinds_and_clears_stale_views);
     RUN(test_tractor_pull_engages_beyond_rest);


### PR DESCRIPTION
## What changed

- added a discoverable, versioned `WORLD_TOW_LINKS` replacement stream carrying generation-safe source/target references, attach ticks, and relation revisions
- made canonical tow mutations monotonic and idempotent on the server
- made the client reject stale revisions, treat equal revisions as duplicate delivery, and rebuild player, NPC, station, asteroid, cargo-pod, and scaffold compatibility projections from the accepted relation set
- retained legacy player/NPC/cargo tow fields strictly as fallback for older servers
- extended native protocol/relationship coverage and the WASM tow smoke with stale, duplicate, attach, hold, release, and per-slot interpolation-isolation checks
- extended the WebSocket latency proxy with seeded world-frame loss, duplication, and adjacent reordering while keeping control frames on their own lane
- added pure deterministic impairment checks and isolated real native-server/WASM/Chromium scenarios for high latency, adverse delivery, and authoritative-ACK lag
- added an opt-in live player fixture that drives real player-to-fragment attach, latched motion, release, immediate reattach, final release, and attached-target retirement through the adverse proxy
- added an independent live station fixture that holds a manifest-backed cargo pod from a real dock module and verifies its canonical link, projected binding, interaction, rendered beam, target motion, and rotating beam source
- added a live NPC fixture that moves a real NPC-owned scaffold through production AI/tow physics and verifies its canonical link, NPC/scaffold projections, and rendered tether under adverse delivery
- rendered remote NPC-to-scaffold tractor tethers, which had no draw path
- replaced shared NPC and scaffold interpolation timers with per-slot clocks so an update for one entity cannot rebase every other entity
- changed NPC render correction to critically damp both position and velocity, eliminating emitter kicks after sparse updates
- retained per-recipient asteroid, cargo-pod, and scaffold removal tombstones and reconciled them at 1 Hz, so a lost removal/relevance-exit frame cannot leave a ghost body or beam; later relevance re-entry forces a full identity upsert
- added a live station relevance fixture that moves only the observing player across the 3,000-unit boundary and proves target identity, interaction, and beam disappear and return without changing the station tow link
- preserved locally predicted towable poses while owner snapshots replay unacknowledged input frames, preventing already-current tow bodies from being stepped a second time during player reconciliation
- normalized browser smoothness assertions to a 50 ms frame while retaining raw sample intervals and the worst transition window for diagnosis
- made interaction identity/drift faults opt-in so station scenarios can impair beam publication without changing the established deterministic motion schedule

## Why

The server already owned towing through a canonical relationship pool, but the wire split that state across player, NPC, cargo, scaffold, and interaction packets. Those packets arrive on different cadences, so a client could observe half an attach or release and later overwrite correct state with a stale compatibility projection.

Remote NPC and scaffold rendering also shared one interpolation clock per entity class. Any sparse update for NPC or scaffold B reset the correction baseline for A, producing visible jumps even when the tow relation itself stayed intact. NPC-owned scaffolds also had no remote tether renderer.

Destructive lifecycle testing exposed one-shot removal streams. If an application-level removal frame was lost, canonical relations and compatibility projections could clear while the client kept extrapolating a retired or irrelevant target indefinitely. Durable per-recipient tombstones now make retirement and relevance transitions converge without preventing re-entry.

The full matrix then exposed a separate player-tow jerk: local reconciliation rewound the owner and replayed unacknowledged frames, but tow bodies were already at the client's current predicted time. Replaying tow physics advanced them twice, producing a 49.5-unit correction in 65 ms while the link itself remained stable. Owner replay now preserves the current poses of attached fragments, cargo pods, and scaffolds.

## Impact

Attach and release now switch every tow projection together. Duplicate snapshots are idempotent, stale snapshots cannot resurrect released links, and station-module pod ownership reaches the same projection path that renders tractor beams.

The player fixture verifies that one fragment beam appears while attached, disappears on release, returns exactly once on immediate reattach, and leaves no stale line after final release. The replay fix removes periodic visual jumps without weakening authority or release behavior.

The station fixture verifies that exactly one station-module-to-pod relation, interaction, and rendered beam remain continuously visible and smooth. Its relevance extension verifies that target identity, interaction, and beam disappear outside the observer's relevance window, remain absent, then return exactly once with the same individual link revision.

The NPC fixture verifies that one NPC-to-scaffold relation remains atomic while both endpoints move and the remote tether stays present and bounded.

The retirement fixture deliberately drops, duplicates, and reorders world frames while the server retires an attached target. The client must converge to an inactive target, no canonical relation, no compatibility projection or target binding, and no beam; 30 subsequent samples ensure none reappear.

Each network scenario receives a fresh authoritative server and data directory, preventing grace-session state from leaking between matrix cases.

## Validation

- native server, native client, and Emscripten builds pass
- `make test-all`: 1,227 passed, 0 failed
- ASan/UBSan fast suite: 1,218 passed, 0 failed
- complete local browser smoke: 17 passed, 9 intentional live/adverse skips
- complete eight-case real browser/network matrix:
  - 450 ms one-way latency plus jitter
  - 160 ms one-way latency plus seeded loss, duplication, reordering, and jitter
  - authoritative player-to-fragment attach/release/reattach lifecycle under adverse delivery
  - station-module-to-cargo-pod relation and visible beam with interaction identity/drift frames also faulted
  - attached target retirement with durable ghost-body/beam cleanup
  - station cargo-pod relevance exit/re-entry without relation churn
  - NPC-to-scaffold relation, projected ownership, endpoint motion, and visible tether under adverse delivery
  - low-ping/high-authoritative-ACK lag
- final player tow sample after replay fix: 473.50 units path; 448.91 displacement; 15.91 raw max step; 12.24 max step normalized to 50 ms; 0.85 normalized residual; 47.17 max velocity jump; 915.93 max jerk; 0.217 s max snapshot age; 93.41 max tow distance
- the failing pre-fix run reproduced a 49.50-unit step in 65 ms, 26.84 normalized residual, and 200.79 max tow distance while the same link revision remained attached
- final station tow sample: 149.60 units target path; 146.09 displacement; 38.01 beam-source path; 8.63 max target step; 3.74 max residual; 4.78 max velocity jump; 80.00 max jerk; 0.342 s max snapshot age; 1.59 max beam-source step; 7.05 max span jump
- final NPC-scaffold sample: 44.56 units target path; 36.91 displacement; 119.62 NPC path; 4.35 max target step; 1.99 max residual; 10.12 max velocity jump; 172.47 max jerk; 0.267 s max scaffold snapshot age; 2.042 s max NPC snapshot age; 12.45 max beam-source step; 7.85 max span jump; 1.05 max source-endpoint error; 0.26 max target-endpoint error
- native protocol regressions prove cargo-pod and scaffold tombstones repeat after simulated frame loss, remain suppressed between heartbeats, and force a full identity upsert on re-entry
- focused relevance regression passes without fixture cache invalidation, preserving the server's retry knowledge across the whole out-of-range interval
- deterministic impairment unit checks
- deterministic build flags and libm checks
- banned API check
- documentation freshness checks
- cppcheck
- `git diff --check`

## Remaining for #617

- expand live adverse coverage to player/NPC cargo-pod combinations and player-owned scaffolds
- add dock/undock, reconnect, and save/load lifecycle cases
- extend relevance exit/re-entry coverage across the remaining owner/target combinations

Refs #617
