### PR TITLE
Persist station authority lifecycle decisions

### DIFF
--- a/docs/operator-onboarding.md
+++ b/docs/operator-onboarding.md
@@ -118,13 +118,19 @@ station's private key:
 
 For stations you operate yourself, keep the same station authority secret
 available across restarts and replicas. Changing it intentionally rekeys
-stations; on load, the server starts a fresh chain identity for any station
-whose saved pubkey no longer matches the configured secret.
+stations; on load, the server records the saved key as trusted-rotated and
+starts a fresh chain identity under the newly derived current key. The public
+registry is bounded and persisted with the world save. Explicitly untrusted or
+revoked historical keys are never reactivated: a configured secret that would
+derive one causes the load to fail closed.
 
 The private key is never written to disk and never sent over the wire. Layer B
 keeps `station_secret` as the last field of `station_t` and re-derives it on
 load via `station_authority_rederive_secret`
 ([`server/station_authority.h`](../server/station_authority.h)).
+Only public current/rotated/untrusted/revoked key records are saved. A v76 or
+earlier world synthesizes one current record from each station's saved pubkey;
+it does not invent historical trust.
 
 ### 3. Wire your station's pubkey into the world
 

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -78,7 +78,10 @@
 #define SAVE_MAGIC     0x5349474E  /* "SIGN" */
 #define SAVE_CRC_MAGIC 0x43524332u /* "CRC2" */
 #define SAVE_STATION_SLOTS_V25 64
-#define SAVE_VERSION 76  /* v76: cargo pods persist their named tow hardpoint.
+#define SAVE_VERSION 77  /* v77: stations persist a bounded public authority
+                          * lifecycle registry (current, rotated, untrusted,
+                          * revoked); private keys remain memory-only.
+                          * v76: cargo pods persist their named tow hardpoint.
                           * v75: station finished-goods residue is persisted
                           * separately; whole stock exists only in manifests.
                           * v74: cargo pods persist their active module tractor
@@ -586,6 +589,19 @@ static bool write_station_session(FILE *f, const station_t *s) {
     WRITE_FIELD(f, s->faction_allegiance);
     WRITE_FIELD(f, s->faction_ideology);
     WRITE_FIELD(f, s->faction_relations);
+    /* v77: public station-authority lifecycle. The fixed-width registry
+     * preserves historical signing identities and explicit distrust
+     * without ever persisting station_secret. */
+    if (!station_authority_registry_validate(s)) return false;
+    WRITE_FIELD(f, s->authority_registry_version);
+    WRITE_FIELD(f, s->authority_registry_count);
+    WRITE_FIELD(f, s->authority_registry_pad);
+    for (int i = 0; i < STATION_AUTHORITY_REGISTRY_CAP; i++) {
+        if (fwrite(s->authority_registry[i].pubkey, 32, 1, f) != 1)
+            return false;
+        WRITE_FIELD(f, s->authority_registry[i].state);
+        WRITE_FIELD(f, s->authority_registry[i]._pad);
+    }
     /* v41: Layer C of #479 — chain log state. The actual events live in
      * side files under chain/<base58(pubkey)>.log; only the
      * continuation pointers (last full-record hash + monotonic event
@@ -795,6 +811,22 @@ static bool read_station_session(FILE *f, station_t *s) {
         memset(s->station_pubkey, 0, sizeof(s->station_pubkey));
         memset(s->outpost_founder_pubkey, 0, sizeof(s->outpost_founder_pubkey));
         s->outpost_planted_tick = 0;
+    }
+    if (g_loaded_save_version >= 77) {
+        READ_FIELD(f, s->authority_registry_version);
+        READ_FIELD(f, s->authority_registry_count);
+        READ_FIELD(f, s->authority_registry_pad);
+        for (int i = 0; i < STATION_AUTHORITY_REGISTRY_CAP; i++) {
+            if (fread(s->authority_registry[i].pubkey, 32, 1, f) != 1)
+                return false;
+            READ_FIELD(f, s->authority_registry[i].state);
+            READ_FIELD(f, s->authority_registry[i]._pad);
+        }
+        if (!station_authority_registry_validate(s)) return false;
+    } else {
+        /* v76 and earlier know only the saved live key. Preserve it as
+         * current, but never infer historical trust that was not stored. */
+        station_authority_registry_init(s);
     }
     /* v41: Layer C of #479 — chain log state. v40 and earlier saves
      * don't carry the continuation pointers; treat the chain as fresh
@@ -2297,9 +2329,16 @@ static bool world_load_payload(world_t *w, FILE *f) {
     for (int i = 0; i < MAX_STATIONS; i++) {
         if (i < SIGNAL_SEEDED_STATION_COUNT ||
             memcmp(w->stations[i].station_pubkey, zero_pub, 32) != 0) {
-            bool rekeyed = station_authority_rederive_secret(&w->stations[i],
-                                                             w->belt_seed, i);
-            if (rekeyed) {
+            station_authority_rederive_result_t result =
+                station_authority_rederive_secret(&w->stations[i],
+                                                  w->belt_seed, i);
+            if (result == STATION_AUTHORITY_REDERIVE_REJECTED) {
+                SIM_LOG("[chain] station %d (%s): configured authority "
+                        "rekey rejected by lifecycle registry\n",
+                        i, w->stations[i].name);
+                return false;
+            }
+            if (result == STATION_AUTHORITY_REDERIVE_REKEYED) {
                 station_t *st = &w->stations[i];
                 st->chain_event_count = 0;
                 memset(st->chain_last_hash, 0, sizeof(st->chain_last_hash));

--- a/server/station_authority.c
+++ b/server/station_authority.c
@@ -12,6 +12,19 @@
 #include "sha256.h"
 #include "signal_crypto.h"
 
+_Static_assert((int)STATION_AUTHORITY_TRUST_CURRENT ==
+                   (int)CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT,
+               "station current trust must match receipt trust");
+_Static_assert((int)STATION_AUTHORITY_TRUST_ROTATED ==
+                   (int)CARGO_RECEIPT_AUTHORITY_TRUSTED_ROTATED,
+               "station rotated trust must match receipt trust");
+_Static_assert((int)STATION_AUTHORITY_TRUST_UNTRUSTED ==
+                   (int)CARGO_RECEIPT_AUTHORITY_UNTRUSTED,
+               "station untrusted state must match receipt trust");
+_Static_assert((int)STATION_AUTHORITY_TRUST_REVOKED ==
+                   (int)CARGO_RECEIPT_AUTHORITY_REVOKED,
+               "station revoked state must match receipt trust");
+
 /* Domain-separation strings. Bumping these (e.g. "-v2") would
  * invalidate every previously-derived station pubkey, so keep them
  * frozen unless a deliberate identity migration is in flight. */
