### PR TITLE
Guarantee the first laser refit supply path

### DIFF
--- a/client/station_ui.c
+++ b/client/station_ui.c
@@ -412,6 +412,89 @@ static bool ui_upgrade_input_gate_label(ship_upgrade_t upgrade,
     return true;
 }
 
+static bool ui_upgrade_stock_source_label(ship_upgrade_t upgrade,
+                                          const ship_t *ship,
+                                          int station_units,
+                                          char *out,
+                                          size_t cap)
+{
+    if (!out || cap == 0) return false;
+    out[0] = '\0';
+    if (!ship || station_units <= 0) return false;
+
+    commodity_t product = ui_upgrade_product_commodity(upgrade);
+    if (product >= COMMODITY_COUNT) return false;
+
+    int best_station = -1;
+    int best_stock = 0;
+    bool best_subsidy = false;
+    float best_distance_sq = 0.0f;
+    for (int s = 0; s < MAX_STATIONS; s++) {
+        const station_t *candidate = &g.world.stations[s];
+        if (!station_exists(candidate)) continue;
+        int stock = (int)floorf(client_station_stock_amount(candidate, product)
+                                + FLOAT_EPSILON);
+        if (stock < station_units) continue;
+        bool subsidy =
+            upgrade == SHIP_UPGRADE_MINING &&
+            ship->mining_level == 0 &&
+            strcmp(candidate->station_slug, "kepler") == 0;
+        float distance_sq = v2_dist_sq(ship->pos, candidate->pos);
+        if (best_station < 0 ||
+            (subsidy && !best_subsidy) ||
+            (subsidy == best_subsidy && distance_sq < best_distance_sq)) {
+            best_station = s;
+            best_stock = stock;
+            best_subsidy = subsidy;
+            best_distance_sq = distance_sq;
+        }
+    }
+    if (best_station < 0) return false;
+
+    char station_name[16];
+    ui_station_name_short(best_station, station_name, sizeof(station_name));
+    if (best_subsidy) {
+        snprintf(out, cap, "%s has %d; 0 cr starter refit; dock + [M]",
+                 station_name, best_stock);
+    } else {
+        const station_t *source = &g.world.stations[best_station];
+        float fill = fminf(1.0f, (float)best_stock / MAX_PRODUCT_STOCK);
+        float deficit = 1.0f - fill;
+        float unit_price = source->base_price[product] *
+                           (1.0f + deficit * deficit);
+        int price = (int)lroundf((float)station_units * unit_price);
+        snprintf(out, cap, "%s has %d; %d cr; dock + [M]",
+                 station_name, best_stock, price);
+    }
+    return true;
+}
+
+static bool ui_upgrade_production_source_label(ship_upgrade_t upgrade,
+                                               char *out,
+                                               size_t cap)
+{
+    if (!out || cap == 0) return false;
+    out[0] = '\0';
+    commodity_t product = ui_upgrade_product_commodity(upgrade);
+    module_type_t producer = ui_product_producer_module(product);
+    if (product >= COMMODITY_COUNT || producer >= MODULE_COUNT)
+        return false;
+
+    for (int s = 0; s < MAX_STATIONS; s++) {
+        const station_t *candidate = &g.world.stations[s];
+        if (!station_exists(candidate) ||
+            !station_has_module(candidate, producer)) {
+            continue;
+        }
+        char station_name[16];
+        ui_station_name_short(s, station_name, sizeof(station_name));
+        snprintf(out, cap, "%s production pending; check WORK / haul",
+                 station_name);
+        return true;
+    }
+    return false;
+}
+
 static int ui_required_mining_level_for_tier(asteroid_tier_t tier)
 {
     switch (tier) {
@@ -497,6 +580,7 @@ bool station_laser_refit_summary(char *out, size_t out_size)
 
     char source[112];
     char gate[80];
+    char supply[96];
     bool has_source = ui_upgrade_source_label(SHIP_UPGRADE_MINING,
                                               source, sizeof(source));
     bool has_gate = ui_upgrade_input_gate_label(SHIP_UPGRADE_MINING, ship,
@@ -509,18 +593,35 @@ bool station_laser_refit_summary(char *out, size_t out_size)
              ? ui.mining_units_needed
              : ui.mining_units_in_cargo);
     if (from_station < 0) from_station = 0;
+    bool has_supply = ui_upgrade_stock_source_label(
+        SHIP_UPGRADE_MINING, ship, from_station, supply, sizeof(supply));
+    if (!has_supply) {
+        has_supply = ui_upgrade_production_source_label(
+            SHIP_UPGRADE_MINING, supply, sizeof(supply));
+    }
 
     if (upgrade_uses_starter_refit_subsidy(ui.station, ship,
                                            SHIP_UPGRADE_MINING,
                                            from_station)) {
         snprintf(out, out_size,
-                 "Kepler starter reserve ready: %d Laser Modules; %s",
+                 "Kepler starter reserve ready: %d Laser Modules; "
+                 "0 cr; press M; %s",
                  ui.mining_units_at_station,
                  ui_upgrade_effect_label(SHIP_UPGRADE_MINING, ship));
         return true;
     }
 
-    if (has_source && has_gate) {
+    if (has_supply && has_source && has_gate) {
+        snprintf(out, out_size,
+                 "need %d Laser Modules; ship %d station %d; %s; %s; %s",
+                 short_by, ui.mining_units_in_cargo,
+                 ui.mining_units_at_station, supply, source, gate);
+    } else if (has_supply && has_source) {
+        snprintf(out, out_size,
+                 "need %d Laser Modules; ship %d station %d; %s; %s",
+                 short_by, ui.mining_units_in_cargo,
+                 ui.mining_units_at_station, supply, source);
+    } else if (has_source && has_gate) {
         snprintf(out, out_size,
                  "need %d Laser Modules; ship %d station %d; %s; %s",
                  short_by, ui.mining_units_in_cargo,
@@ -4763,6 +4864,22 @@ static void draw_verbs_view(const station_ui_state_t *ui,
                 draw_row_lr(cx, my, inner_right, COL_DIM, "next laser",
                             COL_FADED,
                             ui_upgrade_effect_label(refit[i].upgrade, ship));
+                my += row_h;
+            }
+            char supply[96];
+            int station_units = needed -
+                (needed < refit[i].in_cargo ? needed : refit[i].in_cargo);
+            bool has_supply = ui_upgrade_stock_source_label(
+                refit[i].upgrade, ship, station_units,
+                supply, sizeof(supply));
+            if (!has_supply) {
+                has_supply = ui_upgrade_production_source_label(
+                    refit[i].upgrade, supply, sizeof(supply));
+            }
+            if (has_supply &&
+                my + row_h + remaining_primary * row_h <= content_bottom) {
+                draw_row_lr(cx, my, inner_right, COL_DIM, "available",
+                            COL_FADED, supply);
                 my += row_h;
             }
             char source[112];

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -13789,9 +13789,18 @@ static void world_seed_genesis_ship_assets(world_t *w) {
     (void)world_ship_asset_mint(
         w, HULL_CLASS_DRONE_TRACTOR, SHIP_ASSET_OWNER_STATION,
         1, 1, SHIP_ASSET_PROVENANCE_GENESIS, false, 1, NULL, NULL);
-    (void)world_ship_asset_mint(
+    ship_asset_t *helios_miner = world_ship_asset_mint(
         w, HULL_CLASS_NPC_MINER, SHIP_ASSET_OWNER_STATION,
         2, 2, SHIP_ASSET_PROVENANCE_GENESIS, false, 2, NULL, NULL);
+    if (helios_miner) {
+        /* Helios is the advanced-beamworks endpoint in the starter
+         * economy. Its resident industrial workboat is the honest,
+         * repeatable source of Crystal that closes the first laser-refit
+         * loop after Kepler's finite reserve is consumed. Player loaners
+         * still start at L1; only this station-owned genesis hull carries
+         * the L3 mining head needed by the documented supply route. */
+        helios_miner->stored_ship.mining_level = 2;
+    }
     (void)world_ship_asset_mint(
         w, HULL_CLASS_DRONE_TRACTOR, SHIP_ASSET_OWNER_STATION,
         2, 2, SHIP_ASSET_PROVENANCE_GENESIS, false, 2, NULL, NULL);

--- a/shared/station_util.c
+++ b/shared/station_util.c
@@ -787,14 +787,14 @@ float station_raw_ore_chain_need_score(const station_t *st, commodity_t ore) {
                           shortage01(station_inventory_amount(st, ingot), 12.0f) * 0.5f);
         }
         break;
-    case COMMODITY_CUPRITE_ORE:
+    case COMMODITY_CRYSTAL_ORE:
         if (station_has_module(st, MODULE_LASER_FAB)) {
             score = fmaxf(shortage01(station_inventory_amount(st, COMMODITY_LASER_MODULE),
                                       12.0f),
                           shortage01(station_inventory_amount(st, ingot), 12.0f) * 0.5f);
         }
         break;
-    case COMMODITY_CRYSTAL_ORE:
+    case COMMODITY_CUPRITE_ORE:
         if (station_has_module(st, MODULE_TRACTOR_FAB)) {
             score = fmaxf(shortage01(station_inventory_amount(st, COMMODITY_TRACTOR_MODULE),
                                       12.0f),

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -1563,6 +1563,9 @@ test.describe('Browser smoke tests', () => {
     const refitSummary = await laserRefitSummary(page);
     expect(refitSummary).toContain('Laser Modules: Crystal Ingots + Frames');
     expect(refitSummary).toContain('Crystal source requires L3 laser');
+    expect(refitSummary).toContain('Kepler has 8');
+    expect(refitSummary).toContain('0 cr starter refit');
+    expect(refitSummary).toContain('dock + [M]');
 
     const productionSummary = await stationProductionSummary(page);
     expect(productionSummary).toContain('Ferrite Ore -> Ferrite Ingots');

--- a/tests/c/test_economy.c
+++ b/tests/c/test_economy.c
@@ -1245,24 +1245,24 @@ TEST(test_raw_ore_contract_prefers_starved_downstream_output) {
     helios->_inventory_cache[COMMODITY_CUPRITE_ORE] = 0.0f;
     helios->_inventory_cache[COMMODITY_CRYSTAL_ORE] = 0.0f;
     ASSERT(test_set_station_finished_units(
-        helios, COMMODITY_CUPRITE_INGOT, 0));
+        helios, COMMODITY_CUPRITE_INGOT, 12));
     ASSERT(test_set_station_finished_units(
         helios, COMMODITY_LASER_MODULE, 0));
     ASSERT(test_set_station_finished_units(
-        helios, COMMODITY_CRYSTAL_INGOT, 12));
+        helios, COMMODITY_CRYSTAL_INGOT, 0));
     ASSERT(test_set_station_finished_units(
         helios, COMMODITY_TRACTOR_MODULE, 12));
 
     world_sim_step(&w, SIM_DT);
 
-    bool found_cuprite = false;
+    bool found_crystal = false;
     for (int k = 0; k < MAX_CONTRACTS; k++) {
         if (!w.contracts[k].active || w.contracts[k].station_index != 2) continue;
-        if (w.contracts[k].commodity == COMMODITY_CUPRITE_ORE)
-            found_cuprite = true;
-        ASSERT(w.contracts[k].commodity != COMMODITY_CRYSTAL_ORE);
+        if (w.contracts[k].commodity == COMMODITY_CRYSTAL_ORE)
+            found_crystal = true;
+        ASSERT(w.contracts[k].commodity != COMMODITY_CUPRITE_ORE);
     }
-    ASSERT(found_cuprite);
+    ASSERT(found_crystal);
 }
 
 TEST(test_sell_price_uses_contract_price) {
@@ -3818,6 +3818,41 @@ TEST(test_top_demand_severity_clamped_zero_to_one) {
     ASSERT(d.commodity != COMMODITY_FERRITE_ORE);
 }
 
+TEST(test_raw_ore_chain_demand_matches_advanced_fab_recipes) {
+    WORLD_DECL;
+    world_reset(&w);
+    station_t *helios = &w.stations[2];
+
+    /* Isolate the downstream finished-good pressure. Laser fabs consume
+     * Crystal Ingots; tractor fabs consume Cuprite Ingots. A historical
+     * swap here asked Helios for the wrong ore and could starve the only
+     * repeatable source of starter Laser Modules. */
+    ASSERT(test_set_station_finished_units(
+        helios, COMMODITY_CRYSTAL_INGOT, 12));
+    ASSERT(test_set_station_finished_units(
+        helios, COMMODITY_CUPRITE_INGOT, 12));
+    ASSERT(test_set_station_finished_units(
+        helios, COMMODITY_LASER_MODULE, 0));
+    ASSERT(test_set_station_finished_units(
+        helios, COMMODITY_TRACTOR_MODULE, 12));
+
+    ASSERT(station_raw_ore_chain_need_score(
+               helios, COMMODITY_CRYSTAL_ORE) > 0.99f);
+    ASSERT_EQ_FLOAT(station_raw_ore_chain_need_score(
+                        helios, COMMODITY_CUPRITE_ORE),
+                    0.0f, 0.001f);
+
+    ASSERT(test_set_station_finished_units(
+        helios, COMMODITY_LASER_MODULE, 12));
+    ASSERT(test_set_station_finished_units(
+        helios, COMMODITY_TRACTOR_MODULE, 0));
+    ASSERT_EQ_FLOAT(station_raw_ore_chain_need_score(
+                        helios, COMMODITY_CRYSTAL_ORE),
+                    0.0f, 0.001f);
+    ASSERT(station_raw_ore_chain_need_score(
+               helios, COMMODITY_CUPRITE_ORE) > 0.99f);
+}
+
 /* Demand pricing: a station that's starving for an ingot should post a
  * higher contract price than one that's stocked. Pool_factor and the
  * existing 1.15× content premium stay; the new demand multiplier
@@ -3922,6 +3957,7 @@ void register_economy_demand_tests(void) {
     RUN(test_top_demand_picks_starving_commodity);
     RUN(test_top_demand_skips_self_produced_commodities);
     RUN(test_top_demand_severity_clamped_zero_to_one);
+    RUN(test_raw_ore_chain_demand_matches_advanced_fab_recipes);
     RUN(test_contract_price_scales_with_demand);
     RUN(test_supply_need_policy_owns_open_refill_and_close_targets);
 }

--- a/tests/c/test_world_sim.c
+++ b/tests/c/test_world_sim.c
@@ -9052,12 +9052,38 @@ TEST(test_fresh_world_kepler_starter_laser_refit_bootstrap) {
     ASSERT_EQ_INT(need, 8);
     ASSERT_EQ_INT(station_finished_count(kepler,
                                          COMMODITY_LASER_MODULE), need);
+
+    /* Kepler's reserve is finite. Helios's station-owned L3 workboat is
+     * the repeatable physical Crystal source that replenishes modules
+     * through the normal fab + contract route after that reserve is used. */
+    npc_ship_t *helios_miner = NULL;
+    for (int n = 0; n < MAX_NPC_SHIPS; n++) {
+        npc_ship_t *npc = &w.npc_ships[n];
+        if (!npc->active || npc->role != NPC_ROLE_MINER ||
+            npc->home_station != 2) {
+            continue;
+        }
+        helios_miner = npc;
+        break;
+    }
+    ASSERT(helios_miner != NULL);
+    ASSERT_EQ_INT(helios_miner->ship->mining_level, 2);
+    test_seed_gate_asteroid(&w, ASTEROID_TIER_M, COMMODITY_CRYSTAL_ORE);
+    ASSERT(mining_level_can_fracture_asteroid(
+        helios_miner->ship->mining_level, &w.asteroids[0]));
+
     ASSERT(upgrade_uses_starter_refit_subsidy(
         kepler, sp->ship, SHIP_UPGRADE_MINING, need));
     ASSERT_EQ_FLOAT(upgrade_station_credit_cost(
         kepler, sp->ship, SHIP_UPGRADE_MINING, need), 0.0f, 0.001f);
     ASSERT(can_afford_upgrade(kepler, sp->ship,
                               SHIP_UPGRADE_MINING, 0.0f));
+
+    /* A temporary Helios shutdown must not remove the independent finite
+     * reserve path. The station is restored below before testing the
+     * repeatable post-depletion route. */
+    float helios_signal_range = w.stations[2].signal_range;
+    w.stations[2].signal_range = 0.0f;
 
     test_seed_gate_asteroid(&w, ASTEROID_TIER_M, COMMODITY_CUPRITE_ORE);
     ASSERT(!mining_level_can_fracture_asteroid(sp->ship->mining_level,
@@ -9079,6 +9105,31 @@ TEST(test_fresh_world_kepler_starter_laser_refit_bootstrap) {
     ASSERT_EQ_INT(sp->ship->mining_level, 1);
     ASSERT_EQ_INT(station_finished_count(kepler,
                                          COMMODITY_LASER_MODULE), 0);
+    w.stations[2].signal_range = helios_signal_range;
+
+    /* Once the reserve is depleted, Kepler must advertise an ordinary,
+     * recipe-provenanced Laser Module import instead of deadlocking the
+     * next starter. Top up the other kit inputs so this tick selects the
+     * missing laser dependency deterministically. */
+    memset(w.contracts, 0, sizeof(w.contracts));
+    ASSERT(test_set_station_finished_units(kepler, COMMODITY_FRAME, 12));
+    ASSERT(test_set_station_finished_units(
+        kepler, COMMODITY_TRACTOR_MODULE, 12));
+    world_sim_step(&w, SIM_DT);
+    contract_t *laser_import = NULL;
+    for (int k = 0; k < MAX_CONTRACTS; k++) {
+        contract_t *ct = &w.contracts[k];
+        if (!ct->active || ct->action != CONTRACT_TRACTOR ||
+            ct->station_index != 1 ||
+            ct->commodity != COMMODITY_LASER_MODULE) {
+            continue;
+        }
+        laser_import = ct;
+        break;
+    }
+    ASSERT(laser_import != NULL);
+    ASSERT((laser_import->proof_flags & CONTRACT_PROOF_REQUIRE_RECIPE) != 0);
+    ASSERT_EQ_INT(laser_import->required_recipe_id, RECIPE_LASER_BASIC);
 
     test_seed_gate_asteroid(&w, ASTEROID_TIER_M, COMMODITY_CUPRITE_ORE);
     ASSERT(mining_level_can_fracture_asteroid(sp->ship->mining_level,
@@ -9086,6 +9137,31 @@ TEST(test_fresh_world_kepler_starter_laser_refit_bootstrap) {
     test_seed_gate_asteroid(&w, ASTEROID_TIER_M, COMMODITY_CRYSTAL_ORE);
     ASSERT(!mining_level_can_fracture_asteroid(sp->ship->mining_level,
                                                &w.asteroids[0]));
+}
+
+TEST(test_starter_laser_bootstrap_is_seed_independent) {
+    WORLD_DECL;
+    const uint32_t seeds[] = { 1u, 2037u, 0x7fffffffu, 0xffffffffu };
+    for (size_t i = 0; i < sizeof(seeds) / sizeof(seeds[0]); i++) {
+        w.rng = seeds[i];
+        world_reset(&w);
+        ASSERT_EQ_INT(w.belt_seed, seeds[i]);
+        ASSERT_EQ_INT(station_finished_count(
+                          &w.stations[1], COMMODITY_LASER_MODULE),
+                      8);
+
+        bool found_l3_helios_miner = false;
+        for (int n = 0; n < MAX_NPC_SHIPS; n++) {
+            npc_ship_t *npc = &w.npc_ships[n];
+            if (!npc->active || npc->role != NPC_ROLE_MINER ||
+                npc->home_station != 2) {
+                continue;
+            }
+            found_l3_helios_miner = npc->ship->mining_level >= 2;
+            break;
+        }
+        ASSERT(found_l3_helios_miner);
+    }
 }
 
 TEST(test_scenario_emergency_recovery) {
@@ -9382,17 +9458,17 @@ TEST(test_npc_miner_prefers_starved_ore_over_nearest_compatible_rock) {
     helios->_inventory_cache[COMMODITY_CUPRITE_ORE] = 0.0f;
     helios->_inventory_cache[COMMODITY_CRYSTAL_ORE] = 0.0f;
     ASSERT(test_set_station_finished_units(helios,
-                                           COMMODITY_CUPRITE_INGOT, 0));
+                                           COMMODITY_CUPRITE_INGOT, 12));
     ASSERT(test_set_station_finished_units(helios,
                                            COMMODITY_LASER_MODULE, 0));
     ASSERT(test_set_station_finished_units(helios,
-                                           COMMODITY_CRYSTAL_INGOT, 12));
+                                           COMMODITY_CRYSTAL_INGOT, 0));
     ASSERT(test_set_station_finished_units(helios,
                                            COMMODITY_TRACTOR_MODULE, 12));
 
     w.asteroids[0].active = true;
     w.asteroids[0].tier = ASTEROID_TIER_L;
-    w.asteroids[0].commodity = COMMODITY_CRYSTAL_ORE;
+    w.asteroids[0].commodity = COMMODITY_CUPRITE_ORE;
     w.asteroids[0].radius = 50.0f;
     w.asteroids[0].hp = 120.0f;
     w.asteroids[0].max_hp = 120.0f;
@@ -9400,7 +9476,7 @@ TEST(test_npc_miner_prefers_starved_ore_over_nearest_compatible_rock) {
 
     w.asteroids[1].active = true;
     w.asteroids[1].tier = ASTEROID_TIER_L;
-    w.asteroids[1].commodity = COMMODITY_CUPRITE_ORE;
+    w.asteroids[1].commodity = COMMODITY_CRYSTAL_ORE;
     w.asteroids[1].radius = 50.0f;
     w.asteroids[1].hp = 120.0f;
     w.asteroids[1].max_hp = 120.0f;
@@ -9897,6 +9973,7 @@ void register_world_sim_basic_tests(void) {
     RUN(test_mining_laser_size_gate_starts_at_m);
     RUN(test_mining_laser_material_gate_requires_upgrades);
     RUN(test_fresh_world_kepler_starter_laser_refit_bootstrap);
+    RUN(test_starter_laser_bootstrap_is_seed_independent);
     RUN(test_world_sim_step_laser_scans_cargo_pod);
     RUN(test_world_sim_step_docking);
     RUN(test_world_sim_step_refinery_hopper_path_retired);


### PR DESCRIPTION
## What changed

- seed Helios's station-owned industrial miner with the L3 mining head needed to supply Crystal after Kepler's finite starter reserve is consumed
- align Crystal/Cuprite ore demand with the actual Laser/Tractor fab recipes
- show the first refit's reachable stock source, price, and next action in the dock UI
- cover reserve depletion, delayed replenishment, temporary Helios shutdown, and multiple world seeds

## Root cause

The finite Kepler reserve covered only the first refit. Its repeatable recovery path depended on Helios producing Laser Modules, but Helios's resident miner started at L1 and could not mine the Crystal used by the laser recipe. The downstream ore-demand scorer also had the Laser and Tractor inputs crossed, reinforcing the wrong supply.

## Player impact

A fresh player can follow visible station information to Kepler's physical eight-module reserve for a zero-credit first refit. After depletion, Helios can physically mine the gated input and Kepler posts a recipe-provenanced import contract, so the economy recovers without free modules or a global-wallet shortcut.

## Validation

- native suite: 1,218 passed, 0 failed
- native client compile and deterministic-build flag check
- release WASM build and deterministic-build flag check
- focused Chromium browser smoke for refit guidance

Closes #618
