### PR TITLE
Add versioned authoritative state roots

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ endif()
 # local_server.c). New server sim files go here.
 set(SIGNAL_SIM_SOURCES
     server/game_sim.c
+    server/state_digest.c
     server/sim_ai.c
     server/gossip.c
     server/sim_autopilot.c
@@ -309,6 +310,7 @@ if(NOT EMSCRIPTEN AND NOT BUILD_SERVER_ONLY)
         tests/c/test_route_history_labels.c
         tests/c/test_rock_usefulness.c
         tests/c/test_signal_field.c
+        tests/c/test_state_digest.c
         tests/c/test_gossip.c
         tests/c/test_npc_radio.c
         client/identity.c

--- a/docs/authoritative-state-digest.md
+++ b/docs/authoritative-state-digest.md
@@ -1,0 +1,66 @@
+# Authoritative state digest
+
+`signal.authoritative_state.v1` is the canonical SHA-256 commitment for a
+post-tick Signal simulation state. Peers may compare the root only when they
+are at the same committed tick and the same ordered-input frontier.
+
+The implementation is `signal_authoritative_state_digest()` in
+`server/state_digest.c`. It packs every included value explicitly in
+little-endian order, hashes IEEE-754 float bits exactly, and never hashes a C
+struct, pointer, enum representation, padding byte, or allocation capacity.
+
+## Coverage contract
+
+| Domain | Included authority | Deliberate exclusions |
+| --- | --- | --- |
+| World clock and scheduling | RNG, belt seed, world sequence, tick/time, spawn/gravity/NPC/frontier timers, frontier counters and decisions, monotonic IDs, player-only mode | Regression telemetry counters |
+| Stations | Public identity and authored text, geometry/dynamics, prices, inventories/residue, services/factions, modules and production progress, ledgers, pending construction/builds/plans, policy decisions, cargo plus receipt chains, repair cadence, chain tail, knowledge and decision-driving HNN memory | `station_secret`, chain-log verification health, dirty flags, stored-hull summary, padding, flow diagnostics, HNN retrieval diagnostics |
+| Ships and hull assets | Generation-safe component slots; complete physics, upgrades, tow projections, cargo, stats, knowledge; asset ownership/custody/provenance and stored-ship state when the asset is actually stored | Component pointers and the stale `stored_ship` snapshot of an assigned asset |
+| Player controllers | Live/grace player membership, identity, hull reference, semantic input, pending movement commands by apply tick/sequence, docking, mining/tow action state, autopilot/teacher state, freshness IDs, damage attribution, pubkey proof state and signed-action nonce | Connections, replication baselines, arrival timestamps, analytics, ACK/result snapshots |
+| NPC controllers | Role/state, hull reference, semantic input, route/job state, identity and decision-driving HNN memory | Inspect/job diagnostics, display tint, pointers and HNN retrieval diagnostics |
+| Physical world | Active asteroids and origin metadata, fracture quorum state, destroyed-rock ledger, scaffolds, cargo pods and exact payloads, live tow links, all generation counters/liveness bits, ship-birth assemblies and character registry | Network dirty bits, pod summary projections, inactive entity payload bytes |
+| Economy and trust | Contracts, delivery debt/settlement records with exact cargo and receipt chains, pubkey registry, handoff replay guard | Operator-local files and secrets |
+| Signal channel | Logical message order, IDs, timestamps, sender, bounded text/audio, entry hashes and chain tail | Unused ring-buffer slots |
+
+The following `world_t` members are intentionally outside consensus:
+
+- `connections`, `replications`, `pending_resolves`, `events`, and
+  `interactions` are transport or current-tick output;
+- `belt`, `asteroid_grid`, and `signal_cache` are rebuilt projections;
+- `signal_field` and `signal_field_decay_tick` are explicitly documented as
+  local advisory memory, not authority;
+- `hopper_smelt_events` and `hopper_smelt_units` are regression telemetry.
+
+If an excluded field begins influencing a future simulation transition,
+settlement decision, authorization decision, or persistent public state, the
+digest schema must change before that behavior ships.
+
+## Versioning rule
+
+The schema string and numeric version are part of the hash preimage and are
+emitted beside replay roots. Any change to field inclusion, ordering,
+normalization, numeric encoding, or entity ordering requires a new schema
+constant and version. Adding a field to `world_t` or to an included nested
+type therefore requires one of:
+
+1. explicitly encode it and bump the schema, or
+2. document why it is derived, transport-only, secret, diagnostic, or
+   otherwise outside consensus.
+
+The legacy replay `prefix_state_hash` and `state_hash` remain diagnostic
+compatibility fields. `prefix_state_root` and `state_root` are the versioned
+peer/quorum commitments.
+
+## Regression gates
+
+`tests/c/test_state_digest.c` verifies:
+
+- stable schema/version reporting and repeatability;
+- root sensitivity across global, station, ship, asteroid, tow, pod,
+  delivery, HNN, signal-channel, ordered-input, and identity domains;
+- root invariance for transport caches, secrets, retry queues, derived pod
+  summaries, local signal memory, and diagnostics.
+
+Native/WASM replay comparison is the cross-runner encoding gate: matching
+JSONL rows now also require matching versioned `prefix_state_root` and
+`state_root`.

--- a/docs/replay-harness.md
+++ b/docs/replay-harness.md
@@ -70,6 +70,10 @@ Each row has schema `signal.replay_counterfactual.v1` and includes:
 
 - `prefix_state_hash`: hash after replaying the shared input prefix.
 - `state_hash`: hash after the candidate branch horizon.
+- `state_digest_schema`: version of the canonical peer/quorum digest.
+- `state_digest_version`: numeric canonical digest version.
+- `prefix_state_root`: canonical authoritative root at the branch point.
+- `state_root`: canonical authoritative root after the branch horizon.
 - `event_hash`: hash of branch events in simulator order.
 - Safety metrics: hull, hull loss, damage events, death events, dock/launch
   events, and repair events.
@@ -113,13 +117,13 @@ one station and fails unless a worker physically carries that contract and its
 market-memory impression into a different station, where the spatial
 signal-field records the received demand locally.
 
-The hashes include the world tick/time, belt seed, player ship state, cargo
-manifest, station identity, station inventory cache, fracture claim windows,
-player ledger balance by session token and pubkey, and station chain tail.
-Float fields are hashed as their exact IEEE-754 bits, not rounded display
-values, so one-bit native/WASM or cross-build drift fails the diff. This makes
-repeated runs with the same seed and prefix cheap to diff and safe to ingest
-from CRLPLRIMES-style experiments.
+The legacy `*_state_hash` fields remain replay diagnostics. The versioned
+`*_state_root` fields use the audited coverage and exclusions in
+[`authoritative-state-digest.md`](authoritative-state-digest.md). Float fields
+are hashed as their exact IEEE-754 bits, not rounded display values, so one-bit
+native/WASM or cross-build drift fails the diff. This makes repeated runs with
+the same seed and prefix cheap to diff and safe to ingest from
+CRLPLRIMES-style experiments.
 
 ## Determinism Check
 

--- a/server/state_digest.c
+++ b/server/state_digest.c
@@ -1,0 +1,1166 @@
+#include "state_digest.h"
+
+#include <stddef.h>
+#include <string.h>
+
+#include "manifest.h"
+#include "sha256.h"
+
+typedef sha256_ctx_t state_digest_ctx_t;
+
+static void digest_bytes(state_digest_ctx_t *ctx, const void *data, size_t len)
+{
+    sha256_update(ctx, data, len);
+}
+
+static void digest_u8(state_digest_ctx_t *ctx, uint8_t value)
+{
+    digest_bytes(ctx, &value, sizeof(value));
+}
+
+static void digest_bool(state_digest_ctx_t *ctx, bool value)
+{
+    digest_u8(ctx, value ? 1u : 0u);
+}
+
+static void digest_u16(state_digest_ctx_t *ctx, uint16_t value)
+{
+    uint8_t packed[2] = {
+        (uint8_t)value,
+        (uint8_t)(value >> 8),
+    };
+    digest_bytes(ctx, packed, sizeof(packed));
+}
+
+static void digest_i16(state_digest_ctx_t *ctx, int16_t value)
+{
+    digest_u16(ctx, (uint16_t)value);
+}
+
+static void digest_u32(state_digest_ctx_t *ctx, uint32_t value)
+{
+    uint8_t packed[4] = {
+        (uint8_t)value,
+        (uint8_t)(value >> 8),
+        (uint8_t)(value >> 16),
+        (uint8_t)(value >> 24),
+    };
+    digest_bytes(ctx, packed, sizeof(packed));
+}
+
+static void digest_i32(state_digest_ctx_t *ctx, int32_t value)
+{
+    digest_u32(ctx, (uint32_t)value);
+}
+
+static void digest_u64(state_digest_ctx_t *ctx, uint64_t value)
+{
+    uint8_t packed[8];
+    for (int i = 0; i < 8; i++)
+        packed[i] = (uint8_t)(value >> (i * 8));
+    digest_bytes(ctx, packed, sizeof(packed));
+}
+
+static void digest_float(state_digest_ctx_t *ctx, float value)
+{
+    uint32_t bits = 0;
+    memcpy(&bits, &value, sizeof(bits));
+    digest_u32(ctx, bits);
+}
+
+static void digest_text(state_digest_ctx_t *ctx, const char *text, size_t cap)
+{
+    size_t len = 0;
+    if (text) {
+        while (len < cap && text[len] != '\0')
+            len++;
+    }
+    digest_u32(ctx, (uint32_t)len);
+    if (len > 0)
+        digest_bytes(ctx, text, len);
+}
+
+static void digest_vec2(state_digest_ctx_t *ctx, vec2 value)
+{
+    digest_float(ctx, value.x);
+    digest_float(ctx, value.y);
+}
+
+static void digest_entity_ref(state_digest_ctx_t *ctx, entity_ref_t ref)
+{
+    if (entity_ref_is_none(ref))
+        ref = entity_ref_none();
+    digest_u8(ctx, ref.kind);
+    digest_i16(ctx, ref.index);
+    digest_i16(ctx, ref.part);
+    digest_u16(ctx, ref.generation);
+}
+
+static void digest_tractor_binding(state_digest_ctx_t *ctx,
+                                   const tractor_binding_t *binding)
+{
+    if (!binding) {
+        digest_u8(ctx, (uint8_t)TRACTOR_SOURCE_NONE);
+        digest_i16(ctx, -1);
+        digest_i16(ctx, -1);
+        digest_u16(ctx, 0);
+        return;
+    }
+    if (binding->kind == TRACTOR_SOURCE_NONE) {
+        digest_u8(ctx, (uint8_t)TRACTOR_SOURCE_NONE);
+        digest_i16(ctx, -1);
+        digest_i16(ctx, -1);
+        digest_u16(ctx, 0);
+        return;
+    }
+    digest_u8(ctx, (uint8_t)binding->kind);
+    digest_i16(ctx, binding->source_index);
+    digest_i16(ctx, binding->source_part);
+    digest_u16(ctx, binding->source_generation);
+}
+
+static void digest_cargo_unit(state_digest_ctx_t *ctx,
+                              const cargo_unit_t *unit)
+{
+    uint8_t packed[CARGO_UNIT_WIRE_SIZE];
+    cargo_unit_t zero = {0};
+    cargo_unit_wire_pack(unit ? unit : &zero, packed);
+    digest_bytes(ctx, packed, sizeof(packed));
+}
+
+static void digest_receipt_chain(state_digest_ctx_t *ctx,
+                                 const cargo_receipt_chain_t *chain)
+{
+    uint8_t len = chain ? chain->len : 0;
+    if (len > CARGO_RECEIPT_CHAIN_MAX_LEN)
+        len = CARGO_RECEIPT_CHAIN_MAX_LEN;
+    digest_u8(ctx, len);
+    for (uint8_t i = 0; i < len; i++) {
+        uint8_t packed[CARGO_RECEIPT_SIZE];
+        cargo_receipt_pack(&chain->links[i], packed);
+        digest_bytes(ctx, packed, sizeof(packed));
+    }
+}
+
+static void digest_cargo_store(state_digest_ctx_t *ctx,
+                               const cargo_store_t *store)
+{
+    const manifest_t *manifest = store ? &store->manifest : NULL;
+    const ship_receipts_t *receipts =
+        store ? cargo_store_receipts_const(store) : NULL;
+    uint16_t count = manifest ? manifest->count : 0;
+
+    digest_u16(ctx, count);
+    digest_u16(ctx, receipts ? receipts->count : 0);
+    for (uint16_t i = 0; i < count; i++) {
+        const cargo_unit_t *unit =
+            manifest && manifest->units ? &manifest->units[i] : NULL;
+        const cargo_receipt_chain_t *chain =
+            receipts && receipts->chains && i < receipts->count
+                ? &receipts->chains[i]
+                : NULL;
+        digest_cargo_unit(ctx, unit);
+        digest_receipt_chain(ctx, chain);
+    }
+}
+
+static void digest_knowledge_view(state_digest_ctx_t *ctx,
+                                  const knowledge_view_t *view)
+{
+    uint8_t count = view ? view->count : 0;
+    uint8_t capacity = view ? view->capacity : 0;
+    if (count > KNOWLEDGE_VIEW_MAX_CAP)
+        count = KNOWLEDGE_VIEW_MAX_CAP;
+    if (capacity > KNOWLEDGE_VIEW_MAX_CAP)
+        capacity = KNOWLEDGE_VIEW_MAX_CAP;
+
+    digest_u8(ctx, count);
+    digest_u8(ctx, capacity);
+    for (uint8_t i = 0; i < count; i++) {
+        const knowledge_item_t *item = &view->items[i];
+        digest_u8(ctx, item->kind);
+        digest_u8(ctx, item->hops);
+        digest_u8(ctx, item->confidence);
+        digest_u8(ctx, item->salience);
+        digest_u8(ctx, item->payload_kind);
+        digest_bytes(ctx, item->subject_hash, sizeof(item->subject_hash));
+        digest_bytes(ctx, item->chain_anchor, sizeof(item->chain_anchor));
+        digest_bytes(ctx, item->source_hash, sizeof(item->source_hash));
+        digest_bytes(ctx, item->witness_hash, sizeof(item->witness_hash));
+        digest_u64(ctx, item->observed_tick);
+        digest_u64(ctx, item->learned_tick);
+        digest_bytes(ctx, item->payload, sizeof(item->payload));
+    }
+}
+
+static void digest_hnn_memory(state_digest_ctx_t *ctx,
+                              const hnn_memory_t *memory)
+{
+    digest_i32(ctx, memory ? memory->experience_count : 0);
+    if (!memory) {
+        for (int i = 0; i < HNN_DIM; i++)
+            digest_float(ctx, 0.0f);
+        return;
+    }
+    for (int i = 0; i < HNN_DIM; i++)
+        digest_float(ctx, memory->store[i]);
+}
+
+static void digest_input_intent(state_digest_ctx_t *ctx,
+                                const input_intent_t *input)
+{
+    input_intent_t zero = {0};
+    if (!input)
+        input = &zero;
+
+    digest_float(ctx, input->turn);
+    digest_float(ctx, input->thrust);
+    digest_bool(ctx, input->mine);
+    digest_bool(ctx, input->dock);
+    digest_bool(ctx, input->launch);
+    digest_bool(ctx, input->interact);
+    digest_bool(ctx, input->service_sell);
+    digest_i32(ctx, (int32_t)input->service_sell_only);
+    digest_i32(ctx, (int32_t)input->service_sell_grade);
+    digest_bool(ctx, input->service_sell_one);
+    digest_bool(ctx, input->service_repair);
+    digest_bool(ctx, input->upgrade_mining);
+    digest_bool(ctx, input->upgrade_hold);
+    digest_bool(ctx, input->upgrade_tractor);
+    digest_bool(ctx, input->place_outpost);
+    digest_u8(ctx, (uint8_t)input->place_target_station);
+    digest_u8(ctx, (uint8_t)input->place_target_ring);
+    digest_u8(ctx, (uint8_t)input->place_target_slot);
+    digest_bool(ctx, input->add_plan);
+    digest_u8(ctx, (uint8_t)input->plan_station);
+    digest_u8(ctx, (uint8_t)input->plan_ring);
+    digest_u8(ctx, (uint8_t)input->plan_slot);
+    digest_i32(ctx, (int32_t)input->plan_type);
+    digest_bool(ctx, input->create_planned_outpost);
+    digest_vec2(ctx, input->planned_outpost_pos);
+    digest_bool(ctx, input->cancel_planned_outpost);
+    digest_u8(ctx, (uint8_t)input->cancel_planned_station);
+    digest_bool(ctx, input->cancel_plan_slot);
+    digest_u8(ctx, (uint8_t)input->cancel_plan_st);
+    digest_u8(ctx, (uint8_t)input->cancel_plan_ring);
+    digest_u8(ctx, (uint8_t)input->cancel_plan_sl);
+    digest_bool(ctx, input->buy_scaffold_kit);
+    digest_i32(ctx, (int32_t)input->scaffold_kit_module);
+    digest_bool(ctx, input->commission_ship);
+    digest_i32(ctx, (int32_t)input->commission_hull_class);
+    digest_bool(ctx, input->buy_product);
+    digest_i32(ctx, (int32_t)input->buy_commodity);
+    digest_bool(ctx, input->buy_station_pod);
+    digest_u16(ctx, input->buy_station_pod_index);
+    digest_i32(ctx, (int32_t)input->buy_grade);
+    digest_i32(ctx, input->mining_target_hint);
+    digest_bool(ctx, input->hail);
+    digest_bool(ctx, input->tractor_hold);
+    digest_bool(ctx, input->release_tow);
+    digest_bool(ctx, input->reset);
+    digest_bool(ctx, input->toggle_autopilot);
+    digest_bool(ctx, input->boost);
+    digest_bool(ctx, input->reverse_thrust);
+}
+
+static void digest_ship(state_digest_ctx_t *ctx, const ship_t *ship)
+{
+    ship_t zero = {0};
+    if (!ship)
+        ship = &zero;
+
+    digest_vec2(ctx, ship->pos);
+    digest_vec2(ctx, ship->vel);
+    digest_float(ctx, ship->angle);
+    digest_float(ctx, ship->hull);
+    for (int c = 0; c < COMMODITY_COUNT; c++)
+        digest_float(ctx, ship->cargo[c]);
+    digest_i32(ctx, (int32_t)ship->hull_class);
+    digest_i32(ctx, ship->mining_level);
+    digest_i32(ctx, ship->hold_level);
+    digest_i32(ctx, ship->tractor_level);
+    for (size_t i = 0;
+         i < sizeof(ship->towed_fragments) / sizeof(ship->towed_fragments[0]);
+         i++) {
+        digest_i16(ctx, ship->towed_fragments[i]);
+    }
+    digest_u8(ctx, ship->towed_count);
+    for (size_t i = 0;
+         i < sizeof(ship->towed_pods) / sizeof(ship->towed_pods[0]);
+         i++) {
+        digest_i16(ctx, ship->towed_pods[i]);
+    }
+    digest_u8(ctx, ship->towed_pod_count);
+    digest_i16(ctx, ship->towed_scaffold);
+    digest_bool(ctx, ship->tractor_active);
+    digest_float(ctx, ship->comm_range);
+    digest_u32(ctx, ship->unlocked_modules);
+    digest_float(ctx, ship->stat_ore_mined);
+    digest_float(ctx, ship->stat_credits_earned);
+    digest_float(ctx, ship->stat_credits_spent);
+    digest_i32(ctx, ship->stat_asteroids_fractured);
+    digest_cargo_store(ctx, &ship->cargo_store);
+    digest_knowledge_view(ctx, &ship->knowledge);
+}
+
+static void digest_station_module(state_digest_ctx_t *ctx,
+                                  const station_module_t *module)
+{
+    digest_i32(ctx, (int32_t)module->type);
+    digest_u8(ctx, module->ring);
+    digest_u8(ctx, module->slot);
+    digest_bool(ctx, module->scaffold);
+    digest_u8(ctx, module->last_smelt_commodity);
+    digest_u8(ctx, module->commodity);
+    digest_float(ctx, module->build_progress);
+    digest_float(ctx, module->input_buffer);
+    digest_float(ctx, module->output_buffer);
+    digest_float(ctx, module->active_pulse);
+    digest_float(ctx, module->craft_progress);
+}
+
+static void digest_station(state_digest_ctx_t *ctx, const station_t *station)
+{
+    int module_count = station->module_count;
+    int pending_scaffold_count = station->pending_scaffold_count;
+    int pending_ship_count = station->pending_ship_build_count;
+    int placement_plan_count = station->placement_plan_count;
+    int ledger_count = station->ledger_count;
+
+    if (module_count < 0) module_count = 0;
+    if (module_count > MAX_MODULES_PER_STATION)
+        module_count = MAX_MODULES_PER_STATION;
+    if (pending_scaffold_count < 0) pending_scaffold_count = 0;
+    if (pending_scaffold_count > 4) pending_scaffold_count = 4;
+    if (pending_ship_count < 0) pending_ship_count = 0;
+    if (pending_ship_count > 4) pending_ship_count = 4;
+    if (placement_plan_count < 0) placement_plan_count = 0;
+    if (placement_plan_count > 8) placement_plan_count = 8;
+    if (ledger_count < 0) ledger_count = 0;
+    if (ledger_count > STATION_LEDGER_MAX)
+        ledger_count = STATION_LEDGER_MAX;
+
+    digest_u32(ctx, station->id);
+    digest_text(ctx, station->name, sizeof(station->name));
+    digest_vec2(ctx, station->pos);
+    digest_vec2(ctx, station->jostle_vel);
+    digest_float(ctx, station->radius);
+    digest_float(ctx, station->dock_radius);
+    digest_float(ctx, station->signal_range);
+    digest_bool(ctx, station->signal_connected);
+    digest_bool(ctx, station->scaffold);
+    digest_bool(ctx, station->planned);
+    digest_u8(ctx, (uint8_t)station->planned_owner);
+    digest_float(ctx, station->scaffold_progress);
+    for (int c = 0; c < COMMODITY_COUNT; c++) {
+        digest_float(ctx, station->base_price[c]);
+        digest_float(ctx, station->_inventory_cache[c]);
+        digest_float(ctx, station->_finished_residue[c]);
+    }
+    digest_u32(ctx, station->services);
+
+    digest_i32(ctx, module_count);
+    for (int i = 0; i < module_count; i++)
+        digest_station_module(ctx, &station->modules[i]);
+
+    digest_i32(ctx, station->arm_count);
+    for (int i = 0; i < MAX_ARMS; i++) {
+        digest_float(ctx, station->arm_rotation[i]);
+        digest_float(ctx, station->arm_speed[i]);
+        digest_float(ctx, station->arm_omega[i]);
+        digest_float(ctx, station->ring_offset[i]);
+    }
+
+    digest_text(ctx, station->hail_message, sizeof(station->hail_message));
+    for (size_t i = 0;
+         i < sizeof(station->miner_chatter) / sizeof(station->miner_chatter[0]);
+         i++) {
+        digest_text(ctx, station->miner_chatter[i],
+                    sizeof(station->miner_chatter[i]));
+    }
+    for (size_t i = 0;
+         i < sizeof(station->hauler_chatter) /
+                 sizeof(station->hauler_chatter[0]);
+         i++) {
+        digest_text(ctx, station->hauler_chatter[i],
+                    sizeof(station->hauler_chatter[i]));
+    }
+    digest_text(ctx, station->rati_hail_message,
+                sizeof(station->rati_hail_message));
+    digest_text(ctx, station->station_slug, sizeof(station->station_slug));
+    digest_text(ctx, station->currency_name, sizeof(station->currency_name));
+    digest_u8(ctx, station->faction_id);
+    digest_u8(ctx, station->faction_allegiance);
+    digest_u8(ctx, station->faction_ideology);
+    for (int i = 0; i < STATION_FACTION_COUNT; i++)
+        digest_u8(ctx, (uint8_t)station->faction_relations[i]);
+
+    digest_i32(ctx, ledger_count);
+    for (int i = 0; i < ledger_count; i++) {
+        digest_bytes(ctx, station->ledger[i].player_pubkey,
+                     sizeof(station->ledger[i].player_pubkey));
+        digest_float(ctx, station->ledger[i].balance);
+        digest_float(ctx, station->ledger[i].lifetime_supply);
+        digest_u64(ctx, station->ledger[i].first_dock_tick);
+        digest_u64(ctx, station->ledger[i].last_dock_tick);
+        digest_u32(ctx, station->ledger[i].total_docks);
+        digest_u32(ctx, station->ledger[i].lifetime_ore_units);
+        digest_u32(ctx, station->ledger[i].lifetime_credits_in);
+        digest_u32(ctx, station->ledger[i].lifetime_credits_out);
+        digest_u8(ctx, station->ledger[i].top_commodity);
+    }
+
+    digest_i32(ctx, pending_scaffold_count);
+    for (int i = 0; i < pending_scaffold_count; i++) {
+        digest_i32(ctx, (int32_t)station->pending_scaffolds[i].type);
+        digest_u8(ctx, (uint8_t)station->pending_scaffolds[i].owner);
+    }
+    digest_i32(ctx, pending_ship_count);
+    for (int i = 0; i < pending_ship_count; i++) {
+        const pending_ship_build_t *build = &station->pending_ship_builds[i];
+        digest_i32(ctx, (int32_t)build->hull_class);
+        digest_u8(ctx, (uint8_t)build->owner);
+        digest_u8(ctx, build->owner_kind);
+        digest_float(ctx, build->build_progress);
+        digest_bytes(ctx, build->owner_pubkey, sizeof(build->owner_pubkey));
+        digest_bytes(ctx, build->owner_session, sizeof(build->owner_session));
+    }
+    digest_i32(ctx, placement_plan_count);
+    for (int i = 0; i < placement_plan_count; i++) {
+        digest_i32(ctx, (int32_t)station->placement_plans[i].type);
+        digest_u8(ctx, station->placement_plans[i].ring);
+        digest_u8(ctx, station->placement_plans[i].slot);
+        digest_u8(ctx, (uint8_t)station->placement_plans[i].owner);
+    }
+
+    digest_u64(ctx, station->policy_tick);
+    digest_u32(ctx, station->policy_generation);
+    digest_u8(ctx, station->policy_budget_trade);
+    digest_u8(ctx, station->policy_budget_construction);
+    digest_u8(ctx, station->policy_budget_finance);
+    digest_u8(ctx, station->policy_card_count);
+    for (int i = 0; i < 8; i++) {
+        digest_u8(ctx, station->policy_card_ids[i]);
+        digest_u8(ctx, station->policy_card_domains[i]);
+        digest_u8(ctx, station->policy_card_costs[i]);
+        digest_float(ctx, station->policy_card_scores[i]);
+    }
+    digest_u8(ctx, station->policy_top_demand_commodity);
+    digest_float(ctx, station->policy_top_demand_severity);
+    digest_float(ctx, station->policy_top_demand_price_mult);
+
+    digest_cargo_store(ctx, &station->cargo_store);
+    digest_float(ctx, station->repair_kit_fab_timer);
+    digest_bytes(ctx, station->station_pubkey,
+                 sizeof(station->station_pubkey));
+    digest_bytes(ctx, station->outpost_founder_pubkey,
+                 sizeof(station->outpost_founder_pubkey));
+    digest_u64(ctx, station->outpost_planted_tick);
+    digest_knowledge_view(ctx, &station->knowledge);
+    digest_bytes(ctx, station->chain_last_hash,
+                 sizeof(station->chain_last_hash));
+    digest_u64(ctx, station->chain_event_count);
+    digest_hnn_memory(ctx, &station->hnn_market_memory);
+    digest_u32(ctx, station->hnn_market_version);
+    digest_u32(ctx, station->hnn_market_decay_tick);
+    digest_hnn_memory(ctx, &station->hnn_experience);
+    digest_u32(ctx, station->hnn_experience_version);
+    digest_u32(ctx, station->hnn_experience_upload_count);
+    digest_u32(ctx, station->hnn_experience_download_count);
+    digest_u8(ctx, station->hnn_experience_last_source_station);
+}
+
+static void digest_player(state_digest_ctx_t *ctx,
+                          const server_player_t *player)
+{
+    uint8_t movement_count = player->movement_queue_count;
+    if (movement_count > PLAYER_MOVEMENT_QUEUE_CAP)
+        movement_count = PLAYER_MOVEMENT_QUEUE_CAP;
+
+    digest_bool(ctx, player->connected);
+    digest_u8(ctx, player->id);
+    digest_bytes(ctx, player->session_token, sizeof(player->session_token));
+    digest_bool(ctx, player->session_ready);
+    digest_bool(ctx, player->grace_period);
+    digest_float(ctx, player->grace_timer);
+    digest_u32(ctx, player->ship_asset_id);
+    digest_entity_ref(ctx, player->ship_ref);
+    digest_input_intent(ctx, &player->input);
+    digest_float(ctx, player->boost_hold_timer);
+    digest_i32(ctx, player->current_station);
+    digest_i32(ctx, player->nearby_station);
+    digest_bool(ctx, player->docked);
+    digest_bool(ctx, player->in_dock_range);
+    digest_bool(ctx, player->docking_approach);
+    digest_i32(ctx, player->dock_berth);
+    digest_bool(ctx, player->beam_active);
+    digest_bool(ctx, player->beam_hit);
+    digest_bool(ctx, player->beam_ineffective);
+    digest_bool(ctx, player->scan_active);
+    digest_i32(ctx, player->scan_target_type);
+    digest_i32(ctx, player->scan_target_index);
+    digest_i32(ctx, player->scan_module_index);
+    digest_i32(ctx, player->hover_asteroid);
+    digest_vec2(ctx, player->beam_start);
+    digest_vec2(ctx, player->beam_end);
+    digest_float(ctx, player->cargo_sale_value);
+    digest_i32(ctx, player->nearby_fragments);
+    digest_i32(ctx, player->tractor_fragments);
+    digest_bool(ctx, player->was_in_signal);
+    digest_bytes(ctx, player->callsign, sizeof(player->callsign));
+    digest_bool(ctx, player->actual_thrusting);
+
+    digest_u8(ctx, player->autopilot_mode);
+    digest_i32(ctx, player->autopilot_target);
+    digest_i32(ctx, player->autopilot_station_target);
+    digest_i32(ctx, (int32_t)player->autopilot_cargo);
+    digest_i32(ctx, player->autopilot_state);
+    digest_float(ctx, player->autopilot_timer);
+    digest_vec2(ctx, player->autopilot_last_pos);
+    digest_float(ctx, player->autopilot_stuck_timer);
+    digest_u8(ctx, player->autopilot_teacher_valid);
+    digest_u8(ctx, player->autopilot_teacher_forward_blocked);
+    digest_u16(ctx, player->autopilot_teacher_allowed_mask);
+    digest_u32(ctx, player->autopilot_teacher_tick);
+    digest_u8(ctx, (uint8_t)player->autopilot_teacher_action);
+    digest_u8(ctx, (uint8_t)player->autopilot_teacher_turn);
+    digest_u8(ctx, (uint8_t)player->autopilot_teacher_thrust);
+    for (size_t i = 0;
+         i < sizeof(player->autopilot_teacher_features) /
+                 sizeof(player->autopilot_teacher_features[0]);
+         i++) {
+        digest_float(ctx, player->autopilot_teacher_features[i]);
+    }
+    digest_u8(ctx, player->autopilot_decision_valid);
+    digest_u8(ctx, player->autopilot_decision_action);
+    digest_u8(ctx, player->autopilot_decision_candidate_count);
+    digest_u32(ctx, player->autopilot_decision_flags);
+    digest_float(ctx, player->autopilot_decision_score);
+    digest_float(ctx, player->autopilot_decision_neural_score);
+    digest_float(ctx, player->autopilot_decision_route_risk);
+    digest_float(ctx, player->autopilot_decision_signal_quality);
+    digest_u8(ctx, player->hail_decision_valid);
+    digest_u8(ctx, (uint8_t)player->hail_decision_station);
+    digest_u8(ctx, player->hail_decision_candidate_count);
+    digest_u32(ctx, player->hail_decision_flags);
+    digest_float(ctx, player->hail_decision_score);
+    digest_float(ctx, player->hail_decision_signal_quality);
+    digest_u64(ctx, player->hail_decision_source_id);
+    digest_u8(ctx, player->server_brain_mode);
+
+    digest_u8(ctx, movement_count);
+    for (uint8_t i = 0; i < movement_count; i++) {
+        const movement_input_cmd_t *command = &player->movement_queue[i];
+        digest_u32(ctx, command->apply_tick);
+        digest_u16(ctx, command->input_seq);
+        digest_input_intent(ctx, &command->intent);
+    }
+    digest_u16(ctx, player->last_input_seq);
+    digest_u32(ctx, player->last_input_tick);
+    digest_u16(ctx, player->last_input_action_id);
+    digest_bool(ctx, player->last_input_action_id_valid);
+    digest_bytes(ctx, player->last_damage_killer_token,
+                 sizeof(player->last_damage_killer_token));
+    digest_u8(ctx, player->last_damage_cause);
+    digest_bytes(ctx, player->pubkey, sizeof(player->pubkey));
+    digest_bool(ctx, player->pubkey_set);
+    digest_bool(ctx, player->pubkey_proof_ok);
+    digest_bool(ctx, player->pubkey_identity_finalized);
+    digest_bool(ctx, player->preserve_live_state_on_pubkey_finalize);
+    digest_u64(ctx, player->last_signed_nonce);
+}
+
+static void digest_npc(state_digest_ctx_t *ctx, const npc_ship_t *npc)
+{
+    digest_i32(ctx, (int32_t)npc->role);
+    digest_i32(ctx, (int32_t)npc->state);
+    digest_u32(ctx, npc->ship_asset_id);
+    digest_entity_ref(ctx, npc->ship_ref);
+    digest_input_intent(ctx, &npc->input);
+    digest_i32(ctx, npc->target_asteroid);
+    digest_i32(ctx, npc->home_station);
+    digest_i32(ctx, npc->dest_station);
+    digest_i32(ctx, npc->pickup_station);
+    digest_i32(ctx, (int32_t)npc->pickup_commodity);
+    digest_u8(ctx, npc->pickup_action);
+    digest_float(ctx, npc->state_timer);
+    digest_bool(ctx, npc->thrusting);
+    digest_bytes(ctx, npc->session_token, sizeof(npc->session_token));
+    digest_u8(ctx, npc->brain_mode);
+    digest_hnn_memory(ctx, &npc->hnn_market_mem);
+    digest_u32(ctx, npc->hnn_market_version);
+    digest_u8(ctx, npc->hnn_market_station);
+    digest_u32(ctx, npc->hnn_market_decay_tick);
+    digest_hnn_memory(ctx, &npc->hnn_mem);
+    digest_u32(ctx, npc->hnn_experience_version);
+    digest_u32(ctx, npc->hnn_experience_local_version);
+    digest_u32(ctx, npc->hnn_experience_uploaded_local_version);
+    digest_u32(ctx, npc->hnn_experience_uploaded_source_version);
+    digest_u8(ctx, npc->hnn_experience_station);
+    digest_u8(ctx, npc->hnn_experience_uploaded_station);
+    digest_u8(ctx, npc->hnn_experience_uploaded_source_station);
+}
+
+static void digest_ship_asset(state_digest_ctx_t *ctx,
+                              const ship_asset_t *asset)
+{
+    digest_u32(ctx, asset->asset_id);
+    digest_i32(ctx, (int32_t)asset->hull_class);
+    digest_entity_ref(ctx, asset->live_ship_ref);
+    digest_u8(ctx, asset->owner_kind);
+    digest_u8(ctx, asset->status);
+    digest_u8(ctx, asset->operator_kind);
+    digest_u8(ctx, asset->provenance);
+    digest_i16(ctx, asset->owner_station);
+    digest_i16(ctx, asset->custody_station);
+    digest_i16(ctx, asset->operator_slot);
+    digest_i16(ctx, asset->build_station);
+    digest_bool(ctx, asset->loaner);
+    digest_bool(ctx, asset->destroyed);
+    digest_bytes(ctx, asset->owner_pubkey, sizeof(asset->owner_pubkey));
+    digest_bytes(ctx, asset->owner_session, sizeof(asset->owner_session));
+    digest_bytes(ctx, asset->birth_soul_pub, sizeof(asset->birth_soul_pub));
+    digest_bytes(ctx, asset->birth_material_root,
+                 sizeof(asset->birth_material_root));
+    digest_bytes(ctx, asset->birth_fragment_pubs,
+                 sizeof(asset->birth_fragment_pubs));
+    if (asset->status == SHIP_ASSET_STATUS_STORED)
+        digest_ship(ctx, &asset->stored_ship);
+}
+
+static void digest_birth_assembly(state_digest_ctx_t *ctx,
+                                  const ship_birth_assembly_t *assembly)
+{
+    for (int i = 0; i < 3; i++)
+        digest_i16(ctx, assembly->fragment_slots[i]);
+    digest_float(ctx, assembly->age);
+    for (int i = 0; i < 3; i++)
+        digest_float(ctx, assembly->start_dist[i]);
+    digest_vec2(ctx, assembly->target);
+    digest_bytes(ctx, assembly->fragment_pubs,
+                 sizeof(assembly->fragment_pubs));
+}
+
+static void digest_character(state_digest_ctx_t *ctx,
+                             const character_t *character)
+{
+    digest_i32(ctx, (int32_t)character->kind);
+    digest_i32(ctx, character->actor_slot);
+    digest_entity_ref(ctx, character->ship_ref);
+}
+
+static void digest_scaffold(state_digest_ctx_t *ctx,
+                            const scaffold_t *scaffold)
+{
+    digest_i32(ctx, (int32_t)scaffold->module_type);
+    digest_i32(ctx, (int32_t)scaffold->state);
+    digest_i32(ctx, scaffold->owner);
+    digest_vec2(ctx, scaffold->pos);
+    digest_vec2(ctx, scaffold->vel);
+    digest_float(ctx, scaffold->radius);
+    digest_float(ctx, scaffold->rotation);
+    digest_float(ctx, scaffold->spin);
+    digest_float(ctx, scaffold->age);
+    digest_i32(ctx, scaffold->placed_station);
+    digest_i32(ctx, scaffold->placed_ring);
+    digest_i32(ctx, scaffold->placed_slot);
+    digest_tractor_binding(ctx, &scaffold->tractor);
+    digest_i32(ctx, scaffold->built_at_station);
+    digest_float(ctx, scaffold->build_amount);
+}
+
+static void digest_cargo_pod(state_digest_ctx_t *ctx,
+                             const cargo_pod_t *pod)
+{
+    uint16_t manifest_count = pod->manifest_count;
+    if (manifest_count > CARGO_POD_MANIFEST_CAP)
+        manifest_count = CARGO_POD_MANIFEST_CAP;
+
+    digest_i32(ctx, (int32_t)pod->kind);
+    digest_i32(ctx, (int32_t)pod->commodity);
+    digest_u16(ctx, pod->quantity);
+    digest_u16(ctx, manifest_count);
+    for (uint16_t i = 0; i < manifest_count; i++)
+        digest_cargo_unit(ctx, &pod->manifest_units[i]);
+    digest_bool(ctx, pod->has_shell_frame);
+    if (pod->has_shell_frame)
+        digest_cargo_unit(ctx, &pod->shell_frame);
+    digest_u16(ctx, pod->shipment_id);
+    digest_vec2(ctx, pod->pos);
+    digest_vec2(ctx, pod->vel);
+    digest_float(ctx, pod->radius);
+    digest_float(ctx, pod->rotation);
+    digest_float(ctx, pod->spin);
+    digest_float(ctx, pod->age);
+    digest_tractor_binding(ctx, &pod->tractor);
+    digest_u8(ctx, pod->tow_hardpoint_tag);
+    digest_u8(ctx, pod->custody_station);
+}
+
+static void digest_asteroid(state_digest_ctx_t *ctx,
+                            const asteroid_t *asteroid)
+{
+    digest_bool(ctx, asteroid->fracture_child);
+    digest_i32(ctx, (int32_t)asteroid->tier);
+    digest_vec2(ctx, asteroid->pos);
+    digest_vec2(ctx, asteroid->vel);
+    digest_float(ctx, asteroid->radius);
+    digest_float(ctx, asteroid->hp);
+    digest_float(ctx, asteroid->max_hp);
+    digest_float(ctx, asteroid->ore);
+    digest_float(ctx, asteroid->max_ore);
+    digest_i32(ctx, (int32_t)asteroid->commodity);
+    digest_float(ctx, asteroid->rotation);
+    digest_float(ctx, asteroid->spin);
+    digest_float(ctx, asteroid->seed);
+    digest_float(ctx, asteroid->age);
+    digest_tractor_binding(ctx, &asteroid->tractor);
+    digest_u8(ctx, (uint8_t)asteroid->last_towed_by);
+    digest_u8(ctx, (uint8_t)asteroid->last_fractured_by);
+    digest_float(ctx, asteroid->smelt_progress);
+    digest_u8(ctx, asteroid->crystal_stage);
+    digest_u8(ctx, asteroid->crystal_stage_station);
+    digest_u8(ctx, asteroid->crystal_stage_module);
+    digest_u8(ctx, asteroid->phase);
+    digest_float(ctx, asteroid->gas_emit_timer);
+    digest_bytes(ctx, asteroid->last_towed_token,
+                 sizeof(asteroid->last_towed_token));
+    digest_bytes(ctx, asteroid->thrown_by_token,
+                 sizeof(asteroid->thrown_by_token));
+    digest_u8(ctx, asteroid->thrown_timer_q);
+    digest_bytes(ctx, asteroid->last_fractured_token,
+                 sizeof(asteroid->last_fractured_token));
+    digest_bytes(ctx, asteroid->fracture_seed,
+                 sizeof(asteroid->fracture_seed));
+    digest_bytes(ctx, asteroid->fragment_pub,
+                 sizeof(asteroid->fragment_pub));
+    digest_u8(ctx, asteroid->grade);
+    digest_bytes(ctx, asteroid->rock_pub, sizeof(asteroid->rock_pub));
+}
+
+static void digest_tow_link(state_digest_ctx_t *ctx,
+                            const tow_link_t *link)
+{
+    digest_entity_ref(ctx, link->source);
+    digest_entity_ref(ctx, link->target);
+    digest_u8(ctx, link->profile);
+    digest_u8(ctx, link->slot);
+    digest_u8(ctx, link->state);
+}
+
+static void digest_fracture_claim(state_digest_ctx_t *ctx,
+                                  const fracture_claim_state_t *claim)
+{
+    digest_bool(ctx, claim->active);
+    digest_bool(ctx, claim->resolved);
+    digest_u32(ctx, claim->fracture_id);
+    digest_u32(ctx, claim->deadline_ms);
+    digest_u16(ctx, claim->burst_cap);
+    digest_u32(ctx, claim->best_nonce);
+    digest_u8(ctx, claim->best_grade);
+    digest_bytes(ctx, claim->best_player_pub,
+                 sizeof(claim->best_player_pub));
+    digest_u8(ctx, claim->seen_claimant_count);
+    digest_bytes(ctx, claim->seen_claimant_tokens,
+                 sizeof(claim->seen_claimant_tokens));
+}
+
+static void digest_contract(state_digest_ctx_t *ctx,
+                            const contract_t *contract)
+{
+    digest_i32(ctx, (int32_t)contract->action);
+    digest_u8(ctx, contract->station_index);
+    digest_i32(ctx, (int32_t)contract->commodity);
+    digest_u8(ctx, contract->required_grade);
+    digest_u8(ctx, contract->proof_flags);
+    digest_u8(ctx, contract->required_prefix_class);
+    digest_u16(ctx, contract->required_recipe_id);
+    digest_bytes(ctx, contract->required_parent,
+                 sizeof(contract->required_parent));
+    digest_bytes(ctx, contract->target_pub, sizeof(contract->target_pub));
+    digest_u64(ctx, contract->forbidden_origin_mask);
+    digest_float(ctx, contract->quantity_needed);
+    digest_float(ctx, contract->base_price);
+    digest_float(ctx, contract->age);
+    digest_vec2(ctx, contract->target_pos);
+    digest_i32(ctx, contract->target_index);
+    digest_u8(ctx, (uint8_t)contract->claimed_by);
+}
+
+static void digest_delivery_shipment(state_digest_ctx_t *ctx,
+                                     const delivery_shipment_t *shipment)
+{
+    uint16_t payload_count = shipment->quantity_bound;
+    if (payload_count > MAX_DELIVERY_BOUND_CARGO)
+        payload_count = MAX_DELIVERY_BOUND_CARGO;
+
+    digest_u16(ctx, shipment->shipment_id);
+    digest_u8(ctx, shipment->origin_station);
+    digest_u8(ctx, shipment->destination_station);
+    digest_u8(ctx, shipment->contract_index);
+    digest_u8(ctx, shipment->debtor_player);
+    digest_u8(ctx, shipment->commodity);
+    digest_u16(ctx, shipment->quantity_total);
+    digest_u16(ctx, shipment->quantity_bound);
+    digest_u16(ctx, shipment->quantity_delivered);
+    digest_u16(ctx, shipment->quantity_black_market_sold);
+    digest_float(ctx, shipment->debt_principal);
+    digest_float(ctx, shipment->destination_payout);
+    digest_float(ctx, shipment->origin_completion_credit);
+    digest_u32(ctx, shipment->due_tick);
+    digest_u8(ctx, shipment->status);
+    digest_u16(ctx, payload_count);
+    for (uint16_t i = 0; i < payload_count; i++) {
+        digest_bytes(ctx, shipment->cargo_pub[i],
+                     sizeof(shipment->cargo_pub[i]));
+        digest_cargo_unit(ctx, &shipment->cargo_units[i]);
+        digest_receipt_chain(ctx, &shipment->cargo_chains[i]);
+    }
+}
+
+static void digest_signal_message(state_digest_ctx_t *ctx,
+                                  const signal_channel_msg_t *message)
+{
+    uint8_t text_len = message->text_len;
+    uint8_t audio_len = message->audio_len;
+    if (text_len >= SIGNAL_CHANNEL_TEXT_MAX)
+        text_len = SIGNAL_CHANNEL_TEXT_MAX - 1;
+    digest_u64(ctx, message->id);
+    digest_u32(ctx, message->timestamp_ms);
+    digest_i16(ctx, message->sender_station);
+    digest_u8(ctx, text_len);
+    digest_bytes(ctx, message->text, text_len);
+    digest_u8(ctx, audio_len);
+    digest_bytes(ctx, message->audio_url, audio_len);
+    digest_bytes(ctx, message->entry_hash, sizeof(message->entry_hash));
+}
+
+static void digest_signal_channel(state_digest_ctx_t *ctx,
+                                  const signal_channel_t *channel)
+{
+    int count = channel->count;
+    int head = channel->head;
+    if (count < 0) count = 0;
+    if (count > SIGNAL_CHANNEL_CAPACITY)
+        count = SIGNAL_CHANNEL_CAPACITY;
+    if (head < 0 || head >= SIGNAL_CHANNEL_CAPACITY)
+        head = 0;
+
+    digest_i32(ctx, count);
+    digest_u64(ctx, channel->next_id);
+    digest_bytes(ctx, channel->last_hash, sizeof(channel->last_hash));
+    int oldest = head - count;
+    while (oldest < 0)
+        oldest += SIGNAL_CHANNEL_CAPACITY;
+    for (int i = 0; i < count; i++) {
+        int slot = (oldest + i) % SIGNAL_CHANNEL_CAPACITY;
+        digest_signal_message(ctx, &channel->msgs[slot]);
+    }
+}
+
+const char *signal_authoritative_state_digest_schema(void)
+{
+    return SIGNAL_AUTH_STATE_DIGEST_SCHEMA;
+}
+
+uint32_t signal_authoritative_state_digest_version(void)
+{
+    return SIGNAL_AUTH_STATE_DIGEST_VERSION;
+}
+
+void signal_authoritative_state_digest(
+    const world_t *world,
+    uint8_t out[SIGNAL_AUTH_STATE_DIGEST_SIZE])
+{
+    state_digest_ctx_t ctx;
+    sha256_init(&ctx);
+    digest_text(&ctx, SIGNAL_AUTH_STATE_DIGEST_SCHEMA,
+                sizeof(SIGNAL_AUTH_STATE_DIGEST_SCHEMA) - 1u);
+    digest_u32(&ctx, SIGNAL_AUTH_STATE_DIGEST_VERSION);
+
+    if (!world) {
+        digest_bool(&ctx, false);
+        sha256_final(&ctx, out);
+        return;
+    }
+    digest_bool(&ctx, true);
+
+    digest_u32(&ctx, world->rng);
+    digest_u32(&ctx, world->belt_seed);
+    digest_u32(&ctx, world->world_seq);
+    digest_float(&ctx, world->time);
+    digest_u32(&ctx, world->tick);
+    digest_float(&ctx, world->field_spawn_timer);
+    digest_float(&ctx, world->gravity_accumulator);
+    digest_float(&ctx, world->npc_respawn_timer);
+    digest_bool(&ctx, world->player_only_mode);
+    digest_i32(&ctx, world->frontier_virtual_pilots);
+    digest_float(&ctx, world->frontier_plan_timer);
+    digest_u32(&ctx, world->frontier_plans_created);
+    digest_u32(&ctx, world->frontier_scaffold_orders);
+    digest_u32(&ctx, world->frontier_module_plans_created);
+    digest_u32(&ctx, world->frontier_module_scaffold_orders);
+    digest_u32(&ctx, world->frontier_virtual_scaffolds_manufactured);
+    digest_u32(&ctx, world->frontier_virtual_scaffold_deliveries);
+    digest_u32(&ctx, world->frontier_virtual_supply_deliveries);
+    digest_u8(&ctx, world->frontier_decision_valid);
+    digest_u8(&ctx, world->frontier_decision_action);
+    digest_u16(&ctx, world->frontier_decision_plan_limit);
+    digest_u32(&ctx, world->frontier_decision_flags);
+    digest_float(&ctx, world->frontier_decision_score);
+    digest_float(&ctx, world->frontier_decision_pressure);
+    digest_u64(&ctx, world->frontier_decision_source_id);
+    digest_u16(&ctx, world->next_npc_token);
+
+    int station_count = world->station_count;
+    if (station_count < 0) station_count = 0;
+    if (station_count > MAX_STATIONS) station_count = MAX_STATIONS;
+    digest_i32(&ctx, station_count);
+    digest_u32(&ctx, world->next_station_id);
+    for (int i = 0; i < station_count; i++) {
+        digest_i32(&ctx, i);
+        digest_station(&ctx, &world->stations[i]);
+    }
+
+    for (int i = 0; i < WORLD_SHIP_CAP; i++) {
+        const ship_slot_t *slot = &world->ships[i];
+        digest_bool(&ctx, slot->active);
+        digest_u16(&ctx, slot->generation);
+        if (slot->active)
+            digest_ship(&ctx, &slot->component);
+    }
+
+    int active_players = 0;
+    for (int i = 0; i < MAX_PLAYERS; i++) {
+        const server_player_t *player = &world->players[i];
+        if (player->connected || player->session_ready ||
+            player->grace_period || !entity_ref_is_none(player->ship_ref)) {
+            active_players++;
+        }
+    }
+    digest_i32(&ctx, active_players);
+    for (int i = 0; i < MAX_PLAYERS; i++) {
+        const server_player_t *player = &world->players[i];
+        if (!player->connected && !player->session_ready &&
+            !player->grace_period && entity_ref_is_none(player->ship_ref)) {
+            continue;
+        }
+        digest_i32(&ctx, i);
+        digest_player(&ctx, player);
+    }
+
+    int active_npcs = 0;
+    for (int i = 0; i < MAX_NPC_SHIPS; i++) {
+        if (world->npc_ships[i].active)
+            active_npcs++;
+    }
+    digest_i32(&ctx, active_npcs);
+    for (int i = 0; i < MAX_NPC_SHIPS; i++) {
+        if (!world->npc_ships[i].active)
+            continue;
+        digest_i32(&ctx, i);
+        digest_npc(&ctx, &world->npc_ships[i]);
+    }
+
+    digest_u32(&ctx, world->next_ship_asset_id);
+    int active_assets = 0;
+    for (int i = 0; i < MAX_SHIP_ASSETS; i++) {
+        if (world->ship_assets[i].active)
+            active_assets++;
+    }
+    digest_i32(&ctx, active_assets);
+    for (int i = 0; i < MAX_SHIP_ASSETS; i++) {
+        if (!world->ship_assets[i].active)
+            continue;
+        digest_i32(&ctx, i);
+        digest_ship_asset(&ctx, &world->ship_assets[i]);
+    }
+
+    int active_assemblies = 0;
+    for (int station = 0; station < MAX_STATIONS; station++) {
+        for (int slot = 0; slot < 4; slot++) {
+            if (world->ship_birth_assemblies[station][slot].active)
+                active_assemblies++;
+        }
+    }
+    digest_i32(&ctx, active_assemblies);
+    for (int station = 0; station < MAX_STATIONS; station++) {
+        for (int slot = 0; slot < 4; slot++) {
+            const ship_birth_assembly_t *assembly =
+                &world->ship_birth_assemblies[station][slot];
+            if (!assembly->active)
+                continue;
+            digest_i32(&ctx, station);
+            digest_i32(&ctx, slot);
+            digest_birth_assembly(&ctx, assembly);
+        }
+    }
+
+    int active_characters = 0;
+    for (int i = 0; i < WORLD_SHIP_CAP; i++) {
+        if (world->characters[i].active)
+            active_characters++;
+    }
+    digest_i32(&ctx, active_characters);
+    for (int i = 0; i < WORLD_SHIP_CAP; i++) {
+        if (!world->characters[i].active)
+            continue;
+        digest_i32(&ctx, i);
+        digest_character(&ctx, &world->characters[i]);
+    }
+
+    int active_asteroids = 0;
+    for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        if (world->asteroids[i].active)
+            active_asteroids++;
+    }
+    digest_i32(&ctx, active_asteroids);
+    for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        if (!world->asteroids[i].active)
+            continue;
+        digest_i32(&ctx, i);
+        digest_asteroid(&ctx, &world->asteroids[i]);
+        digest_bool(&ctx, world->asteroid_origin[i].from_chunk);
+        if (world->asteroid_origin[i].from_chunk) {
+            digest_i32(&ctx, world->asteroid_origin[i].chunk_x);
+            digest_i32(&ctx, world->asteroid_origin[i].chunk_y);
+        }
+    }
+
+    for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        const fracture_claim_state_t *claim = &world->fracture_claims[i];
+        bool present = claim->active || claim->resolved;
+        digest_bool(&ctx, present);
+        if (present)
+            digest_fracture_claim(&ctx, claim);
+    }
+    digest_u32(&ctx, world->next_fracture_id);
+
+    uint16_t destroyed_count = world->destroyed_rock_count;
+    if (destroyed_count > MAX_DESTROYED_ROCKS)
+        destroyed_count = MAX_DESTROYED_ROCKS;
+    digest_u16(&ctx, destroyed_count);
+    for (uint16_t i = 0; i < destroyed_count; i++) {
+        digest_bytes(&ctx, world->destroyed_rocks[i].rock_pub,
+                     sizeof(world->destroyed_rocks[i].rock_pub));
+        digest_u64(&ctx, world->destroyed_rocks[i].destroyed_at_ms);
+    }
+
+    int active_scaffolds = 0;
+    for (int i = 0; i < MAX_SCAFFOLDS; i++) {
+        if (world->scaffolds[i].active)
+            active_scaffolds++;
+    }
+    digest_i32(&ctx, active_scaffolds);
+    for (int i = 0; i < MAX_SCAFFOLDS; i++) {
+        if (!world->scaffolds[i].active)
+            continue;
+        digest_i32(&ctx, i);
+        digest_scaffold(&ctx, &world->scaffolds[i]);
+    }
+
+    int active_pods = 0;
+    for (int i = 0; i < MAX_CARGO_PODS; i++) {
+        if (world->cargo_pods[i].active)
+            active_pods++;
+    }
+    digest_i32(&ctx, active_pods);
+    for (int i = 0; i < MAX_CARGO_PODS; i++) {
+        if (!world->cargo_pods[i].active)
+            continue;
+        digest_i32(&ctx, i);
+        digest_cargo_pod(&ctx, &world->cargo_pods[i]);
+    }
+
+    int active_tow_links = 0;
+    for (int i = 0; i < MAX_TOW_LINKS; i++) {
+        if (world->tow_links[i].active)
+            active_tow_links++;
+    }
+    digest_i32(&ctx, active_tow_links);
+    for (int i = 0; i < MAX_TOW_LINKS; i++) {
+        if (!world->tow_links[i].active)
+            continue;
+        digest_i32(&ctx, i);
+        digest_tow_link(&ctx, &world->tow_links[i]);
+    }
+
+    for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        digest_u16(&ctx, world->asteroid_generation[i]);
+        digest_bool(&ctx, world->asteroid_generation_live[i]);
+    }
+    for (int i = 0; i < MAX_CARGO_PODS; i++) {
+        digest_u16(&ctx, world->cargo_pod_generation[i]);
+        digest_bool(&ctx, world->cargo_pod_generation_live[i]);
+    }
+    for (int i = 0; i < MAX_SCAFFOLDS; i++) {
+        digest_u16(&ctx, world->scaffold_generation[i]);
+        digest_bool(&ctx, world->scaffold_generation_live[i]);
+    }
+    for (int station = 0; station < MAX_STATIONS; station++) {
+        for (int module = 0; module < MAX_MODULES_PER_STATION; module++) {
+            digest_u16(&ctx,
+                       world->station_module_generation[station][module]);
+            digest_bool(
+                &ctx,
+                world->station_module_generation_live[station][module]);
+        }
+    }
+
+    int active_contracts = 0;
+    for (int i = 0; i < MAX_CONTRACTS; i++) {
+        if (world->contracts[i].active)
+            active_contracts++;
+    }
+    digest_i32(&ctx, active_contracts);
+    for (int i = 0; i < MAX_CONTRACTS; i++) {
+        if (!world->contracts[i].active)
+            continue;
+        digest_i32(&ctx, i);
+        digest_contract(&ctx, &world->contracts[i]);
+    }
+
+    digest_u16(&ctx, world->next_delivery_shipment_id);
+    int active_shipments = 0;
+    for (int i = 0; i < MAX_DELIVERY_SHIPMENTS; i++) {
+        if (world->delivery_shipments[i].active)
+            active_shipments++;
+    }
+    digest_i32(&ctx, active_shipments);
+    for (int i = 0; i < MAX_DELIVERY_SHIPMENTS; i++) {
+        if (!world->delivery_shipments[i].active)
+            continue;
+        digest_i32(&ctx, i);
+        digest_delivery_shipment(&ctx, &world->delivery_shipments[i]);
+    }
+
+    digest_signal_channel(&ctx, &world->signal_channel);
+
+    int registry_count = 0;
+    for (int i = 0; i < MAX_PLAYERS; i++) {
+        if (world->pubkey_registry[i].in_use)
+            registry_count++;
+    }
+    digest_i32(&ctx, registry_count);
+    for (int i = 0; i < MAX_PLAYERS; i++) {
+        if (!world->pubkey_registry[i].in_use)
+            continue;
+        digest_i32(&ctx, i);
+        digest_bytes(&ctx, world->pubkey_registry[i].pubkey,
+                     sizeof(world->pubkey_registry[i].pubkey));
+        digest_bytes(&ctx, world->pubkey_registry[i].session_token,
+                     sizeof(world->pubkey_registry[i].session_token));
+    }
+
+    uint16_t handoff_count = world->handoff_consumed_ticket_count;
+    if (handoff_count > 128)
+        handoff_count = 128;
+    digest_u16(&ctx, handoff_count);
+    digest_u16(&ctx, world->handoff_consumed_ticket_next);
+    for (uint16_t i = 0; i < handoff_count; i++) {
+        digest_bytes(&ctx, world->handoff_consumed_ticket_hashes[i],
+                     sizeof(world->handoff_consumed_ticket_hashes[i]));
+    }
+
+    sha256_final(&ctx, out);
+}

