### PR TITLE
Define typed receipt origin trust verdicts

### DIFF
--- a/docs/replay-harness.md
+++ b/docs/replay-harness.md
@@ -77,6 +77,11 @@ Each row has schema `signal.replay_counterfactual.v1` and includes:
   sell credits.
 - Motion metrics: end position, velocity, speed, angle, goal distance, progress,
   and scalar utility.
+- `receipt_trust`: an always-on `signal.receipt_trust.v1` contract vector for
+  trusted SMELT/CRAFT origins, an accepted historical rotated key, unknown and
+  revoked authorities, a missing origin proof, and a tampered receipt chain.
+  Replay aborts if any vector produces a different semantic verdict; the
+  native/WASM and cross-runner gates compare the emitted codes exactly.
 - Optional `hnn` object when `--hnn-trace` is set: flat trace contract,
   routed HoloNet contract, route diagnostics, stored count/load/fidelity, raw
   HNN top action, gated top legal action, legal action mask, candidate

--- a/shared/cargo_receipt.c
+++ b/shared/cargo_receipt.c
@@ -118,6 +118,106 @@ cargo_receipt_result_t cargo_receipt_chain_verify(
     return CARGO_RECEIPT_OK;
 }
 
+/* ---------------- Origin trust contract ---------------------------- */
+
+cargo_receipt_trust_result_t cargo_receipt_trust_verify(
+    const cargo_receipt_t *chain,
+    size_t count,
+    const uint8_t expected_cargo_pub[32],
+    const cargo_receipt_origin_proof_t *origin,
+    cargo_receipt_authority_trust_t authority_trust) {
+    cargo_receipt_trust_result_t out = {
+        .status = CARGO_RECEIPT_TRUST_REJECT_BAD_ARGUMENTS,
+        .chain_result = cargo_receipt_chain_verify(
+            chain, count, expected_cargo_pub),
+        .origin_event = origin
+            ? origin->event_type
+            : CARGO_RECEIPT_ORIGIN_EVENT_NONE,
+        .authority_trust = authority_trust,
+    };
+
+    if (!expected_cargo_pub) return out;
+    if (out.chain_result != CARGO_RECEIPT_OK) {
+        out.status = CARGO_RECEIPT_TRUST_REJECT_CHAIN;
+        return out;
+    }
+    if (!origin) {
+        out.status = CARGO_RECEIPT_TRUST_REJECT_MISSING_ORIGIN;
+        return out;
+    }
+    if (origin->event_type != CARGO_RECEIPT_ORIGIN_EVENT_SMELT &&
+        origin->event_type != CARGO_RECEIPT_ORIGIN_EVENT_CRAFT) {
+        out.status = CARGO_RECEIPT_TRUST_REJECT_ORIGIN_EVENT_TYPE;
+        return out;
+    }
+    if (memcmp(origin->output_cargo_pub, expected_cargo_pub, 32) != 0) {
+        out.status = CARGO_RECEIPT_TRUST_REJECT_ORIGIN_CARGO;
+        return out;
+    }
+    if (memcmp(origin->event_hash, chain[0].prev_receipt_hash, 32) != 0) {
+        out.status = CARGO_RECEIPT_TRUST_REJECT_ORIGIN_PIN;
+        return out;
+    }
+    if (memcmp(origin->authority, chain[0].authoring_station, 32) != 0) {
+        out.status = CARGO_RECEIPT_TRUST_REJECT_ORIGIN_AUTHORITY;
+        return out;
+    }
+
+    switch (authority_trust) {
+        case CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT:
+            out.status = CARGO_RECEIPT_TRUST_VALID_TRUSTED;
+            break;
+        case CARGO_RECEIPT_AUTHORITY_TRUSTED_ROTATED:
+            out.status = CARGO_RECEIPT_TRUST_VALID_TRUSTED_ROTATED;
+            break;
+        case CARGO_RECEIPT_AUTHORITY_UNKNOWN:
+            out.status = CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY;
+            break;
+        case CARGO_RECEIPT_AUTHORITY_UNTRUSTED:
+            out.status = CARGO_RECEIPT_TRUST_REJECT_UNTRUSTED_AUTHORITY;
+            break;
+        case CARGO_RECEIPT_AUTHORITY_REVOKED:
+            out.status = CARGO_RECEIPT_TRUST_REJECT_REVOKED_AUTHORITY;
+            break;
+        default:
+            out.status = CARGO_RECEIPT_TRUST_REJECT_BAD_ARGUMENTS;
+            break;
+    }
+    return out;
+}
+
+const char *cargo_receipt_trust_status_name(
+    cargo_receipt_trust_status_t status) {
+    switch (status) {
+        case CARGO_RECEIPT_TRUST_VALID_TRUSTED:
+            return "valid_trusted";
+        case CARGO_RECEIPT_TRUST_VALID_TRUSTED_ROTATED:
+            return "valid_trusted_rotated";
+        case CARGO_RECEIPT_TRUST_REJECT_BAD_ARGUMENTS:
+            return "reject_bad_arguments";
+        case CARGO_RECEIPT_TRUST_REJECT_CHAIN:
+            return "reject_chain";
+        case CARGO_RECEIPT_TRUST_REJECT_MISSING_ORIGIN:
+            return "reject_missing_origin";
+        case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_EVENT_TYPE:
+            return "reject_origin_event_type";
+        case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_CARGO:
+            return "reject_origin_cargo";
+        case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_PIN:
+            return "reject_origin_pin";
+        case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_AUTHORITY:
+            return "reject_origin_authority";
+        case CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY:
+            return "reject_unknown_authority";
+        case CARGO_RECEIPT_TRUST_REJECT_UNTRUSTED_AUTHORITY:
+            return "reject_untrusted_authority";
+        case CARGO_RECEIPT_TRUST_REJECT_REVOKED_AUTHORITY:
+            return "reject_revoked_authority";
+        default:
+            return "unknown";
+    }
+}
+
 /* ---------------- ship_receipts_t storage --------------------------- */
 
 bool ship_receipts_init(ship_receipts_t *r, uint16_t cap) {

--- a/shared/cargo_receipt.h
+++ b/shared/cargo_receipt.h
@@ -139,6 +139,83 @@ cargo_receipt_result_t cargo_receipt_chain_verify(
     const cargo_receipt_t *chain, size_t count,
     const uint8_t *expected_cargo_pub /* nullable, 32 bytes */);
 
+/* ---------------- origin trust contract ---------------------------- */
+
+/*
+ * Data-only description of a cargo-producing event resolved from a verified
+ * station history. The resolver owns log/federation I/O and event signature
+ * verification; this shared layer checks that the resolved facts match the
+ * receipt's origin pin and the expected cargo.
+ */
+typedef enum {
+    CARGO_RECEIPT_ORIGIN_EVENT_NONE  = 0,
+    CARGO_RECEIPT_ORIGIN_EVENT_SMELT = 1,
+    CARGO_RECEIPT_ORIGIN_EVENT_CRAFT = 2
+} cargo_receipt_origin_event_t;
+
+typedef struct {
+    cargo_receipt_origin_event_t event_type;
+    uint64_t event_id;
+    uint64_t epoch;
+    uint8_t event_hash[32];
+    uint8_t output_cargo_pub[32];
+    uint8_t authority[32];
+} cargo_receipt_origin_proof_t;
+
+/*
+ * Explicit lifecycle decision supplied by the evaluating station's policy.
+ * TRUSTED_ROTATED means the historical key is accepted for this event even
+ * though it is no longer current. Revoked keys are never accepted here.
+ */
+typedef enum {
+    CARGO_RECEIPT_AUTHORITY_UNKNOWN         = 0,
+    CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT = 1,
+    CARGO_RECEIPT_AUTHORITY_TRUSTED_ROTATED = 2,
+    CARGO_RECEIPT_AUTHORITY_UNTRUSTED       = 3,
+    CARGO_RECEIPT_AUTHORITY_REVOKED         = 4
+} cargo_receipt_authority_trust_t;
+
+/*
+ * Stable semantic verdict. Cryptographic chain rejection remains one status
+ * with the precise lower-level reason in cargo_receipt_trust_result_t.
+ */
+typedef enum {
+    CARGO_RECEIPT_TRUST_VALID_TRUSTED = 0,
+    CARGO_RECEIPT_TRUST_VALID_TRUSTED_ROTATED,
+    CARGO_RECEIPT_TRUST_REJECT_BAD_ARGUMENTS,
+    CARGO_RECEIPT_TRUST_REJECT_CHAIN,
+    CARGO_RECEIPT_TRUST_REJECT_MISSING_ORIGIN,
+    CARGO_RECEIPT_TRUST_REJECT_ORIGIN_EVENT_TYPE,
+    CARGO_RECEIPT_TRUST_REJECT_ORIGIN_CARGO,
+    CARGO_RECEIPT_TRUST_REJECT_ORIGIN_PIN,
+    CARGO_RECEIPT_TRUST_REJECT_ORIGIN_AUTHORITY,
+    CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY,
+    CARGO_RECEIPT_TRUST_REJECT_UNTRUSTED_AUTHORITY,
+    CARGO_RECEIPT_TRUST_REJECT_REVOKED_AUTHORITY
+} cargo_receipt_trust_status_t;
+
+typedef struct {
+    cargo_receipt_trust_status_t status;
+    cargo_receipt_result_t chain_result;
+    cargo_receipt_origin_event_t origin_event;
+    cargo_receipt_authority_trust_t authority_trust;
+} cargo_receipt_trust_result_t;
+
+/*
+ * Compose cryptographic receipt validity, a resolved origin event, and an
+ * explicit authority policy. This function performs no I/O, allocation, or
+ * mutation. expected_cargo_pub is required.
+ */
+cargo_receipt_trust_result_t cargo_receipt_trust_verify(
+    const cargo_receipt_t *chain,
+    size_t count,
+    const uint8_t expected_cargo_pub[32],
+    const cargo_receipt_origin_proof_t *origin,
+    cargo_receipt_authority_trust_t authority_trust);
+
+const char *cargo_receipt_trust_status_name(
+    cargo_receipt_trust_status_t status);
+
 /* ---------------- ship_receipts_t ---------------------------------- */
 
 /* Per-cargo receipt store running parallel to ship_t.manifest.

--- a/tests/c/test_cross_station_settlement.c
+++ b/tests/c/test_cross_station_settlement.c
@@ -222,6 +222,180 @@ static bool crs_first_hop(world_t *w, station_t *st, const uint8_t player_pk[32]
     return id != 0;
 }
 
+static cargo_receipt_origin_proof_t crs_origin_proof(
+    const cargo_receipt_t *receipt,
+    cargo_receipt_origin_event_t event_type) {
+    cargo_receipt_origin_proof_t proof = {
+        .event_type = event_type,
+        .event_id = 1,
+        .epoch = receipt->epoch,
+    };
+    memcpy(proof.event_hash, receipt->prev_receipt_hash, 32);
+    memcpy(proof.output_cargo_pub, receipt->cargo_pub, 32);
+    memcpy(proof.authority, receipt->authoring_station, 32);
+    return proof;
+}
+
+TEST(test_receipt_trust_accepts_smelt_craft_and_rotated_authority) {
+    crs_setup("trust_accept");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL);
+    crs_world_init(w, 0xD101);
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0x11);
+    uint8_t cargo_pk[32]; fill_test_pubkey(cargo_pk, 0x41);
+    cargo_receipt_t receipt;
+    ASSERT(crs_first_hop(w, &w->stations[2], player_pk, cargo_pk, &receipt));
+
+    cargo_receipt_origin_proof_t proof = crs_origin_proof(
+        &receipt, CARGO_RECEIPT_ORIGIN_EVENT_SMELT);
+    cargo_receipt_trust_result_t result = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pk, &proof,
+        CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+    ASSERT_EQ_INT(result.status, CARGO_RECEIPT_TRUST_VALID_TRUSTED);
+    ASSERT_EQ_INT(result.chain_result, CARGO_RECEIPT_OK);
+    ASSERT_EQ_INT(result.origin_event, CARGO_RECEIPT_ORIGIN_EVENT_SMELT);
+    ASSERT_STR_EQ(cargo_receipt_trust_status_name(result.status),
+                  "valid_trusted");
+
+    proof.event_type = CARGO_RECEIPT_ORIGIN_EVENT_CRAFT;
+    result = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pk, &proof,
+        CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+    ASSERT_EQ_INT(result.status, CARGO_RECEIPT_TRUST_VALID_TRUSTED);
+    ASSERT_EQ_INT(result.origin_event, CARGO_RECEIPT_ORIGIN_EVENT_CRAFT);
+
+    result = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pk, &proof,
+        CARGO_RECEIPT_AUTHORITY_TRUSTED_ROTATED);
+    ASSERT_EQ_INT(result.status,
+                  CARGO_RECEIPT_TRUST_VALID_TRUSTED_ROTATED);
+    ASSERT_STR_EQ(cargo_receipt_trust_status_name(result.status),
+                  "valid_trusted_rotated");
+    crs_teardown();
+}
+
+TEST(test_receipt_trust_distinguishes_origin_proof_failures) {
+    crs_setup("trust_origin_failures");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL);
+    crs_world_init(w, 0xD102);
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0x12);
+    uint8_t cargo_pk[32]; fill_test_pubkey(cargo_pk, 0x42);
+    cargo_receipt_t receipt;
+    ASSERT(crs_first_hop(w, &w->stations[2], player_pk, cargo_pk, &receipt));
+    cargo_receipt_t receipt_before = receipt;
+    cargo_receipt_origin_proof_t valid = crs_origin_proof(
+        &receipt, CARGO_RECEIPT_ORIGIN_EVENT_SMELT);
+    cargo_receipt_origin_proof_t proof_before = valid;
+
+    cargo_receipt_trust_result_t result = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pk, NULL,
+        CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+    ASSERT_EQ_INT(result.status,
+                  CARGO_RECEIPT_TRUST_REJECT_MISSING_ORIGIN);
+
+    cargo_receipt_origin_proof_t proof = valid;
+    proof.event_type = CARGO_RECEIPT_ORIGIN_EVENT_NONE;
+    result = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pk, &proof,
+        CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+    ASSERT_EQ_INT(result.status,
+                  CARGO_RECEIPT_TRUST_REJECT_ORIGIN_EVENT_TYPE);
+
+    proof = valid;
+    proof.output_cargo_pub[0] ^= 0x80u;
+    result = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pk, &proof,
+        CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+    ASSERT_EQ_INT(result.status, CARGO_RECEIPT_TRUST_REJECT_ORIGIN_CARGO);
+
+    proof = valid;
+    proof.event_hash[1] ^= 0x40u;
+    result = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pk, &proof,
+        CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+    ASSERT_EQ_INT(result.status, CARGO_RECEIPT_TRUST_REJECT_ORIGIN_PIN);
+
+    proof = valid;
+    proof.authority[2] ^= 0x20u;
+    result = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pk, &proof,
+        CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+    ASSERT_EQ_INT(result.status,
+                  CARGO_RECEIPT_TRUST_REJECT_ORIGIN_AUTHORITY);
+
+    ASSERT(memcmp(&receipt, &receipt_before, sizeof(receipt)) == 0);
+    ASSERT(memcmp(&valid, &proof_before, sizeof(valid)) == 0);
+    crs_teardown();
+}
+
+TEST(test_receipt_trust_distinguishes_authority_policy) {
+    crs_setup("trust_authority");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL);
+    crs_world_init(w, 0xD103);
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0x13);
+    uint8_t cargo_pk[32]; fill_test_pubkey(cargo_pk, 0x43);
+    cargo_receipt_t receipt;
+    ASSERT(crs_first_hop(w, &w->stations[2], player_pk, cargo_pk, &receipt));
+    cargo_receipt_origin_proof_t proof = crs_origin_proof(
+        &receipt, CARGO_RECEIPT_ORIGIN_EVENT_SMELT);
+
+    cargo_receipt_trust_result_t result = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pk, &proof, CARGO_RECEIPT_AUTHORITY_UNKNOWN);
+    ASSERT_EQ_INT(result.status,
+                  CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY);
+    ASSERT_STR_EQ(cargo_receipt_trust_status_name(result.status),
+                  "reject_unknown_authority");
+
+    result = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pk, &proof, CARGO_RECEIPT_AUTHORITY_UNTRUSTED);
+    ASSERT_EQ_INT(result.status,
+                  CARGO_RECEIPT_TRUST_REJECT_UNTRUSTED_AUTHORITY);
+
+    result = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pk, &proof, CARGO_RECEIPT_AUTHORITY_REVOKED);
+    ASSERT_EQ_INT(result.status,
+                  CARGO_RECEIPT_TRUST_REJECT_REVOKED_AUTHORITY);
+    ASSERT_STR_EQ(cargo_receipt_trust_status_name(result.status),
+                  "reject_revoked_authority");
+
+    result = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pk, &proof,
+        (cargo_receipt_authority_trust_t)99);
+    ASSERT_EQ_INT(result.status,
+                  CARGO_RECEIPT_TRUST_REJECT_BAD_ARGUMENTS);
+    ASSERT_STR_EQ(cargo_receipt_trust_status_name(
+                      (cargo_receipt_trust_status_t)99),
+                  "unknown");
+    crs_teardown();
+}
+
+TEST(test_receipt_trust_preserves_cryptographic_chain_failure) {
+    crs_setup("trust_chain_failure");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL);
+    crs_world_init(w, 0xD104);
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0x14);
+    uint8_t cargo_pk[32]; fill_test_pubkey(cargo_pk, 0x44);
+    cargo_receipt_t receipt;
+    ASSERT(crs_first_hop(w, &w->stations[2], player_pk, cargo_pk, &receipt));
+    cargo_receipt_origin_proof_t proof = crs_origin_proof(
+        &receipt, CARGO_RECEIPT_ORIGIN_EVENT_SMELT);
+
+    cargo_receipt_t tampered = receipt;
+    tampered.signature[0] ^= 0x01u;
+    cargo_receipt_trust_result_t result = cargo_receipt_trust_verify(
+        &tampered, 1, cargo_pk, &proof,
+        CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+    ASSERT_EQ_INT(result.status, CARGO_RECEIPT_TRUST_REJECT_CHAIN);
+    ASSERT_EQ_INT(result.chain_result, CARGO_RECEIPT_REJECT_BAD_SIGNATURE);
+
+    result = cargo_receipt_trust_verify(
+        &receipt, 1, NULL, &proof,
+        CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+    ASSERT_EQ_INT(result.status,
+                  CARGO_RECEIPT_TRUST_REJECT_BAD_ARGUMENTS);
+    ASSERT_EQ_INT(result.chain_result, CARGO_RECEIPT_OK);
+    crs_teardown();
+}
+
 /* Helper: emit destination-station receipt for the second hop. */
 static bool crs_next_hop(world_t *w, station_t *dst, const uint8_t from_pk[32],
                          const uint8_t cargo_pk[32],
@@ -1121,6 +1295,10 @@ void register_cross_station_settlement_tests(void);
 void register_cross_station_settlement_tests(void) {
     TEST_SECTION("\n--- Cross-Station Settlement (#479 D) ---\n");
     RUN(test_cross_station_single_hop_receipt);
+    RUN(test_receipt_trust_accepts_smelt_craft_and_rotated_authority);
+    RUN(test_receipt_trust_distinguishes_origin_proof_failures);
+    RUN(test_receipt_trust_distinguishes_authority_policy);
+    RUN(test_receipt_trust_preserves_cryptographic_chain_failure);
     RUN(test_cross_station_two_hop_chain);
     RUN(test_cross_station_forged_receipt_rejected);
     RUN(test_cross_station_tampered_cargo_pub_rejected);

--- a/tools/signal_replay.c
+++ b/tools/signal_replay.c
@@ -16,6 +16,8 @@
 #include <string.h>
 
 #include "chain_log.h"
+#include "cargo_receipt.h"
+#include "cargo_receipt_issue.h"
 #include "fixpoint.h"
 #include "game_sim.h"
 #include "gossip.h"
@@ -209,6 +211,16 @@ typedef struct {
 } sr_hnn_eval_t;
 
 typedef struct {
+    cargo_receipt_trust_status_t trusted_smelt;
+    cargo_receipt_trust_status_t trusted_craft;
+    cargo_receipt_trust_status_t trusted_rotated;
+    cargo_receipt_trust_status_t unknown_authority;
+    cargo_receipt_trust_status_t revoked_authority;
+    cargo_receipt_trust_status_t missing_origin;
+    cargo_receipt_trust_status_t tampered_chain;
+} sr_receipt_trust_eval_t;
+
+typedef struct {
     bool ok;
     int candidate;
     int prefix_ticks;
@@ -236,6 +248,7 @@ typedef struct {
     sr_event_counts_t events;
     sr_ai_summary_t ai;
     sr_hnn_eval_t hnn;
+    sr_receipt_trust_eval_t receipt_trust;
     uint8_t prefix_state_hash[32];
     uint8_t state_hash[32];
     uint8_t event_hash[32];
@@ -255,6 +268,78 @@ static const sr_action_def_t SR_ACTIONS[SR_ACTION_COUNT] = {
     {-1, -1, "SA"},
     { 1, -1, "SD"},
 };
+
+static bool sr_receipt_trust_known_vector(
+    const world_t *w,
+    int station_index,
+    sr_receipt_trust_eval_t *out) {
+    if (!w || !out || station_index < 0 || station_index >= MAX_STATIONS)
+        return false;
+
+    uint8_t cargo_pub[32];
+    uint8_t recipient_pub[32];
+    uint8_t origin_hash[32];
+    for (int i = 0; i < 32; i++) {
+        cargo_pub[i] = (uint8_t)(0x31 + i);
+        recipient_pub[i] = (uint8_t)(0x61 + i);
+        origin_hash[i] = (uint8_t)(0x91 + i);
+    }
+
+    const station_t *station = &w->stations[station_index];
+    cargo_receipt_t receipt;
+    if (!cargo_receipt_issue(station, 7u, 11u, cargo_pub, recipient_pub,
+                             origin_hash, &receipt)) {
+        return false;
+    }
+
+    cargo_receipt_origin_proof_t proof = {
+        .event_type = CARGO_RECEIPT_ORIGIN_EVENT_SMELT,
+        .event_id = 11u,
+        .epoch = 7u,
+    };
+    memcpy(proof.event_hash, origin_hash, sizeof(proof.event_hash));
+    memcpy(proof.output_cargo_pub, cargo_pub, sizeof(proof.output_cargo_pub));
+    memcpy(proof.authority, station->station_pubkey, sizeof(proof.authority));
+
+    memset(out, 0, sizeof(*out));
+    out->trusted_smelt = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pub, &proof,
+        CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT).status;
+
+    proof.event_type = CARGO_RECEIPT_ORIGIN_EVENT_CRAFT;
+    out->trusted_craft = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pub, &proof,
+        CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT).status;
+    out->trusted_rotated = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pub, &proof,
+        CARGO_RECEIPT_AUTHORITY_TRUSTED_ROTATED).status;
+    out->unknown_authority = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pub, &proof,
+        CARGO_RECEIPT_AUTHORITY_UNKNOWN).status;
+    out->revoked_authority = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pub, &proof,
+        CARGO_RECEIPT_AUTHORITY_REVOKED).status;
+    out->missing_origin = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pub, NULL,
+        CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT).status;
+
+    cargo_receipt_t tampered = receipt;
+    tampered.signature[0] ^= 0x01u;
+    out->tampered_chain = cargo_receipt_trust_verify(
+        &tampered, 1, cargo_pub, &proof,
+        CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT).status;
+    return out->trusted_smelt == CARGO_RECEIPT_TRUST_VALID_TRUSTED &&
+           out->trusted_craft == CARGO_RECEIPT_TRUST_VALID_TRUSTED &&
+           out->trusted_rotated ==
+               CARGO_RECEIPT_TRUST_VALID_TRUSTED_ROTATED &&
+           out->unknown_authority ==
+               CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY &&
+           out->revoked_authority ==
+               CARGO_RECEIPT_TRUST_REJECT_REVOKED_AUTHORITY &&
+           out->missing_origin ==
+               CARGO_RECEIPT_TRUST_REJECT_MISSING_ORIGIN &&
+           out->tampered_chain == CARGO_RECEIPT_TRUST_REJECT_CHAIN;
+}
 
 static void sr_usage(FILE *fp)
 {
@@ -3401,6 +3486,12 @@ static bool sr_run_branch(const sr_config_t *config, int candidate, sr_result_t 
         free(w);
         return false;
     }
+    if (!sr_receipt_trust_known_vector(
+            w, config->station, &out->receipt_trust)) {
+        world_cleanup(w);
+        free(w);
+        return false;
+    }
     if (!sr_setup_provenance_script(config, w, sp)) {
         world_cleanup(w);
         free(w);
@@ -3863,6 +3954,22 @@ static void sr_write_row(FILE *out, const sr_config_t *config, const sr_result_t
     if (config->hnn_trace && r->hnn.enabled) {
         sr_write_hnn_eval(out, &r->hnn);
     }
+    fprintf(out,
+            ",\"receipt_trust\":{\"schema\":\"signal.receipt_trust.v1\","
+            "\"trusted_smelt\":%d,"
+            "\"trusted_craft\":%d,"
+            "\"trusted_rotated\":%d,"
+            "\"unknown_authority\":%d,"
+            "\"revoked_authority\":%d,"
+            "\"missing_origin\":%d,"
+            "\"tampered_chain\":%d}",
+            (int)r->receipt_trust.trusted_smelt,
+            (int)r->receipt_trust.trusted_craft,
+            (int)r->receipt_trust.trusted_rotated,
+            (int)r->receipt_trust.unknown_authority,
+            (int)r->receipt_trust.revoked_authority,
+            (int)r->receipt_trust.missing_origin,
+            (int)r->receipt_trust.tampered_chain);
     fprintf(out, ",\"authority\":\"deterministic_seed_prefix_replay\"}\n");
 }
 


### PR DESCRIPTION
## What

- add a shared, allocation-free receipt origin proof and authority lifecycle contract
- compose chain cryptography, origin event facts, and station trust policy into one typed verdict
- distinguish trusted current/rotated keys, unknown/untrusted/revoked issuers, missing or mismatched origins, and lower-level chain failures
- expose stable semantic status names for later gameplay, inspection, and CLI consumers
- add an always-on deterministic replay vector for trusted, rotated, unknown, revoked, missing, and tampered cases

## Why

`cargo_receipt_chain_verify()` correctly proves signatures, linkage, and cargo binding, but a self-consistent chain does not prove that its origin pin names a legitimate production event from an authority the evaluating station accepts. Callers need one shared result model before gameplay and settlement enforcement can be added safely.

## Boundaries

This PR performs no chain-log I/O and changes no state-mutating gameplay path. A resolver must supply facts from a verified SMELT/CRAFT event, and station policy must explicitly classify that authority. Local resolution and atomic enforcement remain in #635; player/CLI surfaces remain in #636.

## Validation

- focused receipt-trust tests: 4/4
- native suite: 1229/1229
- ASan/UBSan suite: 1220/1220
- native replay repeatability: 20/20 scenarios
- native-versus-WASM replay: 20/20 scenarios byte-equivalent
- deterministic build flags, banned APIs, deterministic libm, docs freshness, and cppcheck pass
- `git diff --check` passes

Fixes #634  
Refs #622
