### PR TITLE
Add zero-latency reconciliation determinism gate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ set(SIGNAL_SIM_HELPERS
 set(SIGNAL_CLIENT_SOURCES
     client/main.c
     client/client_log.c
+    client/reconciliation_diagnostics.c
     client/net.c
     client/station_ui.c
     client/hud.c
@@ -311,10 +312,12 @@ if(NOT EMSCRIPTEN AND NOT BUILD_SERVER_ONLY)
         tests/c/test_rock_usefulness.c
         tests/c/test_signal_field.c
         tests/c/test_state_digest.c
+        tests/c/test_reconciliation_diagnostics.c
         tests/c/test_gossip.c
         tests/c/test_npc_radio.c
         client/identity.c
         client/client_log.c
+        client/reconciliation_diagnostics.c
         ${SIGNAL_SIM_SOURCES}
         ${SIGNAL_SIM_HELPERS}
         ${SIGNAL_STATIC_FLIGHT_BRAIN_SOURCES}
@@ -746,6 +749,19 @@ if(EMSCRIPTEN)
         "'_get_net_motion_replay_depth'"
         "'_get_net_motion_unacked_inputs'"
         "'_get_net_motion_action_queue_depth'"
+        "'_get_net_reconcile_exact_samples'"
+        "'_get_net_reconcile_bootstrap_samples'"
+        "'_get_net_reconcile_input_frontier_samples'"
+        "'_get_net_reconcile_semantic_samples'"
+        "'_get_net_reconcile_transport_recovery_samples'"
+        "'_get_net_reconcile_numeric_drift_samples'"
+        "'_get_net_reconcile_asteroid_motion_samples'"
+        "'_get_net_reconcile_npc_motion_samples'"
+        "'_get_net_reconcile_death_respawn_events'"
+        "'_get_net_reconcile_first_drift_json'"
+        "'_signal_zero_latency_perturb_player_x_lsb'"
+        "'_signal_smoke_prepare_drift_flight'"
+        "'_signal_smoke_prime_death_respawn'"
         "'_get_hud_hint_text'"
         "'_get_hud_action_text'"
         "'_set_smoke_loop_state'"

--- a/client/client.h
+++ b/client/client.h
@@ -26,6 +26,7 @@
 #include "identity.h"
 #include "trade_paging.h"
 #include "npc_radio.h"
+#include "reconciliation_diagnostics.h"
 
 static inline void client_session_pseudo_pubkey(const uint8_t token[8], uint8_t out[32]) {
     memset(out, 0, 32);
@@ -752,6 +753,10 @@ typedef struct {
         uint32_t total_lerp_samples;
         uint32_t total_input_acks;
     } net_motion;
+    net_reconcile_diagnostics_t net_reconcile;
+    bool net_reconcile_frontier_tainted;
+    bool net_reconcile_semantic_pending;
+    uint16_t net_reconcile_last_authoritative_input_seq;
     struct {
         asteroid_t prev[MAX_ASTEROIDS];
         asteroid_t curr[MAX_ASTEROIDS];

--- a/client/local_server.c
+++ b/client/local_server.c
@@ -466,8 +466,15 @@ static void local_server_emit_private_snapshots(local_server_t *ls,
                                                 int player_slot) {
     if (!ls || player_slot < 0 || player_slot >= MAX_PLAYERS) return;
     server_player_t *sp = &ls->world.players[player_slot];
-    if (sp->replication->force_authoritative_resync)
+    /* Per-tick diagnostic mode promises an authoritative local pose on every
+     * step. The private snapshot helper normally suppresses unchanged poses
+     * while its prior baseline remains valid, so explicitly invalidate that
+     * baseline here. Default throttled loopback keeps the normal heartbeat
+     * and correction cadence used by the dedicated server. */
+    if (!ls->throttled_snapshots ||
+        sp->replication->force_authoritative_resync) {
         server_player_reset_authoritative_ack_state(sp);
+    }
     server_emit_private_snapshot_for_player(
         &ls->world, player_slot, ls->throttled_snapshots,
         local_server_send_packet, NULL,

--- a/client/main.c
+++ b/client/main.c
@@ -25,6 +25,7 @@
 #include "net_input_lead.h"
 #include "net_clock.h"
 #include "client_log.h"
+#include "state_digest.h"
 
 
 #ifdef __EMSCRIPTEN__
@@ -2684,6 +2685,10 @@ EMSCRIPTEN_KEEPALIVE
 #endif
 int reset_net_motion_telemetry(void) {
     memset(&g.net_motion, 0, sizeof(g.net_motion));
+    net_reconcile_diagnostics_reset(&g.net_reconcile);
+    g.net_reconcile_frontier_tainted = false;
+    g.net_reconcile_semantic_pending = false;
+    g.net_reconcile_last_authoritative_input_seq = g.net_last_server_ack;
     g.net_motion.input_lead_margin_ticks =
         NET_INPUT_LEAD_DEFAULT_MARGIN_TICKS;
     net_latency_stats_reset(&g.net_ack_latency);
@@ -2705,6 +2710,249 @@ int reset_net_motion_telemetry(void) {
     g.net_ack_recovery_tier = NET_LATENCY_ACK_RECOVERY_STEADY;
     g.net_max_ack_rtt_5s = 0.0f;
     return 1;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int get_net_reconcile_exact_samples(void) {
+    return (int)g.net_reconcile.class_count[NET_RECONCILE_EXACT];
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int get_net_reconcile_bootstrap_samples(void) {
+    return (int)g.net_reconcile.class_count[NET_RECONCILE_BOOTSTRAP];
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int get_net_reconcile_input_frontier_samples(void) {
+    return (int)g.net_reconcile.class_count[NET_RECONCILE_INPUT_FRONTIER];
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int get_net_reconcile_semantic_samples(void) {
+    return (int)g.net_reconcile.class_count[NET_RECONCILE_SEMANTIC];
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int get_net_reconcile_transport_recovery_samples(void) {
+    return (int)g.net_reconcile.class_count[NET_RECONCILE_TRANSPORT_RECOVERY];
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int get_net_reconcile_numeric_drift_samples(void) {
+    return (int)g.net_reconcile.class_count[NET_RECONCILE_NUMERIC_DRIFT];
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int get_net_reconcile_asteroid_motion_samples(void) {
+    return (int)g.net_reconcile.asteroid_motion_samples;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int get_net_reconcile_npc_motion_samples(void) {
+    return (int)g.net_reconcile.npc_motion_samples;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int get_net_reconcile_death_respawn_events(void) {
+    return (int)g.net_reconcile.death_respawn_events;
+}
+
+static float net_reconcile_float_from_bits(uint32_t bits)
+{
+    float value = 0.0f;
+    memcpy(&value, &bits, sizeof(value));
+    return value;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+const char *get_net_reconcile_first_drift_json(void) {
+    static char json[1024];
+    const net_reconcile_diagnostics_t *diagnostics = &g.net_reconcile;
+    if (!diagnostics->first_numeric_drift_valid) {
+        snprintf(json, sizeof(json), "{}");
+        return json;
+    }
+
+    char root_hex[NET_RECONCILE_ROOT_SIZE * 2u + 1u];
+    if (diagnostics->first_authoritative_root_valid) {
+        static const char hex[] = "0123456789abcdef";
+        for (size_t i = 0; i < NET_RECONCILE_ROOT_SIZE; i++) {
+            uint8_t byte = diagnostics->first_authoritative_root[i];
+            root_hex[i * 2u] = hex[byte >> 4];
+            root_hex[i * 2u + 1u] = hex[byte & 0x0Fu];
+        }
+        root_hex[sizeof(root_hex) - 1u] = '\0';
+    } else {
+        root_hex[0] = '\0';
+    }
+
+    snprintf(
+        json, sizeof(json),
+        "{\"class\":\"numeric-drift\",\"server_tick\":%u,"
+        "\"prediction_tick\":%u,\"predicted_input_seq\":%u,"
+        "\"authoritative_input_seq\":%u,\"entity\":\"player:%u\","
+        "\"domain\":\"%s\",\"predicted\":%.9g,\"authoritative\":%.9g,"
+        "\"predicted_pose\":{\"x\":%.9g,\"y\":%.9g,\"vx\":%.9g,"
+        "\"vy\":%.9g,\"angle\":%.9g},"
+        "\"authoritative_pose\":{\"x\":%.9g,\"y\":%.9g,\"vx\":%.9g,"
+        "\"vy\":%.9g,\"angle\":%.9g},"
+        "\"predicted_bits\":\"0x%08x\","
+        "\"authoritative_bits\":\"0x%08x\","
+        "\"root_schema\":\"%s\",\"authoritative_root\":\"%s\"}",
+        (unsigned)diagnostics->first_server_tick,
+        (unsigned)diagnostics->first_prediction_tick,
+        (unsigned)diagnostics->first_predicted_input_seq,
+        (unsigned)diagnostics->first_authoritative_input_seq,
+        (unsigned)diagnostics->first_entity_id,
+        net_reconcile_domain_name(diagnostics->first_domain),
+        (double)net_reconcile_float_from_bits(
+            diagnostics->first_predicted_bits),
+        (double)net_reconcile_float_from_bits(
+            diagnostics->first_authoritative_bits),
+        (double)net_reconcile_float_from_bits(
+            diagnostics->first_predicted_pose.pos_x),
+        (double)net_reconcile_float_from_bits(
+            diagnostics->first_predicted_pose.pos_y),
+        (double)net_reconcile_float_from_bits(
+            diagnostics->first_predicted_pose.vel_x),
+        (double)net_reconcile_float_from_bits(
+            diagnostics->first_predicted_pose.vel_y),
+        (double)net_reconcile_float_from_bits(
+            diagnostics->first_predicted_pose.angle),
+        (double)net_reconcile_float_from_bits(
+            diagnostics->first_authoritative_pose.pos_x),
+        (double)net_reconcile_float_from_bits(
+            diagnostics->first_authoritative_pose.pos_y),
+        (double)net_reconcile_float_from_bits(
+            diagnostics->first_authoritative_pose.vel_x),
+        (double)net_reconcile_float_from_bits(
+            diagnostics->first_authoritative_pose.vel_y),
+        (double)net_reconcile_float_from_bits(
+            diagnostics->first_authoritative_pose.angle),
+        (unsigned)diagnostics->first_predicted_bits,
+        (unsigned)diagnostics->first_authoritative_bits,
+        signal_authoritative_state_digest_schema(),
+        root_hex);
+    return json;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int signal_zero_latency_perturb_player_x_lsb(void) {
+    if (!g.local_server.active || !net_is_loopback() ||
+        !g.net_local_state_ready ||
+        g.local_player_slot < 0 ||
+        g.local_player_slot >= MAX_PLAYERS ||
+        !g.net_prediction_tick_valid) {
+        return -1;
+    }
+
+    ship_t *ship = g.world.players[g.local_player_slot].ship;
+    if (!ship || !isfinite(ship->pos.x)) return -3;
+
+    server_player_t *predicted_player =
+        &g.world.players[g.local_player_slot];
+    server_player_t *authority_player =
+        &g.local_server.world.players[g.local_player_slot];
+    const input_intent_t *predicted_input = &predicted_player->input;
+    const input_intent_t *authority_input = &authority_player->input;
+    if (net_unacked_input_count() != 0 ||
+        authority_player->movement_queue_count != 0) {
+        return -7;
+    }
+    if (!net_reconcile_movement_intent_equal(
+            predicted_input, authority_input)) {
+        return -8;
+    }
+
+    if (g.net_reconcile_frontier_tainted) {
+        bool throttled = g.local_server.throttled_snapshots;
+        g.local_server.throttled_snapshots = false;
+        net_replay_reset();
+        net_anchor_prediction_tick(g.local_server.world.tick, true);
+        authority_player->replication->force_authoritative_resync = true;
+        local_server_send_initial_snapshot(
+            &g.local_server, g.local_player_slot);
+        g.local_server.throttled_snapshots = throttled;
+
+        /* Build one ordinary predicted step from the freshly decoded
+         * authoritative baseline. This is the same movement path submit_input
+         * uses, without introducing a new network input frontier. */
+        input_intent_t stable_input = *authority_input;
+        predicted_player->input = stable_input;
+        g.net_reconcile_frontier_tainted = false;
+        net_replay_record_prediction(&stable_input, SIM_DT);
+        world_sim_step_player_only(
+            &g.world, g.local_player_slot, SIM_DT);
+        net_adopt_local_tow_prediction(SIM_DT);
+    }
+
+    uint32_t next_authority_tick = g.local_server.world.tick + 1u;
+    if (g.net_prediction_tick != next_authority_tick) return -2;
+
+    for (int i = 0; i < (int)g.net_replay_count; i++) {
+        int index = ((int)g.net_replay_start + i) % NET_REPLAY_FRAME_CAP;
+        const input_replay_frame_t *frame = &g.net_replay[index];
+        if (frame->tick == next_authority_tick) {
+            if (frame->input_seq != authority_player->last_input_seq)
+                return -9;
+            const input_intent_t *frame_input = &frame->intent;
+            if (!net_reconcile_movement_intent_equal(
+                    frame_input, authority_input)) {
+                return -10;
+            }
+        }
+    }
+
+    uint32_t perturbed_bits = 0;
+    memcpy(&perturbed_bits, &ship->pos.x, sizeof(perturbed_bits));
+    perturbed_bits ^= 1u;
+    memcpy(&ship->pos.x, &perturbed_bits, sizeof(ship->pos.x));
+
+    uint32_t drift_before =
+        g.net_reconcile.class_count[NET_RECONCILE_NUMERIC_DRIFT];
+    uint32_t frontier_before =
+        g.net_reconcile.class_count[NET_RECONCILE_INPUT_FRONTIER];
+    uint32_t exact_before =
+        g.net_reconcile.class_count[NET_RECONCILE_EXACT];
+    bool throttled = g.local_server.throttled_snapshots;
+    g.local_server.throttled_snapshots = false;
+    local_server_step_loopback(
+        &g.local_server, g.local_player_slot, SIM_DT);
+    g.local_server.throttled_snapshots = throttled;
+
+    if (g.net_reconcile.class_count[NET_RECONCILE_NUMERIC_DRIFT] >
+        drift_before) {
+        return 1;
+    }
+    if (g.net_reconcile.class_count[NET_RECONCILE_INPUT_FRONTIER] >
+        frontier_before) {
+        return -4;
+    }
+    if (g.net_reconcile.class_count[NET_RECONCILE_EXACT] > exact_before)
+        return -5;
+    return -6;
 }
 
 #ifdef __EMSCRIPTEN__
@@ -3159,6 +3407,110 @@ int get_net_motion_ack_recovery_tier(void) {
 }
 
 #ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+int signal_smoke_prepare_drift_flight(void) {
+    if (!g.local_server.active || !net_is_loopback()) return 0;
+    int player_idx = g.local_player_slot;
+    if (player_idx < 0 || player_idx >= MAX_PLAYERS) return 0;
+
+    world_t *authority = &g.local_server.world;
+    server_player_t *server_player = &authority->players[player_idx];
+    server_player_t *client_player = &g.world.players[player_idx];
+    if (!server_player->connected || !server_player->ship ||
+        !server_player->replication ||
+        !client_player->connected || !client_player->ship) {
+        return 0;
+    }
+
+    const vec2 start = v2(2400.0f, -2400.0f);
+    const float clear_radius_sq = 3600.0f * 3600.0f;
+    for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        if (authority->asteroids[i].active &&
+            v2_dist_sq(authority->asteroids[i].pos, start) <
+                clear_radius_sq) {
+            world_asteroid_clear_tractor(authority, i);
+            memset(&authority->asteroids[i], 0,
+                   sizeof(authority->asteroids[i]));
+            authority->asteroid_generation_live[i] = false;
+        }
+        if (g.world.asteroids[i].active &&
+            v2_dist_sq(g.world.asteroids[i].pos, start) <
+                clear_radius_sq) {
+            memset(&g.world.asteroids[i], 0,
+                   sizeof(g.world.asteroids[i]));
+        }
+        memset(&g.asteroid_interp.prev[i], 0,
+               sizeof(g.asteroid_interp.prev[i]));
+        memset(&g.asteroid_interp.curr[i], 0,
+               sizeof(g.asteroid_interp.curr[i]));
+        g.asteroid_interp.elapsed[i] = 0.0f;
+    }
+
+    world_tow_links_clear_source(authority, server_player->ship_ref);
+    server_player->docked = false;
+    server_player->docking_approach = false;
+    server_player->in_dock_range = false;
+    server_player->nearby_station = -1;
+    server_player->ship->pos = start;
+    server_player->ship->vel = v2(0.0f, 0.0f);
+    server_player->ship->angle = 0.0f;
+    server_player->ship->tractor_active = false;
+    server_player->boost_hold_timer = 0.0f;
+    memset(&server_player->input, 0, sizeof(server_player->input));
+    server_player->input.mining_target_hint = -1;
+    server_player->movement_queue_count = 0;
+    server_player->replication->force_authoritative_resync = true;
+
+    client_player->docked = false;
+    client_player->docking_approach = false;
+    client_player->in_dock_range = false;
+    client_player->nearby_station = -1;
+    client_player->ship->pos = start;
+    client_player->ship->vel = v2(0.0f, 0.0f);
+    client_player->ship->angle = 0.0f;
+    client_player->ship->tractor_active = false;
+    client_player->ship->towed_count = 0;
+    client_player->ship->towed_pod_count = 0;
+    client_player->ship->towed_scaffold = -1;
+    memset(client_player->ship->towed_fragments, -1,
+           sizeof(client_player->ship->towed_fragments));
+    memset(client_player->ship->towed_pods, -1,
+           sizeof(client_player->ship->towed_pods));
+    client_player->boost_hold_timer = 0.0f;
+    memset(&client_player->input, 0, sizeof(client_player->input));
+    client_player->input.mining_target_hint = -1;
+
+    g.local_server.private_snapshot_dirty = true;
+    g.local_player_render_offset = v2(0.0f, 0.0f);
+    g.net_input_have_last = false;
+    net_replay_reset();
+    net_anchor_prediction_tick(authority->tick, true);
+    return 1;
+}
+
+EMSCRIPTEN_KEEPALIVE
+int signal_smoke_prime_death_respawn(void) {
+    if (!g.local_server.active || !net_is_loopback()) return 0;
+    int player_idx = g.local_player_slot;
+    if (player_idx < 0 || player_idx >= MAX_PLAYERS) return 0;
+
+    server_player_t *server_player =
+        &g.local_server.world.players[player_idx];
+    server_player_t *client_player = &g.world.players[player_idx];
+    if (!server_player->connected || !server_player->ship ||
+        server_player->docked ||
+        !client_player->connected || !client_player->ship) {
+        return 0;
+    }
+
+    /* The ordinary boost-turn drain will cross zero on the next applied
+     * input and route through emergency_recover_ship, NET_MSG_DEATH, and
+     * the authoritative respawn snapshot. */
+    server_player->ship->hull = 0.01f;
+    client_player->ship->hull = 0.01f;
+    return 1;
+}
+
 EMSCRIPTEN_KEEPALIVE
 int signal_smoke_prepare_known_ledger_sync(void) {
     if (!g.local_server.active || !net_is_loopback()) return 0;

--- a/client/net_sync.c
+++ b/client/net_sync.c
@@ -10,6 +10,7 @@
 #include "contract_objective.h"
 #include "net_input_lead.h"
 #include "net_clock.h"
+#include "state_digest.h"
 
 #define STATION_RING_CORRECTION_SEC 0.35f
 #define NET_MOTION_TELEMETRY_WINDOW_SEC 5.0f
@@ -263,6 +264,142 @@ static int net_replay_first_after(uint32_t server_tick) {
 static bool net_replay_missing_prefix(uint32_t server_tick, int first_after) {
     if (first_after < 0) return false;
     return net_replay_frame_at(first_after)->tick != server_tick + 1u;
+}
+
+static uint16_t net_replay_input_seq_at_tick(uint32_t tick)
+{
+    for (int i = 0; i < (int)g.net_replay_count; i++) {
+        const input_replay_frame_t *frame = net_replay_frame_at(i);
+        if (frame->tick == tick) return frame->input_seq;
+    }
+    return g.net_input_seq;
+}
+
+static net_reconcile_pose_bits_t net_reconcile_predicted_pose(
+    const server_player_t *sp)
+{
+    if (!sp || !sp->ship)
+        return net_reconcile_pose_bits(0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    return net_reconcile_pose_bits(
+        sp->ship->pos.x, sp->ship->pos.y,
+        sp->ship->vel.x, sp->ship->vel.y,
+        sp->ship->angle);
+}
+
+static bool net_reconcile_motion_changed(float old_x,
+                                         float old_y,
+                                         float old_vx,
+                                         float old_vy,
+                                         float old_angle,
+                                         float new_x,
+                                         float new_y,
+                                         float new_vx,
+                                         float new_vy,
+                                         float new_angle)
+{
+    net_reconcile_pose_bits_t old_pose = net_reconcile_pose_bits(
+        old_x, old_y, old_vx, old_vy, old_angle);
+    net_reconcile_pose_bits_t new_pose = net_reconcile_pose_bits(
+        new_x, new_y, new_vx, new_vy, new_angle);
+    return !net_reconcile_pose_equal(&old_pose, &new_pose);
+}
+
+static bool net_loopback_input_frontier_differs(
+    const NetPlayerState *state,
+    const server_player_t *predicted_player)
+{
+    if (!state || !predicted_player ||
+        !g.local_server.active ||
+        !net_is_loopback() ||
+        g.local_server.world.tick != state->server_tick ||
+        state->player_id >= MAX_PLAYERS) {
+        return false;
+    }
+
+    const input_intent_t *predicted = &predicted_player->input;
+    for (int i = 0; i < (int)g.net_replay_count; i++) {
+        const input_replay_frame_t *frame = net_replay_frame_at(i);
+        if (frame->tick == state->server_tick) {
+            predicted = &frame->intent;
+            break;
+        }
+    }
+    const input_intent_t *authoritative =
+        &g.local_server.world.players[state->player_id].input;
+    return !net_reconcile_movement_intent_equal(predicted, authoritative);
+}
+
+static void net_observe_local_reconciliation(
+    const NetPlayerState *state,
+    net_reconcile_pose_bits_t predicted,
+    bool bootstrap,
+    bool input_frontier,
+    bool semantic_discontinuity,
+    bool transport_recovery)
+{
+    if (!state) return;
+
+    net_reconcile_sample_t sample = {
+        .bootstrap = bootstrap,
+        .input_frontier = input_frontier,
+        .semantic_discontinuity = semantic_discontinuity,
+        .transport_recovery = transport_recovery,
+        .entity_id = state->player_id,
+        .server_tick = state->server_tick,
+        .prediction_tick =
+            g.net_prediction_tick_valid ? g.net_prediction_tick : 0,
+        .predicted_input_seq =
+            net_replay_input_seq_at_tick(state->server_tick),
+        .authoritative_input_seq = state->input_seq_ack,
+        .predicted = predicted,
+        .authoritative = net_reconcile_pose_bits(
+            state->x, state->y, state->vx, state->vy, state->angle),
+        .authoritative_root = NULL,
+    };
+
+    net_reconcile_class_t classification = net_reconcile_classify(&sample);
+    if (classification == NET_RECONCILE_NUMERIC_DRIFT &&
+        g.net_reconcile_frontier_tainted) {
+        sample.input_frontier = true;
+        classification = NET_RECONCILE_INPUT_FRONTIER;
+    }
+
+    uint8_t root[SIGNAL_AUTH_STATE_DIGEST_SIZE];
+    if (classification == NET_RECONCILE_NUMERIC_DRIFT &&
+        !g.net_reconcile.first_numeric_drift_valid &&
+        g.local_server.active &&
+        net_is_loopback() &&
+        g.local_server.world.tick == state->server_tick) {
+        signal_authoritative_state_digest(&g.local_server.world, root);
+        sample.authoritative_root = root;
+    }
+
+    classification =
+        net_reconcile_diagnostics_observe(&g.net_reconcile, &sample);
+    if (classification == NET_RECONCILE_EXACT ||
+        classification == NET_RECONCILE_BOOTSTRAP ||
+        classification == NET_RECONCILE_TRANSPORT_RECOVERY) {
+        g.net_reconcile_frontier_tainted = false;
+    } else if (classification == NET_RECONCILE_INPUT_FRONTIER ||
+               classification == NET_RECONCILE_SEMANTIC) {
+        g.net_reconcile_frontier_tainted = true;
+    }
+    if (classification == NET_RECONCILE_NUMERIC_DRIFT &&
+        g.net_reconcile.class_count[NET_RECONCILE_NUMERIC_DRIFT] == 1u) {
+        fprintf(stderr,
+                "[net-drift] class=%s tick=%u prediction_tick=%u "
+                "input_seq=%u ack=%u entity=player:%u domain=%s "
+                "predicted_bits=0x%08x authoritative_bits=0x%08x\n",
+                net_reconcile_class_name(classification),
+                (unsigned)g.net_reconcile.first_server_tick,
+                (unsigned)g.net_reconcile.first_prediction_tick,
+                (unsigned)g.net_reconcile.first_predicted_input_seq,
+                (unsigned)g.net_reconcile.first_authoritative_input_seq,
+                (unsigned)g.net_reconcile.first_entity_id,
+                net_reconcile_domain_name(g.net_reconcile.first_domain),
+                (unsigned)g.net_reconcile.first_predicted_bits,
+                (unsigned)g.net_reconcile.first_authoritative_bits);
+    }
 }
 
 float net_prediction_latency_blend(void) {
@@ -1021,6 +1158,10 @@ void net_reset_local_input_stream(void) {
     memset(g.net_action_queue, 0, sizeof(g.net_action_queue));
     memset(g.net_input_timing, 0, sizeof(g.net_input_timing));
     memset(&g.net_motion, 0, sizeof(g.net_motion));
+    net_reconcile_diagnostics_reset(&g.net_reconcile);
+    g.net_reconcile_frontier_tainted = false;
+    g.net_reconcile_semantic_pending = false;
+    g.net_reconcile_last_authoritative_input_seq = 0;
     g.net_motion.input_lead_margin_ticks =
         NET_INPUT_LEAD_DEFAULT_MARGIN_TICKS;
     g.local_player_render_offset = v2(0.0f, 0.0f);
@@ -1122,6 +1263,12 @@ void apply_remote_asteroids(const NetAsteroidState* asteroids, int count) {
 
         asteroid_t* a = &g.asteroid_interp.curr[idx];
         bool was_active = a->active;
+        bool motion_changed = was_active &&
+            (asteroids[i].flags & 1) != 0 &&
+            net_reconcile_motion_changed(
+                a->pos.x, a->pos.y, a->vel.x, a->vel.y, 0.0f,
+                asteroids[i].x, asteroids[i].y,
+                asteroids[i].vx, asteroids[i].vy, 0.0f);
         bool was_child = a->fracture_child;
         asteroid_tier_t was_tier = a->tier;
         commodity_t was_commodity = a->commodity;
@@ -1160,6 +1307,8 @@ void apply_remote_asteroids(const NetAsteroidState* asteroids, int count) {
         }
         if (a->max_hp < a->hp) a->max_hp = a->hp;
         if (a->max_ore < a->ore) a->max_ore = a->ore;
+        if (motion_changed)
+            g.net_reconcile.asteroid_motion_samples++;
         net_preserve_local_towed_asteroid_prediction((int)idx);
     }
 
@@ -1206,10 +1355,18 @@ void apply_remote_asteroid_motion(const NetAsteroidMotionState* asteroids,
         vec2 carried_vel = visual.vel;
         bool keep_velocity =
             !isfinite(asteroids[i].vx) || !isfinite(asteroids[i].vy);
+        float next_vx = keep_velocity ? carried_vel.x : asteroids[i].vx;
+        float next_vy = keep_velocity ? carried_vel.y : asteroids[i].vy;
+        if (net_reconcile_motion_changed(
+                a->pos.x, a->pos.y, a->vel.x, a->vel.y, 0.0f,
+                asteroids[i].x, asteroids[i].y,
+                next_vx, next_vy, 0.0f)) {
+            g.net_reconcile.asteroid_motion_samples++;
+        }
         a->pos.x = asteroids[i].x;
         a->pos.y = asteroids[i].y;
-        a->vel.x = keep_velocity ? carried_vel.x : asteroids[i].vx;
-        a->vel.y = keep_velocity ? carried_vel.y : asteroids[i].vy;
+        a->vel.x = next_vx;
+        a->vel.y = next_vy;
         a->age = carried_age;
         net_preserve_local_towed_asteroid_prediction((int)idx);
     }
@@ -1271,6 +1428,12 @@ void apply_remote_npcs(const NetNpcState* npcs, int count) {
         received[idx] = true;
 
         client_npc_render_state_t* n = &g.npc_interp.curr[idx];
+        bool motion_changed = n->active &&
+            (npcs[i].flags & 1) != 0 &&
+            net_reconcile_motion_changed(
+                n->pos.x, n->pos.y, n->vel.x, n->vel.y, n->angle,
+                npcs[i].x, npcs[i].y, npcs[i].vx, npcs[i].vy,
+                npcs[i].angle);
         n->active = (npcs[i].flags & 1) != 0;
         n->role = (npc_role_t)((npcs[i].flags >> 1) & 0x3);
         n->state = (npc_state_t)((npcs[i].flags >> 3) & 0x7);
@@ -1292,6 +1455,8 @@ void apply_remote_npcs(const NetNpcState* npcs, int count) {
         memcpy(n->session_token, npcs[i].session_token, sizeof(n->session_token));
         n->home_station = (npcs[i].home_station == 0xFFu)
             ? -1 : (int)npcs[i].home_station;
+        if (motion_changed)
+            g.net_reconcile.npc_motion_samples++;
     }
 
     for (int i = 0; i < MAX_NPC_SHIPS; i++) {
@@ -1319,6 +1484,12 @@ void apply_remote_npc_motion(const NetNpcMotionState* npcs, int count) {
 
         client_npc_render_state_t* n = &g.npc_interp.curr[idx];
         if (!n->active) continue;
+        if (net_reconcile_motion_changed(
+                n->pos.x, n->pos.y, n->vel.x, n->vel.y, n->angle,
+                npcs[i].x, npcs[i].y, npcs[i].vx, npcs[i].vy,
+                npcs[i].angle)) {
+            g.net_reconcile.npc_motion_samples++;
+        }
         n->thrusting = (npcs[i].flags & (1 << 6)) != 0;
         n->pos.x = npcs[i].x;
         n->pos.y = npcs[i].y;
@@ -1348,6 +1519,11 @@ void apply_remote_npc_pos(const NetNpcPosState* npcs, int count) {
 
         client_npc_render_state_t* n = &g.npc_interp.curr[idx];
         if (!n->active) continue;
+        if (net_reconcile_motion_changed(
+                n->pos.x, n->pos.y, n->vel.x, n->vel.y, n->angle,
+                npcs[i].x, npcs[i].y, n->vel.x, n->vel.y, n->angle)) {
+            g.net_reconcile.npc_motion_samples++;
+        }
         n->pos.x = npcs[i].x;
         n->pos.y = npcs[i].y;
     }
@@ -1371,6 +1547,12 @@ void apply_remote_npc_pose(const NetNpcPoseState* npcs, int count) {
 
         client_npc_render_state_t* n = &g.npc_interp.curr[idx];
         if (!n->active) continue;
+        if (net_reconcile_motion_changed(
+                n->pos.x, n->pos.y, n->vel.x, n->vel.y, n->angle,
+                npcs[i].x, npcs[i].y, n->vel.x, n->vel.y,
+                npcs[i].angle)) {
+            g.net_reconcile.npc_motion_samples++;
+        }
         n->pos.x = npcs[i].x;
         n->pos.y = npcs[i].y;
         n->angle = npcs[i].angle;
@@ -1395,6 +1577,12 @@ void apply_remote_npc_linear(const NetNpcLinearState* npcs, int count) {
 
         client_npc_render_state_t* n = &g.npc_interp.curr[idx];
         if (!n->active) continue;
+        if (net_reconcile_motion_changed(
+                n->pos.x, n->pos.y, n->vel.x, n->vel.y, n->angle,
+                npcs[i].x, npcs[i].y, npcs[i].vx, npcs[i].vy,
+                n->angle)) {
+            g.net_reconcile.npc_motion_samples++;
+        }
         n->pos.x = npcs[i].x;
         n->pos.y = npcs[i].y;
         n->vel.x = npcs[i].vx;
@@ -2474,6 +2662,18 @@ void apply_remote_player_state(const NetPlayerState* state) {
     if (state->player_id == net_local_id()) {
         /* Reconcile local prediction with server-authoritative position. */
         server_player_t* sp = &g.world.players[state->player_id];
+        net_reconcile_pose_bits_t predicted_pose =
+            net_reconcile_predicted_pose(sp);
+        bool input_ack_transition =
+            state->input_seq_ack != 0 &&
+            state->input_seq_ack !=
+                g.net_reconcile_last_authoritative_input_seq;
+        bool semantic_pending = g.net_reconcile_semantic_pending;
+        g.net_reconcile_semantic_pending = false;
+        if (state->input_seq_ack != 0) {
+            g.net_reconcile_last_authoritative_input_seq =
+                state->input_seq_ack;
+        }
         vec2 before_pos = sp->ship->pos;
         if (state->has_input_tick_ack) g.net_input_tick_protocol = true;
         bool force_rebase = false;
@@ -2515,21 +2715,31 @@ void apply_remote_player_state(const NetPlayerState* state) {
         sync_local_tow_state_from_authority(state, sp);
 
         if (!g.net_local_state_ready) {
+            net_observe_local_reconciliation(
+                state, predicted_pose, true, false,
+                semantic_pending, false);
             accept_initial_local_player_state(state, sp);
             return;
         }
 
         bool state_docked = (state->flags & 4) != 0;
         if (state_docked && sp->docked) {
+            net_observe_local_reconciliation(
+                state, predicted_pose, false, false, true, false);
             accept_docked_local_player_state(state, sp);
             return;
         }
         if (!state_docked && sp->docked) {
+            net_observe_local_reconciliation(
+                state, predicted_pose, false, false, true, false);
             accept_authoritative_local_launch_state(state, sp);
             return;
         }
         if (g.local_server.active && net_is_loopback() &&
             !net_replay_enabled()) {
+            net_observe_local_reconciliation(
+                state, predicted_pose, false, false,
+                semantic_pending, true);
             apply_authoritative_local_motion(state, sp);
             sync_local_dock_state_from_authority(state, sp);
             apply_local_player_remote_flags(state, sp);
@@ -2566,6 +2776,17 @@ void apply_remote_player_state(const NetPlayerState* state) {
         bool defer_motion_correction = false;
         bool defer_predicted_undock =
             state_docked && !sp->docked && g.action_predict_timer > 0.0f;
+        net_observe_local_reconciliation(
+            state,
+            predicted_pose,
+            false,
+            input_ack_transition ||
+                has_unacked_input ||
+                !g.net_prediction_tick_valid ||
+                g.net_prediction_tick != state->server_tick ||
+                net_loopback_input_frontier_differs(state, sp),
+            semantic_pending || defer_predicted_undock,
+            force_rebase);
         if (force_rebase) {
             apply_authoritative_local_motion(state, sp);
             net_replay_clear_frames();
@@ -2843,6 +3064,8 @@ void on_remote_death(uint8_t player_id, float pos_x, float pos_y,
                      uint8_t respawn_station, float respawn_fee) {
     if ((int)player_id != g.local_player_slot) return;
     net_replay_reset();
+    g.net_reconcile.death_respawn_events++;
+    g.net_reconcile_semantic_pending = true;
     float impact_speed = sqrtf(vel_x * vel_x + vel_y * vel_y);
     float severity = clampf(impact_speed / 260.0f, 0.8f, 2.4f);
     uint32_t spin_seed = ((uint32_t)player_id << 24) ^

--- a/client/reconciliation_diagnostics.c
+++ b/client/reconciliation_diagnostics.c
@@ -1,0 +1,173 @@
+#include "reconciliation_diagnostics.h"
+
+#include <string.h>
+
+static uint32_t float_bits(float value)
+{
+    uint32_t bits = 0;
+    memcpy(&bits, &value, sizeof(bits));
+    return bits;
+}
+
+net_reconcile_pose_bits_t net_reconcile_pose_bits(float pos_x,
+                                                  float pos_y,
+                                                  float vel_x,
+                                                  float vel_y,
+                                                  float angle)
+{
+    return (net_reconcile_pose_bits_t){
+        .pos_x = float_bits(pos_x),
+        .pos_y = float_bits(pos_y),
+        .vel_x = float_bits(vel_x),
+        .vel_y = float_bits(vel_y),
+        .angle = float_bits(angle),
+    };
+}
+
+bool net_reconcile_pose_equal(const net_reconcile_pose_bits_t *a,
+                              const net_reconcile_pose_bits_t *b)
+{
+    return a && b &&
+        a->pos_x == b->pos_x &&
+        a->pos_y == b->pos_y &&
+        a->vel_x == b->vel_x &&
+        a->vel_y == b->vel_y &&
+        a->angle == b->angle;
+}
+
+bool net_reconcile_movement_intent_equal(const input_intent_t *a,
+                                         const input_intent_t *b)
+{
+    if (!a || !b) return false;
+    return a->turn == b->turn &&
+        a->thrust == b->thrust &&
+        a->mine == b->mine &&
+        (!(a->mine || b->mine) ||
+         a->mining_target_hint == b->mining_target_hint) &&
+        a->tractor_hold == b->tractor_hold &&
+        a->boost == b->boost &&
+        a->reverse_thrust == b->reverse_thrust;
+}
+
+net_reconcile_class_t net_reconcile_classify(
+    const net_reconcile_sample_t *sample)
+{
+    if (!sample ||
+        net_reconcile_pose_equal(&sample->predicted,
+                                 &sample->authoritative)) {
+        return NET_RECONCILE_EXACT;
+    }
+    if (sample->bootstrap) return NET_RECONCILE_BOOTSTRAP;
+    if (sample->semantic_discontinuity) return NET_RECONCILE_SEMANTIC;
+    if (sample->transport_recovery) return NET_RECONCILE_TRANSPORT_RECOVERY;
+    if (sample->input_frontier ||
+        sample->server_tick == 0 ||
+        sample->prediction_tick == 0 ||
+        sample->server_tick != sample->prediction_tick ||
+        (sample->predicted_input_seq != 0 &&
+         sample->authoritative_input_seq != 0 &&
+         sample->predicted_input_seq !=
+             sample->authoritative_input_seq)) {
+        return NET_RECONCILE_INPUT_FRONTIER;
+    }
+    return NET_RECONCILE_NUMERIC_DRIFT;
+}
+
+void net_reconcile_diagnostics_reset(net_reconcile_diagnostics_t *diagnostics)
+{
+    if (diagnostics) memset(diagnostics, 0, sizeof(*diagnostics));
+}
+
+static net_reconcile_domain_t first_divergent_domain(
+    const net_reconcile_pose_bits_t *predicted,
+    const net_reconcile_pose_bits_t *authoritative,
+    uint32_t *predicted_bits,
+    uint32_t *authoritative_bits)
+{
+#define CHECK_DOMAIN(field, domain_value) \
+    do { \
+        if (predicted->field != authoritative->field) { \
+            *predicted_bits = predicted->field; \
+            *authoritative_bits = authoritative->field; \
+            return domain_value; \
+        } \
+    } while (0)
+
+    CHECK_DOMAIN(pos_x, NET_RECONCILE_DOMAIN_PLAYER_POS_X);
+    CHECK_DOMAIN(pos_y, NET_RECONCILE_DOMAIN_PLAYER_POS_Y);
+    CHECK_DOMAIN(vel_x, NET_RECONCILE_DOMAIN_PLAYER_VEL_X);
+    CHECK_DOMAIN(vel_y, NET_RECONCILE_DOMAIN_PLAYER_VEL_Y);
+    CHECK_DOMAIN(angle, NET_RECONCILE_DOMAIN_PLAYER_ANGLE);
+
+#undef CHECK_DOMAIN
+    *predicted_bits = 0;
+    *authoritative_bits = 0;
+    return NET_RECONCILE_DOMAIN_NONE;
+}
+
+net_reconcile_class_t net_reconcile_diagnostics_observe(
+    net_reconcile_diagnostics_t *diagnostics,
+    const net_reconcile_sample_t *sample)
+{
+    net_reconcile_class_t classification = net_reconcile_classify(sample);
+    if (!diagnostics || !sample) return classification;
+
+    diagnostics->total_samples++;
+    diagnostics->class_count[classification]++;
+    if (classification != NET_RECONCILE_EXACT)
+        diagnostics->total_corrections++;
+
+    if (classification != NET_RECONCILE_NUMERIC_DRIFT ||
+        diagnostics->first_numeric_drift_valid) {
+        return classification;
+    }
+
+    diagnostics->first_numeric_drift_valid = true;
+    diagnostics->first_entity_id = sample->entity_id;
+    diagnostics->first_server_tick = sample->server_tick;
+    diagnostics->first_prediction_tick = sample->prediction_tick;
+    diagnostics->first_predicted_input_seq = sample->predicted_input_seq;
+    diagnostics->first_authoritative_input_seq =
+        sample->authoritative_input_seq;
+    diagnostics->first_predicted_pose = sample->predicted;
+    diagnostics->first_authoritative_pose = sample->authoritative;
+    diagnostics->first_domain = first_divergent_domain(
+        &sample->predicted,
+        &sample->authoritative,
+        &diagnostics->first_predicted_bits,
+        &diagnostics->first_authoritative_bits);
+    if (sample->authoritative_root) {
+        diagnostics->first_authoritative_root_valid = true;
+        memcpy(diagnostics->first_authoritative_root,
+               sample->authoritative_root,
+               sizeof(diagnostics->first_authoritative_root));
+    }
+    return classification;
+}
+
+const char *net_reconcile_class_name(net_reconcile_class_t classification)
+{
+    switch (classification) {
+    case NET_RECONCILE_EXACT: return "exact";
+    case NET_RECONCILE_BOOTSTRAP: return "bootstrap";
+    case NET_RECONCILE_INPUT_FRONTIER: return "input-frontier";
+    case NET_RECONCILE_SEMANTIC: return "semantic-discontinuity";
+    case NET_RECONCILE_TRANSPORT_RECOVERY: return "transport-recovery";
+    case NET_RECONCILE_NUMERIC_DRIFT: return "numeric-drift";
+    case NET_RECONCILE_CLASS_COUNT: break;
+    }
+    return "unknown";
+}
+
+const char *net_reconcile_domain_name(net_reconcile_domain_t domain)
+{
+    switch (domain) {
+    case NET_RECONCILE_DOMAIN_NONE: return "none";
+    case NET_RECONCILE_DOMAIN_PLAYER_POS_X: return "player.ship.pos.x";
+    case NET_RECONCILE_DOMAIN_PLAYER_POS_Y: return "player.ship.pos.y";
+    case NET_RECONCILE_DOMAIN_PLAYER_VEL_X: return "player.ship.vel.x";
+    case NET_RECONCILE_DOMAIN_PLAYER_VEL_Y: return "player.ship.vel.y";
+    case NET_RECONCILE_DOMAIN_PLAYER_ANGLE: return "player.ship.angle";
+    }
+    return "unknown";
+}

--- a/client/reconciliation_diagnostics.h
+++ b/client/reconciliation_diagnostics.h
@@ -1,0 +1,94 @@
+#ifndef SIGNAL_RECONCILIATION_DIAGNOSTICS_H
+#define SIGNAL_RECONCILIATION_DIAGNOSTICS_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "types.h"
+
+#define NET_RECONCILE_ROOT_SIZE 32u
+
+typedef enum {
+    NET_RECONCILE_EXACT = 0,
+    NET_RECONCILE_BOOTSTRAP,
+    NET_RECONCILE_INPUT_FRONTIER,
+    NET_RECONCILE_SEMANTIC,
+    NET_RECONCILE_TRANSPORT_RECOVERY,
+    NET_RECONCILE_NUMERIC_DRIFT,
+    NET_RECONCILE_CLASS_COUNT,
+} net_reconcile_class_t;
+
+typedef enum {
+    NET_RECONCILE_DOMAIN_NONE = 0,
+    NET_RECONCILE_DOMAIN_PLAYER_POS_X,
+    NET_RECONCILE_DOMAIN_PLAYER_POS_Y,
+    NET_RECONCILE_DOMAIN_PLAYER_VEL_X,
+    NET_RECONCILE_DOMAIN_PLAYER_VEL_Y,
+    NET_RECONCILE_DOMAIN_PLAYER_ANGLE,
+} net_reconcile_domain_t;
+
+typedef struct {
+    uint32_t pos_x;
+    uint32_t pos_y;
+    uint32_t vel_x;
+    uint32_t vel_y;
+    uint32_t angle;
+} net_reconcile_pose_bits_t;
+
+typedef struct {
+    bool bootstrap;
+    bool input_frontier;
+    bool semantic_discontinuity;
+    bool transport_recovery;
+    uint8_t entity_id;
+    uint32_t server_tick;
+    uint32_t prediction_tick;
+    uint16_t predicted_input_seq;
+    uint16_t authoritative_input_seq;
+    net_reconcile_pose_bits_t predicted;
+    net_reconcile_pose_bits_t authoritative;
+    const uint8_t *authoritative_root;
+} net_reconcile_sample_t;
+
+typedef struct {
+    uint32_t total_samples;
+    uint32_t total_corrections;
+    uint32_t class_count[NET_RECONCILE_CLASS_COUNT];
+    uint32_t asteroid_motion_samples;
+    uint32_t npc_motion_samples;
+    uint32_t death_respawn_events;
+
+    bool first_numeric_drift_valid;
+    uint8_t first_entity_id;
+    net_reconcile_domain_t first_domain;
+    uint32_t first_server_tick;
+    uint32_t first_prediction_tick;
+    uint16_t first_predicted_input_seq;
+    uint16_t first_authoritative_input_seq;
+    net_reconcile_pose_bits_t first_predicted_pose;
+    net_reconcile_pose_bits_t first_authoritative_pose;
+    uint32_t first_predicted_bits;
+    uint32_t first_authoritative_bits;
+    bool first_authoritative_root_valid;
+    uint8_t first_authoritative_root[NET_RECONCILE_ROOT_SIZE];
+} net_reconcile_diagnostics_t;
+
+net_reconcile_pose_bits_t net_reconcile_pose_bits(float pos_x,
+                                                  float pos_y,
+                                                  float vel_x,
+                                                  float vel_y,
+                                                  float angle);
+bool net_reconcile_pose_equal(const net_reconcile_pose_bits_t *a,
+                              const net_reconcile_pose_bits_t *b);
+bool net_reconcile_movement_intent_equal(const input_intent_t *a,
+                                         const input_intent_t *b);
+net_reconcile_class_t net_reconcile_classify(
+    const net_reconcile_sample_t *sample);
+void net_reconcile_diagnostics_reset(net_reconcile_diagnostics_t *diagnostics);
+net_reconcile_class_t net_reconcile_diagnostics_observe(
+    net_reconcile_diagnostics_t *diagnostics,
+    const net_reconcile_sample_t *sample);
+const char *net_reconcile_class_name(net_reconcile_class_t classification);
+const char *net_reconcile_domain_name(net_reconcile_domain_t domain);
+
+#endif /* SIGNAL_RECONCILIATION_DIAGNOSTICS_H */

--- a/docs/zero-latency-reconciliation-gate.md
+++ b/docs/zero-latency-reconciliation-gate.md
@@ -1,0 +1,90 @@
+# Zero-latency reconciliation gate
+
+The loopback determinism gate observes the real local networking path:
+
+1. browser input is encoded as a tick-addressed network command;
+2. the in-process authoritative server consumes that command in
+   `world_sim_step`;
+3. the server serializes an authoritative player snapshot;
+4. the client decodes the snapshot and enters `apply_remote_player_state`;
+5. client prediction is compared with authority before reconciliation changes
+   the local pose.
+
+Pose comparison is bit-exact across `x`, `y`, `vx`, `vy`, and `angle`. The gate
+does not change correction thresholds, replay behavior, or floating-point
+tolerances.
+
+## Classification
+
+Only unequal poses are corrections. Each correction is assigned one class:
+
+- **bootstrap** — the first authoritative local state;
+- **input-frontier** — server and prediction ticks differ, an input is
+  unacknowledged, the authoritative ACK just advanced, or the tick-addressed
+  replay intent differs from the input authority actually applied;
+- **semantic-discontinuity** — launch, dock, or another explicit local state
+  transition, including the death packet followed by its respawn snapshot;
+- **transport-recovery** — prediction is deliberately rebased after recovery
+  or excessive tick skew;
+- **numeric-drift** — pose bits differ after tick and input frontiers are the
+  same and no earlier frontier correction remains unresolved.
+
+An exact authoritative sample clears frontier provenance. This prevents a
+deliberately deferred scheduling correction from being relabeled as numeric
+drift on its next packet.
+
+Death/respawn is also counted as an authoritative semantic event. If client
+prediction already reproduced the respawn pose bit-exactly, it remains an
+exact pose sample rather than being mislabeled as a correction.
+
+## Failure artifact
+
+The first numeric drift records:
+
+- server and prediction ticks;
+- predicted and authoritative input sequences;
+- player entity and first divergent motion field;
+- full predicted and authoritative poses;
+- exact IEEE-754 bit patterns for the first divergent value;
+- the authoritative `signal.authoritative_state.v1` root when the local
+  authority is available.
+
+Browser smoke reads the artifact through
+`get_net_reconcile_first_drift_json`. The gate also writes a compact
+`[net-drift]` line to stderr.
+
+## Bounded scenarios
+
+`tests/browser-smoke.spec.ts` covers:
+
+- launch and dock semantic transitions;
+- authoritative death and respawn through boost-turn hull drain;
+- thrust, turn, boost, and mining controls in a cleared deterministic flight
+  corridor;
+- real loopback tractor hook, hold, asteroid/cargo tow coupling, and release;
+- changed NPC and asteroid motion snapshots during the flight and towing
+  scenarios;
+- a forced one-bit `player.ship.pos.x` perturbation at an identical tick and
+  input frontier.
+
+The perturbation must produce exactly one numeric-drift sample and a
+versioned authoritative root. Normal bounded scenarios must produce zero.
+
+The explicit per-tick local diagnostic mode (`?netcadence=0`) invalidates its
+previous private-pose baseline before each snapshot. Default singleplayer
+keeps the dedicated server's bounded heartbeat/correction cadence.
+
+## Verification
+
+Run the pure classifier tests:
+
+```sh
+./build/signal_test --filter=reconciliation_diagnostics
+```
+
+Run the real browser loopback scenarios:
+
+```sh
+npx playwright test tests/browser-smoke.spec.ts --project=chromium \
+  --grep "E docks|loopback flight corrections|hooks, holds, and releases"
+```

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -64,6 +64,15 @@ type NetMotionSnapshot = {
   replayDepth: number;
   unackedInputs: number;
   actionQueueDepth: number;
+  reconcileExact: number;
+  reconcileBootstrap: number;
+  reconcileInputFrontier: number;
+  reconcileSemantic: number;
+  reconcileTransportRecovery: number;
+  reconcileNumericDrift: number;
+  reconcileAsteroidMotion: number;
+  reconcileNpcMotion: number;
+  reconcileDeathRespawnEvents: number;
 };
 
 type PlayerCameraSnapshot = {
@@ -368,6 +377,15 @@ async function netMotionSnapshot(page: Page): Promise<NetMotionSnapshot> {
         replayDepth: 0,
         unackedInputs: 0,
         actionQueueDepth: 0,
+        reconcileExact: 0,
+        reconcileBootstrap: 0,
+        reconcileInputFrontier: 0,
+        reconcileSemantic: 0,
+        reconcileTransportRecovery: 0,
+        reconcileNumericDrift: 0,
+        reconcileAsteroidMotion: 0,
+        reconcileNpcMotion: 0,
+        reconcileDeathRespawnEvents: 0,
       };
     }
 
@@ -420,6 +438,15 @@ async function netMotionSnapshot(page: Page): Promise<NetMotionSnapshot> {
       replayDepth: read('get_net_motion_replay_depth'),
       unackedInputs: read('get_net_motion_unacked_inputs'),
       actionQueueDepth: read('get_net_motion_action_queue_depth'),
+      reconcileExact: read('get_net_reconcile_exact_samples'),
+      reconcileBootstrap: read('get_net_reconcile_bootstrap_samples'),
+      reconcileInputFrontier: read('get_net_reconcile_input_frontier_samples'),
+      reconcileSemantic: read('get_net_reconcile_semantic_samples'),
+      reconcileTransportRecovery: read('get_net_reconcile_transport_recovery_samples'),
+      reconcileNumericDrift: read('get_net_reconcile_numeric_drift_samples'),
+      reconcileAsteroidMotion: read('get_net_reconcile_asteroid_motion_samples'),
+      reconcileNpcMotion: read('get_net_reconcile_npc_motion_samples'),
+      reconcileDeathRespawnEvents: read('get_net_reconcile_death_respawn_events'),
     };
   });
 }
@@ -437,6 +464,54 @@ async function resetNetMotionTelemetry(page: Page): Promise<void> {
     } else if (mod && typeof mod.ccall === 'function') {
       mod.ccall('reset_net_motion_telemetry', 'number', [], []);
     }
+  });
+}
+
+async function firstNetDriftJson(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const mod = (window as unknown as {
+      Module?: {
+        ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => string;
+      };
+    }).Module;
+    if (!mod || typeof mod.ccall !== 'function') return '{}';
+    return mod.ccall('get_net_reconcile_first_drift_json', 'string', [], []) || '{}';
+  });
+}
+
+async function perturbLoopbackPlayerX(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const mod = (window as unknown as {
+      Module?: {
+        ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => number;
+      };
+    }).Module;
+    if (!mod || typeof mod.ccall !== 'function') return 0;
+    return mod.ccall('signal_zero_latency_perturb_player_x_lsb', 'number', [], []);
+  });
+}
+
+async function prepareDriftFlight(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const mod = (window as unknown as {
+      Module?: {
+        ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => number;
+      };
+    }).Module;
+    if (!mod || typeof mod.ccall !== 'function') return 0;
+    return mod.ccall('signal_smoke_prepare_drift_flight', 'number', [], []);
+  });
+}
+
+async function primeDeathRespawn(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const mod = (window as unknown as {
+      Module?: {
+        ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => number;
+      };
+    }).Module;
+    if (!mod || typeof mod.ccall !== 'function') return 0;
+    return mod.ccall('signal_smoke_prime_death_respawn', 'number', [], []);
   });
 }
 
@@ -1083,6 +1158,7 @@ test.describe('Browser smoke tests', () => {
 
     await expect.poll(async () => (await playerStateSnapshot(page))?.docked ?? -1)
       .toBe(1);
+    await resetNetMotionTelemetry(page);
     await tap(page, 'E');
     await expect
       .poll(async () => (await playerStateSnapshot(page))?.docked ?? -1, {
@@ -1099,6 +1175,12 @@ test.describe('Browser smoke tests', () => {
         timeout: 8_000,
       })
       .toBe(1);
+    const dockMotion = await netMotionSnapshot(page);
+    expect(
+      dockMotion.reconcileNumericDrift,
+      `first launch/dock drift: ${await firstNetDriftJson(page)}`,
+    ).toBe(0);
+    expect(dockMotion.reconcileSemantic).toBeGreaterThan(0);
 
     expectNoFatalErrors(logs);
   });
@@ -1146,9 +1228,15 @@ test.describe('Browser smoke tests', () => {
       })
       .toBe(0);
 
+    expect(await prepareDriftFlight(page)).toBe(1);
+    await page.waitForTimeout(250);
     await resetNetMotionTelemetry(page);
     const acksBefore = (await netMotionSnapshot(page)).inputAcks;
-    await hold(page, 'W', 2_500);
+    await hold(page, 'W', 1_800);
+    await hold(page, 'A', 350);
+    await hold(page, 'D', 350);
+    await hold(page, 'Shift', 500);
+    await hold(page, 'M', 350);
 
     await expect
       .poll(async () => (await netMotionSnapshot(page)).inputAcks, {
@@ -1172,6 +1260,84 @@ test.describe('Browser smoke tests', () => {
     expect(motion.maxRenderOffset).toBeLessThan(40);
     expect(motion.snapSamples).toBe(0);
     expect(motion.maxTickSkewAbs).toBeLessThan(12);
+    expect(
+      motion.reconcileNumericDrift,
+      `first loopback drift: ${await firstNetDriftJson(page)}`,
+    ).toBe(0);
+    expect(motion.reconcileExact).toBeGreaterThan(0);
+    expect(motion.reconcileNpcMotion).toBeGreaterThan(0);
+
+    await expect
+      .poll(async () => perturbLoopbackPlayerX(page), {
+        timeout: 5_000,
+        message: 'one-bit local pose perturbation should be observed at the same tick frontier',
+      })
+      .toBe(1);
+    const perturbedMotion = await netMotionSnapshot(page);
+    expect(perturbedMotion.reconcileNumericDrift).toBe(1);
+    const firstDrift = JSON.parse(await firstNetDriftJson(page)) as {
+      class?: string;
+      server_tick?: number;
+      prediction_tick?: number;
+      domain?: string;
+      predicted_bits?: string;
+      authoritative_bits?: string;
+      root_schema?: string;
+      authoritative_root?: string;
+    };
+    expect(firstDrift.class).toBe('numeric-drift');
+    expect(firstDrift.server_tick).toBe(firstDrift.prediction_tick);
+    expect(firstDrift.domain).toBe('player.ship.pos.x');
+    expect(firstDrift.predicted_bits).not.toBe(firstDrift.authoritative_bits);
+    expect(firstDrift.root_schema).toBe('signal.authoritative_state.v1');
+    expect(firstDrift.authoritative_root).toMatch(/^[0-9a-f]{64}$/);
+
+    expectNoFatalErrors(logs);
+  });
+
+  test('classifies authoritative death and respawn as a semantic transition', async ({ page }) => {
+    test.skip(usesLiveSmokeUrl(), 'requires local singleplayer loopback');
+    test.setTimeout(30_000);
+
+    const logs = installFatalCollectors(page);
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const canvas = await loadGame(page);
+
+    await canvas.click();
+    await tap(page, 'Escape');
+    await tap(page, 'E');
+    await expect
+      .poll(async () => (await playerStateSnapshot(page))?.docked ?? 1, {
+        timeout: 8_000,
+        message: 'local loopback launch should leave dock before the death fixture',
+      })
+      .toBe(0);
+
+    expect(await prepareDriftFlight(page)).toBe(1);
+    await page.waitForTimeout(250);
+    await resetNetMotionTelemetry(page);
+    expect(await primeDeathRespawn(page)).toBe(1);
+
+    await page.keyboard.down('Shift');
+    await page.keyboard.down('A');
+    try {
+      await expect
+        .poll(async () => (await playerStateSnapshot(page))?.docked ?? 0, {
+          timeout: 8_000,
+          message: 'boost-turn hull drain should traverse real death and authoritative respawn',
+        })
+        .toBe(1);
+    } finally {
+      await page.keyboard.up('A');
+      await page.keyboard.up('Shift');
+    }
+
+    const motion = await netMotionSnapshot(page);
+    expect(
+      motion.reconcileNumericDrift,
+      `first death/respawn drift: ${await firstNetDriftJson(page)}`,
+    ).toBe(0);
+    expect(motion.reconcileDeathRespawnEvents).toBe(1);
 
     expectNoFatalErrors(logs);
   });
@@ -1749,6 +1915,7 @@ test.describe('Browser smoke tests', () => {
         message: 'the seeded fragment and cargo pod should reach both authority and client',
       })
       .toBe(0b1100000011);
+    await resetNetMotionTelemetry(page);
 
     await page.keyboard.down('Space');
     try {
@@ -1790,6 +1957,13 @@ test.describe('Browser smoke tests', () => {
         message: 'a Space tap should clear both authoritative bindings and all tow-list projections',
       })
       .toBe(0);
+    const towMotion = await netMotionSnapshot(page);
+    expect(
+      towMotion.reconcileNumericDrift,
+      `first towing drift: ${await firstNetDriftJson(page)}`,
+    ).toBe(0);
+    expect(towMotion.reconcileExact).toBeGreaterThan(0);
+    expect(towMotion.reconcileAsteroidMotion).toBeGreaterThan(0);
 
     expectNoFatalErrors(logs);
   });

--- a/tests/c/test_main.c
+++ b/tests/c/test_main.c
@@ -83,6 +83,7 @@ void register_rock_usefulness_tests(void);
 void register_settlement_engine_tests(void);
 void register_signal_field_tests(void);
 void register_state_digest_tests(void);
+void register_reconciliation_diagnostics_tests(void);
 void register_gossip_tests(void);
 void register_npc_radio_tests(void);
 
@@ -213,6 +214,7 @@ int main(int argc, char **argv) {
     register_settlement_engine_tests();
     register_signal_field_tests();
     register_state_digest_tests();
+    register_reconciliation_diagnostics_tests();
     register_gossip_tests();
     register_npc_radio_tests();
 

--- a/tests/c/test_reconciliation_diagnostics.c
+++ b/tests/c/test_reconciliation_diagnostics.c
@@ -1,0 +1,131 @@
+#include "test_harness.h"
+
+#include "reconciliation_diagnostics.h"
+
+static net_reconcile_sample_t matching_sample(void)
+{
+    net_reconcile_pose_bits_t pose =
+        net_reconcile_pose_bits(10.0f, -20.0f, 3.0f, -4.0f, 0.5f);
+    return (net_reconcile_sample_t){
+        .entity_id = 2,
+        .server_tick = 44,
+        .prediction_tick = 44,
+        .predicted_input_seq = 8,
+        .authoritative_input_seq = 8,
+        .predicted = pose,
+        .authoritative = pose,
+    };
+}
+
+TEST(test_reconciliation_diagnostics_require_bit_exact_pose)
+{
+    net_reconcile_sample_t sample = matching_sample();
+    ASSERT_EQ_INT(net_reconcile_classify(&sample), NET_RECONCILE_EXACT);
+
+    sample.predicted.pos_x ^= 1u;
+    ASSERT_EQ_INT(net_reconcile_classify(&sample),
+                  NET_RECONCILE_NUMERIC_DRIFT);
+    ASSERT(!net_reconcile_pose_equal(&sample.predicted,
+                                     &sample.authoritative));
+}
+
+TEST(test_reconciliation_diagnostics_classify_expected_corrections)
+{
+    net_reconcile_sample_t sample = matching_sample();
+    sample.predicted.pos_y ^= 1u;
+
+    sample.bootstrap = true;
+    ASSERT_EQ_INT(net_reconcile_classify(&sample), NET_RECONCILE_BOOTSTRAP);
+    sample.bootstrap = false;
+
+    sample.semantic_discontinuity = true;
+    ASSERT_EQ_INT(net_reconcile_classify(&sample), NET_RECONCILE_SEMANTIC);
+    sample.semantic_discontinuity = false;
+
+    sample.transport_recovery = true;
+    ASSERT_EQ_INT(net_reconcile_classify(&sample),
+                  NET_RECONCILE_TRANSPORT_RECOVERY);
+    sample.transport_recovery = false;
+
+    sample.input_frontier = true;
+    ASSERT_EQ_INT(net_reconcile_classify(&sample),
+                  NET_RECONCILE_INPUT_FRONTIER);
+    sample.input_frontier = false;
+
+    sample.predicted_input_seq++;
+    ASSERT_EQ_INT(net_reconcile_classify(&sample),
+                  NET_RECONCILE_INPUT_FRONTIER);
+    sample.predicted_input_seq = sample.authoritative_input_seq;
+
+    sample.prediction_tick++;
+    ASSERT_EQ_INT(net_reconcile_classify(&sample),
+                  NET_RECONCILE_INPUT_FRONTIER);
+}
+
+TEST(test_reconciliation_diagnostics_compare_only_active_movement_intent)
+{
+    input_intent_t a = {
+        .thrust = 1.0f,
+        .mining_target_hint = -1,
+    };
+    input_intent_t b = a;
+    b.mining_target_hint = 42;
+    ASSERT(net_reconcile_movement_intent_equal(&a, &b));
+
+    a.mine = true;
+    b.mine = true;
+    ASSERT(!net_reconcile_movement_intent_equal(&a, &b));
+    b.mining_target_hint = a.mining_target_hint;
+    ASSERT(net_reconcile_movement_intent_equal(&a, &b));
+
+    b.boost = true;
+    ASSERT(!net_reconcile_movement_intent_equal(&a, &b));
+}
+
+TEST(test_reconciliation_diagnostics_preserve_first_numeric_drift)
+{
+    const uint8_t root[NET_RECONCILE_ROOT_SIZE] = {
+        0x12, 0x34, 0x56, 0x78,
+    };
+    net_reconcile_diagnostics_t diagnostics;
+    net_reconcile_diagnostics_reset(&diagnostics);
+
+    net_reconcile_sample_t exact = matching_sample();
+    ASSERT_EQ_INT(net_reconcile_diagnostics_observe(&diagnostics, &exact),
+                  NET_RECONCILE_EXACT);
+
+    net_reconcile_sample_t drift = matching_sample();
+    drift.predicted.vel_y ^= 1u;
+    drift.authoritative_root = root;
+    ASSERT_EQ_INT(net_reconcile_diagnostics_observe(&diagnostics, &drift),
+                  NET_RECONCILE_NUMERIC_DRIFT);
+
+    net_reconcile_sample_t later = matching_sample();
+    later.server_tick = 45;
+    later.prediction_tick = 45;
+    later.predicted.angle ^= 2u;
+    ASSERT_EQ_INT(net_reconcile_diagnostics_observe(&diagnostics, &later),
+                  NET_RECONCILE_NUMERIC_DRIFT);
+
+    ASSERT_EQ_INT(diagnostics.total_samples, 3);
+    ASSERT_EQ_INT(diagnostics.total_corrections, 2);
+    ASSERT_EQ_INT(diagnostics.class_count[NET_RECONCILE_EXACT], 1);
+    ASSERT_EQ_INT(diagnostics.class_count[NET_RECONCILE_NUMERIC_DRIFT], 2);
+    ASSERT(diagnostics.first_numeric_drift_valid);
+    ASSERT_EQ_INT(diagnostics.first_domain,
+                  NET_RECONCILE_DOMAIN_PLAYER_VEL_Y);
+    ASSERT_EQ_INT(diagnostics.first_server_tick, 44);
+    ASSERT_EQ_INT(diagnostics.first_prediction_tick, 44);
+    ASSERT_EQ_INT(diagnostics.first_predicted_input_seq, 8);
+    ASSERT_EQ_INT(diagnostics.first_authoritative_input_seq, 8);
+    ASSERT_EQ_INT(diagnostics.first_authoritative_root[0], 0x12);
+    ASSERT_EQ_INT(diagnostics.first_authoritative_root[3], 0x78);
+}
+
+void register_reconciliation_diagnostics_tests(void)
+{
+    RUN(test_reconciliation_diagnostics_require_bit_exact_pose);
+    RUN(test_reconciliation_diagnostics_classify_expected_corrections);
+    RUN(test_reconciliation_diagnostics_compare_only_active_movement_intent);
+    RUN(test_reconciliation_diagnostics_preserve_first_numeric_drift);
+}


### PR DESCRIPTION
## Summary

- observe the real input, local authority, snapshot, decode, prediction, and reconciliation loop with bit-exact player pose comparisons
- classify bootstrap, input-frontier, semantic, transport-recovery, exact, and numeric-drift samples without changing correction tolerances
- preserve the first numeric divergence with tick, input frontier, field bits, full poses, and signal.authoritative_state.v1 root
- cover flight, boost, mining, dock/launch, real towing and release, death/respawn, changed asteroid motion, and changed NPC motion
- add a controlled one-bit player.ship.pos.x perturbation that must produce exactly one numeric-drift artifact
- fix per-tick local diagnostic cadence so unchanged authoritative poses are actually emitted while default cadence remains unchanged

## Verification

- make test — 1223 passed, 0 failed
- make build-web — deterministic build flags passed
- Chromium browser smoke — 18 passed, 4 intentional live-network skips
- make replay-repeatability — 20 fast scenarios passed
- make banned-apis deterministic-libm doc-freshness
- make cppcheck
- git diff --check

## Stack

This is intentionally stacked on draft PR #628, which provides signal.authoritative_state.v1. The parent deterministic replay checks are green; its unrelated fuzz-runner failure is tracked separately in #613.

Closes #629.