### PR TITLE
Resolve receipt origins from verified station history

### DIFF
--- a/server/cargo_receipt_issue.c
+++ b/server/cargo_receipt_issue.c
@@ -11,6 +11,7 @@
 #include "manifest.h"
 #include "station_authority.h"
 
+#include <stdio.h>
 #include <string.h>
 
 bool cargo_receipt_issue(const station_t *s,
@@ -44,9 +45,15 @@ uint64_t cargo_receipt_emit_transfer(world_t *w, station_t *s,
                                      const uint8_t to_pubkey[32],
                                      const uint8_t cargo_pub[32],
                                      uint8_t cargo_kind,
-                                     const uint8_t prev_receipt_hash[32],
+                                     const cargo_receipt_chain_t *incoming_chain,
                                      cargo_receipt_t *out_receipt) {
     if (!s || !out_receipt) return 0;
+    cargo_receipt_transfer_link_t link =
+        cargo_receipt_prepare_transfer_link(s, cargo_pub, incoming_chain);
+    if (link.status != CARGO_RECEIPT_TRANSFER_LINK_READY) {
+        memset(out_receipt, 0, sizeof(*out_receipt));
+        return 0;
+    }
     /* Wire-stable EVT_TRANSFER payload — typedef'd in chain_log.h so
      * the on-disk byte format has a single source of truth across
      * every emit site. */
@@ -66,9 +73,123 @@ uint64_t cargo_receipt_emit_transfer(world_t *w, station_t *s,
     uint64_t epoch_ticks = w ? (uint64_t)(w->time * 120.0) : 0;
     if (!cargo_receipt_issue(s, epoch_ticks, event_id, cargo_pub,
                              to_pubkey ? to_pubkey : (const uint8_t[32]){0},
-                             prev_receipt_hash, out_receipt))
+                             link.prev_receipt_hash, out_receipt))
         return 0;
     return event_id;
+}
+
+cargo_receipt_origin_resolve_status_t cargo_receipt_resolve_local_origin(
+    const station_t *station,
+    const uint8_t cargo_pub[32],
+    cargo_receipt_origin_proof_t *out_proof) {
+    static const uint8_t zero32[32] = {0};
+    if (out_proof) memset(out_proof, 0, sizeof(*out_proof));
+    if (!station || !cargo_pub || !out_proof ||
+        memcmp(cargo_pub, zero32, sizeof(zero32)) == 0) {
+        return CARGO_RECEIPT_ORIGIN_RESOLVE_BAD_ARGUMENTS;
+    }
+
+    char path[256];
+    if (!chain_log_path_for(station->station_pubkey, path, sizeof(path)))
+        return CARGO_RECEIPT_ORIGIN_RESOLVE_HISTORY_UNAVAILABLE;
+    FILE *history = fopen(path, "rb");
+    if (!history)
+        return CARGO_RECEIPT_ORIGIN_RESOLVE_HISTORY_UNAVAILABLE;
+    fclose(history);
+
+    chain_log_verify_report_t report;
+    if (!chain_log_verify_station(station, NULL, NULL, &report))
+        return CARGO_RECEIPT_ORIGIN_RESOLVE_HISTORY_INVALID;
+
+    chain_cargo_transform_t transform;
+    if (!chain_log_find_cargo_transform(station, cargo_pub, &transform))
+        return CARGO_RECEIPT_ORIGIN_RESOLVE_TRANSFORM_NOT_FOUND;
+
+    switch ((chain_event_type_t)transform.type) {
+        case CHAIN_EVT_SMELT:
+            out_proof->event_type = CARGO_RECEIPT_ORIGIN_EVENT_SMELT;
+            memcpy(out_proof->output_cargo_pub, transform.smelt.ingot_pub,
+                   sizeof(out_proof->output_cargo_pub));
+            break;
+        case CHAIN_EVT_CRAFT:
+            out_proof->event_type = CARGO_RECEIPT_ORIGIN_EVENT_CRAFT;
+            memcpy(out_proof->output_cargo_pub, transform.craft.output_pub,
+                   sizeof(out_proof->output_cargo_pub));
+            break;
+        default:
+            return CARGO_RECEIPT_ORIGIN_RESOLVE_TRANSFORM_NOT_FOUND;
+    }
+    out_proof->event_id = transform.event_id;
+    out_proof->epoch = transform.epoch;
+    memcpy(out_proof->event_hash, transform.header_hash,
+           sizeof(out_proof->event_hash));
+    memcpy(out_proof->authority, transform.authority,
+           sizeof(out_proof->authority));
+    return CARGO_RECEIPT_ORIGIN_RESOLVE_VERIFIED;
+}
+
+const char *cargo_receipt_origin_resolve_status_name(
+    cargo_receipt_origin_resolve_status_t status) {
+    switch (status) {
+        case CARGO_RECEIPT_ORIGIN_RESOLVE_NOT_ATTEMPTED:
+            return "not_attempted";
+        case CARGO_RECEIPT_ORIGIN_RESOLVE_VERIFIED:
+            return "verified";
+        case CARGO_RECEIPT_ORIGIN_RESOLVE_BAD_ARGUMENTS:
+            return "bad_arguments";
+        case CARGO_RECEIPT_ORIGIN_RESOLVE_HISTORY_UNAVAILABLE:
+            return "history_unavailable";
+        case CARGO_RECEIPT_ORIGIN_RESOLVE_HISTORY_INVALID:
+            return "history_invalid";
+        case CARGO_RECEIPT_ORIGIN_RESOLVE_TRANSFORM_NOT_FOUND:
+            return "transform_not_found";
+        default:
+            return "unknown";
+    }
+}
+
+cargo_receipt_transfer_link_t cargo_receipt_prepare_transfer_link(
+    const station_t *station,
+    const uint8_t cargo_pub[32],
+    const cargo_receipt_chain_t *incoming_chain) {
+    cargo_receipt_transfer_link_t out = {
+        .status = CARGO_RECEIPT_TRANSFER_LINK_REJECT_BAD_ARGUMENTS,
+        .chain_result = CARGO_RECEIPT_REJECT_EMPTY,
+        .origin_status = CARGO_RECEIPT_ORIGIN_RESOLVE_BAD_ARGUMENTS,
+    };
+    if (!station || !cargo_pub) return out;
+
+    if (incoming_chain && incoming_chain->len > 0) {
+        if (incoming_chain->len >= CARGO_RECEIPT_CHAIN_MAX_LEN) {
+            out.status = CARGO_RECEIPT_TRANSFER_LINK_REJECT_CHAIN_FULL;
+            return out;
+        }
+        out.chain_result = cargo_receipt_chain_verify(
+            incoming_chain->links, incoming_chain->len, cargo_pub);
+        if (out.chain_result != CARGO_RECEIPT_OK) {
+            out.status = CARGO_RECEIPT_TRANSFER_LINK_REJECT_CHAIN;
+            return out;
+        }
+        cargo_receipt_hash(
+            &incoming_chain->links[incoming_chain->len - 1],
+            out.prev_receipt_hash);
+        out.origin_status = CARGO_RECEIPT_ORIGIN_RESOLVE_NOT_ATTEMPTED;
+        out.status = CARGO_RECEIPT_TRANSFER_LINK_READY;
+        return out;
+    }
+
+    cargo_receipt_origin_proof_t proof;
+    out.origin_status = cargo_receipt_resolve_local_origin(
+        station, cargo_pub, &proof);
+    if (out.origin_status != CARGO_RECEIPT_ORIGIN_RESOLVE_VERIFIED) {
+        out.status = CARGO_RECEIPT_TRANSFER_LINK_REJECT_ORIGIN;
+        return out;
+    }
+    memcpy(out.prev_receipt_hash, proof.event_hash,
+           sizeof(out.prev_receipt_hash));
+    out.chain_result = CARGO_RECEIPT_OK;
+    out.status = CARGO_RECEIPT_TRANSFER_LINK_READY;
+    return out;
 }
 
 static bool receipt_chain_prefix_matches(const cargo_receipt_chain_t *existing,

--- a/server/cargo_receipt_issue.h
+++ b/server/cargo_receipt_issue.h
@@ -42,25 +42,60 @@ bool cargo_receipt_issue(const station_t *s,
                          const uint8_t prev_receipt_hash[32],
                          cargo_receipt_t *out);
 
-/* Convenience: emit an EVT_TRANSFER and produce the matching receipt
- * in one call. The returned receipt's event_id matches the emitted
- * event's id. The transfer payload is the canonical
- * (from, to, cargo_pub, kind) shape used elsewhere in main.c.
- *
- * `prev_receipt_hash` follows the same rule as cargo_receipt_issue
- * above. The caller chooses whether this transfer is "origin" (anchor
- * to a SMELT/CRAFT event hash) or "hop N" (anchor to the previous
- * receipt's hash).
- *
- * Returns the new chain event_id (>= 1) and writes the receipt
- * through `out_receipt`. Returns 0 on failure (chain_log_emit failed
- * or station unkeyed). */
+typedef enum {
+    CARGO_RECEIPT_ORIGIN_RESOLVE_NOT_ATTEMPTED = 0,
+    CARGO_RECEIPT_ORIGIN_RESOLVE_VERIFIED,
+    CARGO_RECEIPT_ORIGIN_RESOLVE_BAD_ARGUMENTS,
+    CARGO_RECEIPT_ORIGIN_RESOLVE_HISTORY_UNAVAILABLE,
+    CARGO_RECEIPT_ORIGIN_RESOLVE_HISTORY_INVALID,
+    CARGO_RECEIPT_ORIGIN_RESOLVE_TRANSFORM_NOT_FOUND
+} cargo_receipt_origin_resolve_status_t;
+
+/* Resolve a cargo-producing SMELT/CRAFT event from one station's verified
+ * local history. Missing history, invalid history, and a verified history
+ * without this cargo are distinct outcomes; none may be treated as proof. */
+cargo_receipt_origin_resolve_status_t cargo_receipt_resolve_local_origin(
+    const station_t *station,
+    const uint8_t cargo_pub[32],
+    cargo_receipt_origin_proof_t *out_proof);
+
+const char *cargo_receipt_origin_resolve_status_name(
+    cargo_receipt_origin_resolve_status_t status);
+
+typedef enum {
+    CARGO_RECEIPT_TRANSFER_LINK_READY = 0,
+    CARGO_RECEIPT_TRANSFER_LINK_REJECT_BAD_ARGUMENTS,
+    CARGO_RECEIPT_TRANSFER_LINK_REJECT_CHAIN_FULL,
+    CARGO_RECEIPT_TRANSFER_LINK_REJECT_CHAIN,
+    CARGO_RECEIPT_TRANSFER_LINK_REJECT_ORIGIN
+} cargo_receipt_transfer_link_status_t;
+
+typedef struct {
+    cargo_receipt_transfer_link_status_t status;
+    cargo_receipt_result_t chain_result;
+    cargo_receipt_origin_resolve_status_t origin_status;
+    uint8_t prev_receipt_hash[32];
+} cargo_receipt_transfer_link_t;
+
+/* Prepare the immutable linkage for a transfer before any cargo, balance, or
+ * ownership mutation. A non-empty incoming chain links to its final receipt.
+ * An empty chain must resolve an exact verified local production event. */
+cargo_receipt_transfer_link_t cargo_receipt_prepare_transfer_link(
+    const station_t *station,
+    const uint8_t cargo_pub[32],
+    const cargo_receipt_chain_t *incoming_chain);
+
+/* Convenience: emit an EVT_TRANSFER and produce the matching receipt.
+ * Callers pass the incoming receipt chain, never an arbitrary hash. Empty
+ * chains are accepted only when the station's verified local history contains
+ * the exact SMELT/CRAFT output; multi-hop chains derive their link from the
+ * final receipt. The returned receipt's event_id matches the emitted event. */
 uint64_t cargo_receipt_emit_transfer(world_t *w, station_t *s,
                                      const uint8_t from_pubkey[32],
                                      const uint8_t to_pubkey[32],
                                      const uint8_t cargo_pub[32],
                                      uint8_t cargo_kind,
-                                     const uint8_t prev_receipt_hash[32],
+                                     const cargo_receipt_chain_t *incoming_chain,
                                      cargo_receipt_t *out_receipt);
 
 typedef enum {

--- a/server/chain_log.c
+++ b/server/chain_log.c
@@ -510,6 +510,9 @@ bool chain_log_find_cargo_transform(const station_t *s,
                 out->type = CHAIN_EVT_SMELT;
                 out->event_id = hdr.event_id;
                 out->epoch = hdr.epoch;
+                chain_event_header_hash(&hdr, out->header_hash);
+                memcpy(out->authority, hdr.authority,
+                       sizeof(out->authority));
                 out->smelt = payload;
                 found = true;
             }
@@ -522,6 +525,9 @@ bool chain_log_find_cargo_transform(const station_t *s,
                 out->type = CHAIN_EVT_CRAFT;
                 out->event_id = hdr.event_id;
                 out->epoch = hdr.epoch;
+                chain_event_header_hash(&hdr, out->header_hash);
+                memcpy(out->authority, hdr.authority,
+                       sizeof(out->authority));
                 out->craft = payload;
                 found = true;
             }

--- a/server/chain_log.h
+++ b/server/chain_log.h
@@ -446,12 +446,16 @@ typedef struct {
 
 /* Read model for one cargo-producing event. A player-facing lineage view can
  * follow a cargo pubkey back through CRAFT outputs and SMELT outputs without
- * treating the chain log as inventory authority. The payload matching `type`
- * is populated; the other payload stays zeroed. */
+ * treating the chain log as inventory authority. header_hash is the exact
+ * signed record hash used for receipt origin pins; authority is copied from
+ * the event header. The payload matching `type` is populated and the other
+ * payload stays zeroed. */
 typedef struct {
     uint8_t type; /* CHAIN_EVT_SMELT or CHAIN_EVT_CRAFT */
     uint64_t event_id;
     uint64_t epoch;
+    uint8_t header_hash[32];
+    uint8_t authority[32];
     chain_payload_smelt_t smelt;
     chain_payload_craft_t craft;
 } chain_cargo_transform_t;

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -12551,6 +12551,10 @@ static void server_dispatch_buy_named_ingot(
     if (station_receipts && slot < (int)station_receipts->count)
         station_chain = station_receipts->chains[slot];
     if (station_chain.len >= CARGO_RECEIPT_CHAIN_MAX_LEN) return;
+    cargo_receipt_transfer_link_t transfer_link =
+        cargo_receipt_prepare_transfer_link(st, src->pub, &station_chain);
+    if (transfer_link.status != CARGO_RECEIPT_TRANSFER_LINK_READY)
+        return;
 
     bool spent = server_player_can_use_pubkey_persistence(sp)
         ? ledger_spend_by_pubkey(st, sp->pubkey, (float)price, ship)
@@ -12564,18 +12568,14 @@ static void server_dispatch_buy_named_ingot(
     }
 
     cargo_receipt_t receipt = {0};
-    uint8_t prev_hash[32] = {0};
     cargo_receipt_chain_t outgoing_chain = station_chain;
-    if (station_chain.len > 0)
-        cargo_receipt_hash(&station_chain.links[station_chain.len - 1],
-                           prev_hash);
     uint64_t xfer_id = cargo_receipt_emit_transfer(
         w, st,
         st->station_pubkey,
         sp->pubkey,
         copy.pub,
         (uint8_t)CARGO_KIND_INGOT,
-        station_chain.len > 0 ? prev_hash : st->chain_last_hash,
+        &station_chain,
         &receipt);
     if (xfer_id != 0 && outgoing_chain.len < CARGO_RECEIPT_CHAIN_MAX_LEN)
         outgoing_chain.links[outgoing_chain.len++] = receipt;
@@ -12651,6 +12651,11 @@ static void server_dispatch_deliver_named_ingot(
         }
     }
 
+    cargo_receipt_transfer_link_t transfer_link =
+        cargo_receipt_prepare_transfer_link(st, copy.pub, &attached_chain);
+    if (transfer_link.status != CARGO_RECEIPT_TRANSFER_LINK_READY)
+        return;
+
     if (st->manifest.count >= st->manifest.cap) {
         cargo_unit_t evicted = {0};
         if (station_manifest_remove_with_chain(st, 0, &evicted, NULL) &&
@@ -12662,14 +12667,6 @@ static void server_dispatch_deliver_named_ingot(
                      ev_cs);
             signal_channel_post(w, sidx, ev_msg, "");
         }
-    }
-
-    uint8_t prev_hash[32] = {0};
-    bool have_prev = false;
-    if (attached_chain.len > 0) {
-        cargo_receipt_hash(&attached_chain.links[attached_chain.len - 1],
-                           prev_hash);
-        have_prev = true;
     }
 
     cargo_receipt_chain_t removed_chain = {0};
@@ -12686,7 +12683,7 @@ static void server_dispatch_deliver_named_ingot(
         st->station_pubkey,
         copy.pub,
         (uint8_t)CARGO_KIND_INGOT,
-        have_prev ? prev_hash : st->chain_last_hash,
+        &removed_chain,
         &receipt);
     if (xfer_id != 0 && station_chain.len < CARGO_RECEIPT_CHAIN_MAX_LEN)
         station_chain.links[station_chain.len++] = receipt;

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -668,18 +668,11 @@ static bool append_station_transfer_receipt(world_t *w, station_t *author,
     if (npc_hash32_is_zero(unit->pub)) return false;
     if (chain->len >= CARGO_RECEIPT_CHAIN_MAX_LEN) return false;
 
-    uint8_t prev_hash[32] = {0};
-    const uint8_t *prev = author->chain_last_hash;
-    if (chain->len > 0) {
-        cargo_receipt_hash(&chain->links[chain->len - 1], prev_hash);
-        prev = prev_hash;
-    }
-
     cargo_receipt_t receipt = {0};
     uint64_t xfer_id = cargo_receipt_emit_transfer(w, author,
                                                    from_pubkey, to_pubkey,
                                                    unit->pub, unit->kind,
-                                                   prev, &receipt);
+                                                   chain, &receipt);
     if (xfer_id == 0) return false;
     chain->links[chain->len++] = receipt;
     return true;

--- a/tests/c/test_chain_log.c
+++ b/tests/c/test_chain_log.c
@@ -937,6 +937,8 @@ TEST(test_chain_log_cargo_transform_reader) {
     smelt.mined_block = 4422;
     ASSERT(chain_log_emit(w, &w->stations[0], CHAIN_EVT_SMELT,
                           &smelt, sizeof(smelt)) == 1);
+    uint8_t smelt_hash[32];
+    memcpy(smelt_hash, w->stations[0].chain_last_hash, sizeof(smelt_hash));
 
     chain_payload_craft_t craft = {0};
     craft.recipe_id = (uint16_t)RECIPE_FRAME_BASIC;
@@ -946,12 +948,16 @@ TEST(test_chain_log_cargo_transform_reader) {
         craft.output_pub[i] = (uint8_t)(0xA0 + i);
     ASSERT(chain_log_emit(w, &w->stations[0], CHAIN_EVT_CRAFT,
                           &craft, sizeof(craft)) == 2);
+    uint8_t craft_hash[32];
+    memcpy(craft_hash, w->stations[0].chain_last_hash, sizeof(craft_hash));
 
     chain_cargo_transform_t found = {0};
     ASSERT(chain_log_find_cargo_transform(&w->stations[0],
                                           craft.output_pub, &found));
     ASSERT_EQ_INT(found.type, CHAIN_EVT_CRAFT);
     ASSERT_EQ_INT((int)found.event_id, 2);
+    ASSERT(memcmp(found.header_hash, craft_hash, sizeof(craft_hash)) == 0);
+    ASSERT(memcmp(found.authority, w->stations[0].station_pubkey, 32) == 0);
     ASSERT_EQ_INT(found.craft.recipe_id, RECIPE_FRAME_BASIC);
     ASSERT(memcmp(found.craft.input_pubs[0], smelt.ingot_pub, 32) == 0);
 
@@ -960,6 +966,8 @@ TEST(test_chain_log_cargo_transform_reader) {
                                           smelt.ingot_pub, &found));
     ASSERT_EQ_INT(found.type, CHAIN_EVT_SMELT);
     ASSERT_EQ_INT((int)found.event_id, 1);
+    ASSERT(memcmp(found.header_hash, smelt_hash, sizeof(smelt_hash)) == 0);
+    ASSERT(memcmp(found.authority, w->stations[0].station_pubkey, 32) == 0);
     ASSERT_EQ_INT((int)found.smelt.mined_block, 4422);
     ASSERT(memcmp(found.smelt.fragment_pub, smelt.fragment_pub, 32) == 0);
 

--- a/tests/c/test_cross_station_settlement.c
+++ b/tests/c/test_cross_station_settlement.c
@@ -40,10 +40,12 @@
 static void crs_setup(const char *suffix) {
     char path[256];
     snprintf(path, sizeof(path), "%s_crs_%s", TMP("crs"), suffix);
+    chain_log_set_disk_enabled(true);
     chain_log_set_dir(path);
 }
 
 static void crs_teardown(void) {
+    chain_log_set_disk_enabled(true);
     chain_log_set_dir(NULL);
 }
 
@@ -167,38 +169,35 @@ TEST(test_cross_station_single_hop_receipt) {
     uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0x10);
     uint8_t cargo_pk[32];  fill_test_pubkey(cargo_pk,  0x40);
 
-    /* Helios (idx 2) issues a receipt for cargo to the player. */
+    /* Helios cannot issue a first-hop receipt without a matching local
+     * production event. */
     station_t *helios = &w->stations[2];
-    cargo_receipt_t r;
+    cargo_receipt_t r = {0};
+    cargo_receipt_chain_t empty_chain = {0};
     uint64_t event_id = cargo_receipt_emit_transfer(
         w, helios,
         helios->station_pubkey, player_pk,
         cargo_pk, (uint8_t)CARGO_KIND_INGOT,
-        helios->chain_last_hash, /* origin pin to event already in log? — empty log → 0
-                                    * — use a non-zero string-of-zeros placeholder via SMELT first */
-        &r);
-    /* chain_last_hash is all-zero for an empty log; the helper uses it
-     * as the origin pin. cargo_receipt_chain_verify rejects all-zero
-     * pins, so first emit a synthetic "anchor" event so the receipt's
-     * origin pin is the hash of THAT event. */
-    ASSERT(event_id == 0 || event_id >= 1);
-    /* If the empty-log path triggered, redo with a SMELT seed first. */
-    if (event_id != 0) {
-        /* Receipt was issued; verify signature in isolation first. */
-        ASSERT(cargo_receipt_verify_signature(&r));
-        /* prev_receipt_hash equals the post-emit chain_last_hash, which
-         * is the hash of THIS transfer event itself (anchored). */
-    } else {
-        /* Re-emit a SMELT first so the chain has a non-zero last hash. */
-        ASSERT(chain_log_emit(w, helios, CHAIN_EVT_SMELT, "x", 1) >= 1);
-        event_id = cargo_receipt_emit_transfer(
-            w, helios,
-            helios->station_pubkey, player_pk,
-            cargo_pk, (uint8_t)CARGO_KIND_INGOT,
-            helios->chain_last_hash, &r);
-        ASSERT(event_id >= 1);
-        ASSERT(cargo_receipt_verify_signature(&r));
-    }
+        &empty_chain, &r);
+    ASSERT_EQ_INT((int)event_id, 0);
+
+    chain_payload_smelt_t smelt = {0};
+    memcpy(smelt.ingot_pub, cargo_pk, sizeof(smelt.ingot_pub));
+    ASSERT(chain_log_emit(w, helios, CHAIN_EVT_SMELT,
+                          &smelt, sizeof(smelt)) >= 1);
+    uint8_t origin_hash[32];
+    memcpy(origin_hash, helios->chain_last_hash, sizeof(origin_hash));
+    ASSERT(chain_log_emit(w, helios, CHAIN_EVT_LEDGER, "later", 5) >= 1);
+    event_id = cargo_receipt_emit_transfer(
+        w, helios,
+        helios->station_pubkey, player_pk,
+        cargo_pk, (uint8_t)CARGO_KIND_INGOT,
+        &empty_chain, &r);
+    ASSERT(event_id >= 1);
+    ASSERT(cargo_receipt_verify_signature(&r));
+    ASSERT(memcmp(r.prev_receipt_hash, origin_hash, sizeof(origin_hash)) == 0);
+    ASSERT(memcmp(r.prev_receipt_hash, helios->chain_last_hash,
+                  sizeof(origin_hash)) != 0);
     /* Receipt fields are populated correctly. */
     ASSERT(memcmp(r.cargo_pub, cargo_pk, 32) == 0);
     ASSERT(memcmp(r.recipient_pubkey, player_pk, 32) == 0);
@@ -214,11 +213,14 @@ TEST(test_cross_station_single_hop_receipt) {
 /* Helper: emit cargo issuance from station + first hop receipt for player. */
 static bool crs_first_hop(world_t *w, station_t *st, const uint8_t player_pk[32],
                           const uint8_t cargo_pk[32], cargo_receipt_t *out) {
-    /* Anchor: emit a synthetic SMELT first so chain_last_hash is non-zero. */
-    if (chain_log_emit(w, st, CHAIN_EVT_SMELT, "smelt", 5) == 0) return false;
+    chain_payload_smelt_t smelt = {0};
+    memcpy(smelt.ingot_pub, cargo_pk, sizeof(smelt.ingot_pub));
+    if (chain_log_emit(w, st, CHAIN_EVT_SMELT,
+                       &smelt, sizeof(smelt)) == 0) return false;
+    cargo_receipt_chain_t empty_chain = {0};
     uint64_t id = cargo_receipt_emit_transfer(
         w, st, st->station_pubkey, player_pk, cargo_pk,
-        (uint8_t)CARGO_KIND_INGOT, st->chain_last_hash, out);
+        (uint8_t)CARGO_KIND_INGOT, &empty_chain, out);
     return id != 0;
 }
 
@@ -234,6 +236,94 @@ static cargo_receipt_origin_proof_t crs_origin_proof(
     memcpy(proof.output_cargo_pub, receipt->cargo_pub, 32);
     memcpy(proof.authority, receipt->authoring_station, 32);
     return proof;
+}
+
+TEST(test_local_origin_resolver_distinguishes_history_states) {
+    crs_setup("origin_resolver_states");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL);
+    crs_world_init(w, 0xD016);
+    station_t *st = &w->stations[2];
+
+    uint8_t smelt_pub[32];
+    uint8_t craft_pub[32];
+    uint8_t unknown_pub[32];
+    fill_test_pubkey(smelt_pub, 0x31);
+    fill_test_pubkey(craft_pub, 0x61);
+    fill_test_pubkey(unknown_pub, 0x91);
+    cargo_receipt_origin_proof_t proof = {0};
+
+    ASSERT_EQ_INT(
+        cargo_receipt_resolve_local_origin(st, smelt_pub, &proof),
+        CARGO_RECEIPT_ORIGIN_RESOLVE_HISTORY_UNAVAILABLE);
+    ASSERT(strcmp(cargo_receipt_origin_resolve_status_name(
+                      CARGO_RECEIPT_ORIGIN_RESOLVE_HISTORY_UNAVAILABLE),
+                  "history_unavailable") == 0);
+
+    chain_payload_smelt_t smelt = {0};
+    memcpy(smelt.ingot_pub, smelt_pub, sizeof(smelt.ingot_pub));
+    ASSERT(chain_log_emit(w, st, CHAIN_EVT_SMELT,
+                          &smelt, sizeof(smelt)) == 1);
+    uint8_t smelt_hash[32];
+    memcpy(smelt_hash, st->chain_last_hash, sizeof(smelt_hash));
+
+    ASSERT_EQ_INT(
+        cargo_receipt_resolve_local_origin(st, smelt_pub, &proof),
+        CARGO_RECEIPT_ORIGIN_RESOLVE_VERIFIED);
+    ASSERT_EQ_INT(proof.event_type, CARGO_RECEIPT_ORIGIN_EVENT_SMELT);
+    ASSERT_EQ_INT((int)proof.event_id, 1);
+    ASSERT(memcmp(proof.event_hash, smelt_hash, sizeof(smelt_hash)) == 0);
+    ASSERT(memcmp(proof.output_cargo_pub, smelt_pub, sizeof(smelt_pub)) == 0);
+    ASSERT(memcmp(proof.authority, st->station_pubkey, 32) == 0);
+
+    ASSERT_EQ_INT(
+        cargo_receipt_resolve_local_origin(st, unknown_pub, &proof),
+        CARGO_RECEIPT_ORIGIN_RESOLVE_TRANSFORM_NOT_FOUND);
+
+    chain_payload_craft_t craft = {0};
+    craft.recipe_id = (uint16_t)RECIPE_FRAME_BASIC;
+    craft.input_count = 1;
+    memcpy(craft.input_pubs[0], smelt_pub, sizeof(smelt_pub));
+    memcpy(craft.output_pub, craft_pub, sizeof(craft.output_pub));
+    ASSERT(chain_log_emit(w, st, CHAIN_EVT_CRAFT,
+                          &craft, sizeof(craft)) == 2);
+    uint8_t craft_hash[32];
+    memcpy(craft_hash, st->chain_last_hash, sizeof(craft_hash));
+    ASSERT_EQ_INT(
+        cargo_receipt_resolve_local_origin(st, craft_pub, &proof),
+        CARGO_RECEIPT_ORIGIN_RESOLVE_VERIFIED);
+    ASSERT_EQ_INT(proof.event_type, CARGO_RECEIPT_ORIGIN_EVENT_CRAFT);
+    ASSERT_EQ_INT((int)proof.event_id, 2);
+    ASSERT(memcmp(proof.event_hash, craft_hash, sizeof(craft_hash)) == 0);
+    ASSERT(memcmp(proof.output_cargo_pub, craft_pub, sizeof(craft_pub)) == 0);
+
+    char path[256];
+    ASSERT(chain_log_path_for(st->station_pubkey, path, sizeof(path)));
+    FILE *f = fopen(path, "r+b");
+    ASSERT(f != NULL);
+    ASSERT(fseek(f, CHAIN_EVENT_HEADER_SIZE + (long)sizeof(uint16_t) + 5,
+                 SEEK_SET) == 0);
+    int byte = fgetc(f);
+    ASSERT(byte != EOF);
+    ASSERT(fseek(f, -1, SEEK_CUR) == 0);
+    ASSERT(fputc(byte ^ 0x01, f) != EOF);
+    ASSERT(fclose(f) == 0);
+    ASSERT_EQ_INT(
+        cargo_receipt_resolve_local_origin(st, smelt_pub, &proof),
+        CARGO_RECEIPT_ORIGIN_RESOLVE_HISTORY_INVALID);
+
+    station_t *memory_only = &w->stations[1];
+    chain_log_set_disk_enabled(false);
+    chain_payload_smelt_t memory_smelt = {0};
+    memcpy(memory_smelt.ingot_pub, unknown_pub,
+           sizeof(memory_smelt.ingot_pub));
+    ASSERT(chain_log_emit(w, memory_only, CHAIN_EVT_SMELT,
+                          &memory_smelt, sizeof(memory_smelt)) == 1);
+    ASSERT_EQ_INT(
+        cargo_receipt_resolve_local_origin(memory_only, unknown_pub, &proof),
+        CARGO_RECEIPT_ORIGIN_RESOLVE_HISTORY_UNAVAILABLE);
+    chain_log_set_disk_enabled(true);
+
+    crs_teardown();
 }
 
 TEST(test_receipt_trust_accepts_smelt_craft_and_rotated_authority) {
@@ -399,12 +489,19 @@ TEST(test_receipt_trust_preserves_cryptographic_chain_failure) {
 /* Helper: emit destination-station receipt for the second hop. */
 static bool crs_next_hop(world_t *w, station_t *dst, const uint8_t from_pk[32],
                          const uint8_t cargo_pk[32],
-                         const cargo_receipt_t *prev, cargo_receipt_t *out) {
-    uint8_t prev_hash[32];
-    cargo_receipt_hash(prev, prev_hash);
+                         const cargo_receipt_t *incoming, uint8_t incoming_len,
+                         cargo_receipt_t *out) {
+    if (!incoming || incoming_len == 0 ||
+        incoming_len >= CARGO_RECEIPT_CHAIN_MAX_LEN) {
+        return false;
+    }
+    cargo_receipt_chain_t chain = {0};
+    memcpy(chain.links, incoming,
+           (size_t)incoming_len * sizeof(chain.links[0]));
+    chain.len = incoming_len;
     uint64_t id = cargo_receipt_emit_transfer(
         w, dst, from_pk, dst->station_pubkey, cargo_pk,
-        (uint8_t)CARGO_KIND_INGOT, prev_hash, out);
+        (uint8_t)CARGO_KIND_INGOT, &chain, out);
     return id != 0;
 }
 
@@ -425,7 +522,7 @@ TEST(test_cross_station_two_hop_chain) {
      * prev_receipt_hash = SHA-256(r1). */
     station_t *kepler = &w->stations[1];
     cargo_receipt_t r2;
-    ASSERT(crs_next_hop(w, kepler, player_pk, cargo_pk, &r1, &r2));
+    ASSERT(crs_next_hop(w, kepler, player_pk, cargo_pk, &r1, 1, &r2));
 
     /* Two-hop chain verifies. */
     cargo_receipt_t chain[2] = { r1, r2 };
@@ -508,17 +605,21 @@ TEST(test_cross_station_broken_linkage_rejected) {
     station_t *kepler = &w->stations[1];
     cargo_receipt_t r1, r2;
     ASSERT(crs_first_hop(w, helios, player_pk, cargo_pk, &r1));
-    ASSERT(crs_next_hop(w, kepler, player_pk, cargo_pk, &r1, &r2));
+    ASSERT(crs_next_hop(w, kepler, player_pk, cargo_pk, &r1, 1, &r2));
 
     /* Replace r1 with a different first-hop receipt issued by Helios
      * for the same cargo but in a fresh chain (different chain_last_hash
      * → different prev_receipt_hash). r2's prev_receipt_hash still
      * points at the original r1, so the linkage check must fail. */
     cargo_receipt_t r1_alt;
-    ASSERT(chain_log_emit(w, helios, CHAIN_EVT_SMELT, "alt", 3) >= 1);
+    chain_payload_smelt_t alt_smelt = {0};
+    memcpy(alt_smelt.ingot_pub, cargo_pk, sizeof(alt_smelt.ingot_pub));
+    ASSERT(chain_log_emit(w, helios, CHAIN_EVT_SMELT,
+                          &alt_smelt, sizeof(alt_smelt)) >= 1);
+    cargo_receipt_chain_t empty_chain = {0};
     uint64_t alt_id = cargo_receipt_emit_transfer(
         w, helios, helios->station_pubkey, player_pk, cargo_pk,
-        (uint8_t)CARGO_KIND_INGOT, helios->chain_last_hash, &r1_alt);
+        (uint8_t)CARGO_KIND_INGOT, &empty_chain, &r1_alt);
     ASSERT(alt_id != 0);
     /* Sanity: the alternative receipt verifies on its own. */
     ASSERT(cargo_receipt_verify_signature(&r1_alt));
@@ -548,11 +649,13 @@ TEST(test_cross_station_three_hop_chain) {
     cargo_receipt_t r1, r2, r3;
     ASSERT(crs_first_hop(w, prospect, player_pk, cargo_pk, &r1));
     /* Hop 2: player -> Kepler. */
-    ASSERT(crs_next_hop(w, kepler, player_pk, cargo_pk, &r1, &r2));
+    ASSERT(crs_next_hop(w, kepler, player_pk, cargo_pk, &r1, 1, &r2));
     /* Hop 3: player -> Helios (re-extract from Kepler back through
      * the player; in real flow Kepler issues to player, player carries
      * to Helios). */
-    ASSERT(crs_next_hop(w, helios, player_pk, cargo_pk, &r2, &r3));
+    cargo_receipt_t first_two[2] = {r1, r2};
+    ASSERT(crs_next_hop(w, helios, player_pk, cargo_pk,
+                        first_two, 2, &r3));
 
     cargo_receipt_t chain[3] = { r1, r2, r3 };
     ASSERT(cargo_receipt_chain_verify(chain, 3, cargo_pk) == CARGO_RECEIPT_OK);
@@ -582,7 +685,7 @@ TEST(test_cross_station_npc_mediated_transfer) {
 
     cargo_receipt_t r1, r2;
     ASSERT(crs_first_hop(w, helios, npc_pk, cargo_pk, &r1));
-    ASSERT(crs_next_hop(w, kepler, npc_pk, cargo_pk, &r1, &r2));
+    ASSERT(crs_next_hop(w, kepler, npc_pk, cargo_pk, &r1, 1, &r2));
 
     /* Kepler accepts: chain validates. */
     cargo_receipt_t chain[2] = { r1, r2 };
@@ -627,7 +730,7 @@ TEST(test_cross_station_save_load_preserves_receipts) {
 
     cargo_receipt_t r1, r2;
     ASSERT(crs_first_hop(w, helios, player_pk, cargo_pk, &r1));
-    ASSERT(crs_next_hop(w, kepler, player_pk, cargo_pk, &r1, &r2));
+    ASSERT(crs_next_hop(w, kepler, player_pk, cargo_pk, &r1, 1, &r2));
     cargo_receipt_t chain[2] = { r1, r2 };
     ASSERT(ship_receipts_push_chain(rcpts, chain, 2));
     /* Parity: receipts.count == manifest.count == 1. */
@@ -699,17 +802,21 @@ TEST(test_cross_station_chain_length_cap) {
      * by ship_receipts_extend (cap = 16). We check both: the verifier
      * rejects a 17-element chain and ship_receipts_extend refuses to
      * grow beyond 16. */
-    cargo_receipt_t chain[CARGO_RECEIPT_CHAIN_MAX_LEN + 1];
+    cargo_receipt_t chain[CARGO_RECEIPT_CHAIN_MAX_LEN + 1] = {0};
 
     station_t *st = &w->stations[2];
     ASSERT(crs_first_hop(w, st, player_pk, cargo_pk, &chain[0]));
-    for (int i = 1; i <= CARGO_RECEIPT_CHAIN_MAX_LEN; i++) {
+    for (int i = 1; i < CARGO_RECEIPT_CHAIN_MAX_LEN; i++) {
         /* Alternate stations 1 and 2 for each subsequent hop so each
          * hop is signed by a real keyed station. */
         station_t *next = &w->stations[(i % 2 == 0) ? 2 : 1];
         ASSERT(crs_next_hop(w, next, player_pk, cargo_pk,
-                            &chain[i - 1], &chain[i]));
+                            chain, i, &chain[i]));
     }
+    station_t *overflow = &w->stations[1];
+    ASSERT(!crs_next_hop(w, overflow, player_pk, cargo_pk,
+                         chain, CARGO_RECEIPT_CHAIN_MAX_LEN,
+                         &chain[CARGO_RECEIPT_CHAIN_MAX_LEN]));
     /* The 17-element chain trips the TOO_LONG cap in chain_verify. */
     ASSERT(cargo_receipt_chain_verify(chain, CARGO_RECEIPT_CHAIN_MAX_LEN + 1,
                                       cargo_pk)
@@ -803,12 +910,16 @@ TEST(test_present_foreign_authority_receipt_chain) {
                       w->stations[i].station_pubkey, 32) != 0);
     }
 
-    ASSERT(chain_log_emit(w, &foreign, CHAIN_EVT_SMELT, "foreign", 7) >= 1);
+    chain_payload_smelt_t smelt = {0};
+    memcpy(smelt.ingot_pub, cargo_pk, sizeof(smelt.ingot_pub));
+    ASSERT(chain_log_emit(w, &foreign, CHAIN_EVT_SMELT,
+                          &smelt, sizeof(smelt)) >= 1);
+    cargo_receipt_chain_t empty_chain = {0};
     cargo_receipt_t r1;
     ASSERT(cargo_receipt_emit_transfer(w, &foreign,
                                        foreign.station_pubkey, player_pk,
                                        cargo_pk, (uint8_t)CARGO_KIND_INGOT,
-                                       foreign.chain_last_hash, &r1) != 0);
+                                       &empty_chain, &r1) != 0);
     ASSERT(crs_prepare_player_carrier(w, player_pk, cargo_pk, NULL));
 
     server_player_t *sp = &w->players[0];
@@ -1299,6 +1410,7 @@ void register_cross_station_settlement_tests(void) {
     RUN(test_receipt_trust_distinguishes_origin_proof_failures);
     RUN(test_receipt_trust_distinguishes_authority_policy);
     RUN(test_receipt_trust_preserves_cryptographic_chain_failure);
+    RUN(test_local_origin_resolver_distinguishes_history_states);
     RUN(test_cross_station_two_hop_chain);
     RUN(test_cross_station_forged_receipt_rejected);
     RUN(test_cross_station_tampered_cargo_pub_rejected);

--- a/tests/c/test_economy.c
+++ b/tests/c/test_economy.c
@@ -93,12 +93,15 @@ static bool economy_issue_single_receipt(world_t *w,
         return false;
     station_t *st = &w->stations[station_idx];
     memset(out, 0, sizeof(*out));
-    if (chain_log_emit(w, st, CHAIN_EVT_SMELT, "legality", 8) == 0)
+    chain_payload_smelt_t smelt = {0};
+    memcpy(smelt.ingot_pub, cargo_pub, sizeof(smelt.ingot_pub));
+    if (chain_log_emit(w, st, CHAIN_EVT_SMELT,
+                       &smelt, (uint16_t)sizeof(smelt)) == 0)
         return false;
     cargo_receipt_t receipt = {0};
     if (cargo_receipt_emit_transfer(w, st, st->station_pubkey, recipient,
                                     cargo_pub, (uint8_t)CARGO_KIND_INGOT,
-                                    st->chain_last_hash, &receipt) == 0) {
+                                    out, &receipt) == 0) {
         return false;
     }
     out->links[0] = receipt;


### PR DESCRIPTION
## Summary

- retain each SMELT/CRAFT event's exact signed header hash and authority in the cargo-transform read model
- resolve origin proofs only from a completely verified local station log, with distinct unavailable, invalid, and no-match results
- make transfer issuance accept an incoming receipt chain instead of a caller-selected hash: empty chains require a verified production event and later hops derive linkage from the final receipt
- preflight named station buys/deliveries before their first cargo or ledger mutation, and use the same issuance path for NPC transfers
- cover SMELT, CRAFT, corrupted history, absent/disk-disabled history, no-match history, intervening events, full multi-hop validation, and chain-cap refusal

## Stack

This PR is based on `codex/issue-634-receipt-trust-core` / #637 because it consumes the shared origin-proof contract introduced there.

## Validation

- `./build/signal_test --quiet` — 1221/1221
- `make test-san` — 1221/1221 across 8 shards
- `cmake --build build --target signal_server --parallel`
- `make banned-apis deterministic-libm doc-freshness cppcheck`
- `make replay-repeatability` — 20 scenarios
- `make replay-native-wasm` — 20 scenarios
- focused resolver, first-hop pin, cargo-transform, and chain-cap regressions

Closes #639