--- a/server/state_digest.h
+++ b/server/state_digest.h
@@ -1,0 +1,18 @@
+#ifndef SIGNAL_STATE_DIGEST_H
+#define SIGNAL_STATE_DIGEST_H
+
+#include <stdint.h>
+
+#include "game_sim.h"
+
+#define SIGNAL_AUTH_STATE_DIGEST_SCHEMA "signal.authoritative_state.v1"
+#define SIGNAL_AUTH_STATE_DIGEST_VERSION 1u
+#define SIGNAL_AUTH_STATE_DIGEST_SIZE 32u
+
+const char *signal_authoritative_state_digest_schema(void);
+uint32_t signal_authoritative_state_digest_version(void);
+void signal_authoritative_state_digest(
+    const world_t *world,
+    uint8_t out[SIGNAL_AUTH_STATE_DIGEST_SIZE]);
+
+#endif /* SIGNAL_STATE_DIGEST_H */

--- a/tests/c/test_main.c
+++ b/tests/c/test_main.c
@@ -82,6 +82,7 @@ void register_route_history_label_tests(void);
 void register_rock_usefulness_tests(void);
 void register_settlement_engine_tests(void);
 void register_signal_field_tests(void);
+void register_state_digest_tests(void);
 void register_gossip_tests(void);
 void register_npc_radio_tests(void);
 
