### PR TITLE
Enforce station cargo trust at gameplay gates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ set(SIGNAL_SIM_SOURCES
     server/chain_log.c
     server/chain_log_verify.c
     server/cargo_receipt_issue.c
+    server/cargo_receipt_trust.c
     server/handoff_flow.c
     server/sim_asteroid.c
     server/sim_physics.c

--- a/client/hud.c
+++ b/client/hud.c
@@ -1475,6 +1475,46 @@ static bool hud_market_source_chain_label(const NetInspectSnapshotRow *row,
     return inspect_label_market_source_chain(row, out, cap);
 }
 
+static const char *hud_cargo_trust_label(
+    const NetInspectSnapshotRow *row) {
+    if (!row || !row->trust_evaluated) return "";
+    if (row->trust_accepted) {
+        switch ((cargo_receipt_trust_status_t)row->trust_status) {
+        case CARGO_RECEIPT_TRUST_VALID_TRUSTED:
+            return "trusted";
+        case CARGO_RECEIPT_TRUST_VALID_TRUSTED_ROTATED:
+            return "trusted/rotated";
+        case CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY:
+            return "accepted/unknown";
+        case CARGO_RECEIPT_TRUST_REJECT_UNTRUSTED_AUTHORITY:
+            return "accepted/untrusted";
+        default:
+            return "accepted";
+        }
+    }
+    switch ((cargo_receipt_trust_status_t)row->trust_status) {
+    case CARGO_RECEIPT_TRUST_REJECT_CHAIN:
+        return "rejected/chain";
+    case CARGO_RECEIPT_TRUST_REJECT_MISSING_ORIGIN:
+        return "rejected/no-origin";
+    case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_EVENT_TYPE:
+    case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_CARGO:
+    case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_PIN:
+        return "rejected/origin";
+    case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_AUTHORITY:
+        return "rejected/authority";
+    case CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY:
+        return "rejected/unknown";
+    case CARGO_RECEIPT_TRUST_REJECT_UNTRUSTED_AUTHORITY:
+        return "rejected/untrusted";
+    case CARGO_RECEIPT_TRUST_REJECT_REVOKED_AUTHORITY:
+        return "rejected/revoked";
+    case CARGO_RECEIPT_TRUST_REJECT_BAD_ARGUMENTS:
+    default:
+        return "rejected";
+    }
+}
+
 static void hud_job_reason_label(const NetInspectSnapshotRow *row,
                                  char *out,
                                  size_t cap) {
@@ -2751,11 +2791,14 @@ static void hud_draw_inspect_snapshot_pane(float screen_w, float screen_h) {
         }
         sdtx_pos(px / cell, y / cell);
         sdtx_color4b(rr, gg, bb, a8_label);
-        sdtx_printf("%-5s %s %-10s x%u",
+        const char *trust_label = hud_cargo_trust_label(row);
+        sdtx_printf("%-5s %s %-10s x%u%s%s",
                     hud_grade_short_label(row->grade),
                     commodity_code((commodity_t)row->commodity),
                     cargo_disp,
-                    qty);
+                    qty,
+                    trust_label[0] ? "  " : "",
+                    trust_label);
 
         next_y = y + 14.0f;
         bool drew_contract_fit = false;

--- a/client/net.c
+++ b/client/net.c
@@ -2786,8 +2786,15 @@ static void handle_message(const uint8_t* data, int len) {
                 NetInspectSnapshotRow *row = &snap.rows[i];
                 row->commodity = p[0];
                 row->grade = p[1];
-                row->chain_len = p[2];
+                uint8_t trust_code =
+                    inspect_snapshot_trust_code(p[2], p[3]);
+                row->chain_len = inspect_snapshot_chain_value(p[2]);
                 row->flags = p[3];
+                row->trust_evaluated = trust_code != 0;
+                row->trust_accepted =
+                    (p[2] & INSPECT_ROW_TRUST_ACCEPTED) != 0;
+                row->trust_status = trust_code > 0
+                    ? (uint8_t)(trust_code - 1u) : 0xffu;
                 row->event_id = read_u64_le(&p[4]);
                 row->quantity = read_u16_le(&p[12]);
                 memcpy(row->cargo_pub, &p[14], 32);

--- a/client/net.h
+++ b/client/net.h
@@ -422,6 +422,9 @@ typedef struct {
     uint8_t  grade;
     uint8_t  chain_len;
     uint8_t  flags;
+    bool     trust_evaluated;
+    bool     trust_accepted;
+    uint8_t  trust_status; /* cargo_receipt_trust_status_t, 0xff = none */
     uint64_t event_id;
     uint16_t quantity;
     uint8_t  cargo_pub[32];

--- a/server/cargo_receipt_issue.c
+++ b/server/cargo_receipt_issue.c
@@ -7,6 +7,7 @@
  */
 #include "cargo_receipt_issue.h"
 
+#include "cargo_receipt_trust.h"
 #include "game_sim.h"
 #include "manifest.h"
 #include "station_authority.h"
@@ -78,19 +79,24 @@ uint64_t cargo_receipt_emit_transfer(world_t *w, station_t *s,
     return event_id;
 }
 
-cargo_receipt_origin_resolve_status_t cargo_receipt_resolve_local_origin(
-    const station_t *station,
+cargo_receipt_origin_resolve_status_t cargo_receipt_resolve_origin_for_authority(
+    const uint8_t authority[32],
     const uint8_t cargo_pub[32],
     cargo_receipt_origin_proof_t *out_proof) {
     static const uint8_t zero32[32] = {0};
     if (out_proof) memset(out_proof, 0, sizeof(*out_proof));
-    if (!station || !cargo_pub || !out_proof ||
+    if (!authority || !cargo_pub || !out_proof ||
+        memcmp(authority, zero32, sizeof(zero32)) == 0 ||
         memcmp(cargo_pub, zero32, sizeof(zero32)) == 0) {
         return CARGO_RECEIPT_ORIGIN_RESOLVE_BAD_ARGUMENTS;
     }
 
+    station_t authority_view = {0};
+    memcpy(authority_view.station_pubkey, authority,
+           sizeof(authority_view.station_pubkey));
+
     char path[256];
-    if (!chain_log_path_for(station->station_pubkey, path, sizeof(path)))
+    if (!chain_log_path_for(authority, path, sizeof(path)))
         return CARGO_RECEIPT_ORIGIN_RESOLVE_HISTORY_UNAVAILABLE;
     FILE *history = fopen(path, "rb");
     if (!history)
@@ -98,11 +104,11 @@ cargo_receipt_origin_resolve_status_t cargo_receipt_resolve_local_origin(
     fclose(history);
 
     chain_log_verify_report_t report;
-    if (!chain_log_verify_station(station, NULL, NULL, &report))
+    if (!chain_log_verify_station(&authority_view, NULL, NULL, &report))
         return CARGO_RECEIPT_ORIGIN_RESOLVE_HISTORY_INVALID;
 
     chain_cargo_transform_t transform;
-    if (!chain_log_find_cargo_transform(station, cargo_pub, &transform))
+    if (!chain_log_find_cargo_transform(&authority_view, cargo_pub, &transform))
         return CARGO_RECEIPT_ORIGIN_RESOLVE_TRANSFORM_NOT_FOUND;
 
     switch ((chain_event_type_t)transform.type) {
@@ -126,6 +132,18 @@ cargo_receipt_origin_resolve_status_t cargo_receipt_resolve_local_origin(
     memcpy(out_proof->authority, transform.authority,
            sizeof(out_proof->authority));
     return CARGO_RECEIPT_ORIGIN_RESOLVE_VERIFIED;
+}
+
+cargo_receipt_origin_resolve_status_t cargo_receipt_resolve_local_origin(
+    const station_t *station,
+    const uint8_t cargo_pub[32],
+    cargo_receipt_origin_proof_t *out_proof) {
+    if (!station) {
+        if (out_proof) memset(out_proof, 0, sizeof(*out_proof));
+        return CARGO_RECEIPT_ORIGIN_RESOLVE_BAD_ARGUMENTS;
+    }
+    return cargo_receipt_resolve_origin_for_authority(
+        station->station_pubkey, cargo_pub, out_proof);
 }
 
 const char *cargo_receipt_origin_resolve_status_name(
@@ -207,13 +225,15 @@ static bool receipt_chain_prefix_matches(const cargo_receipt_chain_t *existing,
 }
 
 cargo_receipt_present_result_t cargo_receipt_present_to_ship(
+    const world_t *world,
+    int evaluating_station,
     server_player_t *sp,
     const uint8_t cargo_pub[32],
     const cargo_receipt_t *chain,
     uint8_t chain_len) {
     static const uint8_t zero32[32] = {0};
 
-    if (!sp || !cargo_pub || !chain || chain_len == 0 ||
+    if (!world || !sp || !cargo_pub || !chain || chain_len == 0 ||
         chain_len > CARGO_RECEIPT_CHAIN_MAX_LEN) {
         return CARGO_RECEIPT_PRESENT_REJECT_BAD_ARGS;
     }
@@ -229,29 +249,43 @@ cargo_receipt_present_result_t cargo_receipt_present_to_ship(
     if (memcmp(chain[chain_len - 1].recipient_pubkey, sp->pubkey, 32) != 0)
         return CARGO_RECEIPT_PRESENT_REJECT_RECIPIENT;
 
-    if (!ship_manifest_bootstrap(sp->ship))
-        return CARGO_RECEIPT_PRESENT_REJECT_RECEIPT_STORE;
-
     int idx = manifest_find(&sp->ship->manifest, cargo_pub);
     if (idx < 0) return CARGO_RECEIPT_PRESENT_REJECT_NOT_CARRIED;
 
-    ship_receipts_t *receipts = ship_get_receipts(sp->ship);
-    if (!receipts) return CARGO_RECEIPT_PRESENT_REJECT_RECEIPT_STORE;
-    if ((uint16_t)idx >= receipts->count) {
-        if (!ship_receipts_reserve(receipts, sp->ship->manifest.count))
-            return CARGO_RECEIPT_PRESENT_REJECT_RECEIPT_STORE;
-        while (receipts->count < sp->ship->manifest.count) {
-            if (!ship_receipts_push_empty(receipts))
-                return CARGO_RECEIPT_PRESENT_REJECT_RECEIPT_STORE;
-        }
+    cargo_receipt_chain_t presented = {.len = chain_len};
+    memcpy(presented.links, chain,
+           (size_t)chain_len * sizeof(presented.links[0]));
+    cargo_receipt_station_evaluation_t trust =
+        cargo_receipt_evaluate_at_station(
+            world, evaluating_station,
+            &sp->ship->manifest.units[idx], &presented);
+    if (!trust.accepted) return CARGO_RECEIPT_PRESENT_REJECT_TRUST;
+
+    cargo_store_t staged = {0};
+    if (!cargo_store_clone(&staged, &sp->ship->cargo_store))
+        return CARGO_RECEIPT_PRESENT_REJECT_RECEIPT_STORE;
+    uint16_t default_cap = staged.manifest.cap > 0
+        ? staged.manifest.cap : SHIP_MANIFEST_DEFAULT_CAP;
+    if (!cargo_store_bootstrap(&staged, default_cap)) {
+        cargo_store_cleanup(&staged);
+        return CARGO_RECEIPT_PRESENT_REJECT_RECEIPT_STORE;
     }
 
+    ship_receipts_t *receipts = cargo_store_receipts(&staged);
+    if (!receipts || (uint16_t)idx >= receipts->count) {
+        cargo_store_cleanup(&staged);
+        return CARGO_RECEIPT_PRESENT_REJECT_RECEIPT_STORE;
+    }
     cargo_receipt_chain_t *slot = &receipts->chains[idx];
-    if (!receipt_chain_prefix_matches(slot, chain, chain_len))
+    if (!receipt_chain_prefix_matches(slot, chain, chain_len)) {
+        cargo_store_cleanup(&staged);
         return CARGO_RECEIPT_PRESENT_REJECT_EXISTING_MISMATCH;
+    }
 
     memset(slot, 0, sizeof(*slot));
     memcpy(slot->links, chain, (size_t)chain_len * sizeof(chain[0]));
     slot->len = chain_len;
+    cargo_store_cleanup(&sp->ship->cargo_store);
+    sp->ship->cargo_store = staged;
     return CARGO_RECEIPT_PRESENT_OK;
 }

--- a/server/cargo_receipt_issue.h
+++ b/server/cargo_receipt_issue.h
@@ -59,6 +59,15 @@ cargo_receipt_origin_resolve_status_t cargo_receipt_resolve_local_origin(
     const uint8_t cargo_pub[32],
     cargo_receipt_origin_proof_t *out_proof);
 
+/* Resolve an origin against the exact authority key that authored the first
+ * receipt. This is the historical-key form of the resolver: rotated station
+ * keys have their own immutable log path and must not be looked up through a
+ * station's newer current key. */
+cargo_receipt_origin_resolve_status_t cargo_receipt_resolve_origin_for_authority(
+    const uint8_t authority[32],
+    const uint8_t cargo_pub[32],
+    cargo_receipt_origin_proof_t *out_proof);
+
 const char *cargo_receipt_origin_resolve_status_name(
     cargo_receipt_origin_resolve_status_t status);
 
@@ -106,16 +115,20 @@ typedef enum {
     CARGO_RECEIPT_PRESENT_REJECT_VERIFY,
     CARGO_RECEIPT_PRESENT_REJECT_RECIPIENT,
     CARGO_RECEIPT_PRESENT_REJECT_EXISTING_MISMATCH,
-    CARGO_RECEIPT_PRESENT_REJECT_RECEIPT_STORE
+    CARGO_RECEIPT_PRESENT_REJECT_RECEIPT_STORE,
+    CARGO_RECEIPT_PRESENT_REJECT_TRUST
 } cargo_receipt_present_result_t;
 
 /* Accept a peer-presented receipt chain for cargo currently carried by `sp`.
  *
  * The chain must verify for `cargo_pub`, its head recipient must be the
- * player's registered pubkey, and any already-attached local chain must be
- * an exact prefix of the presented chain. On success the chain is stored in
- * the ship's parallel receipt store at the matching manifest index. */
+ * player's registered pubkey, pass the named station's composed trust
+ * evaluator, and extend any already-attached exact prefix. Installation is
+ * staged in a cloned cargo store, so every rejection leaves the manifest and
+ * receipt store byte-identical. */
 cargo_receipt_present_result_t cargo_receipt_present_to_ship(
+    const world_t *world,
+    int evaluating_station,
     server_player_t *sp,
     const uint8_t cargo_pub[32],
     const cargo_receipt_t *chain,

--- a/server/cargo_receipt_trust.c
+++ b/server/cargo_receipt_trust.c
@@ -1,0 +1,353 @@
+#include "cargo_receipt_trust.h"
+
+#include "station_authority.h"
+
+#include <string.h>
+
+typedef struct {
+    cargo_receipt_authority_trust_t trust;
+    int station_index;
+} authority_resolution_t;
+
+static int trust_precedence(cargo_receipt_authority_trust_t trust) {
+    switch (trust) {
+        case CARGO_RECEIPT_AUTHORITY_REVOKED: return 5;
+        case CARGO_RECEIPT_AUTHORITY_UNTRUSTED: return 4;
+        case CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT: return 3;
+        case CARGO_RECEIPT_AUTHORITY_TRUSTED_ROTATED: return 2;
+        case CARGO_RECEIPT_AUTHORITY_UNKNOWN: return 1;
+        default: return 0;
+    }
+}
+
+static authority_resolution_t resolve_authority(
+    const world_t *world,
+    int evaluating_station,
+    const uint8_t pubkey[32]) {
+    authority_resolution_t out = {
+        .trust = CARGO_RECEIPT_AUTHORITY_UNKNOWN,
+        .station_index = -1,
+    };
+    if (!world || !pubkey || evaluating_station < 0 ||
+        evaluating_station >= MAX_STATIONS) {
+        return out;
+    }
+
+    const station_t *viewer = &world->stations[evaluating_station];
+    cargo_receipt_authority_trust_t local =
+        station_authority_trust_for_pubkey(viewer, pubkey);
+    if (local == CARGO_RECEIPT_AUTHORITY_REVOKED ||
+        local == CARGO_RECEIPT_AUTHORITY_UNTRUSTED) {
+        out.trust = local;
+        return out;
+    }
+
+    int station_count = world->station_count;
+    if (station_count < 0) station_count = 0;
+    if (station_count > MAX_STATIONS) station_count = MAX_STATIONS;
+    for (int i = 0; i < station_count; i++) {
+        const station_t *candidate = &world->stations[i];
+        if (!station_exists(candidate)) continue;
+        cargo_receipt_authority_trust_t trust =
+            station_authority_trust_for_pubkey(candidate, pubkey);
+        if (trust_precedence(trust) > trust_precedence(out.trust)) {
+            out.trust = trust;
+            out.station_index = i;
+        }
+        if (trust == CARGO_RECEIPT_AUTHORITY_REVOKED) break;
+    }
+    return out;
+}
+
+static cargo_receipt_trust_result_t empty_chain_trust_result(void) {
+    return (cargo_receipt_trust_result_t){
+        .status = CARGO_RECEIPT_TRUST_REJECT_CHAIN,
+        .chain_result = CARGO_RECEIPT_REJECT_EMPTY,
+        .origin_event = CARGO_RECEIPT_ORIGIN_EVENT_NONE,
+        .authority_trust = CARGO_RECEIPT_AUTHORITY_UNKNOWN,
+    };
+}
+
+static bool authority_policy_accepts(
+    cargo_receipt_authority_trust_t trust,
+    bool screens,
+    bool tolerates) {
+    switch (trust) {
+        case CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT:
+        case CARGO_RECEIPT_AUTHORITY_TRUSTED_ROTATED:
+            return true;
+        case CARGO_RECEIPT_AUTHORITY_UNKNOWN:
+            return !screens || tolerates;
+        case CARGO_RECEIPT_AUTHORITY_UNTRUSTED:
+            return tolerates;
+        case CARGO_RECEIPT_AUTHORITY_REVOKED:
+        default:
+            return false;
+    }
+}
+
+static cargo_receipt_trust_status_t rejection_for_authority(
+    cargo_receipt_authority_trust_t trust) {
+    switch (trust) {
+        case CARGO_RECEIPT_AUTHORITY_REVOKED:
+            return CARGO_RECEIPT_TRUST_REJECT_REVOKED_AUTHORITY;
+        case CARGO_RECEIPT_AUTHORITY_UNTRUSTED:
+            return CARGO_RECEIPT_TRUST_REJECT_UNTRUSTED_AUTHORITY;
+        case CARGO_RECEIPT_AUTHORITY_UNKNOWN:
+            return CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY;
+        default:
+            return CARGO_RECEIPT_TRUST_REJECT_BAD_ARGUMENTS;
+    }
+}
+
+static cargo_legality_result_t legality_base(
+    const station_t *viewer,
+    int evaluating_station) {
+    cargo_legality_result_t out = {
+        .status = CARGO_LEGALITY_CLEAN,
+        .receipt_result = CARGO_RECEIPT_OK,
+        .origin_station = -1,
+        .black_market_station = -1,
+    };
+    if (cargo_legality_station_screens(viewer, evaluating_station))
+        out.reasons |= CARGO_LEGALITY_REASON_POLICY_SCREENS;
+    if (cargo_legality_station_tolerates_contraband(
+            viewer, evaluating_station)) {
+        out.reasons |= CARGO_LEGALITY_REASON_POLICY_TOLERATES;
+    }
+    return out;
+}
+
+static void mark_authority_legality(
+    cargo_legality_result_t *legality,
+    cargo_receipt_authority_trust_t trust,
+    bool screens) {
+    if (!legality) return;
+    if (trust == CARGO_RECEIPT_AUTHORITY_UNKNOWN ||
+        trust == CARGO_RECEIPT_AUTHORITY_UNTRUSTED) {
+        legality->reasons |= CARGO_LEGALITY_REASON_UNKNOWN_AUTHORITY;
+        legality->status = screens ? CARGO_LEGALITY_CONTRABAND
+                                   : CARGO_LEGALITY_SUSPICIOUS;
+    } else if (trust == CARGO_RECEIPT_AUTHORITY_REVOKED) {
+        legality->reasons |= CARGO_LEGALITY_REASON_RECEIPT_REJECTED;
+        legality->status = CARGO_LEGALITY_CONTRABAND;
+    }
+}
+
+cargo_receipt_station_evaluation_t cargo_receipt_evaluate_at_station(
+    const world_t *world,
+    int evaluating_station,
+    const cargo_unit_t *unit,
+    const cargo_receipt_chain_t *chain) {
+    cargo_receipt_station_evaluation_t out = {
+        .accepted = false,
+        .trust = {
+            .status = CARGO_RECEIPT_TRUST_REJECT_BAD_ARGUMENTS,
+            .chain_result = CARGO_RECEIPT_OK,
+            .origin_event = CARGO_RECEIPT_ORIGIN_EVENT_NONE,
+            .authority_trust = CARGO_RECEIPT_AUTHORITY_UNKNOWN,
+        },
+        .origin_status = CARGO_RECEIPT_ORIGIN_RESOLVE_BAD_ARGUMENTS,
+        .legality = {
+            .status = CARGO_LEGALITY_SUSPICIOUS,
+            .receipt_result = CARGO_RECEIPT_OK,
+            .origin_station = -1,
+            .black_market_station = -1,
+        },
+        .origin_station = -1,
+        .first_rejected_link = -1,
+    };
+    if (!world || !unit || evaluating_station < 0 ||
+        evaluating_station >= world->station_count ||
+        evaluating_station >= MAX_STATIONS ||
+        !station_exists(&world->stations[evaluating_station])) {
+        return out;
+    }
+
+    const station_t *viewer = &world->stations[evaluating_station];
+    bool screens = cargo_legality_station_screens(
+        viewer, evaluating_station);
+    bool tolerates = cargo_legality_station_tolerates_contraband(
+        viewer, evaluating_station);
+    out.legality = legality_base(viewer, evaluating_station);
+
+    if (!chain || chain->len == 0) {
+        cargo_receipt_origin_proof_t origin = {0};
+        out.trust = empty_chain_trust_result();
+        /* Frozen save-migration cargo predates portable receipts and signed
+         * production events by definition. Do not scan and re-verify a
+         * station's growing history for a transform that this recipe cannot
+         * have. Existing saves grandfather it at every station, while a
+         * revoked hinted origin still fails closed. */
+        if (unit->recipe_id == (uint16_t)RECIPE_LEGACY_MIGRATE) {
+            cargo_receipt_authority_trust_t hinted_trust =
+                CARGO_RECEIPT_AUTHORITY_UNKNOWN;
+            out.origin_status =
+                CARGO_RECEIPT_ORIGIN_RESOLVE_TRANSFORM_NOT_FOUND;
+            out.legality.reasons |=
+                CARGO_LEGALITY_REASON_MISSING_RECEIPT |
+                CARGO_LEGALITY_REASON_UNKNOWN_AUTHORITY;
+            out.legality.status = screens
+                ? CARGO_LEGALITY_CONTRABAND
+                : CARGO_LEGALITY_SUSPICIOUS;
+            if (unit->origin_station < world->station_count &&
+                unit->origin_station < MAX_STATIONS &&
+                station_exists(&world->stations[unit->origin_station])) {
+                authority_resolution_t hinted = resolve_authority(
+                    world, evaluating_station,
+                    world->stations[unit->origin_station].station_pubkey);
+                if (hinted.trust == CARGO_RECEIPT_AUTHORITY_REVOKED)
+                    hinted_trust = hinted.trust;
+                out.origin_station = unit->origin_station;
+                out.legality.origin_station = unit->origin_station;
+            }
+            out.trust.status = rejection_for_authority(hinted_trust);
+            out.trust.authority_trust = hinted_trust;
+            out.accepted =
+                hinted_trust != CARGO_RECEIPT_AUTHORITY_REVOKED;
+            return out;
+        }
+        out.origin_status = cargo_receipt_resolve_local_origin(
+            viewer, unit->pub, &origin);
+        if (out.origin_status != CARGO_RECEIPT_ORIGIN_RESOLVE_VERIFIED) {
+            authority_resolution_t hinted = {
+                .trust = CARGO_RECEIPT_AUTHORITY_UNKNOWN,
+                .station_index = -1,
+            };
+            if (unit->origin_station < world->station_count &&
+                unit->origin_station < MAX_STATIONS &&
+                station_exists(&world->stations[unit->origin_station])) {
+                const station_t *hinted_station =
+                    &world->stations[unit->origin_station];
+                out.origin_status =
+                    cargo_receipt_resolve_origin_for_authority(
+                        hinted_station->station_pubkey,
+                        unit->pub, &origin);
+                if (out.origin_status ==
+                    CARGO_RECEIPT_ORIGIN_RESOLVE_VERIFIED) {
+                    hinted = resolve_authority(
+                        world, evaluating_station,
+                        hinted_station->station_pubkey);
+                    out.local_origin_without_receipt = true;
+                    out.origin_station = unit->origin_station;
+                    out.legality.origin_station = unit->origin_station;
+                    out.trust = (cargo_receipt_trust_result_t){
+                        .status = hinted.trust ==
+                                CARGO_RECEIPT_AUTHORITY_TRUSTED_ROTATED
+                            ? CARGO_RECEIPT_TRUST_VALID_TRUSTED_ROTATED
+                            : hinted.trust ==
+                                CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT
+                                ? CARGO_RECEIPT_TRUST_VALID_TRUSTED
+                                : rejection_for_authority(hinted.trust),
+                        .chain_result = CARGO_RECEIPT_OK,
+                        .origin_event = origin.event_type,
+                        .authority_trust = hinted.trust,
+                    };
+                    out.legality.reasons |=
+                        CARGO_LEGALITY_REASON_MISSING_RECEIPT;
+                    out.legality.status = screens
+                        ? CARGO_LEGALITY_CONTRABAND
+                        : CARGO_LEGALITY_SUSPICIOUS;
+                    mark_authority_legality(
+                        &out.legality, hinted.trust, screens);
+                    if (!authority_policy_accepts(
+                            hinted.trust, screens, tolerates)) {
+                        return out;
+                    }
+                    goto origin_resolved_without_receipt;
+                }
+            }
+            out.trust.status =
+                CARGO_RECEIPT_TRUST_REJECT_MISSING_ORIGIN;
+            out.legality.reasons |= CARGO_LEGALITY_REASON_MISSING_RECEIPT;
+            out.legality.status = screens
+                ? CARGO_LEGALITY_CONTRABAND
+                : CARGO_LEGALITY_SUSPICIOUS;
+            return out;
+        }
+        out.local_origin_without_receipt = true;
+        out.origin_station = evaluating_station;
+        out.legality.origin_station = evaluating_station;
+        out.trust = (cargo_receipt_trust_result_t){
+            .status = CARGO_RECEIPT_TRUST_VALID_TRUSTED,
+            .chain_result = CARGO_RECEIPT_OK,
+            .origin_event = origin.event_type,
+            .authority_trust =
+                CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT,
+        };
+origin_resolved_without_receipt:
+        ;
+    } else {
+        const cargo_receipt_t *origin_receipt = &chain->links[0];
+        cargo_receipt_origin_proof_t origin = {0};
+        out.origin_status = cargo_receipt_resolve_origin_for_authority(
+            origin_receipt->authoring_station, unit->pub, &origin);
+        authority_resolution_t origin_authority = resolve_authority(
+            world, evaluating_station, origin_receipt->authoring_station);
+        out.origin_station = origin_authority.station_index;
+        out.legality.origin_station = origin_authority.station_index;
+        out.trust = cargo_receipt_trust_verify(
+            chain->links, chain->len, unit->pub,
+            out.origin_status == CARGO_RECEIPT_ORIGIN_RESOLVE_VERIFIED
+                ? &origin : NULL,
+            origin_authority.trust);
+        out.legality.receipt_result = out.trust.chain_result;
+        if (out.trust.chain_result != CARGO_RECEIPT_OK) {
+            out.legality.reasons |= cargo_legality_reason_from_receipt_result(
+                out.trust.chain_result);
+            out.legality.status = CARGO_LEGALITY_CONTRABAND;
+            return out;
+        }
+        if (out.origin_status != CARGO_RECEIPT_ORIGIN_RESOLVE_VERIFIED) {
+            out.legality.reasons |= CARGO_LEGALITY_REASON_RECEIPT_REJECTED;
+            out.legality.status = CARGO_LEGALITY_CONTRABAND;
+            return out;
+        }
+        mark_authority_legality(&out.legality, origin_authority.trust,
+                                screens);
+        if (!authority_policy_accepts(origin_authority.trust,
+                                      screens, tolerates)) {
+            out.trust.status = rejection_for_authority(
+                origin_authority.trust);
+            out.first_rejected_link = 0;
+            return out;
+        }
+
+        for (uint8_t i = 0; i < chain->len; i++) {
+            authority_resolution_t author = resolve_authority(
+                world, evaluating_station,
+                chain->links[i].authoring_station);
+            mark_authority_legality(&out.legality, author.trust, screens);
+            if (author.station_index >= 0 &&
+                cargo_legality_station_tolerates_contraband(
+                    &world->stations[author.station_index],
+                    author.station_index)) {
+                out.legality.reasons |=
+                    CARGO_LEGALITY_REASON_BLACK_MARKET_AUTHORITY;
+                out.legality.black_market_station =
+                    author.station_index;
+                out.legality.status = CARGO_LEGALITY_CONTRABAND;
+            }
+            if (!authority_policy_accepts(author.trust,
+                                          screens, tolerates)) {
+                out.trust.status = rejection_for_authority(author.trust);
+                out.trust.authority_trust = author.trust;
+                out.first_rejected_link = (int)i;
+                return out;
+            }
+        }
+    }
+
+    if (out.origin_station >= 0 && out.origin_station < 64) {
+        uint64_t forbidden =
+            station_policy_forbidden_origin_mask_for_station(
+                viewer, evaluating_station,
+                (commodity_t)unit->commodity);
+        if ((forbidden & (1ULL << out.origin_station)) != 0) {
+            out.legality.reasons |= CARGO_LEGALITY_REASON_BANNED_ORIGIN;
+            out.legality.status = CARGO_LEGALITY_CONTRABAND;
+        }
+    }
+    out.accepted = cargo_legality_station_accepts(out.legality);
+    return out;
+}

--- a/server/cargo_receipt_trust.h
+++ b/server/cargo_receipt_trust.h
@@ -1,0 +1,51 @@
+/*
+ * cargo_receipt_trust.h -- Station-composed cargo trust policy.
+ *
+ * Gameplay mutation sites call this read-only evaluator before changing
+ * manifests, balances, contracts, construction, or ownership. It composes
+ * cryptographic receipt validation, an exact verified origin event, public
+ * authority lifecycle, and the evaluating station's current policy.
+ */
+#ifndef SERVER_CARGO_RECEIPT_TRUST_H
+#define SERVER_CARGO_RECEIPT_TRUST_H
+
+#include "game_sim.h"
+#include "cargo_legality.h"
+#include "cargo_receipt_issue.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    bool accepted;
+    bool local_origin_without_receipt;
+    cargo_receipt_trust_result_t trust;
+    cargo_receipt_origin_resolve_status_t origin_status;
+    cargo_legality_result_t legality;
+    int origin_station;
+    int first_rejected_link;
+} cargo_receipt_station_evaluation_t;
+
+/* Evaluate one finished cargo unit at a station without mutation.
+ *
+ * Empty chains are accepted only for cargo proven in that evaluating
+ * station's current signed history. This covers newly produced local stock
+ * before its first transfer receipt is issued; it cannot bless foreign
+ * chainless cargo.
+ *
+ * Unknown authorities follow the station's screening policy, explicitly
+ * untrusted authorities require black-market tolerance, and revoked
+ * authorities always fail. Every receipt author is checked, not only the
+ * origin author. */
+cargo_receipt_station_evaluation_t cargo_receipt_evaluate_at_station(
+    const world_t *world,
+    int evaluating_station,
+    const cargo_unit_t *unit,
+    const cargo_receipt_chain_t *chain);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SERVER_CARGO_RECEIPT_TRUST_H */

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -48,6 +48,7 @@
 #include "sim_mining.h"
 #include "signal_model.h"
 #include "cargo_receipt_issue.h"
+#include "cargo_receipt_trust.h"
 #include "handoff_flow.h"
 #include "mining.h"
 #include "pubkey_proof.h"
@@ -840,7 +841,7 @@ bool can_place_outpost(const world_t *w, vec2 pos) {
     return false;
 }
 
-static cargo_legality_result_t classify_ship_manifest_unit_at_station(
+static bool ship_manifest_unit_trusted_at_station(
     const world_t *w, const ship_t *ship, uint16_t index, int station_index);
 
 static bool cargo_unit_pub_nonzero(const cargo_unit_t *unit) {
@@ -878,7 +879,8 @@ static void step_scaffold_delivery(world_t *w, server_player_t *sp) {
     station_t *st = &w->stations[sp->current_station];
     if (!st->scaffold) return;
     int held = ship_finished_count(sp->ship, COMMODITY_FRAME) +
-               ship_towed_pods_manifest_count(w, sp->ship, COMMODITY_FRAME);
+               ship_towed_pods_trusted_manifest_count(
+                   w, sp->ship, COMMODITY_FRAME, sp->current_station);
     if (held <= 0) return;
     float needed_f = SCAFFOLD_MATERIAL_NEEDED * (1.0f - st->scaffold_progress);
     int needed = (int)ceilf(needed_f - 0.0001f);
@@ -891,11 +893,10 @@ static void step_scaffold_delivery(world_t *w, server_player_t *sp) {
             const cargo_unit_t *unit = &sp->ship->manifest.units[i];
             if (!unit || unit->commodity != (uint8_t)COMMODITY_FRAME)
                 continue;
-            cargo_legality_result_t legality =
-                classify_ship_manifest_unit_at_station(
-                    w, sp->ship, i, sp->current_station);
-            if (legality.status == CARGO_LEGALITY_CONTRABAND)
+            if (!ship_manifest_unit_trusted_at_station(
+                    w, sp->ship, i, sp->current_station)) {
                 continue;
+            }
             idx = (int)i;
             break;
         }
@@ -914,8 +915,9 @@ static void step_scaffold_delivery(world_t *w, server_player_t *sp) {
     }
     while (accepted < request) {
         cargo_unit_t unit = {0};
-        if (!ship_towed_pods_take_manifest_unit(w, sp->ship,
-                                                COMMODITY_FRAME, &unit)) {
+        if (!ship_towed_pods_take_trusted_manifest_unit(
+                w, sp->ship, COMMODITY_FRAME,
+                sp->current_station, &unit)) {
             break;
         }
         float progress_after = st->scaffold_progress +
@@ -3195,6 +3197,70 @@ bool ship_towed_pods_take_manifest_unit(world_t *w, ship_t *ship,
     return false;
 }
 
+int ship_towed_pods_trusted_manifest_count(
+    const world_t *w, const ship_t *ship, commodity_t commodity,
+    int evaluating_station) {
+    if (!w || !ship || commodity >= COMMODITY_COUNT ||
+        evaluating_station < 0 ||
+        evaluating_station >= w->station_count ||
+        evaluating_station >= MAX_STATIONS) {
+        return 0;
+    }
+    int total = 0;
+    for (int t = 0; t < ship->towed_pod_count && t < 10; t++) {
+        int idx = ship->towed_pods[t];
+        if (idx < 0 || idx >= MAX_CARGO_PODS) continue;
+        const cargo_pod_t *pod = &w->cargo_pods[idx];
+        if (!cargo_pod_has_exact_manifest(pod, commodity)) continue;
+        for (uint16_t u = 0; u < pod->manifest_count; u++) {
+            cargo_receipt_station_evaluation_t evaluated =
+                cargo_receipt_evaluate_at_station(
+                    w, evaluating_station, &pod->manifest_units[u], NULL);
+            if (evaluated.accepted) total++;
+        }
+    }
+    return total;
+}
+
+bool ship_towed_pods_take_trusted_manifest_unit(
+    world_t *w, ship_t *ship, commodity_t commodity,
+    int evaluating_station, cargo_unit_t *out_unit) {
+    if (!w || !ship || !out_unit || commodity >= COMMODITY_COUNT ||
+        evaluating_station < 0 ||
+        evaluating_station >= w->station_count ||
+        evaluating_station >= MAX_STATIONS) {
+        return false;
+    }
+    for (int t = 0; t < ship->towed_pod_count && t < 10; t++) {
+        int idx = ship->towed_pods[t];
+        if (idx < 0 || idx >= MAX_CARGO_PODS) continue;
+        cargo_pod_t *pod = &w->cargo_pods[idx];
+        if (!cargo_pod_has_exact_manifest(pod, commodity)) continue;
+        for (uint16_t u = 0; u < pod->manifest_count; u++) {
+            cargo_receipt_station_evaluation_t evaluated =
+                cargo_receipt_evaluate_at_station(
+                    w, evaluating_station, &pod->manifest_units[u], NULL);
+            if (!evaluated.accepted) continue;
+            *out_unit = pod->manifest_units[u];
+            uint16_t last = (uint16_t)(pod->manifest_count - 1u);
+            for (uint16_t move = u; move < last; move++)
+                pod->manifest_units[move] = pod->manifest_units[move + 1u];
+            memset(&pod->manifest_units[last], 0,
+                   sizeof(pod->manifest_units[last]));
+            pod->manifest_count--;
+            pod->quantity--;
+            if (pod->manifest_count == 0) {
+                if (!cargo_pod_fold_shell_to_frame(pod)) {
+                    world_cargo_pod_clear_tractor(w, idx);
+                    memset(pod, 0, sizeof(*pod));
+                }
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
 int spawn_cargo_pod(world_t *w, vec2 pos, vec2 vel, commodity_t commodity,
                     uint16_t quantity, cargo_pod_kind_t kind) {
     if (!w || commodity >= COMMODITY_COUNT || quantity == 0 ||
@@ -3599,6 +3665,32 @@ int world_ensure_starter_laser_module_reserve(world_t *w) {
 
 static bool cargo_pod_fits_contract_exact(const cargo_pod_t *pod,
                                           const contract_t *ct);
+static bool is_finished_good(commodity_t c);
+
+static bool cargo_pod_trusted_at_station(
+    const world_t *w, const cargo_pod_t *pod, int station_idx) {
+    if (!w || !pod || station_idx < 0 ||
+        station_idx >= w->station_count ||
+        station_idx >= MAX_STATIONS) {
+        return false;
+    }
+    if (!is_finished_good(pod->commodity)) return true;
+    if (pod->manifest_count == 0 ||
+        pod->manifest_count != pod->quantity ||
+        pod->manifest_count > CARGO_POD_MANIFEST_CAP) {
+        return false;
+    }
+    for (uint16_t i = 0; i < pod->manifest_count; i++) {
+        const cargo_unit_t *unit = &pod->manifest_units[i];
+        if (unit->commodity != (uint8_t)pod->commodity)
+            return false;
+        cargo_receipt_station_evaluation_t evaluated =
+            cargo_receipt_evaluate_at_station(
+                w, station_idx, unit, NULL);
+        if (!evaluated.accepted) return false;
+    }
+    return true;
+}
 
 static float black_market_pod_quote(const station_t *st,
                                     const cargo_pod_t *pod) {
@@ -3649,6 +3741,8 @@ static float station_intake_pod_quote(world_t *w,
         pod->quantity == 0) {
         return 0.0f;
     }
+    if (!cargo_pod_trusted_at_station(w, pod, station_idx))
+        return 0.0f;
     commodity_t c = pod->commodity;
     int matched_contract = -1;
     for (int k = 0; k < MAX_CONTRACTS; k++) {
@@ -3772,6 +3866,8 @@ try_sell_towed_pods(world_t *w, server_player_t *sp,
         commodity_t c = pod->commodity;
         if (c >= COMMODITY_COUNT) continue;
         if (filter != COMMODITY_COUNT && filter != c) continue;
+        if (!cargo_pod_trusted_at_station(w, pod, station_idx))
+            continue;
 
         int units = (int)pod->quantity;
         if (units <= 0) {
@@ -4440,22 +4536,18 @@ static const cargo_receipt_chain_t *ship_receipt_chain_at(
     return &receipts->chains[index];
 }
 
-static cargo_legality_result_t classify_ship_manifest_unit_at_station(
+static bool ship_manifest_unit_trusted_at_station(
     const world_t *w, const ship_t *ship, uint16_t index, int station_index) {
-    cargo_legality_result_t result = {
-        .status = CARGO_LEGALITY_SUSPICIOUS,
-        .origin_station = -1,
-        .black_market_station = -1,
-    };
     if (!w || !ship || !ship->manifest.units ||
         index >= ship->manifest.count ||
         station_index < 0 || station_index >= MAX_STATIONS) {
-        result.reasons = CARGO_LEGALITY_REASON_UNKNOWN_AUTHORITY;
-        return result;
+        return false;
     }
-    return cargo_legality_classify(
-        w->stations, MAX_STATIONS, station_index, &ship->manifest.units[index],
-        ship_receipt_chain_at(ship, index));
+    cargo_receipt_station_evaluation_t evaluated =
+        cargo_receipt_evaluate_at_station(
+            w, station_index, &ship->manifest.units[index],
+            ship_receipt_chain_at(ship, index));
+    return evaluated.accepted;
 }
 
 static bool is_finished_good(commodity_t c) {
@@ -4519,6 +4611,36 @@ static int delivery_towed_pod_slot_for_shipment(const world_t *w,
         return t;
     }
     return -1;
+}
+
+static bool delivery_shipment_range_trusted_at_station(
+    const world_t *w,
+    const delivery_shipment_t *shipment,
+    uint16_t cargo_offset,
+    uint16_t quantity,
+    int station_idx) {
+    if (!w || !shipment || quantity == 0 ||
+        station_idx < 0 || station_idx >= w->station_count ||
+        station_idx >= MAX_STATIONS ||
+        cargo_offset > shipment->quantity_bound ||
+        cargo_offset + quantity > shipment->quantity_bound ||
+        cargo_offset + quantity > MAX_DELIVERY_BOUND_CARGO) {
+        return false;
+    }
+    for (uint16_t i = 0; i < quantity; i++) {
+        uint16_t cargo_idx = (uint16_t)(cargo_offset + i);
+        const cargo_unit_t *unit = &shipment->cargo_units[cargo_idx];
+        if (unit->commodity != shipment->commodity ||
+            memcmp(unit->pub, shipment->cargo_pub[cargo_idx], 32) != 0) {
+            return false;
+        }
+        cargo_receipt_station_evaluation_t evaluated =
+            cargo_receipt_evaluate_at_station(
+                w, station_idx, unit,
+                &shipment->cargo_chains[cargo_idx]);
+        if (!evaluated.accepted) return false;
+    }
+    return true;
 }
 
 static bool delivery_materialize_pod_manifest(cargo_pod_t *pod,
@@ -4799,9 +4921,23 @@ static bool delivery_contract_has_source(const contract_t *ct) {
            ct->target_index < MAX_STATIONS;
 }
 
-static int delivery_find_source_stock_unit(const station_t *origin,
+static const cargo_receipt_chain_t *station_receipt_chain_at(
+    const station_t *station, uint16_t index) {
+    const ship_receipts_t *receipts = station_get_receipts_const(station);
+    if (!receipts || !receipts->chains || index >= receipts->count)
+        return NULL;
+    return &receipts->chains[index];
+}
+
+static int delivery_find_source_stock_unit(const world_t *w,
+                                           int origin_index,
                                            const contract_t *ct) {
-    if (!origin || !ct || !origin->manifest.units) return -1;
+    if (!w || origin_index < 0 || origin_index >= w->station_count ||
+        origin_index >= MAX_STATIONS || !ct) {
+        return -1;
+    }
+    const station_t *origin = &w->stations[origin_index];
+    if (!origin->manifest.units) return -1;
     for (uint16_t i = 0; i < origin->manifest.count; i++) {
         const cargo_unit_t *unit = &origin->manifest.units[i];
         if (!contract_fit_is_ok(contract_fit_cargo_unit(ct, unit))) continue;
@@ -4810,14 +4946,25 @@ static int delivery_find_source_stock_unit(const station_t *origin,
             (ingot_prefix_t)unit->prefix_class != INGOT_PREFIX_ANONYMOUS) {
             continue;
         }
+        cargo_receipt_station_evaluation_t evaluated =
+            cargo_receipt_evaluate_at_station(
+                w, origin_index, unit,
+                station_receipt_chain_at(origin, i));
+        if (!evaluated.accepted) continue;
         return (int)i;
     }
     return -1;
 }
 
-static int delivery_source_stock_count(const station_t *origin,
+static int delivery_source_stock_count(const world_t *w,
+                                       int origin_index,
                                        const contract_t *ct) {
-    if (!origin || !ct || !origin->manifest.units) return 0;
+    if (!w || origin_index < 0 || origin_index >= w->station_count ||
+        origin_index >= MAX_STATIONS || !ct) {
+        return 0;
+    }
+    const station_t *origin = &w->stations[origin_index];
+    if (!origin->manifest.units) return 0;
     int count = 0;
     for (uint16_t i = 0; i < origin->manifest.count; i++) {
         const cargo_unit_t *unit = &origin->manifest.units[i];
@@ -4827,6 +4974,34 @@ static int delivery_source_stock_count(const station_t *origin,
             (ingot_prefix_t)unit->prefix_class != INGOT_PREFIX_ANONYMOUS) {
             continue;
         }
+        count++;
+    }
+    return count;
+}
+
+static int delivery_trusted_source_stock_count(const world_t *w,
+                                               int origin_index,
+                                               const contract_t *ct) {
+    if (!w || origin_index < 0 || origin_index >= w->station_count ||
+        origin_index >= MAX_STATIONS || !ct) {
+        return 0;
+    }
+    const station_t *origin = &w->stations[origin_index];
+    if (!origin->manifest.units) return 0;
+    int count = 0;
+    for (uint16_t i = 0; i < origin->manifest.count; i++) {
+        const cargo_unit_t *unit = &origin->manifest.units[i];
+        if (!contract_fit_is_ok(contract_fit_cargo_unit(ct, unit))) continue;
+        if (ct->proof_flags == 0 &&
+            (cargo_kind_t)unit->kind == CARGO_KIND_INGOT &&
+            (ingot_prefix_t)unit->prefix_class != INGOT_PREFIX_ANONYMOUS) {
+            continue;
+        }
+        cargo_receipt_station_evaluation_t evaluated =
+            cargo_receipt_evaluate_at_station(
+                w, origin_index, unit,
+                station_receipt_chain_at(origin, i));
+        if (!evaluated.accepted) continue;
         count++;
     }
     return count;
@@ -4858,7 +5033,7 @@ static int delivery_pickup_from_origin(world_t *w, server_player_t *sp,
         return 0;
     }
     if (ship_tow_body_space(sp->ship) <= 0) return 0;
-    int stock = delivery_source_stock_count(origin, ct);
+    int stock = delivery_trusted_source_stock_count(w, origin_idx, ct);
     if (stock <= 0) return 0;
     int needed = (int)ceilf(ct->quantity_needed);
     if (needed <= 0) needed = 1;
@@ -4884,7 +5059,7 @@ static int delivery_pickup_from_origin(world_t *w, server_player_t *sp,
     int moved = 0;
     float debt = 0.0f;
     while (moved < take) {
-        int idx = delivery_find_source_stock_unit(origin, ct);
+        int idx = delivery_find_source_stock_unit(w, origin_idx, ct);
         if (idx < 0) break;
         cargo_unit_t unit = {0};
         cargo_receipt_chain_t chain = {0};
@@ -4981,6 +5156,11 @@ static float delivery_try_deliver_bound_cargo(world_t *w,
         if (pod_idx < 0 || pod_idx >= MAX_CARGO_PODS) continue;
         cargo_pod_t *pod = &w->cargo_pods[pod_idx];
         if (pod->quantity != remaining) continue;
+        if (!delivery_shipment_range_trusted_at_station(
+                w, shipment, shipment->quantity_delivered,
+                remaining, station_idx)) {
+            continue;
+        }
 
         float shipment_payout = 0.0f;
         bool ok = true;
@@ -8239,10 +8419,13 @@ static void place_towed_scaffold(world_t *w, server_player_t *sp) {
             if (!station_exists(&w->stations[s])) { slot = s; break; }
         }
         if (slot >= 0) {
+            if (slot >= w->station_count) w->station_count = slot + 1;
             station_t *st = &w->stations[slot];
             station_cleanup(st);
             memset(st, 0, sizeof(*st));
             (void)station_manifest_bootstrap(st);
+            if (w->next_station_id == 0) w->next_station_id = 1;
+            st->id = w->next_station_id++;
             generate_outpost_name(st->name, sizeof(st->name), sc->pos, slot);
             st->pos = sc->pos;
             st->radius = OUTPOST_RADIUS;
@@ -8706,7 +8889,8 @@ static int hail_find_station_work_contract(world_t *w, server_player_t *sp,
                 if (shipment && shipment->status == DELIVERY_SHIPMENT_DELIVERED) {
                     score += 1000.0f;
                 } else if (!shipment) {
-                    int stock = delivery_source_stock_count(&w->stations[origin], c);
+                    int stock = delivery_trusted_source_stock_count(
+                        w, origin, c);
                     if (stock <= 0) continue;
                     score += 800.0f + (float)stock * 10.0f;
                 } else {
@@ -9702,7 +9886,7 @@ static int delivery_best_source_for_contract(const world_t *w,
         if (s == dest) continue;
         const station_t *source = &w->stations[s];
         if (!station_exists(source)) continue;
-        int stock = delivery_source_stock_count(source, &fit);
+        int stock = delivery_source_stock_count(w, s, &fit);
         if (stock <= 0) continue;
         float d = v2_len(v2_sub(source->pos, w->stations[dest].pos));
         float score = (float)stock * 1000.0f - d;
@@ -9740,7 +9924,7 @@ static void delivery_maybe_post_credit_contracts(world_t *w) {
         contract_t fit = *demand;
         fit.action = CONTRACT_DELIVERY;
         fit.target_index = origin;
-        int stock = delivery_source_stock_count(&w->stations[origin], &fit);
+        int stock = delivery_source_stock_count(w, origin, &fit);
         if (stock <= 0) continue;
         int qty = (int)ceilf(demand->quantity_needed);
         if (qty <= 0) qty = 1;
@@ -12551,6 +12735,10 @@ static void server_dispatch_buy_named_ingot(
     if (station_receipts && slot < (int)station_receipts->count)
         station_chain = station_receipts->chains[slot];
     if (station_chain.len >= CARGO_RECEIPT_CHAIN_MAX_LEN) return;
+    cargo_receipt_station_evaluation_t trust =
+        cargo_receipt_evaluate_at_station(
+            w, sidx, src, &station_chain);
+    if (!trust.accepted) return;
     cargo_receipt_transfer_link_t transfer_link =
         cargo_receipt_prepare_transfer_link(st, src->pub, &station_chain);
     if (transfer_link.status != CARGO_RECEIPT_TRANSFER_LINK_READY)
@@ -12635,20 +12823,15 @@ static void server_dispatch_deliver_named_ingot(
     if (rcpts && hidx < (int)rcpts->count) {
         const cargo_receipt_chain_t *attached = &rcpts->chains[hidx];
         attached_chain = *attached;
-        if (attached->len > 0) {
-            cargo_receipt_result_t vr = cargo_receipt_chain_verify(
-                attached->links, attached->len, copy.pub);
-            if (vr != CARGO_RECEIPT_OK) {
-                printf("[server] receipt_chain_invalid: deliver from player %d, reason=%d\n",
-                       pid, (int)vr);
-                return;
-            }
-            if (attached->len >= CARGO_RECEIPT_CHAIN_MAX_LEN) {
-                printf("[server] receipt_chain_cap_exceeded: deliver from player %d\n",
-                       pid);
-                return;
-            }
-        }
+    }
+    cargo_receipt_station_evaluation_t trust =
+        cargo_receipt_evaluate_at_station(
+            w, sidx, &copy, &attached_chain);
+    if (!trust.accepted) return;
+    if (attached_chain.len >= CARGO_RECEIPT_CHAIN_MAX_LEN) {
+        printf("[server] receipt_chain_cap_exceeded: deliver from player %d\n",
+               pid);
+        return;
     }
 
     cargo_receipt_transfer_link_t transfer_link =
@@ -12812,8 +12995,16 @@ bool server_dispatch_receipt_presentation_message(
         (void)cargo_receipt_unpack(p, &chain[i]);
     }
 
-    cargo_receipt_present_result_t result = cargo_receipt_present_to_ship(
-        &w->players[player_idx], cargo_pub, chain, (uint8_t)chain_len);
+    server_player_t *sp = &w->players[player_idx];
+    cargo_receipt_present_result_t result =
+        CARGO_RECEIPT_PRESENT_REJECT_TRUST;
+    if (sp->docked && sp->current_station >= 0 &&
+        sp->current_station < w->station_count &&
+        sp->current_station < MAX_STATIONS) {
+        result = cargo_receipt_present_to_ship(
+            w, sp->current_station, sp, cargo_pub,
+            chain, (uint8_t)chain_len);
+    }
     if (out) {
         out->evaluated = true;
         out->result = result;

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -33,6 +33,7 @@ enum {
     MAX_DELIVERY_SHIPMENTS = 24,
     MAX_DELIVERY_BOUND_CARGO = 16,
     MAX_DESTROYED_ROCKS = 4096,
+    SERVER_INSPECT_TRUST_CACHE_ROWS = 8,
 };
 
 enum {
@@ -481,6 +482,13 @@ typedef struct {
      * PROVE_PUBKEY arrives; when it does, skip the pubkey save reload that
      * would otherwise overwrite the live transferred ship state. */
     bool    preserve_live_state_on_pubkey_finalize;
+    /* Runtime-only server-authored inspection verdict cache. Row-aligned
+     * with the last serialized eight-row scan snapshot; refreshed when the
+     * snapshot changes or at least once per second. */
+    uint64_t inspect_trust_signature;
+    uint8_t inspect_trust_cache_row_count;
+    uint8_t inspect_trust_cache_code[SERVER_INSPECT_TRUST_CACHE_ROWS];
+    uint8_t inspect_trust_cache_accepted[SERVER_INSPECT_TRUST_CACHE_ROWS];
     /* Layer A.3 of #479 — monotonic per-player nonce for NET_MSG_SIGNED_ACTION.
      * Persisted in the player save (PLY6+). Any signed action whose nonce is
      * <= this value is rejected as a replay; on accept, this becomes the
@@ -1200,6 +1208,12 @@ int ship_towed_pods_manifest_count(const world_t *w, const ship_t *ship,
 bool ship_towed_pods_take_manifest_unit(world_t *w, ship_t *ship,
                                         commodity_t commodity,
                                         cargo_unit_t *out_unit);
+int ship_towed_pods_trusted_manifest_count(
+    const world_t *w, const ship_t *ship, commodity_t commodity,
+    int evaluating_station);
+bool ship_towed_pods_take_trusted_manifest_unit(
+    world_t *w, ship_t *ship, commodity_t commodity,
+    int evaluating_station, cargo_unit_t *out_unit);
 bool world_save(const world_t *w, const char *path);
 bool world_load(world_t *w, const char *path);
 /* Apply stock migrations that are keyed only by the decoded save version.

--- a/server/net_protocol.h
+++ b/server/net_protocol.h
@@ -13,6 +13,7 @@
 
 #include "game_sim.h"
 #include "cargo_receipt.h"
+#include "cargo_receipt_trust.h"
 #include "handoff_ticket.h"
 #include "manifest.h"
 #include "sim_ai.h"
@@ -6502,10 +6503,129 @@ static inline int serialize_player_ship_for_world(
         buf, id, sp, server_player_station_balance_in_world(w, sp));
 }
 
+static inline int inspect_snapshot_evaluating_station(
+    const world_t *w, const server_player_t *sp) {
+    if (!w || !sp) return -1;
+    int station_idx = sp->docked
+        ? sp->current_station : sp->nearby_station;
+    if (station_idx < 0 || station_idx >= w->station_count ||
+        station_idx >= MAX_STATIONS ||
+        !station_exists(&w->stations[station_idx])) {
+        return -1;
+    }
+    return station_idx;
+}
+
+static inline cargo_receipt_station_evaluation_t
+inspect_snapshot_evaluate_manifest_index(
+    const world_t *w, int station_idx, const ship_t *ship,
+    uint16_t manifest_idx) {
+    const ship_receipts_t *receipts = ship_get_receipts_const(ship);
+    const cargo_receipt_chain_t *chain =
+        receipts && manifest_idx < receipts->count
+            ? &receipts->chains[manifest_idx] : NULL;
+    return cargo_receipt_evaluate_at_station(
+        w, station_idx, &ship->manifest.units[manifest_idx], chain);
+}
+
+static inline void inspect_snapshot_refresh_trust_cache(
+    uint8_t *buf, int len, const world_t *w, server_player_t *sp,
+    const ship_t *target_ship) {
+    if (!buf || len < INSPECT_SNAPSHOT_HEADER || !w || !sp ||
+        !target_ship || !target_ship->manifest.units) {
+        return;
+    }
+    int station_idx = inspect_snapshot_evaluating_station(w, sp);
+    if (station_idx < 0) return;
+
+    uint8_t row_count = buf[8];
+    if (row_count > INSPECT_SNAPSHOT_MAX_ROWS)
+        row_count = INSPECT_SNAPSHOT_MAX_ROWS;
+    uint64_t signature = net_payload_hash(buf, (size_t)len);
+    signature = net_fnv1a64_update(signature, (uint8_t)station_idx);
+    uint32_t trust_epoch = w->tick / 120u;
+    for (int shift = 0; shift < 4; shift++)
+        signature = net_fnv1a64_update(
+            signature, (uint8_t)(trust_epoch >> (shift * 8)));
+
+    if (sp->inspect_trust_signature != signature ||
+        sp->inspect_trust_cache_row_count != row_count) {
+        memset(sp->inspect_trust_cache_code, 0,
+               sizeof(sp->inspect_trust_cache_code));
+        memset(sp->inspect_trust_cache_accepted, 0,
+               sizeof(sp->inspect_trust_cache_accepted));
+        sp->inspect_trust_signature = signature;
+        sp->inspect_trust_cache_row_count = row_count;
+
+        for (uint8_t row_idx = 0; row_idx < row_count; row_idx++) {
+            const uint8_t *row =
+                &buf[INSPECT_SNAPSHOT_HEADER +
+                     row_idx * INSPECT_SNAPSHOT_ROW];
+            if ((row[3] & INSPECT_ROW_DIAGNOSTIC) != 0) continue;
+
+            bool any = false;
+            bool accepted = true;
+            cargo_receipt_trust_status_t status =
+                CARGO_RECEIPT_TRUST_REJECT_BAD_ARGUMENTS;
+            bool grouped = (row[3] & INSPECT_ROW_GROUPED) != 0;
+            for (uint16_t manifest_idx = 0;
+                 manifest_idx < target_ship->manifest.count;
+                 manifest_idx++) {
+                const cargo_unit_t *unit =
+                    &target_ship->manifest.units[manifest_idx];
+                bool matches;
+                if (grouped) {
+                    matches = inspect_snapshot_unit_is_groupable(unit) &&
+                              unit->commodity == row[0] &&
+                              unit->grade == row[1];
+                } else {
+                    matches = memcmp(unit->pub, &row[14], 32) == 0;
+                }
+                if (!matches) continue;
+                cargo_receipt_station_evaluation_t evaluated =
+                    inspect_snapshot_evaluate_manifest_index(
+                        w, station_idx, target_ship, manifest_idx);
+                if (!any || (accepted && !evaluated.accepted) ||
+                    (accepted == evaluated.accepted &&
+                     evaluated.trust.status > status)) {
+                    status = evaluated.trust.status;
+                }
+                any = true;
+                accepted = accepted && evaluated.accepted;
+                if (!grouped) break;
+            }
+            if (!any || status >
+                    CARGO_RECEIPT_TRUST_REJECT_REVOKED_AUTHORITY) {
+                continue;
+            }
+            sp->inspect_trust_cache_code[row_idx] =
+                (uint8_t)status + 1u;
+            sp->inspect_trust_cache_accepted[row_idx] =
+                accepted ? 1u : 0u;
+        }
+    }
+
+    for (uint8_t row_idx = 0; row_idx < row_count; row_idx++) {
+        uint8_t code = sp->inspect_trust_cache_code[row_idx];
+        if (code == 0) continue;
+        uint8_t *row =
+            &buf[INSPECT_SNAPSHOT_HEADER +
+                 row_idx * INSPECT_SNAPSHOT_ROW];
+        row[3] = (uint8_t)(
+            (row[3] & ~INSPECT_ROW_TRUST_CODE_LOW_MASK) |
+            ((code & 0x07u) << 5));
+        row[2] = (uint8_t)(
+            (row[2] & INSPECT_ROW_CHAIN_VALUE_MASK) |
+            ((code & 0x08u) ? INSPECT_ROW_TRUST_CODE_HIGH : 0u) |
+            (sp->inspect_trust_cache_accepted[row_idx]
+                 ? INSPECT_ROW_TRUST_ACCEPTED : 0u));
+    }
+}
+
 static inline int serialize_inspect_snapshot_for_world(
     uint8_t *buf,
     const world_t *w,
-    const server_player_t *sp) {
+    server_player_t *sp) {
     if (!buf) return 0;
     if (!w || !sp || !sp->scan_active ||
         sp->scan_target_type == INSPECT_TARGET_NONE) {
@@ -6518,17 +6638,24 @@ static inline int serialize_inspect_snapshot_for_world(
         sp->scan_target_index < MAX_NPC_SHIPS) {
         const npc_ship_t *npc = &w->npc_ships[sp->scan_target_index];
         ship_t *ship = world_npc_ship_for((world_t *)w, sp->scan_target_index);
-        return serialize_inspect_snapshot_npc_with_station_receipts(
+        int len = serialize_inspect_snapshot_npc_with_station_receipts(
             buf, (uint8_t)sp->scan_target_index, npc, ship,
             w->stations, MAX_STATIONS);
+        inspect_snapshot_refresh_trust_cache(buf, len, w, sp, ship);
+        return len;
     }
 
     if (sp->scan_target_type == INSPECT_TARGET_PLAYER &&
         sp->scan_target_index >= 0 &&
         sp->scan_target_index < MAX_PLAYERS) {
-        return serialize_inspect_snapshot_player(
+        const server_player_t *target =
+            &w->players[sp->scan_target_index];
+        int len = serialize_inspect_snapshot_player(
             buf, (uint8_t)sp->scan_target_index,
-            &w->players[sp->scan_target_index]);
+            target);
+        inspect_snapshot_refresh_trust_cache(
+            buf, len, w, sp, target->ship);
+        return len;
     }
 
     return serialize_inspect_snapshot_target(buf, sp->scan_target_type,

--- a/server/sim_ai.c
+++ b/server/sim_ai.c
@@ -26,7 +26,7 @@
 #include "chain_log.h"
 #include "sha256.h"
 #include "station_authority.h"
-#include "cargo_legality.h"
+#include "cargo_receipt_trust.h"
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -845,6 +845,11 @@ static bool hauler_contract_matches_summary(const contract_t *ct,
                   sizeof(ct->required_parent)) == 0;
 }
 
+static const cargo_receipt_chain_t *npc_station_receipt_chain_at(
+    const station_t *station, uint16_t index);
+static const cargo_receipt_chain_t *npc_ship_receipt_chain_at(
+    const ship_t *ship, uint16_t index);
+
 static contract_t *hauler_pickup_contract_from_summary(
     world_t *w, const contract_summary_t *cs, const manifest_t *manifest) {
     if (!w || !cs || !manifest || !cs->active) return NULL;
@@ -889,6 +894,7 @@ static void npc_update_manifest_rarity_tint(npc_ship_t *npc, float dt) {
 }
 
 static int hauler_load_station_units_for_contract(world_t *w, int npc_slot,
+                                                  int source_station,
                                                   station_t *src, ship_t *dst,
                                                   const contract_t *contract,
                                                   int n) {
@@ -909,11 +915,16 @@ static int hauler_load_station_units_for_contract(world_t *w, int npc_slot,
         if (dst->manifest.count >= dst->manifest.cap) break;
         int idx = -1;
         for (uint16_t i = 0; i < src->manifest.count; i++) {
-            if (contract_fit_is_ok(contract_fit_cargo_unit(contract,
-                                                           &src->manifest.units[i]))) {
-                idx = (int)i;
-                break;
-            }
+            const cargo_unit_t *candidate = &src->manifest.units[i];
+            if (!contract_fit_is_ok(
+                    contract_fit_cargo_unit(contract, candidate))) continue;
+            cargo_receipt_station_evaluation_t evaluated =
+                cargo_receipt_evaluate_at_station(
+                    w, source_station, candidate,
+                    npc_station_receipt_chain_at(src, i));
+            if (!evaluated.accepted) continue;
+            idx = (int)i;
+            break;
         }
         if (idx < 0) break;
         cargo_unit_t unit = {0};
@@ -935,7 +946,8 @@ static int hauler_load_station_units_for_contract(world_t *w, int npc_slot,
 }
 
 static int hauler_unload_ship_units_for_contract(world_t *w, int npc_slot,
-                                                 ship_t *src, station_t *dst,
+                                                 ship_t *src, int dest_station,
+                                                 station_t *dst,
                                                  const contract_t *contract,
                                                  int n) {
     if (!w || !src || !dst || !contract || n <= 0) return 0;
@@ -953,11 +965,16 @@ static int hauler_unload_ship_units_for_contract(world_t *w, int npc_slot,
         if (dst->manifest.count >= dst->manifest.cap) break;
         int idx = -1;
         for (uint16_t i = 0; i < src->manifest.count; i++) {
-            if (contract_fit_is_ok(contract_fit_cargo_unit(contract,
-                                                           &src->manifest.units[i]))) {
-                idx = (int)i;
-                break;
-            }
+            const cargo_unit_t *candidate = &src->manifest.units[i];
+            if (!contract_fit_is_ok(
+                    contract_fit_cargo_unit(contract, candidate))) continue;
+            cargo_receipt_station_evaluation_t evaluated =
+                cargo_receipt_evaluate_at_station(
+                    w, dest_station, candidate,
+                    npc_ship_receipt_chain_at(src, i));
+            if (!evaluated.accepted) continue;
+            idx = (int)i;
+            break;
         }
         if (idx < 0) break;
         cargo_unit_t unit = {0};
@@ -4384,6 +4401,52 @@ static int npc_delivery_find_bound_ship_unit(const ship_t *ship,
     return -1;
 }
 
+static const cargo_receipt_chain_t *npc_station_receipt_chain_at(
+    const station_t *station, uint16_t index) {
+    const ship_receipts_t *receipts =
+        station_get_receipts_const(station);
+    if (!receipts || !receipts->chains || index >= receipts->count)
+        return NULL;
+    return &receipts->chains[index];
+}
+
+static const cargo_receipt_chain_t *npc_ship_receipt_chain_at(
+    const ship_t *ship, uint16_t index) {
+    const ship_receipts_t *receipts =
+        ship_get_receipts_const(ship);
+    if (!receipts || !receipts->chains || index >= receipts->count)
+        return NULL;
+    return &receipts->chains[index];
+}
+
+static bool npc_delivery_remaining_trusted_at_station(
+    const world_t *w, const ship_t *ship,
+    const delivery_shipment_t *shipment, int station_idx) {
+    if (!w || !ship || !shipment || station_idx < 0 ||
+        station_idx >= w->station_count || station_idx >= MAX_STATIONS) {
+        return false;
+    }
+    for (uint16_t cargo_idx = shipment->quantity_delivered;
+         cargo_idx < shipment->quantity_total; cargo_idx++) {
+        if (cargo_idx >= shipment->quantity_bound ||
+            cargo_idx >= MAX_DELIVERY_BOUND_CARGO) {
+            return false;
+        }
+        int manifest_idx = manifest_find(
+            &ship->manifest, shipment->cargo_pub[cargo_idx]);
+        if (manifest_idx < 0) return false;
+        const cargo_unit_t *unit = &ship->manifest.units[manifest_idx];
+        if (unit->commodity != shipment->commodity) return false;
+        cargo_receipt_station_evaluation_t evaluated =
+            cargo_receipt_evaluate_at_station(
+                w, station_idx, unit,
+                npc_ship_receipt_chain_at(
+                    ship, (uint16_t)manifest_idx));
+        if (!evaluated.accepted) return false;
+    }
+    return true;
+}
+
 static void npc_delivery_emit_receipt_memory(world_t *w,
                                              npc_ship_t *npc,
                                              station_t *dest,
@@ -4501,11 +4564,16 @@ static int npc_delivery_pickup_from_origin(world_t *w,
     while (moved < take && ship->manifest.count < ship->manifest.cap) {
         int idx = -1;
         for (uint16_t i = 0; i < origin->manifest.count; i++) {
-            if (contract_fit_is_ok(contract_fit_cargo_unit(
-                    ct, &origin->manifest.units[i]))) {
-                idx = (int)i;
-                break;
-            }
+            const cargo_unit_t *candidate = &origin->manifest.units[i];
+            if (!contract_fit_is_ok(
+                    contract_fit_cargo_unit(ct, candidate))) continue;
+            cargo_receipt_station_evaluation_t evaluated =
+                cargo_receipt_evaluate_at_station(
+                    w, ct->target_index, candidate,
+                    npc_station_receipt_chain_at(origin, i));
+            if (!evaluated.accepted) continue;
+            idx = (int)i;
+            break;
         }
         if (idx < 0) break;
         cargo_unit_t unit = {0};
@@ -4525,6 +4593,8 @@ static int npc_delivery_pickup_from_origin(world_t *w,
             break;
         }
         memcpy(shipment->cargo_pub[moved], unit.pub, 32);
+        shipment->cargo_units[moved] = unit;
+        shipment->cargo_chains[moved] = outgoing;
         moved++;
         float unit_debt = station_sell_price(origin, ct->commodity);
         if (unit_debt <= 0.0f)
@@ -4574,6 +4644,11 @@ static float npc_delivery_try_deliver_bound_cargo(world_t *w,
         uint16_t remaining = shipment->quantity_total > shipment->quantity_delivered
             ? (uint16_t)(shipment->quantity_total - shipment->quantity_delivered)
             : 0;
+        if (remaining == 0 ||
+            !npc_delivery_remaining_trusted_at_station(
+                w, ship, shipment, station_idx)) {
+            continue;
+        }
         float shipment_payout = 0.0f;
         while (remaining > 0 && dest->manifest.count < dest->manifest.cap) {
             int idx = npc_delivery_find_bound_ship_unit(ship, shipment, c);
@@ -5540,7 +5615,7 @@ static int npc_hauler_load_from_source(world_t *w,
     if (take_units <= 0) return 0;
     if (!hauler_ship) return 0;
     int moved = hauler_load_station_units_for_contract(
-        w, npc_slot, src, hauler_ship, ct, take_units);
+        w, npc_slot, source_station, src, hauler_ship, ct, take_units);
     if (moved > 0) {
         station_finished_sync(src, commodity);
         ship_finished_sync(hauler_ship, commodity);
@@ -5704,7 +5779,8 @@ static void step_hauler(world_t *w, npc_ship_t *npc, int n, float dt) {
                     int request = held < space_units ? held : space_units;
                     if (request > needed) request = needed;
                     int moved = hauler_unload_ship_units_for_contract(
-                        w, n, hauler_ship, dest, ct, request);
+                        w, n, hauler_ship, unload_station,
+                        dest, ct, request);
                     if (moved <= 0) continue;
                     station_finished_sync(dest, cargo);
                     ship_finished_sync(hauler_ship, cargo);

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -8,7 +8,7 @@
 #include "sim_asteroid.h"      /* fracture_claim_state_reset */
 #include "sim_construction.h"  /* module_build_material, module_build_cost */
 #include "manifest.h"
-#include "cargo_legality.h"
+#include "cargo_receipt_trust.h"
 #include "mining.h"            /* grade roll at smelt time */
 #include "fixpoint.h"
 #include "sha256.h"
@@ -1631,15 +1631,6 @@ void step_module_flow(world_t *w, float dt) {
 /* Module delivery (docked ship -> scaffold)                           */
 /* ------------------------------------------------------------------ */
 
-static int manifest_find_first_commodity(const manifest_t *manifest, commodity_t c) {
-    if (!manifest || !manifest->units) return -1;
-    for (uint16_t i = 0; i < manifest->count; i++) {
-        if (manifest->units[i].commodity == (uint8_t)c)
-            return (int)i;
-    }
-    return -1;
-}
-
 static const cargo_receipt_chain_t *production_ship_receipt_chain_at(
     const ship_t *ship, uint16_t index) {
     const ship_receipts_t *receipts = ship_get_receipts_const(ship);
@@ -1648,17 +1639,43 @@ static const cargo_receipt_chain_t *production_ship_receipt_chain_at(
     return &receipts->chains[index];
 }
 
-static bool ship_manifest_unit_legal_for_station(
+static const cargo_receipt_chain_t *production_station_receipt_chain_at(
+    const station_t *station, uint16_t index) {
+    const ship_receipts_t *receipts =
+        station_get_receipts_const(station);
+    if (!receipts || !receipts->chains || index >= receipts->count)
+        return NULL;
+    return &receipts->chains[index];
+}
+
+static int station_manifest_find_first_trusted_commodity(
+    const world_t *w, const station_t *station, int station_idx,
+    commodity_t commodity) {
+    if (!w || !station || !station->manifest.units) return -1;
+    for (uint16_t i = 0; i < station->manifest.count; i++) {
+        const cargo_unit_t *unit = &station->manifest.units[i];
+        if (unit->commodity != (uint8_t)commodity) continue;
+        cargo_receipt_station_evaluation_t evaluated =
+            cargo_receipt_evaluate_at_station(
+                w, station_idx, unit,
+                production_station_receipt_chain_at(station, i));
+        if (evaluated.accepted) return (int)i;
+    }
+    return -1;
+}
+
+static bool ship_manifest_unit_trusted_for_station(
     const world_t *w, const ship_t *ship, uint16_t index, int station_idx) {
     if (!w || !ship || !ship->manifest.units ||
         index >= ship->manifest.count ||
         station_idx < 0 || station_idx >= MAX_STATIONS) {
         return false;
     }
-    cargo_legality_result_t result = cargo_legality_classify(
-        w->stations, MAX_STATIONS, station_idx, &ship->manifest.units[index],
-        production_ship_receipt_chain_at(ship, index));
-    return result.status != CARGO_LEGALITY_CONTRABAND;
+    cargo_receipt_station_evaluation_t evaluated =
+        cargo_receipt_evaluate_at_station(
+            w, station_idx, &ship->manifest.units[index],
+            production_ship_receipt_chain_at(ship, index));
+    return evaluated.accepted;
 }
 
 static int ship_manifest_count_legal_commodity(const world_t *w,
@@ -1669,7 +1686,7 @@ static int ship_manifest_count_legal_commodity(const world_t *w,
     int count = 0;
     for (uint16_t i = 0; i < ship->manifest.count; i++) {
         if (ship->manifest.units[i].commodity != (uint8_t)c) continue;
-        if (!ship_manifest_unit_legal_for_station(w, ship, i, station_idx))
+        if (!ship_manifest_unit_trusted_for_station(w, ship, i, station_idx))
             continue;
         count++;
     }
@@ -1683,7 +1700,7 @@ static int ship_manifest_find_first_legal_commodity(const world_t *w,
     if (!ship || !ship->manifest.units) return -1;
     for (uint16_t i = 0; i < ship->manifest.count; i++) {
         if (ship->manifest.units[i].commodity != (uint8_t)c) continue;
-        if (!ship_manifest_unit_legal_for_station(w, ship, i, station_idx))
+        if (!ship_manifest_unit_trusted_for_station(w, ship, i, station_idx))
             continue;
         return (int)i;
     }
@@ -1750,7 +1767,8 @@ float step_module_delivery(world_t *w, station_t *st, int station_idx,
         if (needed < 0.01f) continue;
 
         int pod_units = ship
-            ? ship_towed_pods_manifest_count(w, ship, mat) : 0;
+            ? ship_towed_pods_trusted_manifest_count(
+                w, ship, mat, station_idx) : 0;
         if (pod_units > 0) {
             int whole = (int)ceilf(needed - 0.0001f);
             if (whole > pod_units) whole = pod_units;
@@ -1760,8 +1778,8 @@ float step_module_delivery(world_t *w, station_t *st, int station_idx,
                 int removed = 0;
                 while (removed < whole) {
                     cargo_unit_t unit = {0};
-                    if (!ship_towed_pods_take_manifest_unit(w, ship,
-                                                            mat, &unit)) {
+                    if (!ship_towed_pods_take_trusted_manifest_unit(
+                            w, ship, mat, station_idx, &unit)) {
                         break;
                     }
                     m->build_progress += 1.0f / cost;
@@ -1815,8 +1833,9 @@ float step_module_delivery(world_t *w, station_t *st, int station_idx,
             if (whole < 0) whole = 0;
             int removed = 0;
             while (removed < whole) {
-                int cargo_idx = manifest_find_first_commodity(
-                    &st->manifest, mat);
+                int cargo_idx =
+                    station_manifest_find_first_trusted_commodity(
+                        w, st, station_idx, mat);
                 if (cargo_idx < 0) break;
                 cargo_unit_t unit = {0};
                 if (!station_manifest_remove_with_chain(

--- a/shared/protocol.h
+++ b/shared/protocol.h
@@ -1105,7 +1105,15 @@ enum {
  * bit1 = row is a grouped bulk/finished-good row with no individual cargo
  * identity; bit2 = row is a diagnostic row, not cargo; bit3 = receipt chain
  * was retrieved from local station storage rather than carried cargo; bit4 =
- * receipt chain was retrieved from another local relay/custodian ship. */
+ * receipt chain was retrieved from another local relay/custodian ship.
+ *
+ * Server-authored trust metadata reuses previously reserved bits without
+ * changing the 142-byte row: flags bits5..7 hold trust-code bits0..2,
+ * the row's chain/prefix byte bit7 holds trust-code bit3, and bit6 is the
+ * station-policy acceptance bit. The low five bits remain the receipt-chain
+ * length (or grouped-row prefix class). Trust code zero means not evaluated;
+ * otherwise code-1 is cargo_receipt_trust_status_t. Clients only decode these
+ * bits and never send this stream. */
 enum {
     INSPECT_TARGET_NONE    = 0,
     INSPECT_TARGET_STATION = 1,
@@ -1121,7 +1129,22 @@ enum {
     INSPECT_ROW_DIAGNOSTIC    = 1 << 2,
     INSPECT_ROW_STATION_RECEIPT = 1 << 3,
     INSPECT_ROW_RELAY_RECEIPT   = 1 << 4,
+    INSPECT_ROW_TRUST_CODE_LOW_MASK = 0xE0,
+    INSPECT_ROW_CHAIN_VALUE_MASK = 0x1F,
+    INSPECT_ROW_TRUST_ACCEPTED = 1 << 6,
+    INSPECT_ROW_TRUST_CODE_HIGH = 1 << 7,
 };
+
+static inline uint8_t inspect_snapshot_trust_code(uint8_t chain_value,
+                                                   uint8_t flags) {
+    return (uint8_t)(((flags >> 5) & 0x07u) |
+                     ((chain_value & INSPECT_ROW_TRUST_CODE_HIGH)
+                          ? 0x08u : 0u));
+}
+
+static inline uint8_t inspect_snapshot_chain_value(uint8_t wire_value) {
+    return (uint8_t)(wire_value & INSPECT_ROW_CHAIN_VALUE_MASK);
+}
 
 typedef enum {
     INSPECT_DIAG_NONE = 0,

--- a/tests/c/test_construction.c
+++ b/tests/c/test_construction.c
@@ -536,7 +536,11 @@ TEST(test_module_delivery_emits_construction_chain_event) {
     cargo_unit_t unit = {0};
     unit.kind = CARGO_KIND_FRAME;
     unit.commodity = COMMODITY_FRAME;
-    unit.recipe_id = RECIPE_FRAME_BASIC;
+    /* This fixture bypasses the production/receipt pipeline on purpose; mark
+     * it as migrated legacy stock so the station applies its explicit
+     * unknown-provenance policy instead of treating it as forged modern
+     * cargo. */
+    unit.recipe_id = RECIPE_LEGACY_MIGRATE;
     for (int b = 0; b < 32; b++)
         unit.pub[b] = (uint8_t)(0xA0 + b);
     ASSERT(manifest_push(&ship.manifest, &unit));

--- a/tests/c/test_cross_station_settlement.c
+++ b/tests/c/test_cross_station_settlement.c
@@ -18,6 +18,7 @@
 
 #include "cargo_receipt.h"
 #include "cargo_receipt_issue.h"
+#include "cargo_receipt_trust.h"
 #include "chain_log.h"
 #include "handoff_flow.h"
 #include "handoff_ticket.h"
@@ -151,6 +152,32 @@ static bool crs_prepare_player_carrier(world_t *w,
     return ship_manifest_push_with_chain(sp->ship, &cu, chain);
 }
 
+static void crs_assert_cargo_store_equal(const cargo_store_t *actual,
+                                         const cargo_store_t *expected) {
+    ASSERT(actual != NULL);
+    ASSERT(expected != NULL);
+    ASSERT_EQ_INT(actual->manifest.count, expected->manifest.count);
+    ASSERT_EQ_INT(actual->manifest.cap, expected->manifest.cap);
+    if (actual->manifest.count > 0) {
+        ASSERT(memcmp(actual->manifest.units, expected->manifest.units,
+                      (size_t)actual->manifest.count *
+                          sizeof(actual->manifest.units[0])) == 0);
+    }
+    const ship_receipts_t *actual_receipts =
+        cargo_store_receipts_const(actual);
+    const ship_receipts_t *expected_receipts =
+        cargo_store_receipts_const(expected);
+    ASSERT_EQ_INT(actual_receipts != NULL, expected_receipts != NULL);
+    if (!actual_receipts || !expected_receipts) return;
+    ASSERT_EQ_INT(actual_receipts->count, expected_receipts->count);
+    ASSERT_EQ_INT(actual_receipts->cap, expected_receipts->cap);
+    if (actual_receipts->count > 0) {
+        ASSERT(memcmp(actual_receipts->chains, expected_receipts->chains,
+                      (size_t)actual_receipts->count *
+                          sizeof(actual_receipts->chains[0])) == 0);
+    }
+}
+
 static void crs_init_foreign_station(station_t *foreign) {
     memset(foreign, 0, sizeof(*foreign));
     snprintf(foreign->name, sizeof(foreign->name), "Foreign");
@@ -237,6 +264,13 @@ static cargo_receipt_origin_proof_t crs_origin_proof(
     memcpy(proof.authority, receipt->authoring_station, 32);
     return proof;
 }
+
+static bool crs_next_hop(world_t *w, station_t *dst,
+                         const uint8_t from_pk[32],
+                         const uint8_t cargo_pk[32],
+                         const cargo_receipt_t *incoming,
+                         uint8_t incoming_len,
+                         cargo_receipt_t *out);
 
 TEST(test_local_origin_resolver_distinguishes_history_states) {
     crs_setup("origin_resolver_states");
@@ -483,6 +517,185 @@ TEST(test_receipt_trust_preserves_cryptographic_chain_failure) {
     ASSERT_EQ_INT(result.status,
                   CARGO_RECEIPT_TRUST_REJECT_BAD_ARGUMENTS);
     ASSERT_EQ_INT(result.chain_result, CARGO_RECEIPT_OK);
+    crs_teardown();
+}
+
+static cargo_unit_t crs_test_ingot(const uint8_t cargo_pk[32]) {
+    cargo_unit_t unit = {
+        .kind = CARGO_KIND_INGOT,
+        .commodity = COMMODITY_FERRITE_INGOT,
+        .grade = MINING_GRADE_COMMON,
+        .recipe_id = RECIPE_SMELT,
+        .prefix_class = INGOT_PREFIX_M,
+        .quantity = 1,
+    };
+    memcpy(unit.pub, cargo_pk, sizeof(unit.pub));
+    return unit;
+}
+
+TEST(test_station_trust_evaluator_accepts_current_and_local_origin) {
+    crs_setup("station_eval_current_local");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL);
+    crs_world_init(w, 0xD105);
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0x15);
+    uint8_t remote_pub[32]; fill_test_pubkey(remote_pub, 0x45);
+    cargo_receipt_t receipt = {0};
+    ASSERT(crs_first_hop(w, &w->stations[2], player_pk,
+                         remote_pub, &receipt));
+    cargo_unit_t remote = crs_test_ingot(remote_pub);
+    cargo_receipt_chain_t remote_chain = {.len = 1};
+    remote_chain.links[0] = receipt;
+
+    cargo_receipt_station_evaluation_t evaluated =
+        cargo_receipt_evaluate_at_station(
+            w, 1, &remote, &remote_chain);
+    ASSERT(evaluated.accepted);
+    ASSERT(!evaluated.local_origin_without_receipt);
+    ASSERT_EQ_INT(evaluated.trust.status,
+                  CARGO_RECEIPT_TRUST_VALID_TRUSTED);
+    ASSERT_EQ_INT(evaluated.origin_status,
+                  CARGO_RECEIPT_ORIGIN_RESOLVE_VERIFIED);
+    ASSERT_EQ_INT(evaluated.origin_station, 2);
+
+    uint8_t local_pub[32]; fill_test_pubkey(local_pub, 0x75);
+    chain_payload_craft_t craft = {0};
+    craft.recipe_id = (uint16_t)RECIPE_FRAME_BASIC;
+    memcpy(craft.output_pub, local_pub, sizeof(craft.output_pub));
+    ASSERT(chain_log_emit(w, &w->stations[1], CHAIN_EVT_CRAFT,
+                          &craft, sizeof(craft)) >= 1);
+    cargo_unit_t local = crs_test_ingot(local_pub);
+    local.kind = CARGO_KIND_FRAME;
+    local.commodity = COMMODITY_FRAME;
+    local.recipe_id = RECIPE_FRAME_BASIC;
+    cargo_receipt_chain_t empty = {0};
+    evaluated = cargo_receipt_evaluate_at_station(w, 1, &local, &empty);
+    ASSERT(evaluated.accepted);
+    ASSERT(evaluated.local_origin_without_receipt);
+    ASSERT_EQ_INT(evaluated.trust.status,
+                  CARGO_RECEIPT_TRUST_VALID_TRUSTED);
+    ASSERT_EQ_INT(evaluated.origin_station, 1);
+
+    uint8_t missing_pub[32]; fill_test_pubkey(missing_pub, 0xA5);
+    cargo_unit_t missing = crs_test_ingot(missing_pub);
+    evaluated = cargo_receipt_evaluate_at_station(
+        w, 1, &missing, &empty);
+    ASSERT(!evaluated.accepted);
+    ASSERT_EQ_INT(evaluated.trust.status,
+                  CARGO_RECEIPT_TRUST_REJECT_MISSING_ORIGIN);
+    crs_teardown();
+}
+
+TEST(test_station_trust_evaluator_accepts_rotated_origin_key) {
+    crs_setup("station_eval_rotated");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL);
+    crs_world_init(w, 0xD106);
+    station_t historical = {0};
+    crs_init_foreign_station(&historical);
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0x16);
+    uint8_t cargo_pk[32]; fill_test_pubkey(cargo_pk, 0x46);
+    cargo_receipt_t receipt = {0};
+    ASSERT(crs_first_hop(w, &historical, player_pk, cargo_pk, &receipt));
+
+    station_t *owner = &w->stations[2];
+    ASSERT_EQ_INT(owner->authority_registry_count, 1);
+    memcpy(owner->authority_registry[1].pubkey,
+           historical.station_pubkey, 32);
+    owner->authority_registry[1].state =
+        STATION_AUTHORITY_TRUST_ROTATED;
+    owner->authority_registry_count = 2;
+    ASSERT(station_authority_registry_validate(owner));
+
+    cargo_unit_t unit = crs_test_ingot(cargo_pk);
+    cargo_receipt_chain_t chain = {.len = 1};
+    chain.links[0] = receipt;
+    cargo_receipt_station_evaluation_t evaluated =
+        cargo_receipt_evaluate_at_station(w, 1, &unit, &chain);
+    ASSERT(evaluated.accepted);
+    ASSERT_EQ_INT(evaluated.trust.status,
+                  CARGO_RECEIPT_TRUST_VALID_TRUSTED_ROTATED);
+    ASSERT_EQ_INT(evaluated.origin_station, 2);
+    crs_teardown();
+}
+
+TEST(test_station_trust_evaluator_applies_unknown_untrusted_and_revoked_policy) {
+    crs_setup("station_eval_policy");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL);
+    crs_world_init(w, 0xD107);
+    station_t foreign = {0};
+    crs_init_foreign_station(&foreign);
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0x17);
+    uint8_t cargo_pk[32]; fill_test_pubkey(cargo_pk, 0x47);
+    cargo_receipt_t receipt = {0};
+    ASSERT(crs_first_hop(w, &foreign, player_pk, cargo_pk, &receipt));
+    cargo_unit_t unit = crs_test_ingot(cargo_pk);
+    cargo_receipt_chain_t chain = {.len = 1};
+    chain.links[0] = receipt;
+
+    int viewer_idx = -1;
+    for (int i = 0; i < w->station_count; i++) {
+        if (!cargo_legality_station_tolerates_contraband(
+                &w->stations[i], i)) {
+            viewer_idx = i;
+            break;
+        }
+    }
+    ASSERT(viewer_idx >= 0);
+    station_t *viewer = &w->stations[viewer_idx];
+    bool screens = cargo_legality_station_screens(viewer, viewer_idx);
+
+    cargo_receipt_station_evaluation_t evaluated =
+        cargo_receipt_evaluate_at_station(
+            w, viewer_idx, &unit, &chain);
+    ASSERT_EQ_INT(evaluated.trust.status,
+                  CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY);
+    ASSERT_EQ_INT(evaluated.accepted, !screens);
+
+    ASSERT(station_authority_registry_set_trust(
+        viewer, foreign.station_pubkey,
+        CARGO_RECEIPT_AUTHORITY_UNTRUSTED));
+    evaluated = cargo_receipt_evaluate_at_station(
+        w, viewer_idx, &unit, &chain);
+    ASSERT(!evaluated.accepted);
+    ASSERT_EQ_INT(evaluated.trust.status,
+                  CARGO_RECEIPT_TRUST_REJECT_UNTRUSTED_AUTHORITY);
+
+    ASSERT(station_authority_registry_set_trust(
+        viewer, foreign.station_pubkey,
+        CARGO_RECEIPT_AUTHORITY_REVOKED));
+    evaluated = cargo_receipt_evaluate_at_station(
+        w, viewer_idx, &unit, &chain);
+    ASSERT(!evaluated.accepted);
+    ASSERT_EQ_INT(evaluated.trust.status,
+                  CARGO_RECEIPT_TRUST_REJECT_REVOKED_AUTHORITY);
+    crs_teardown();
+}
+
+TEST(test_station_trust_evaluator_rejects_revoked_intermediate_author) {
+    crs_setup("station_eval_revoked_intermediate");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL);
+    crs_world_init(w, 0xD108);
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0x18);
+    uint8_t cargo_pk[32]; fill_test_pubkey(cargo_pk, 0x48);
+    cargo_receipt_t first = {0};
+    cargo_receipt_t second = {0};
+    ASSERT(crs_first_hop(w, &w->stations[2], player_pk,
+                         cargo_pk, &first));
+    ASSERT(crs_next_hop(w, &w->stations[0], player_pk,
+                        cargo_pk, &first, 1, &second));
+    ASSERT(station_authority_registry_set_trust(
+        &w->stations[1], w->stations[0].station_pubkey,
+        CARGO_RECEIPT_AUTHORITY_REVOKED));
+
+    cargo_unit_t unit = crs_test_ingot(cargo_pk);
+    cargo_receipt_chain_t chain = {.len = 2};
+    chain.links[0] = first;
+    chain.links[1] = second;
+    cargo_receipt_station_evaluation_t evaluated =
+        cargo_receipt_evaluate_at_station(w, 1, &unit, &chain);
+    ASSERT(!evaluated.accepted);
+    ASSERT_EQ_INT(evaluated.first_rejected_link, 1);
+    ASSERT_EQ_INT(evaluated.trust.status,
+                  CARGO_RECEIPT_TRUST_REJECT_REVOKED_AUTHORITY);
     crs_teardown();
 }
 
@@ -850,7 +1063,7 @@ TEST(test_present_receipt_chain_to_carried_cargo) {
     ASSERT(crs_prepare_player_carrier(w, player_pk, cargo_pk, NULL));
 
     server_player_t *sp = &w->players[0];
-    ASSERT(cargo_receipt_present_to_ship(sp, cargo_pk, &r1, 1)
+    ASSERT(cargo_receipt_present_to_ship(w, 2, sp, cargo_pk, &r1, 1)
            == CARGO_RECEIPT_PRESENT_OK);
 
     ship_receipts_t *rcpts = ship_get_receipts(sp->ship);
@@ -873,6 +1086,8 @@ TEST(test_present_receipt_chain_dispatch_attaches) {
     cargo_receipt_t r1;
     ASSERT(crs_first_hop(w, &w->stations[2], player_pk, cargo_pk, &r1));
     ASSERT(crs_prepare_player_carrier(w, player_pk, cargo_pk, NULL));
+    w->players[0].docked = true;
+    w->players[0].current_station = 2;
 
     uint8_t msg[35 + CARGO_RECEIPT_SIZE];
     msg[0] = NET_MSG_PRESENT_RECEIPT_CHAIN;
@@ -922,8 +1137,19 @@ TEST(test_present_foreign_authority_receipt_chain) {
                                        &empty_chain, &r1) != 0);
     ASSERT(crs_prepare_player_carrier(w, player_pk, cargo_pk, NULL));
 
+    int evaluating_station = -1;
+    for (int i = 0; i < w->station_count; i++) {
+        if (!cargo_legality_station_screens(&w->stations[i], i) ||
+            cargo_legality_station_tolerates_contraband(
+                &w->stations[i], i)) {
+            evaluating_station = i;
+            break;
+        }
+    }
+    ASSERT(evaluating_station >= 0);
     server_player_t *sp = &w->players[0];
-    ASSERT(cargo_receipt_present_to_ship(sp, cargo_pk, &r1, 1)
+    ASSERT(cargo_receipt_present_to_ship(
+               w, evaluating_station, sp, cargo_pk, &r1, 1)
            == CARGO_RECEIPT_PRESENT_OK);
     ship_receipts_t *rcpts = ship_get_receipts(sp->ship);
     ASSERT(rcpts != NULL);
@@ -948,7 +1174,7 @@ TEST(test_present_receipt_chain_rejects_wrong_recipient) {
     ASSERT(crs_prepare_player_carrier(w, player_pk, cargo_pk, NULL));
 
     server_player_t *sp = &w->players[0];
-    ASSERT(cargo_receipt_present_to_ship(sp, cargo_pk, &r1, 1)
+    ASSERT(cargo_receipt_present_to_ship(w, 2, sp, cargo_pk, &r1, 1)
            == CARGO_RECEIPT_PRESENT_REJECT_RECIPIENT);
     ship_receipts_t *rcpts = ship_get_receipts(sp->ship);
     ASSERT(rcpts != NULL);
@@ -977,13 +1203,146 @@ TEST(test_present_receipt_chain_rejects_existing_mismatch) {
     ASSERT(crs_prepare_player_carrier(w, player_pk, cargo_pk, &existing));
 
     server_player_t *sp = &w->players[0];
-    ASSERT(cargo_receipt_present_to_ship(sp, cargo_pk, &alternate, 1)
+    ASSERT(cargo_receipt_present_to_ship(
+               w, 2, sp, cargo_pk, &alternate, 1)
            == CARGO_RECEIPT_PRESENT_REJECT_EXISTING_MISMATCH);
     ship_receipts_t *rcpts = ship_get_receipts(sp->ship);
     ASSERT(rcpts != NULL);
     ASSERT_EQ_INT((int)rcpts->chains[0].len, 1);
     ASSERT(memcmp(&rcpts->chains[0].links[0], &original, sizeof(original)) == 0);
 
+    crs_teardown();
+}
+
+TEST(test_present_receipt_chain_trust_rejection_is_transactionally_inert) {
+    crs_setup("present_trust_atomic");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL);
+    crs_world_init(w, 0xD020);
+
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0xA4);
+    uint8_t cargo_pk[32]; fill_test_pubkey(cargo_pk, 0xD4);
+    cargo_receipt_t receipt = {0};
+    ASSERT(crs_first_hop(w, &w->stations[2], player_pk,
+                         cargo_pk, &receipt));
+    ASSERT(crs_prepare_player_carrier(w, player_pk, cargo_pk, NULL));
+    ASSERT(station_authority_registry_set_trust(
+        &w->stations[1], w->stations[2].station_pubkey,
+        CARGO_RECEIPT_AUTHORITY_REVOKED));
+
+    cargo_store_t before = {0};
+    ASSERT(cargo_store_clone(
+        &before, &w->players[0].ship->cargo_store));
+    ASSERT_EQ_INT(
+        cargo_receipt_present_to_ship(
+            w, 1, &w->players[0], cargo_pk, &receipt, 1),
+        CARGO_RECEIPT_PRESENT_REJECT_TRUST);
+    crs_assert_cargo_store_equal(
+        &w->players[0].ship->cargo_store, &before);
+    cargo_store_cleanup(&before);
+    crs_teardown();
+}
+
+TEST(test_named_trade_trust_rejection_preserves_cargo_and_ledger) {
+    crs_setup("named_trade_trust_atomic");
+    WORLD_HEAP w = calloc(1, sizeof(world_t)); ASSERT(w != NULL);
+    crs_world_init(w, 0xD021);
+    uint8_t player_pk[32]; fill_test_pubkey(player_pk, 0xA5);
+    uint8_t buy_pub[32]; fill_test_pubkey(buy_pub, 0xD5);
+
+    server_player_t *sp = &w->players[0];
+    player_init_ship(sp, w);
+    sp->connected = true;
+    sp->pubkey_set = true;
+    sp->pubkey_proof_ok = true;
+    sp->pubkey_identity_finalized = true;
+    memcpy(sp->pubkey, player_pk, sizeof(sp->pubkey));
+    sp->docked = true;
+    sp->current_station = 1;
+    ASSERT(ship_manifest_bootstrap(sp->ship));
+
+    cargo_receipt_t buy_receipt = {0};
+    ASSERT(crs_first_hop(w, &w->stations[2],
+                         w->stations[1].station_pubkey,
+                         buy_pub, &buy_receipt));
+    cargo_receipt_chain_t buy_chain = {.len = 1};
+    buy_chain.links[0] = buy_receipt;
+    cargo_unit_t buy_unit = crs_test_ingot(buy_pub);
+    ASSERT(station_manifest_push_with_chain(
+        &w->stations[1], &buy_unit, &buy_chain));
+    ledger_earn_by_pubkey(&w->stations[1], player_pk, 10000.0f);
+    ASSERT(station_authority_registry_set_trust(
+        &w->stations[1], w->stations[2].station_pubkey,
+        CARGO_RECEIPT_AUTHORITY_REVOKED));
+
+    cargo_store_t station_before = {0};
+    cargo_store_t ship_before = {0};
+    ASSERT(cargo_store_clone(
+        &station_before, &w->stations[1].cargo_store));
+    ASSERT(cargo_store_clone(&ship_before, &sp->ship->cargo_store));
+    float balance_before =
+        ledger_balance_by_pubkey(&w->stations[1], player_pk);
+    server_signed_action_dispatch_result_t dispatch = {0};
+    ASSERT(server_dispatch_signed_action_payload(
+        w, 0, SIGNED_ACTION_BUY_INGOT, buy_pub, sizeof(buy_pub),
+        NULL, NULL, &dispatch));
+    crs_assert_cargo_store_equal(
+        &w->stations[1].cargo_store, &station_before);
+    crs_assert_cargo_store_equal(&sp->ship->cargo_store, &ship_before);
+    ASSERT_EQ_FLOAT(
+        ledger_balance_by_pubkey(&w->stations[1], player_pk),
+        balance_before, 0.001f);
+    cargo_store_cleanup(&station_before);
+    cargo_store_cleanup(&ship_before);
+
+    /* Use a fresh world because revoked lifecycle state is monotonic. */
+    crs_teardown();
+    crs_setup("named_deliver_trust_atomic");
+    WORLD_HEAP delivery_world = calloc(1, sizeof(world_t));
+    ASSERT(delivery_world != NULL);
+    crs_world_init(delivery_world, 0xD022);
+    uint8_t deliver_pub[32]; fill_test_pubkey(deliver_pub, 0xE5);
+    cargo_receipt_t deliver_receipt = {0};
+    ASSERT(crs_first_hop(
+        delivery_world, &delivery_world->stations[2],
+        player_pk, deliver_pub, &deliver_receipt));
+    cargo_receipt_chain_t deliver_chain = {.len = 1};
+    deliver_chain.links[0] = deliver_receipt;
+    ASSERT(crs_prepare_player_carrier(
+        delivery_world, player_pk, deliver_pub, &deliver_chain));
+    server_player_t *deliverer = &delivery_world->players[0];
+    deliverer->pubkey_proof_ok = true;
+    deliverer->pubkey_identity_finalized = true;
+    deliverer->docked = true;
+    deliverer->current_station = 1;
+    ASSERT(station_manifest_bootstrap(&delivery_world->stations[1]));
+    ASSERT(station_authority_registry_set_trust(
+        &delivery_world->stations[1],
+        delivery_world->stations[2].station_pubkey,
+        CARGO_RECEIPT_AUTHORITY_REVOKED));
+
+    station_before = (cargo_store_t){0};
+    ship_before = (cargo_store_t){0};
+    ASSERT(cargo_store_clone(
+        &station_before,
+        &delivery_world->stations[1].cargo_store));
+    ASSERT(cargo_store_clone(
+        &ship_before, &deliverer->ship->cargo_store));
+    balance_before = ledger_balance_by_pubkey(
+        &delivery_world->stations[1], player_pk);
+    uint8_t target = 0;
+    ASSERT(server_dispatch_signed_action_payload(
+        delivery_world, 0, SIGNED_ACTION_DELIVER,
+        &target, sizeof(target), NULL, NULL, &dispatch));
+    crs_assert_cargo_store_equal(
+        &delivery_world->stations[1].cargo_store, &station_before);
+    crs_assert_cargo_store_equal(
+        &deliverer->ship->cargo_store, &ship_before);
+    ASSERT_EQ_FLOAT(
+        ledger_balance_by_pubkey(
+            &delivery_world->stations[1], player_pk),
+        balance_before, 0.001f);
+    cargo_store_cleanup(&station_before);
+    cargo_store_cleanup(&ship_before);
     crs_teardown();
 }
 
@@ -1410,6 +1769,10 @@ void register_cross_station_settlement_tests(void) {
     RUN(test_receipt_trust_distinguishes_origin_proof_failures);
     RUN(test_receipt_trust_distinguishes_authority_policy);
     RUN(test_receipt_trust_preserves_cryptographic_chain_failure);
+    RUN(test_station_trust_evaluator_accepts_current_and_local_origin);
+    RUN(test_station_trust_evaluator_accepts_rotated_origin_key);
+    RUN(test_station_trust_evaluator_applies_unknown_untrusted_and_revoked_policy);
+    RUN(test_station_trust_evaluator_rejects_revoked_intermediate_author);
     RUN(test_local_origin_resolver_distinguishes_history_states);
     RUN(test_cross_station_two_hop_chain);
     RUN(test_cross_station_forged_receipt_rejected);
@@ -1424,6 +1787,8 @@ void register_cross_station_settlement_tests(void) {
     RUN(test_present_foreign_authority_receipt_chain);
     RUN(test_present_receipt_chain_rejects_wrong_recipient);
     RUN(test_present_receipt_chain_rejects_existing_mismatch);
+    RUN(test_present_receipt_chain_trust_rejection_is_transactionally_inert);
+    RUN(test_named_trade_trust_rejection_preserves_cargo_and_ledger);
     RUN(test_handoff_ticket_roundtrip_verifies_ship_and_cargo);
     RUN(test_handoff_ticket_rejects_tampered_ship_state);
     RUN(test_handoff_ticket_rejects_tampered_cargo_root);

--- a/tests/c/test_econ_sim.c
+++ b/tests/c/test_econ_sim.c
@@ -874,6 +874,7 @@ static float run_sell_with_grades(int g0, int g1, int g2,
         units[i].kind = CARGO_KIND_INGOT;
         units[i].grade = (uint8_t)grades[i];
         units[i].prefix_class = (uint8_t)INGOT_PREFIX_ANONYMOUS;
+        units[i].recipe_id = RECIPE_LEGACY_MIGRATE;
         units[i].pub[0] = (uint8_t)(i + 1);
     }
     int pod_idx = spawn_cargo_pod_with_manifest(

--- a/tests/c/test_economy.c
+++ b/tests/c/test_economy.c
@@ -737,6 +737,14 @@ TEST(test_contract_delivery_requires_heritage_recipe) {
 
     w.cargo_pods[pod_idx].manifest_units[0].recipe_id =
         (uint16_t)RECIPE_FRAME_BASIC;
+    w.cargo_pods[pod_idx].manifest_units[0].origin_station = 1;
+    chain_payload_craft_t craft = {0};
+    craft.recipe_id = (uint16_t)RECIPE_FRAME_BASIC;
+    memcpy(craft.output_pub,
+           w.cargo_pods[pod_idx].manifest_units[0].pub,
+           sizeof(craft.output_pub));
+    ASSERT(chain_log_emit(&w, &w.stations[1], CHAIN_EVT_CRAFT,
+                          &craft, sizeof(craft)) != 0);
     world_sim_step(&w, SIM_DT);
 
     ASSERT_EQ_INT(w.players[0].ship->towed_pod_count, 0);
@@ -757,6 +765,12 @@ TEST(test_contract_delivery_bans_enemy_origin_station) {
     cargo_unit_t *unit = &w.cargo_pods[pod_idx].manifest_units[0];
     unit->recipe_id = (uint16_t)RECIPE_FRAME_BASIC;
     unit->origin_station = 2;
+    chain_payload_craft_t enemy_craft = {0};
+    enemy_craft.recipe_id = (uint16_t)RECIPE_FRAME_BASIC;
+    memcpy(enemy_craft.output_pub, unit->pub,
+           sizeof(enemy_craft.output_pub));
+    ASSERT(chain_log_emit(&w, &w.stations[2], CHAIN_EVT_CRAFT,
+                          &enemy_craft, sizeof(enemy_craft)) != 0);
 
     w.contracts[0] = (contract_t){
         .active = true,
@@ -784,6 +798,12 @@ TEST(test_contract_delivery_bans_enemy_origin_station) {
 
     unit = &w.cargo_pods[pod_idx].manifest_units[0];
     unit->origin_station = 1;
+    chain_payload_craft_t local_craft = {0};
+    local_craft.recipe_id = (uint16_t)RECIPE_FRAME_BASIC;
+    memcpy(local_craft.output_pub, unit->pub,
+           sizeof(local_craft.output_pub));
+    ASSERT(chain_log_emit(&w, &w.stations[1], CHAIN_EVT_CRAFT,
+                          &local_craft, sizeof(local_craft)) != 0);
     world_sim_step(&w, SIM_DT);
 
     ASSERT_EQ_INT(w.players[0].ship->towed_pod_count, 0);

--- a/tests/c/test_protocol.c
+++ b/tests/c/test_protocol.c
@@ -1,7 +1,6 @@
 #include "test_harness.h"
 #include "cargo_receipt_issue.h"
 #include "station_authority.h"
-#include "cargo_receipt_issue.h"
 #include "faction.h"
 #include "station_policy.h"
 #include "wire_codec.h"
@@ -5939,6 +5938,71 @@ TEST(test_roundtrip_inspect_snapshot_player_manifest_chain) {
     ship_cleanup(player.ship);
 }
 
+TEST(test_inspect_snapshot_exposes_server_authored_station_trust_verdict) {
+    WORLD_DECL;
+    w.rng = 0xD141u;
+    world_reset(&w);
+    for (int station = 0; station < 3; station++)
+        chain_log_reset(&w.stations[station]);
+
+    server_player_t *scanner = &w.players[0];
+    server_player_t *target = &w.players[1];
+    scanner->connected = true;
+    scanner->docked = true;
+    scanner->current_station = 1;
+    scanner->nearby_station = 1;
+    scanner->scan_active = true;
+    scanner->scan_target_type = INSPECT_TARGET_PLAYER;
+    scanner->scan_target_index = 1;
+    target->connected = true;
+    target->id = 1;
+    target->pubkey_set = true;
+    for (int i = 0; i < 32; i++)
+        target->pubkey[i] = (uint8_t)(0x70 + i);
+
+    uint8_t fragment_pub[32] = {0};
+    fragment_pub[0] = 0xA1;
+    cargo_unit_t unit = {0};
+    ASSERT(hash_ingot(COMMODITY_FERRITE_INGOT, MINING_GRADE_RARE,
+                      fragment_pub, 41, &unit));
+    unit.prefix_class = (uint8_t)INGOT_PREFIX_H;
+    unit.origin_station = 2;
+
+    station_t *origin = &w.stations[2];
+    chain_payload_smelt_t smelt = {0};
+    memcpy(smelt.ingot_pub, unit.pub, sizeof(smelt.ingot_pub));
+    ASSERT(chain_log_emit(&w, origin, CHAIN_EVT_SMELT,
+                          &smelt, sizeof(smelt)) >= 1);
+    cargo_receipt_chain_t chain = {0};
+    ASSERT(cargo_receipt_emit_transfer(
+               &w, origin, origin->station_pubkey, target->pubkey,
+               unit.pub, (uint8_t)CARGO_KIND_INGOT, &chain,
+               &chain.links[0]) >= 1);
+    chain.len = 1;
+    ASSERT(ship_manifest_push_with_chain(target->ship, &unit, &chain));
+
+    uint8_t buf[INSPECT_SNAPSHOT_MAX_SIZE] = {0};
+    int len = serialize_inspect_snapshot_for_world(buf, &w, scanner);
+    ASSERT_EQ_INT(len, INSPECT_SNAPSHOT_HEADER + INSPECT_SNAPSHOT_ROW);
+    uint8_t *row = &buf[INSPECT_SNAPSHOT_HEADER];
+    ASSERT_EQ_INT(inspect_snapshot_chain_value(row[2]), 1);
+    ASSERT_EQ_INT(inspect_snapshot_trust_code(row[2], row[3]),
+                  CARGO_RECEIPT_TRUST_VALID_TRUSTED + 1);
+    ASSERT(row[2] & INSPECT_ROW_TRUST_ACCEPTED);
+
+    ASSERT(station_authority_registry_set_trust(
+        &w.stations[1], origin->station_pubkey,
+        CARGO_RECEIPT_AUTHORITY_REVOKED));
+    w.tick += 120u;
+    len = serialize_inspect_snapshot_for_world(buf, &w, scanner);
+    ASSERT_EQ_INT(len, INSPECT_SNAPSHOT_HEADER + INSPECT_SNAPSHOT_ROW);
+    row = &buf[INSPECT_SNAPSHOT_HEADER];
+    ASSERT_EQ_INT(inspect_snapshot_chain_value(row[2]), 1);
+    ASSERT_EQ_INT(inspect_snapshot_trust_code(row[2], row[3]),
+                  CARGO_RECEIPT_TRUST_REJECT_REVOKED_AUTHORITY + 1);
+    ASSERT(!(row[2] & INSPECT_ROW_TRUST_ACCEPTED));
+}
+
 TEST(test_inspect_snapshot_npc_includes_market_memory_diagnostics) {
     npc_ship_t npc;
     ship_t npc_ship = {0};
@@ -8889,6 +8953,7 @@ void register_protocol_main_tests(void) {
     RUN(test_inspect_snapshot_npc_expands_matching_receipt_chain);
     RUN(test_inspect_snapshot_npc_retrieves_matching_station_receipt_chain);
     RUN(test_roundtrip_inspect_snapshot_player_manifest_chain);
+    RUN(test_inspect_snapshot_exposes_server_authored_station_trust_verdict);
     RUN(test_inspect_snapshot_npc_includes_market_memory_diagnostics);
     RUN(test_inspect_snapshot_npc_expands_matching_job_source_memory);
     RUN(test_inspect_snapshot_npc_includes_job_offer_diagnostics);

--- a/tests/c/test_save.c
+++ b/tests/c/test_save.c
@@ -4,18 +4,23 @@
 #include "faction.h"
 #include <stddef.h>
 
-static bool test_issue_station_receipt(station_t *st, const uint8_t cargo_pub[32],
+static bool test_issue_station_receipt(world_t *w, station_t *st,
+                                       const uint8_t cargo_pub[32],
                                        uint64_t event_id,
                                        cargo_receipt_chain_t *out_chain) {
     uint8_t recipient[32];
-    uint8_t origin_pin[32];
     for (int i = 0; i < 32; i++) {
         recipient[i] = (uint8_t)(0x30 + i);
-        origin_pin[i] = (uint8_t)(0x90 + i);
+    }
+    chain_payload_smelt_t smelt = {0};
+    memcpy(smelt.ingot_pub, cargo_pub, sizeof(smelt.ingot_pub));
+    if (chain_log_emit(w, st, CHAIN_EVT_SMELT,
+                       &smelt, sizeof(smelt)) == 0) {
+        return false;
     }
     memset(out_chain, 0, sizeof(*out_chain));
     if (!cargo_receipt_issue(st, 1, event_id, cargo_pub, recipient,
-                             origin_pin, &out_chain->links[0])) {
+                             st->chain_last_hash, &out_chain->links[0])) {
         return false;
     }
     out_chain->len = 1;
@@ -1011,7 +1016,8 @@ TEST(test_world_save_round_trips_station_manifest) {
     unit.pub[0] = 0xA5;
     unit.pub[31] = 0x5A;
     cargo_receipt_chain_t chain = {0};
-    ASSERT(test_issue_station_receipt(&w.stations[0], unit.pub, 4242, &chain));
+    ASSERT(test_issue_station_receipt(
+        &w, &w.stations[0], unit.pub, 4242, &chain));
     ASSERT(station_manifest_push_with_chain(&w.stations[0], &unit, &chain));
     ASSERT_EQ_INT(w.stations[0].manifest.count, 1);
     ASSERT(world_save(&w, TMP("test_manifest_roundtrip.sav")));
@@ -1601,7 +1607,7 @@ TEST(test_world_save_load_preserves_hauler_manifest_cargo) {
         fragment_pub[31] = (uint8_t)(0x60 + i);
         ASSERT(hash_ingot(COMMODITY_FERRITE_INGOT, MINING_GRADE_RARE,
                           fragment_pub, (uint16_t)i, &units[i]));
-        ASSERT(test_issue_station_receipt(home, units[i].pub,
+        ASSERT(test_issue_station_receipt(w, home, units[i].pub,
                                           (uint64_t)(900 + i), &chains[i]));
         ASSERT(station_manifest_push_with_chain(home, &units[i], &chains[i]));
     }

--- a/tests/c/test_world_sim.c
+++ b/tests/c/test_world_sim.c
@@ -304,19 +304,24 @@ static bool test_view_has_market_memory(const knowledge_view_t *view,
     return false;
 }
 
-static bool test_issue_world_station_receipt(station_t *st,
+static bool test_issue_world_station_receipt(world_t *w,
+                                             station_t *st,
                                              const uint8_t cargo_pub[32],
                                              uint64_t event_id,
                                              cargo_receipt_chain_t *out_chain) {
     uint8_t recipient[32];
-    uint8_t origin_pin[32];
     for (int i = 0; i < 32; i++) {
         recipient[i] = (uint8_t)(0x50 + i);
-        origin_pin[i] = (uint8_t)(0xA0 + i);
+    }
+    chain_payload_smelt_t smelt = {0};
+    memcpy(smelt.ingot_pub, cargo_pub, sizeof(smelt.ingot_pub));
+    if (chain_log_emit(w, st, CHAIN_EVT_SMELT,
+                       &smelt, sizeof(smelt)) == 0) {
+        return false;
     }
     memset(out_chain, 0, sizeof(*out_chain));
     if (!cargo_receipt_issue(st, 1, event_id, cargo_pub, recipient,
-                             origin_pin, &out_chain->links[0])) {
+                             st->chain_last_hash, &out_chain->links[0])) {
         return false;
     }
     out_chain->len = 1;
@@ -1182,6 +1187,9 @@ TEST(test_towed_shell_pod_keeps_shell_after_intake_custody_sale) {
     fragment_pub[31] = 0x5a;
     ASSERT(hash_ingot(COMMODITY_FERRITE_INGOT, MINING_GRADE_FINE,
                       fragment_pub, 0, &ingot));
+    /* This shell-custody fixture bypasses smelting; classify the synthetic
+     * ingot as migrated stock so the test remains about physical custody. */
+    ingot.recipe_id = RECIPE_LEGACY_MIGRATE;
     ASSERT(hash_legacy_migrate_unit(shell_origin, COMMODITY_FRAME, 0,
                                     &shell));
 
@@ -2934,7 +2942,7 @@ TEST(test_hauler_preserves_cargo_identity_in_transit) {
         fragment_pub[31] = (uint8_t)(0x40 + i);
         ASSERT(hash_ingot(COMMODITY_FERRITE_INGOT, MINING_GRADE_RARE,
                           fragment_pub, (uint16_t)i, &units[i]));
-        ASSERT(test_issue_world_station_receipt(home, units[i].pub,
+        ASSERT(test_issue_world_station_receipt(&w, home, units[i].pub,
                                                 (uint64_t)(700 + i),
                                                 &chains[i]));
         ASSERT(station_manifest_push_with_chain(home, &units[i], &chains[i]));
@@ -3116,7 +3124,8 @@ TEST(test_black_market_contract_accepts_npc_module_delivery) {
     ASSERT(hash_legacy_migrate_unit(origin, COMMODITY_TRACTOR_MODULE, 0,
                                     &unit));
     cargo_receipt_chain_t chain = {0};
-    ASSERT(test_issue_world_station_receipt(home, unit.pub, 910, &chain));
+    ASSERT(test_issue_world_station_receipt(
+        &w, home, unit.pub, 910, &chain));
     ASSERT(ship_manifest_push_with_chain(hauler_ship, &unit, &chain));
 
     w.contracts[0] = (contract_t){
@@ -4210,6 +4219,11 @@ TEST(test_frame_press_accepts_player_towed_ingot_pod_at_press) {
     memset(w.cargo_pods, 0, sizeof(w.cargo_pods));
     ASSERT(hash_ingot(COMMODITY_FERRITE_INGOT, MINING_GRADE_FINE,
                       fragment_a, 0, &input));
+    input.origin_station = 1;
+    chain_payload_smelt_t smelt = {0};
+    memcpy(smelt.ingot_pub, input.pub, sizeof(smelt.ingot_pub));
+    ASSERT(chain_log_emit(&w, st, CHAIN_EVT_SMELT,
+                          &smelt, sizeof(smelt)) != 0);
 
     vec2 press_pos = module_world_pos_ring(
         st, st->modules[press_idx].ring, st->modules[press_idx].slot);
@@ -4274,6 +4288,11 @@ TEST(test_station_hopper_accepts_player_towed_ingot_pod) {
 
     ASSERT(hash_ingot(COMMODITY_FERRITE_INGOT, MINING_GRADE_FINE,
                       fragment_a, 0, &input));
+    input.origin_station = 1;
+    chain_payload_smelt_t smelt = {0};
+    memcpy(smelt.ingot_pub, input.pub, sizeof(smelt.ingot_pub));
+    ASSERT(chain_log_emit(&w, st, CHAIN_EVT_SMELT,
+                          &smelt, sizeof(smelt)) != 0);
     ASSERT(station_finished_mint(st, COMMODITY_FRAME, 1, NULL) == 1);
 
     vec2 ferrite_hopper_pos = st->pos;


### PR DESCRIPTION
## Summary

- compose cryptographic receipt verification, exact signed origin, authority lifecycle, and station policy in one read-only evaluator
- gate named trading, receipt presentation, contract cargo, construction/module inputs, pod intake, and NPC transfers before mutation
- expose server-authored inspection verdicts without changing the inspect-row wire size
- preserve explicit legacy migration semantics and register tow-founded outposts in authority range

## Validation

- `./build-test/signal_test --fast` — 1,234/1,234 passed
- ASan/UBSan `./build-san/signal_test --quiet --no-soak` — 1,234/1,234 passed
- `python3 scripts/check_deterministic_build_flags.py build-test/compile_commands.json`
- `python3 scripts/check_replay_repeatability.py ./build-test/signal_replay` — 20 fast scenarios
- `git diff --cached --check`

Closes #641
