### PR TITLE
Keep decoder fuzzing headless

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,7 +438,9 @@ endif()
 
 # ------------------------------------------------------------------
 # Fuzz targets (libFuzzer, clang only). Off by default; enable with
-# -DSIGNAL_BUILD_FUZZERS=ON. Harnesses live in tests/fuzz/ and probe
+# -DSIGNAL_BUILD_FUZZERS=ON. Headless builders should also set
+# -DBUILD_TESTS_ONLY=ON -DBUILD_TOOLS=OFF so decoder fuzzing never discovers
+# desktop audio/window dependencies. Harnesses live in tests/fuzz/ and probe
 # untrusted decode paths (cargo receipts, handoff tickets/snapshots).
 # See REMEDIATION_PLAN.md §12.
 # ------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -437,7 +437,8 @@ test-tsan:
 # when present. Override with FUZZ_CC=... . FUZZ_TIME bounds the run;
 # crash artifacts land in tests/fuzz/artifacts/ for standalone replay.
 # New coverage inputs land in the ignored build tree so routine fuzz runs
-# do not dirty the curated, tracked seed corpus.
+# do not dirty the curated, tracked seed corpus. Keep this configuration
+# headless: decoder fuzzing must not depend on desktop audio/window libraries.
 FUZZ_CC ?= $(shell if [ -x /opt/homebrew/opt/llvm/bin/clang ]; then echo /opt/homebrew/opt/llvm/bin/clang; else echo clang; fi)
 FUZZ_TIME ?= 60
 FUZZ_WORK_CORPUS ?= build-fuzz/corpus
@@ -447,6 +448,7 @@ FUZZ_WORK_CORPUS ?= build-fuzz/corpus
 FUZZ_MAX_LEN ?= 131072
 fuzz-receipts:
 	cmake $(GENERATOR) -S . -B build-fuzz -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DBUILD_TESTS_ONLY=ON -DBUILD_TOOLS=OFF \
 		-DSIGNAL_BUILD_FUZZERS=ON -DCMAKE_C_COMPILER=$(FUZZ_CC)
 	cmake --build build-fuzz --parallel --target fuzz_cargo_receipt
 	mkdir -p tests/fuzz/artifacts tests/fuzz/corpus $(FUZZ_WORK_CORPUS)

--- a/tests/fuzz/fuzz_cargo_receipt.c
+++ b/tests/fuzz/fuzz_cargo_receipt.c
@@ -13,7 +13,8 @@
  *
  * Build (clang only):  make fuzz-receipts
  * Or manually:
- *   cmake -S . -B build-fuzz -DSIGNAL_BUILD_FUZZERS=ON
+ *   cmake -S . -B build-fuzz -DBUILD_TESTS_ONLY=ON -DBUILD_TOOLS=OFF \
+ *     -DSIGNAL_BUILD_FUZZERS=ON -DCMAKE_C_COMPILER=clang
  *   cmake --build build-fuzz
  *   ./build-fuzz/fuzz_cargo_receipt -max_total_time=300 corpus_dir
  *


### PR DESCRIPTION
## What

- configure the existing `make fuzz-receipts` entry point as a headless, test-only build
- disable tool targets so decoder fuzzing does not discover desktop client dependencies
- document the same contract for manual CMake builds

## Why

The Linux fuzz job only installs CMake, Ninja, and Clang, but the default CMake configuration reached desktop dependency discovery and failed on missing ALSA before compiling the receipt decoder harness. That made every pull request report an infrastructure failure instead of a meaningful fuzz result.

## Impact

The receipt-chain, receipt-store, and handoff corpus modes now build and run without ALSA, X11, or OpenGL. Normal desktop configuration is unchanged.

## Validation

- `make fuzz-receipts FUZZ_TIME=1`: 69 tracked corpus inputs, all three modes exercised, 492 executions, no crash
- `make fuzz-receipts-standalone`: corpus replayed under ASan/UBSan
- CMake cache: `BUILD_TESTS_ONLY=ON`, `BUILD_TOOLS=OFF`, `SIGNAL_BUILD_FUZZERS=ON`; no ALSA/OpenGL/X11 entries
- target graph contains `fuzz_cargo_receipt` without desktop or server binaries
- native tests: 1225/1225
- sanitizer tests: 1216/1216
- banned APIs, deterministic libm, documentation freshness, and cppcheck all pass

Fixes #631