@@ -211,6 +212,7 @@ int main(int argc, char **argv) {
     register_rock_usefulness_tests();
     register_settlement_engine_tests();
     register_signal_field_tests();
+    register_state_digest_tests();
     register_gossip_tests();
     register_npc_radio_tests();
 

--- a/tests/c/test_state_digest.c
+++ b/tests/c/test_state_digest.c
@@ -1,0 +1,164 @@
+#include "test_harness.h"
+#include "state_digest.h"
+
+static void state_root(const world_t *world,
+                       uint8_t out[SIGNAL_AUTH_STATE_DIGEST_SIZE])
+{
+    signal_authoritative_state_digest(world, out);
+}
+
+static bool roots_equal(
+    const uint8_t a[SIGNAL_AUTH_STATE_DIGEST_SIZE],
+    const uint8_t b[SIGNAL_AUTH_STATE_DIGEST_SIZE])
+{
+    return memcmp(a, b, SIGNAL_AUTH_STATE_DIGEST_SIZE) == 0;
+}
+
+TEST(test_state_digest_reports_versioned_schema_and_is_repeatable)
+{
+    WORLD_DECL;
+    uint8_t first[SIGNAL_AUTH_STATE_DIGEST_SIZE];
+    uint8_t second[SIGNAL_AUTH_STATE_DIGEST_SIZE];
+
+    world_reset(&w);
+    ASSERT_STR_EQ(signal_authoritative_state_digest_schema(),
+                  "signal.authoritative_state.v1");
+    ASSERT_EQ_INT((int)signal_authoritative_state_digest_version(), 1);
+
+    state_root(&w, first);
+    state_root(&w, second);
+    ASSERT(roots_equal(first, second));
+}
+
+TEST(test_state_digest_commits_each_authoritative_domain)
+{
+    WORLD_DECL;
+    uint8_t before[SIGNAL_AUTH_STATE_DIGEST_SIZE];
+    uint8_t after[SIGNAL_AUTH_STATE_DIGEST_SIZE];
+
+    world_reset(&w);
+    ASSERT(world_player_ship_slot_activate(&w, 0));
+
+    state_root(&w, before);
+    w.rng++;
+    state_root(&w, after);
+    ASSERT(!roots_equal(before, after));
+
+    memcpy(before, after, sizeof(before));
+    w.stations[0].base_price[COMMODITY_FERRITE_ORE] += 1.0f;
+    state_root(&w, after);
+    ASSERT(!roots_equal(before, after));
+
+    memcpy(before, after, sizeof(before));
+    w.ships[WORLD_PLAYER_SHIP_BASE].component.mining_level++;
+    state_root(&w, after);
+    ASSERT(!roots_equal(before, after));
+
+    w.asteroids[0].active = true;
+    w.asteroids[0].max_hp = 10.0f;
+    state_root(&w, before);
+    w.asteroids[0].max_hp = 11.0f;
+    state_root(&w, after);
+    ASSERT(!roots_equal(before, after));
+
+    w.tow_links[0].active = true;
+    w.tow_links[0].state = TOW_LINK_CAPTURE;
+    state_root(&w, before);
+    w.tow_links[0].state = TOW_LINK_HELD;
+    state_root(&w, after);
+    ASSERT(!roots_equal(before, after));
+
+    w.cargo_pods[0].active = true;
+    w.cargo_pods[0].radius = 20.0f;
+    state_root(&w, before);
+    w.cargo_pods[0].radius = 21.0f;
+    state_root(&w, after);
+    ASSERT(!roots_equal(before, after));
+
+    w.delivery_shipments[0].active = true;
+    w.delivery_shipments[0].debt_principal = 100.0f;
+    state_root(&w, before);
+    w.delivery_shipments[0].debt_principal = 101.0f;
+    state_root(&w, after);
+    ASSERT(!roots_equal(before, after));
+
+    w.stations[0].hnn_market_memory.store[0] = 0.25f;
+    state_root(&w, before);
+    w.stations[0].hnn_market_memory.store[0] = 0.50f;
+    state_root(&w, after);
+    ASSERT(!roots_equal(before, after));
+
+    w.signal_channel.count = 1;
+    w.signal_channel.head = 1;
+    w.signal_channel.next_id = 2;
+    w.signal_channel.msgs[0].id = 1;
+    w.signal_channel.msgs[0].text_len = 1;
+    w.signal_channel.msgs[0].text[0] = 'a';
+    state_root(&w, before);
+    w.signal_channel.msgs[0].text[0] = 'b';
+    state_root(&w, after);
+    ASSERT(!roots_equal(before, after));
+
+    w.players[0].movement_queue_count = 1;
+    w.players[0].movement_queue[0].apply_tick = w.tick + 1;
+    w.players[0].movement_queue[0].input_seq = 1;
+    state_root(&w, before);
+    w.players[0].movement_queue[0].intent.thrust = 1.0f;
+    state_root(&w, after);
+    ASSERT(!roots_equal(before, after));
+
+    w.pubkey_registry[0].in_use = true;
+    w.pubkey_registry[0].pubkey[0] = 1;
+    state_root(&w, before);
+    w.pubkey_registry[0].pubkey[0] = 2;
+    state_root(&w, after);
+    ASSERT(!roots_equal(before, after));
+}
+
+TEST(test_state_digest_excludes_transport_secrets_and_derived_views)
+{
+    WORLD_DECL;
+    uint8_t before[SIGNAL_AUTH_STATE_DIGEST_SIZE];
+    uint8_t after[SIGNAL_AUTH_STATE_DIGEST_SIZE];
+
+    world_reset(&w);
+    state_root(&w, before);
+
+    w.connections[0].analytics_metrics_seq++;
+    w.replications[0].world_time_sent = true;
+    w.pending_resolves[0].active = true;
+    w.pending_resolves[0].tx_count = 2;
+    w.stations[0].station_secret[0] ^= 0x5au;
+    w.stations[0].modules[0].flow_diag = STATION_FLOW_DIAG_NO_INPUT;
+    w.stations[0].hnn_market_memory.last_margin = 0.75f;
+    w.signal_field.cells[0].strength[0] = 0.5f;
+    w.signal_field_decay_tick++;
+
+    state_root(&w, after);
+    ASSERT(roots_equal(before, after));
+
+    w.cargo_pods[0].active = true;
+    state_root(&w, before);
+    w.cargo_pods[0].summary_flags = 1;
+    w.cargo_pods[0].summary_grade = MINING_GRADE_RATI;
+    w.cargo_pods[0].tractor.source_index = 7;
+    w.cargo_pods[0].tractor.source_part = 3;
+    w.cargo_pods[0].tractor.source_generation = 9;
+    state_root(&w, after);
+    ASSERT(roots_equal(before, after));
+
+    w.asteroids[0].active = true;
+    w.asteroid_origin[0].from_chunk = false;
+    state_root(&w, before);
+    w.asteroid_origin[0].chunk_x = 44;
+    w.asteroid_origin[0].chunk_y = -12;
+    state_root(&w, after);
+    ASSERT(roots_equal(before, after));
+}
+
+void register_state_digest_tests(void)
+{
+    RUN(test_state_digest_reports_versioned_schema_and_is_repeatable);
+    RUN(test_state_digest_commits_each_authoritative_domain);
+    RUN(test_state_digest_excludes_transport_secrets_and_derived_views);
+}

--- a/tools/signal_replay.c
+++ b/tools/signal_replay.c
@@ -28,6 +28,7 @@
 #include "sim_nav.h"
 #include "sim_physics.h"
 #include "station_util.h"
+#include "state_digest.h"
 
 #define SR_SCHEMA "signal.replay_counterfactual.v1"
 #define SR_ACTION_COUNT 9
@@ -238,6 +239,8 @@ typedef struct {
     sr_hnn_eval_t hnn;
     uint8_t prefix_state_hash[32];
     uint8_t state_hash[32];
+    uint8_t prefix_state_root[32];
+    uint8_t state_root[32];
     uint8_t event_hash[32];
 } sr_result_t;
 
@@ -3431,6 +3434,7 @@ static bool sr_run_branch(const sr_config_t *config, int candidate, sr_result_t 
     out->start_cargo = ship_total_cargo(sp->ship);
     out->start_balance = sr_player_station_balance(w, sp);
     sr_state_hash(w, sp, out->prefix_state_hash);
+    signal_authoritative_state_digest(w, out->prefix_state_root);
 
     sha256_init(&event_hash);
     sha256_update(&event_hash, "signal-replay-events-v2-float-bits", 34);
@@ -3490,6 +3494,7 @@ static bool sr_run_branch(const sr_config_t *config, int candidate, sr_result_t 
         out->ai.branch = branch;
     }
     sr_state_hash(w, sp, out->state_hash);
+    signal_authoritative_state_digest(w, out->state_root);
     out->ok = true;
     ok = true;
 
@@ -3764,7 +3769,9 @@ static void sr_write_row(FILE *out, const sr_config_t *config, const sr_result_t
             "\"prefix_ticks\":%d,"
             "\"horizon_ticks\":%d,"
             "\"candidate\":%d,"
-            "\"candidate_name\":\"%s\",",
+            "\"candidate_name\":\"%s\","
+            "\"state_digest_schema\":\"%s\","
+            "\"state_digest_version\":%" PRIu32 ",",
             SR_SCHEMA,
             config->seed,
             config->station,
@@ -3772,10 +3779,16 @@ static void sr_write_row(FILE *out, const sr_config_t *config, const sr_result_t
             r->prefix_ticks,
             r->horizon_ticks,
             r->candidate,
-            SR_ACTIONS[r->candidate].name);
+            SR_ACTIONS[r->candidate].name,
+            signal_authoritative_state_digest_schema(),
+            signal_authoritative_state_digest_version());
     sr_json_hash(out, "prefix_state_hash", r->prefix_state_hash);
     fprintf(out, ",");
     sr_json_hash(out, "state_hash", r->state_hash);
+    fprintf(out, ",");
+    sr_json_hash(out, "prefix_state_root", r->prefix_state_root);
+    fprintf(out, ",");
+    sr_json_hash(out, "state_root", r->state_root);
     fprintf(out, ",");
     sr_json_hash(out, "event_hash", r->event_hash);
     fprintf(out,


### PR DESCRIPTION
## Summary

- add the public `signal.authoritative_state.v1` SHA-256 root for post-tick peer/quorum comparison
- explicitly encode consensus fields in canonical little-endian form and document every top-level inclusion/exclusion
- expose schema/version plus `prefix_state_root` and `state_root` in replay JSON without removing legacy diagnostic hashes
- cover authoritative-domain sensitivity and transport/secret/derived-state invariance

This is execution step 2 of #588. It does not start a broad fixed-point rewrite or close the remaining live-loopback and long-run gates.

## Evidence

Head: `f1819fcb12a0642a8f70cde3fed4cfb0eb6446ff`

- `cmake --build /tmp/signal-588-build --target signal_test signal_replay -j4`
- `/tmp/signal-588-build/signal_test --soak --quiet` — 1,228 passed
- `python3 scripts/check_replay_repeatability.py /tmp/signal-588-build/signal_replay` — 20 fast scenarios passed
- `python3 scripts/check_deterministic_build_flags.py /tmp/signal-588-release/compile_commands.json`
- `python3 scripts/check_replay_cross_build.py /tmp/signal-588-build/signal_replay /tmp/signal-588-release/signal_replay` — 20 fast scenarios passed
- `python3 scripts/check_deterministic_build_flags.py /tmp/signal-588-wasm/compile_commands.json`
- `python3 scripts/check_replay_cross_build.py /tmp/signal-588-release/signal_replay /tmp/signal-588-wasm/signal_replay.js` — 20 fast scenarios passed
- `cmake --build /tmp/signal-588-full --target signal signal_server -j4`
- `make banned-apis deterministic-libm`
- `make doc-freshness`

Refs #588