@@ -24,6 +37,240 @@ static const char DEV_SECRET[]           = "signal-dev-station-authority-secret"
 
 static uint8_t station_auth_secret_root[32];
 static bool station_auth_secret_ready = false;
+
+static bool station_authority_pubkey_is_zero(const uint8_t pubkey[32]) {
+    static const uint8_t zero[32] = {0};
+    return !pubkey || memcmp(pubkey, zero, sizeof(zero)) == 0;
+}
+
+static void station_authority_record_clear(station_authority_record_t *record) {
+    if (record) memset(record, 0, sizeof(*record));
+}
+
+static bool station_authority_record_is_zero(
+    const station_authority_record_t *record) {
+    static const station_authority_record_t zero = {0};
+    return record && memcmp(record, &zero, sizeof(zero)) == 0;
+}
+
+static int station_authority_registry_find(const station_t *s,
+                                           const uint8_t pubkey[32]) {
+    if (!s || !pubkey ||
+        s->authority_registry_count > STATION_AUTHORITY_REGISTRY_CAP) {
+        return -1;
+    }
+    for (uint8_t i = 0; i < s->authority_registry_count; i++) {
+        if (memcmp(s->authority_registry[i].pubkey, pubkey, 32) == 0)
+            return (int)i;
+    }
+    return -1;
+}
+
+void station_authority_registry_init(station_t *s) {
+    if (!s) return;
+    s->authority_registry_version = STATION_AUTHORITY_REGISTRY_VERSION;
+    s->authority_registry_count = 0;
+    memset(s->authority_registry_pad, 0,
+           sizeof(s->authority_registry_pad));
+    memset(s->authority_registry, 0, sizeof(s->authority_registry));
+    if (station_authority_pubkey_is_zero(s->station_pubkey)) return;
+    memcpy(s->authority_registry[0].pubkey, s->station_pubkey, 32);
+    s->authority_registry[0].state = STATION_AUTHORITY_TRUST_CURRENT;
+    s->authority_registry_count = 1;
+}
+
+bool station_authority_registry_validate(const station_t *s) {
+    if (!s) return false;
+    bool station_empty =
+        station_authority_pubkey_is_zero(s->station_pubkey);
+    if (station_empty && s->authority_registry_version == 0 &&
+        s->authority_registry_count == 0) {
+        static const uint8_t zero_pad[
+            sizeof(s->authority_registry_pad)] = {0};
+        if (memcmp(s->authority_registry_pad, zero_pad,
+                   sizeof(s->authority_registry_pad)) != 0) {
+            return false;
+        }
+        for (uint8_t i = 0; i < STATION_AUTHORITY_REGISTRY_CAP; i++) {
+            if (!station_authority_record_is_zero(
+                    &s->authority_registry[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+    if (s->authority_registry_version !=
+            STATION_AUTHORITY_REGISTRY_VERSION ||
+        s->authority_registry_count > STATION_AUTHORITY_REGISTRY_CAP) {
+        return false;
+    }
+    for (size_t i = 0; i < sizeof(s->authority_registry_pad); i++) {
+        if (s->authority_registry_pad[i] != 0) return false;
+    }
+    if (station_empty) {
+        if (s->authority_registry_count != 0) return false;
+        for (uint8_t i = 0; i < STATION_AUTHORITY_REGISTRY_CAP; i++) {
+            if (!station_authority_record_is_zero(
+                    &s->authority_registry[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+    if (s->authority_registry_count == 0 ||
+        memcmp(s->authority_registry[0].pubkey,
+               s->station_pubkey, 32) != 0 ||
+        s->authority_registry[0].state !=
+            STATION_AUTHORITY_TRUST_CURRENT) {
+        return false;
+    }
+    for (uint8_t i = 0; i < s->authority_registry_count; i++) {
+        const station_authority_record_t *record =
+            &s->authority_registry[i];
+        if (station_authority_pubkey_is_zero(record->pubkey))
+            return false;
+        if (record->state < STATION_AUTHORITY_TRUST_CURRENT ||
+            record->state > STATION_AUTHORITY_TRUST_REVOKED) {
+            return false;
+        }
+        if (i > 0 && record->state == STATION_AUTHORITY_TRUST_CURRENT)
+            return false;
+        for (size_t p = 0; p < sizeof(record->_pad); p++) {
+            if (record->_pad[p] != 0) return false;
+        }
+        for (uint8_t prior = 0; prior < i; prior++) {
+            if (memcmp(s->authority_registry[prior].pubkey,
+                       record->pubkey, 32) == 0) {
+                return false;
+            }
+        }
+    }
+    for (uint8_t i = s->authority_registry_count;
+         i < STATION_AUTHORITY_REGISTRY_CAP; i++) {
+        if (!station_authority_record_is_zero(
+                &s->authority_registry[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+cargo_receipt_authority_trust_t station_authority_trust_for_pubkey(
+    const station_t *s,
+    const uint8_t pubkey[32]) {
+    if (!s || station_authority_pubkey_is_zero(pubkey))
+        return CARGO_RECEIPT_AUTHORITY_UNKNOWN;
+    if (!station_authority_registry_validate(s))
+        return CARGO_RECEIPT_AUTHORITY_REVOKED;
+    int found = station_authority_registry_find(s, pubkey);
+    if (found < 0) return CARGO_RECEIPT_AUTHORITY_UNKNOWN;
+    return (cargo_receipt_authority_trust_t)
+        s->authority_registry[found].state;
+}
+
+static void station_authority_registry_remove(station_t *s, int index) {
+    if (!s || index < 0 ||
+        index >= (int)s->authority_registry_count) {
+        return;
+    }
+    for (int i = index + 1; i < (int)s->authority_registry_count; i++)
+        s->authority_registry[i - 1] = s->authority_registry[i];
+    s->authority_registry_count--;
+    station_authority_record_clear(
+        &s->authority_registry[s->authority_registry_count]);
+}
+
+static int station_authority_registry_oldest_rotated(
+    const station_t *s) {
+    if (!s) return -1;
+    for (int i = (int)s->authority_registry_count - 1; i >= 1; i--) {
+        if (s->authority_registry[i].state ==
+            STATION_AUTHORITY_TRUST_ROTATED) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+static bool station_authority_registry_rekey(
+    station_t *s,
+    const uint8_t new_pubkey[32]) {
+    if (!station_authority_registry_validate(s) ||
+        station_authority_pubkey_is_zero(new_pubkey)) {
+        return false;
+    }
+    if (memcmp(s->station_pubkey, new_pubkey, 32) == 0)
+        return true;
+
+    int existing = station_authority_registry_find(s, new_pubkey);
+    if (existing >= 0) {
+        uint8_t state = s->authority_registry[existing].state;
+        if (state == STATION_AUTHORITY_TRUST_UNTRUSTED ||
+            state == STATION_AUTHORITY_TRUST_REVOKED ||
+            existing == 0) {
+            return false;
+        }
+        station_authority_registry_remove(s, existing);
+    }
+
+    if (s->authority_registry_count >=
+        STATION_AUTHORITY_REGISTRY_CAP) {
+        int evict = station_authority_registry_oldest_rotated(s);
+        if (evict < 0) return false;
+        station_authority_registry_remove(s, evict);
+    }
+
+    for (int i = (int)s->authority_registry_count; i > 1; i--)
+        s->authority_registry[i] = s->authority_registry[i - 1];
+    s->authority_registry[1] = s->authority_registry[0];
+    s->authority_registry[1].state =
+        STATION_AUTHORITY_TRUST_ROTATED;
+    memcpy(s->authority_registry[0].pubkey, new_pubkey, 32);
+    s->authority_registry[0].state =
+        STATION_AUTHORITY_TRUST_CURRENT;
+    memset(s->authority_registry[0]._pad, 0,
+           sizeof(s->authority_registry[0]._pad));
+    memcpy(s->station_pubkey, new_pubkey, 32);
+    s->authority_registry_count++;
+    return true;
+}
+
+bool station_authority_registry_set_trust(
+    station_t *s,
+    const uint8_t pubkey[32],
+    cargo_receipt_authority_trust_t trust) {
+    if (!station_authority_registry_validate(s) ||
+        station_authority_pubkey_is_zero(pubkey) ||
+        (trust != CARGO_RECEIPT_AUTHORITY_UNTRUSTED &&
+         trust != CARGO_RECEIPT_AUTHORITY_REVOKED)) {
+        return false;
+    }
+    int found = station_authority_registry_find(s, pubkey);
+    if (found == 0) return false;
+    if (found > 0) {
+        uint8_t current = s->authority_registry[found].state;
+        if (current == STATION_AUTHORITY_TRUST_REVOKED)
+            return trust == CARGO_RECEIPT_AUTHORITY_REVOKED;
+        if (current == STATION_AUTHORITY_TRUST_UNTRUSTED &&
+            trust != CARGO_RECEIPT_AUTHORITY_REVOKED) {
+            return trust == CARGO_RECEIPT_AUTHORITY_UNTRUSTED;
+        }
+        s->authority_registry[found].state = (uint8_t)trust;
+        return true;
+    }
+
+    int slot = (int)s->authority_registry_count;
+    if (slot >= STATION_AUTHORITY_REGISTRY_CAP) {
+        slot = station_authority_registry_oldest_rotated(s);
+        if (slot < 0) return false;
+    } else {
+        s->authority_registry_count++;
+    }
+    station_authority_record_clear(&s->authority_registry[slot]);
+    memcpy(s->authority_registry[slot].pubkey, pubkey, 32);
+    s->authority_registry[slot].state = (uint8_t)trust;
+    return true;
+}
 
 static void station_authority_hash_secret(const char *secret,
                                           uint8_t out_root[32]) {
@@ -112,6 +359,7 @@ void station_authority_init_seeded(station_t *s,
     uint8_t seed[32];
     station_authority_seeded_seed(world_seed, station_index, seed);
     signal_crypto_keypair_from_seed(seed, s->station_pubkey, s->station_secret);
+    station_authority_registry_init(s);
     /* Seeded stations have no founder / planted_tick provenance. */
     memset(s->outpost_founder_pubkey, 0, sizeof(s->outpost_founder_pubkey));
     s->outpost_planted_tick = 0;
@@ -130,12 +378,14 @@ void station_authority_init_outpost(station_t *s,
     station_authority_outpost_seed(s->outpost_founder_pubkey, s->name,
                                     planted_tick, seed);
     signal_crypto_keypair_from_seed(seed, s->station_pubkey, s->station_secret);
+    station_authority_registry_init(s);
 }
 
-bool station_authority_rederive_secret(station_t *s,
-                                       uint32_t world_seed,
-                                       int station_index) {
-    if (!s) return false;
+station_authority_rederive_result_t station_authority_rederive_secret(
+    station_t *s,
+    uint32_t world_seed,
+    int station_index) {
+    if (!s) return STATION_AUTHORITY_REDERIVE_REJECTED;
     uint8_t seed[32];
     if (station_index >= 0 && station_index < SIGNAL_SEEDED_STATION_COUNT) {
         station_authority_seeded_seed(world_seed,
@@ -147,20 +397,49 @@ bool station_authority_rederive_secret(station_t *s,
                                         s->outpost_planted_tick, seed);
     }
     uint8_t derived_pub[32];
-    signal_crypto_keypair_from_seed(seed, derived_pub, s->station_secret);
+    uint8_t derived_secret[64];
+    signal_crypto_keypair_from_seed(seed, derived_pub, derived_secret);
     /* If the saved pubkey is zero (pre-v40 save with no station
      * identity field), stamp the rederived pubkey so the station has a
      * usable identity. If a non-zero saved pubkey no longer matches the
      * configured operator secret, rotate it deliberately instead of
      * keeping a public key that cannot verify signatures from the
      * rederived private key. */
-    static const uint8_t zero_pub[32] = {0};
-    bool saved_zero = memcmp(s->station_pubkey, zero_pub, 32) == 0;
-    bool rekeyed = !saved_zero && memcmp(s->station_pubkey, derived_pub, 32) != 0;
-    if (saved_zero || rekeyed) {
+    bool saved_zero = station_authority_pubkey_is_zero(s->station_pubkey);
+    if (saved_zero) {
         memcpy(s->station_pubkey, derived_pub, 32);
+        memcpy(s->station_secret, derived_secret, 64);
+        station_authority_registry_init(s);
+        return STATION_AUTHORITY_REDERIVE_UNCHANGED;
     }
-    return rekeyed;
+
+    /* A v76-and-earlier load synthesizes this registry in the reader.
+     * Also accept the exact all-zero legacy representation here so
+     * focused callers cannot accidentally create an unusable station. */
+    if (s->authority_registry_version == 0 &&
+        s->authority_registry_count == 0) {
+        static const uint8_t zero_registry[
+            sizeof(s->authority_registry)] = {0};
+        static const uint8_t zero_pad[
+            sizeof(s->authority_registry_pad)] = {0};
+        if (memcmp(s->authority_registry, zero_registry,
+                   sizeof(s->authority_registry)) == 0 &&
+            memcmp(s->authority_registry_pad, zero_pad,
+                   sizeof(s->authority_registry_pad)) == 0) {
+            station_authority_registry_init(s);
+        }
+    }
+    if (!station_authority_registry_validate(s))
+        return STATION_AUTHORITY_REDERIVE_REJECTED;
+
+    if (memcmp(s->station_pubkey, derived_pub, 32) == 0) {
+        memcpy(s->station_secret, derived_secret, 64);
+        return STATION_AUTHORITY_REDERIVE_UNCHANGED;
+    }
+    if (!station_authority_registry_rekey(s, derived_pub))
+        return STATION_AUTHORITY_REDERIVE_REJECTED;
+    memcpy(s->station_secret, derived_secret, 64);
+    return STATION_AUTHORITY_REDERIVE_REKEYED;
 }
 
 void station_sign(const station_t *s, const uint8_t *msg, size_t len,
@@ -205,4 +484,5 @@ void station_authority_init_outpost_keypair(station_t *s,
     memcpy(s->station_secret, nacl_secret, 64);
     memcpy(s->station_pubkey, nacl_secret + 32, 32);
     s->outpost_planted_tick = 0; /* imported keypair */
+    station_authority_registry_init(s);
 }

--- a/server/station_authority.h
+++ b/server/station_authority.h
@@ -30,6 +30,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "cargo_receipt.h"
 #include "types.h"
 
 #ifdef __cplusplus
@@ -92,13 +93,44 @@ void station_authority_init_outpost_keypair(station_t *s,
 
 /* Re-populate s->station_secret from operator secret + already-set
  * identity material. Called by the world loader so the secret never
- * has to be written to disk. Returns true when a non-zero saved pubkey
- * did not match the currently configured operator secret and was
- * replaced with the derived pubkey; callers should treat that as an
- * intentional station rekey and start a fresh chain head. */
-bool station_authority_rederive_secret(station_t *s,
-                                       uint32_t world_seed,
-                                       int station_index);
+ * has to be written to disk. A changed operator secret rotates the
+ * previous current key into verified history. Rekey is rejected when
+ * it would reactivate an explicitly untrusted/revoked key or when the
+ * bounded registry cannot preserve explicit distrust. */
+typedef enum {
+    STATION_AUTHORITY_REDERIVE_UNCHANGED = 0,
+    STATION_AUTHORITY_REDERIVE_REKEYED,
+    STATION_AUTHORITY_REDERIVE_REJECTED
+} station_authority_rederive_result_t;
+
+station_authority_rederive_result_t station_authority_rederive_secret(
+    station_t *s,
+    uint32_t world_seed,
+    int station_index);
+
+/* Initialize the public lifecycle registry from station_pubkey. This is the
+ * v76-and-earlier migration rule too: preserve the one saved current key, but
+ * never invent historical trust. */
+void station_authority_registry_init(station_t *s);
+
+/* Strict canonical-layout validation used by persistence. Empty station slots
+ * may have an all-zero registry; occupied stations require record zero to be
+ * the live trusted-current key and reject duplicate or malformed rows. */
+bool station_authority_registry_validate(const station_t *s);
+
+/* Resolve one signing key into the shared receipt-trust lifecycle. Malformed
+ * registries and duplicate/conflicting rows fail closed as revoked. */
+cargo_receipt_authority_trust_t station_authority_trust_for_pubkey(
+    const station_t *s,
+    const uint8_t pubkey[32]);
+
+/* Mark a non-current key explicitly untrusted or revoked. Distrust is
+ * monotonic: revoked cannot be downgraded and current keys must rotate before
+ * they can be distrusted. Unknown keys may be added as deny-list entries. */
+bool station_authority_registry_set_trust(
+    station_t *s,
+    const uint8_t pubkey[32],
+    cargo_receipt_authority_trust_t trust);
 
 /* Sign msg[0..len) with station s's private key. Writes 64 bytes to
  * sig. The station must have a populated secret — pass through the

--- a/shared/types.h
+++ b/shared/types.h
@@ -191,6 +191,29 @@ typedef enum {
     CHAIN_HEALTH_FAILED = 6,
 } chain_health_status_t;
 
+enum {
+    STATION_AUTHORITY_REGISTRY_VERSION = 1,
+    STATION_AUTHORITY_REGISTRY_CAP = 8,
+};
+
+/* Public trust lifecycle for station signing keys. Values deliberately match
+ * cargo_receipt_authority_trust_t for the four non-unknown decisions; the
+ * server asserts that contract where it maps registry rows into receipt
+ * verdicts. */
+typedef enum {
+    STATION_AUTHORITY_TRUST_EMPTY = 0,
+    STATION_AUTHORITY_TRUST_CURRENT = 1,
+    STATION_AUTHORITY_TRUST_ROTATED = 2,
+    STATION_AUTHORITY_TRUST_UNTRUSTED = 3,
+    STATION_AUTHORITY_TRUST_REVOKED = 4,
+} station_authority_trust_state_t;
+
+typedef struct {
+    uint8_t pubkey[32];
+    uint8_t state; /* station_authority_trust_state_t */
+    uint8_t _pad[3];
+} station_authority_record_t;
+
 typedef struct {
     const char* name;
     float max_hull;
@@ -854,6 +877,14 @@ typedef struct {
     uint8_t  station_pubkey[32];
     uint8_t  outpost_founder_pubkey[32];
     uint64_t outpost_planted_tick;
+    /* Persisted public authority lifecycle. Record zero is the live current
+     * key for a healthy occupied station; later rows retain historical or
+     * explicitly distrusted keys. No private material is stored here. */
+    uint8_t authority_registry_version;
+    uint8_t authority_registry_count;
+    uint8_t authority_registry_pad[6];
+    station_authority_record_t
+        authority_registry[STATION_AUTHORITY_REGISTRY_CAP];
     /* Layer C of #479 — signed event chain log state.
      *
      * `chain_last_hash` is the SHA256 of the most recent event header

--- a/tests/c/test_save.c
+++ b/tests/c/test_save.c
@@ -2053,8 +2053,10 @@ TEST(test_player_load_restores_towed_cargo_pods_from_world) {
              * tractor_module; two starter pods add four bytes.
              * v75: 64 station residue arrays add 5,120 bytes.
              * v76: each active pod persists its named tow hardpoint; two
-             * starter pods add two bytes. */
-			#define EXPECTED_SAVE_SIZE 772770
+             * starter pods add two bytes.
+             * v77: +296B per station for the fixed public station-authority
+             * lifecycle registry, × MAX_STATIONS=128. */
+			#define EXPECTED_SAVE_SIZE 810658
 
 TEST(test_save_file_size_stable) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
@@ -2091,7 +2093,7 @@ TEST(test_save_header_golden_bytes) {
     ASSERT_EQ_INT((int)fread(&spawn_timer, 4, 1, f), 1);
     fclose(f);
     ASSERT_EQ_INT((int)magic, (int)0x5349474E);    /* "SIGN" */
-    ASSERT_EQ_INT((int)version, 76);
+    ASSERT_EQ_INT((int)version, 77);
     ASSERT(rng != 0);  /* seed is set */
     ASSERT_EQ_FLOAT(time_val, 0.0f, 0.001f);
     ASSERT_EQ_FLOAT(spawn_timer, 0.0f, 0.001f);

--- a/tests/c/test_station_authority.c
+++ b/tests/c/test_station_authority.c
@@ -247,6 +247,219 @@ TEST(test_station_authority_outpost_save_load) {
     remove(TMP("test_outpost_auth.sav"));
 }
 
+TEST(test_station_authority_registry_current_and_unknown) {
+    WORLD_HEAP w = calloc(1, sizeof(world_t));
+    ASSERT(w);
+    w->rng = 638u;
+    world_reset(w);
+
+    for (int i = 0; i < SIGNAL_SEEDED_STATION_COUNT; i++) {
+        const station_t *st = &w->stations[i];
+        ASSERT(station_authority_registry_validate(st));
+        ASSERT_EQ_INT(st->authority_registry_version,
+                      STATION_AUTHORITY_REGISTRY_VERSION);
+        ASSERT_EQ_INT(st->authority_registry_count, 1);
+        ASSERT(memcmp(st->authority_registry[0].pubkey,
+                      st->station_pubkey, 32) == 0);
+        ASSERT_EQ_INT(station_authority_trust_for_pubkey(
+                          st, st->station_pubkey),
+                      CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+    }
+
+    uint8_t unknown[32];
+    memset(unknown, 0xA5, sizeof(unknown));
+    ASSERT_EQ_INT(station_authority_trust_for_pubkey(
+                      &w->stations[0], unknown),
+                  CARGO_RECEIPT_AUTHORITY_UNKNOWN);
+
+    station_t empty;
+    memset(&empty, 0, sizeof(empty));
+    ASSERT(station_authority_registry_validate(&empty));
+}
+
+TEST(test_station_authority_registry_rekey_and_monotonic_distrust) {
+    station_t st;
+    memset(&st, 0, sizeof(st));
+    station_authority_configure_secret("registry-operator-alpha");
+    station_authority_init_seeded(&st, 638u, 0);
+
+    uint8_t alpha_pub[32];
+    memcpy(alpha_pub, st.station_pubkey, sizeof(alpha_pub));
+
+    station_authority_configure_secret("registry-operator-beta");
+    ASSERT_EQ_INT(station_authority_rederive_secret(&st, 638u, 0),
+                  STATION_AUTHORITY_REDERIVE_REKEYED);
+    uint8_t beta_pub[32];
+    memcpy(beta_pub, st.station_pubkey, sizeof(beta_pub));
+    ASSERT(memcmp(alpha_pub, beta_pub, 32) != 0);
+    ASSERT(station_authority_registry_validate(&st));
+    ASSERT_EQ_INT(st.authority_registry_count, 2);
+    ASSERT_EQ_INT(station_authority_trust_for_pubkey(&st, beta_pub),
+                  CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+    ASSERT_EQ_INT(station_authority_trust_for_pubkey(&st, alpha_pub),
+                  CARGO_RECEIPT_AUTHORITY_TRUSTED_ROTATED);
+
+    /* A deliberate rollback to a verified historical key is a rotation,
+     * not a duplicate row. */
+    station_authority_configure_secret("registry-operator-alpha");
+    ASSERT_EQ_INT(station_authority_rederive_secret(&st, 638u, 0),
+                  STATION_AUTHORITY_REDERIVE_REKEYED);
+    ASSERT_EQ_INT(station_authority_trust_for_pubkey(&st, alpha_pub),
+                  CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+    ASSERT_EQ_INT(station_authority_trust_for_pubkey(&st, beta_pub),
+                  CARGO_RECEIPT_AUTHORITY_TRUSTED_ROTATED);
+    ASSERT_EQ_INT(st.authority_registry_count, 2);
+
+    /* Rotate away once more, then make alpha's distrust monotonic. */
+    station_authority_configure_secret("registry-operator-beta");
+    ASSERT_EQ_INT(station_authority_rederive_secret(&st, 638u, 0),
+                  STATION_AUTHORITY_REDERIVE_REKEYED);
+    ASSERT(station_authority_registry_set_trust(
+        &st, alpha_pub, CARGO_RECEIPT_AUTHORITY_UNTRUSTED));
+    ASSERT_EQ_INT(station_authority_trust_for_pubkey(&st, alpha_pub),
+                  CARGO_RECEIPT_AUTHORITY_UNTRUSTED);
+    ASSERT(station_authority_registry_set_trust(
+        &st, alpha_pub, CARGO_RECEIPT_AUTHORITY_REVOKED));
+    ASSERT_EQ_INT(station_authority_trust_for_pubkey(&st, alpha_pub),
+                  CARGO_RECEIPT_AUTHORITY_REVOKED);
+    ASSERT(!station_authority_registry_set_trust(
+        &st, alpha_pub, CARGO_RECEIPT_AUTHORITY_UNTRUSTED));
+
+    /* Reconfiguring the operator secret must not reactivate a revoked
+     * key or overwrite the in-memory secret before rejection. */
+    uint8_t beta_secret[64];
+    memcpy(beta_secret, st.station_secret, sizeof(beta_secret));
+    station_authority_configure_secret("registry-operator-alpha");
+    ASSERT_EQ_INT(station_authority_rederive_secret(&st, 638u, 0),
+                  STATION_AUTHORITY_REDERIVE_REJECTED);
+    ASSERT(memcmp(st.station_pubkey, beta_pub, 32) == 0);
+    ASSERT(memcmp(st.station_secret, beta_secret, 64) == 0);
+
+    station_authority_use_dev_secret();
+}
+
+TEST(test_station_authority_registry_duplicate_fails_closed) {
+    station_t st;
+    memset(&st, 0, sizeof(st));
+    station_authority_init_seeded(&st, 638u, 0);
+    st.authority_registry_count = 2;
+    st.authority_registry[1] = st.authority_registry[0];
+    st.authority_registry[1].state = STATION_AUTHORITY_TRUST_REVOKED;
+
+    ASSERT(!station_authority_registry_validate(&st));
+    ASSERT_EQ_INT(station_authority_trust_for_pubkey(
+                      &st, st.station_pubkey),
+                  CARGO_RECEIPT_AUTHORITY_REVOKED);
+}
+
+TEST(test_station_authority_registry_capacity_preserves_distrust) {
+    station_t st;
+    memset(&st, 0, sizeof(st));
+    station_authority_configure_secret("registry-capacity-alpha");
+    station_authority_init_seeded(&st, 638u, 0);
+
+    uint8_t denied[STATION_AUTHORITY_REGISTRY_CAP - 1][32];
+    for (int i = 0; i < STATION_AUTHORITY_REGISTRY_CAP - 1; i++) {
+        memset(denied[i], 0, sizeof(denied[i]));
+        denied[i][0] = (uint8_t)(0x40 + i);
+        denied[i][31] = (uint8_t)(0xA0 + i);
+        ASSERT(station_authority_registry_set_trust(
+            &st, denied[i], CARGO_RECEIPT_AUTHORITY_UNTRUSTED));
+    }
+    ASSERT_EQ_INT(st.authority_registry_count,
+                  STATION_AUTHORITY_REGISTRY_CAP);
+
+    /* With no rotated row to evict, a rekey must reject rather than
+     * erase an explicit deny-list decision. */
+    station_authority_configure_secret("registry-capacity-beta");
+    ASSERT_EQ_INT(station_authority_rederive_secret(&st, 638u, 0),
+                  STATION_AUTHORITY_REDERIVE_REJECTED);
+    for (int i = 0; i < STATION_AUTHORITY_REGISTRY_CAP - 1; i++) {
+        ASSERT_EQ_INT(station_authority_trust_for_pubkey(&st, denied[i]),
+                      CARGO_RECEIPT_AUTHORITY_UNTRUSTED);
+    }
+    station_authority_use_dev_secret();
+}
+
+TEST(test_station_authority_registry_legacy_synthesizes_current_only) {
+    station_t st;
+    memset(&st, 0, sizeof(st));
+    station_authority_init_seeded(&st, 638u, 0);
+    memset(st.authority_registry, 0, sizeof(st.authority_registry));
+    memset(st.authority_registry_pad, 0, sizeof(st.authority_registry_pad));
+    st.authority_registry_version = 0;
+    st.authority_registry_count = 0;
+
+    ASSERT_EQ_INT(station_authority_rederive_secret(&st, 638u, 0),
+                  STATION_AUTHORITY_REDERIVE_UNCHANGED);
+    ASSERT(station_authority_registry_validate(&st));
+    ASSERT_EQ_INT(st.authority_registry_count, 1);
+    ASSERT_EQ_INT(station_authority_trust_for_pubkey(
+                      &st, st.station_pubkey),
+                  CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+    station_authority_use_dev_secret();
+}
+
+TEST(test_station_authority_registry_save_load_lifecycle) {
+    const char *first_path = TMP("test_auth_registry_first.sav");
+    const char *second_path = TMP("test_auth_registry_second.sav");
+    station_authority_configure_secret("save-registry-alpha");
+
+    WORLD_HEAP original = calloc(1, sizeof(world_t));
+    ASSERT(original);
+    original->rng = 638u;
+    world_reset(original);
+    uint8_t old_station0[32];
+    uint8_t old_station1[32];
+    memcpy(old_station0, original->stations[0].station_pubkey, 32);
+    memcpy(old_station1, original->stations[1].station_pubkey, 32);
+    ASSERT(world_save(original, first_path));
+
+    station_authority_configure_secret("save-registry-beta");
+    WORLD_HEAP rotated = calloc(1, sizeof(world_t));
+    ASSERT(rotated);
+    ASSERT(world_load(rotated, first_path));
+    ASSERT_EQ_INT(station_authority_trust_for_pubkey(
+                      &rotated->stations[0], old_station0),
+                  CARGO_RECEIPT_AUTHORITY_TRUSTED_ROTATED);
+    ASSERT_EQ_INT(station_authority_trust_for_pubkey(
+                      &rotated->stations[1], old_station1),
+                  CARGO_RECEIPT_AUTHORITY_TRUSTED_ROTATED);
+
+    uint8_t current_station0[32];
+    memcpy(current_station0, rotated->stations[0].station_pubkey, 32);
+    uint8_t denied_unknown[32];
+    memset(denied_unknown, 0xD3, sizeof(denied_unknown));
+    ASSERT(station_authority_registry_set_trust(
+        &rotated->stations[0], old_station0,
+        CARGO_RECEIPT_AUTHORITY_REVOKED));
+    ASSERT(station_authority_registry_set_trust(
+        &rotated->stations[0], denied_unknown,
+        CARGO_RECEIPT_AUTHORITY_UNTRUSTED));
+    ASSERT(world_save(rotated, second_path));
+
+    WORLD_HEAP loaded = calloc(1, sizeof(world_t));
+    ASSERT(loaded);
+    ASSERT(world_load(loaded, second_path));
+    ASSERT(station_authority_registry_validate(&loaded->stations[0]));
+    ASSERT_EQ_INT(station_authority_trust_for_pubkey(
+                      &loaded->stations[0], current_station0),
+                  CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+    ASSERT_EQ_INT(station_authority_trust_for_pubkey(
+                      &loaded->stations[0], old_station0),
+                  CARGO_RECEIPT_AUTHORITY_REVOKED);
+    ASSERT_EQ_INT(station_authority_trust_for_pubkey(
+                      &loaded->stations[0], denied_unknown),
+                  CARGO_RECEIPT_AUTHORITY_UNTRUSTED);
+    ASSERT_EQ_INT(station_authority_trust_for_pubkey(
+                      &loaded->stations[1], old_station1),
+                  CARGO_RECEIPT_AUTHORITY_TRUSTED_ROTATED);
+
+    station_authority_use_dev_secret();
+    remove(first_path);
+    remove(second_path);
+}
+
 void register_station_authority_tests(void);
 void register_station_authority_tests(void) {
     TEST_SECTION("\n--- Station Authority (#479 B) ---\n");
@@ -258,4 +471,10 @@ void register_station_authority_tests(void) {
     RUN(test_station_authority_save_load_rederives_secret);
     RUN(test_station_authority_wire_omits_secret);
     RUN(test_station_authority_outpost_save_load);
+    RUN(test_station_authority_registry_current_and_unknown);
+    RUN(test_station_authority_registry_rekey_and_monotonic_distrust);
+    RUN(test_station_authority_registry_duplicate_fails_closed);
+    RUN(test_station_authority_registry_capacity_preserves_distrust);
+    RUN(test_station_authority_registry_legacy_synthesizes_current_only);
+    RUN(test_station_authority_registry_save_load_lifecycle);
 }


### PR DESCRIPTION
## Summary

- add a bounded, versioned public authority lifecycle registry to each station
- preserve deliberate rekeys as trusted-rotated history and reject rollback to explicitly untrusted or revoked keys
- persist the fixed registry in save v77 while keeping station private keys memory-only
- migrate v76-and-earlier saves by synthesizing only the saved current key
- fail closed on malformed, duplicate, conflicting, or capacity-exhausted lifecycle state

## Validation

- `make test-all` — 1235/1235 passed
- `make test-san SAN_TEST_FLAGS=--soak` — 1235/1235 passed
- `make build-server build-web banned-apis deterministic-libm doc-freshness cppcheck`
- `make replay-repeatability replay-native-wasm replay-cross-build` — 20 scenarios passed in each comparison
- focused authority lifecycle, v77 golden header, and stable save-size tests

## Stack

- closes #638
- stacked after #639 / draft PR #642, which itself depends on #634 / #637
- intentionally excludes gameplay and settlement gates tracked by #641 and #640
