### PR TITLE
Gate settlement imports on cargo trust

### DIFF
--- a/docs/settlement-event-model.md
+++ b/docs/settlement-event-model.md
@@ -200,7 +200,7 @@ typedef struct {
     uint8_t  kind;
     uint8_t  direction;   /* 0 = BUY (station→player), 1 = SELL (player→station) */
     uint8_t  _pad[6];
-} settlement_payload_trade_t;  /* 144 bytes */
+} settlement_payload_trade_t;  /* 112 bytes */
 ```
 
 ### ISSUE_CREDIT_NOTE (0x12) / REDEEM_CREDIT_NOTE (0x13)
@@ -241,7 +241,7 @@ Input cargo consumed to advance scaffold build progress.
 typedef struct {
     uint8_t  scaffold_id[32];
     uint8_t  station_pubkey[32];
-    uint8_t  input_pubs[4][32];
+    uint8_t  input_pubs[3][32];
     uint8_t  input_count;
     uint8_t  module_type;
     uint8_t  ring;

--- a/shared/settlement_engine.c
+++ b/shared/settlement_engine.c
@@ -4,6 +4,20 @@
 #include <string.h>
 #include <stdlib.h>
 
+enum {
+    SETTL_EVT_TRANSFER_CARGO = 0x04,
+    SETTL_EVT_SELL = 0x11,
+    SETTL_EVT_DELIVER_CONSTRUCTION_INPUT = 0x21,
+    SETTL_TRANSFER_PAYLOAD_SIZE = 144,
+    SETTL_TRADE_PAYLOAD_SIZE = 112,
+    SETTL_TRADE_DIRECTION_OFFSET = 105,
+    SETTL_MAX_CONSTRUCTION_INPUTS = 3,
+    SETTL_CONSTRUCTION_INPUT_COUNT_OFFSET =
+        32 + 32 + SETTL_MAX_CONSTRUCTION_INPUTS * 32,
+    SETTL_CONSTRUCTION_INPUT_PAYLOAD_SIZE =
+        SETTL_CONSTRUCTION_INPUT_COUNT_OFFSET + 8
+};
+
 static int cmp_u8_32(const void *a, const void *b) {
     return memcmp(a, b, 32);
 }
@@ -30,6 +44,39 @@ static int find_ledger_entry(const settl_ledger_entry_t *ledger,
 
 void settlement_state_init(settlement_state_t *s) {
     memset(s, 0, sizeof(*s));
+}
+
+const char *settlement_import_status_name(settlement_import_status_t status) {
+    switch (status) {
+    case SETTL_IMPORT_OK: return "ok";
+    case SETTL_IMPORT_REJECT_BAD_ARGUMENTS: return "reject_bad_arguments";
+    case SETTL_IMPORT_REJECT_PAYLOAD_HASH: return "reject_payload_hash";
+    case SETTL_IMPORT_REJECT_MISSING_EVIDENCE: return "reject_missing_evidence";
+    case SETTL_IMPORT_REJECT_EVIDENCE_COUNT: return "reject_evidence_count";
+    case SETTL_IMPORT_REJECT_EVIDENCE_EVENT: return "reject_evidence_event";
+    case SETTL_IMPORT_REJECT_EVIDENCE_CARGO: return "reject_evidence_cargo";
+    case SETTL_IMPORT_REJECT_TRUST_BAD_ARGUMENTS:
+        return "reject_trust_bad_arguments";
+    case SETTL_IMPORT_REJECT_TRUST_CHAIN: return "reject_trust_chain";
+    case SETTL_IMPORT_REJECT_TRUST_MISSING_ORIGIN:
+        return "reject_trust_missing_origin";
+    case SETTL_IMPORT_REJECT_TRUST_ORIGIN_EVENT_TYPE:
+        return "reject_trust_origin_event_type";
+    case SETTL_IMPORT_REJECT_TRUST_ORIGIN_CARGO:
+        return "reject_trust_origin_cargo";
+    case SETTL_IMPORT_REJECT_TRUST_ORIGIN_PIN:
+        return "reject_trust_origin_pin";
+    case SETTL_IMPORT_REJECT_TRUST_ORIGIN_AUTHORITY:
+        return "reject_trust_origin_authority";
+    case SETTL_IMPORT_REJECT_TRUST_UNKNOWN_AUTHORITY:
+        return "reject_trust_unknown_authority";
+    case SETTL_IMPORT_REJECT_TRUST_UNTRUSTED_AUTHORITY:
+        return "reject_trust_untrusted_authority";
+    case SETTL_IMPORT_REJECT_TRUST_REVOKED_AUTHORITY:
+        return "reject_trust_revoked_authority";
+    case SETTL_IMPORT_REJECT_EVENT: return "reject_event";
+    default: return "unknown";
+    }
 }
 
 /* ---- state root ---- */
@@ -110,11 +157,28 @@ void settlement_compute_root(const settlement_state_t *s, uint8_t root_out[32]) 
 
 /* ---- event application ---- */
 
-bool settlement_apply_event(settlement_state_t *s,
-                            const void *hdr_arg,
-                            const uint8_t *payload,
-                            uint16_t payload_len) {
+static bool settlement_payload_hash_matches(const chain_event_header_t *hdr,
+                                            const uint8_t *payload,
+                                            uint16_t payload_len) {
+    if (!hdr || !payload) return false;
+    uint8_t hash[32];
+    sha256_bytes(payload, payload_len, hash);
+    return memcmp(hash, hdr->payload_hash, sizeof(hash)) == 0;
+}
+
+static bool settlement_event_requires_trust(uint8_t type) {
+    return type == SETTL_EVT_TRANSFER_CARGO ||
+           type == SETTL_EVT_SELL ||
+           type == SETTL_EVT_DELIVER_CONSTRUCTION_INPUT;
+}
+
+static bool settlement_apply_event_preflighted(settlement_state_t *s,
+                                               const void *hdr_arg,
+                                               const uint8_t *payload,
+                                               uint16_t payload_len) {
     const chain_event_header_t *hdr = (const chain_event_header_t *)hdr_arg;
+    if (!s || !settlement_payload_hash_matches(hdr, payload, payload_len))
+        return false;
     int st = 0; /* single-station for now — extended in multi-station world */
     cargo_unit_t *manifest = s->station_manifests[st];
     uint16_t *mc = &s->station_manifest_counts[st];
@@ -178,8 +242,8 @@ bool settlement_apply_event(settlement_state_t *s,
         return true;
     }
 
-    case 0x04: { /* TRANSFER_CARGO */
-        if (payload_len < 96) return false;
+    case SETTL_EVT_TRANSFER_CARGO: { /* TRANSFER_CARGO */
+        if (payload_len < SETTL_TRANSFER_PAYLOAD_SIZE) return false;
         int idx = find_manifest_unit(manifest, *mc, payload);
         if (idx < 0) return false;
         cargo_unit_t unit = manifest[idx];
@@ -191,11 +255,14 @@ bool settlement_apply_event(settlement_state_t *s,
     }
 
     case 0x10: /* BUY */
-    case 0x11: { /* SELL */
-        if (payload_len < 112) return false;
+    case SETTL_EVT_SELL: { /* SELL */
+        if (payload_len < SETTL_TRADE_PAYLOAD_SIZE) return false;
         int64_t delta;
         memcpy(&delta, payload + 96, 8);
-        uint8_t dir = payload[104];
+        uint8_t dir = payload[SETTL_TRADE_DIRECTION_OFFSET];
+        if ((hdr->type == 0x10 && dir != 0) ||
+            (hdr->type == SETTL_EVT_SELL && dir != 1))
+            return false;
 
         if (dir == 0) { /* BUY: station→player, remove from manifest */
             int idx = find_manifest_unit(manifest, *mc, payload);
@@ -259,16 +326,44 @@ bool settlement_apply_event(settlement_state_t *s,
         return true;
     }
 
-    case 0x21: { /* DELIVER_CONSTRUCTION_INPUT */
-        if (payload_len < 168) return false;
-        for (uint16_t i = 0; i < s->construction_site_count; i++)
-            if (memcmp(s->construction_sites[i].scaffold_id, payload, 32) == 0) {
-                s->construction_sites[i].build_progress += 0.1f;
-                if (s->construction_sites[i].build_progress > 1.0f)
-                    s->construction_sites[i].build_progress = 1.0f;
-                return true;
+    case SETTL_EVT_DELIVER_CONSTRUCTION_INPUT: {
+        /* DELIVER_CONSTRUCTION_INPUT */
+        if (payload_len < SETTL_CONSTRUCTION_INPUT_PAYLOAD_SIZE) return false;
+        uint8_t input_count = payload[SETTL_CONSTRUCTION_INPUT_COUNT_OFFSET];
+        if (input_count == 0 || input_count > SETTL_MAX_CONSTRUCTION_INPUTS)
+            return false;
+
+        int site_idx = -1;
+        for (uint16_t i = 0; i < s->construction_site_count; i++) {
+            if (memcmp(s->construction_sites[i].scaffold_id, payload, 32) == 0 &&
+                s->construction_sites[i].active) {
+                site_idx = (int)i;
+                break;
             }
-        return false;
+        }
+        if (site_idx < 0) return false;
+
+        /*
+         * Validate the whole input set before removal. Duplicate pubs would
+         * otherwise make a direct event application partially consume cargo.
+         */
+        for (uint8_t i = 0; i < input_count; i++) {
+            const uint8_t *pub = payload + 64 + i * 32;
+            if (find_manifest_unit(manifest, *mc, pub) < 0) return false;
+            for (uint8_t j = 0; j < i; j++)
+                if (memcmp(pub, payload + 64 + j * 32, 32) == 0)
+                    return false;
+        }
+        for (uint8_t i = 0; i < input_count; i++) {
+            int idx = find_manifest_unit(
+                manifest, *mc, payload + 64 + i * 32);
+            settlement_manifest_remove(manifest, mc, (uint16_t)idx);
+        }
+
+        settl_construction_site_t *site = &s->construction_sites[site_idx];
+        site->build_progress += 0.1f * (float)input_count;
+        if (site->build_progress > 1.0f) site->build_progress = 1.0f;
+        return true;
     }
 
     case 0x22: { /* COMPLETE_STATION_MODULE */
@@ -305,30 +400,214 @@ bool settlement_apply_event(settlement_state_t *s,
     }
 }
 
+bool settlement_apply_event(settlement_state_t *s,
+                            const void *hdr_arg,
+                            const uint8_t *payload,
+                            uint16_t payload_len) {
+    const chain_event_header_t *hdr = (const chain_event_header_t *)hdr_arg;
+    if (!hdr || settlement_event_requires_trust(hdr->type)) return false;
+    return settlement_apply_event_preflighted(
+        s, hdr_arg, payload, payload_len);
+}
+
+static settlement_import_status_t settlement_status_from_trust(
+    cargo_receipt_trust_status_t status) {
+    switch (status) {
+    case CARGO_RECEIPT_TRUST_VALID_TRUSTED:
+    case CARGO_RECEIPT_TRUST_VALID_TRUSTED_ROTATED:
+        return SETTL_IMPORT_OK;
+    case CARGO_RECEIPT_TRUST_REJECT_BAD_ARGUMENTS:
+        return SETTL_IMPORT_REJECT_TRUST_BAD_ARGUMENTS;
+    case CARGO_RECEIPT_TRUST_REJECT_CHAIN:
+        return SETTL_IMPORT_REJECT_TRUST_CHAIN;
+    case CARGO_RECEIPT_TRUST_REJECT_MISSING_ORIGIN:
+        return SETTL_IMPORT_REJECT_TRUST_MISSING_ORIGIN;
+    case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_EVENT_TYPE:
+        return SETTL_IMPORT_REJECT_TRUST_ORIGIN_EVENT_TYPE;
+    case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_CARGO:
+        return SETTL_IMPORT_REJECT_TRUST_ORIGIN_CARGO;
+    case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_PIN:
+        return SETTL_IMPORT_REJECT_TRUST_ORIGIN_PIN;
+    case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_AUTHORITY:
+        return SETTL_IMPORT_REJECT_TRUST_ORIGIN_AUTHORITY;
+    case CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY:
+        return SETTL_IMPORT_REJECT_TRUST_UNKNOWN_AUTHORITY;
+    case CARGO_RECEIPT_TRUST_REJECT_UNTRUSTED_AUTHORITY:
+        return SETTL_IMPORT_REJECT_TRUST_UNTRUSTED_AUTHORITY;
+    case CARGO_RECEIPT_TRUST_REJECT_REVOKED_AUTHORITY:
+        return SETTL_IMPORT_REJECT_TRUST_REVOKED_AUTHORITY;
+    default:
+        return SETTL_IMPORT_REJECT_TRUST_BAD_ARGUMENTS;
+    }
+}
+
+static void settlement_result_set(settlement_import_result_t *result,
+                                  settlement_import_status_t status,
+                                  uint32_t event_index,
+                                  uint8_t cargo_index,
+                                  cargo_receipt_result_t chain_result) {
+    if (!result) return;
+    result->status = status;
+    result->event_index = event_index;
+    result->cargo_index = cargo_index;
+    result->chain_result = chain_result;
+}
+
+static bool settlement_preflight_event(
+    const chain_event_header_t *hdr,
+    const uint8_t *payload,
+    uint16_t payload_len,
+    const settlement_event_trust_evidence_t *evidence,
+    uint32_t event_index,
+    settlement_import_result_t *result) {
+    if (!settlement_payload_hash_matches(hdr, payload, payload_len)) {
+        settlement_result_set(result, SETTL_IMPORT_REJECT_PAYLOAD_HASH,
+                              event_index, UINT8_MAX, CARGO_RECEIPT_OK);
+        return false;
+    }
+
+    const uint8_t *cargo_pubs[SETTL_MAX_CONSTRUCTION_INPUTS] = {0};
+    uint8_t cargo_count = 0;
+    switch (hdr->type) {
+    case SETTL_EVT_TRANSFER_CARGO:
+        if (payload_len < SETTL_TRANSFER_PAYLOAD_SIZE) {
+            settlement_result_set(result, SETTL_IMPORT_REJECT_EVENT,
+                                  event_index, UINT8_MAX, CARGO_RECEIPT_OK);
+            return false;
+        }
+        cargo_pubs[cargo_count++] = payload;
+        break;
+    case SETTL_EVT_SELL:
+        if (payload_len < SETTL_TRADE_PAYLOAD_SIZE) {
+            settlement_result_set(result, SETTL_IMPORT_REJECT_EVENT,
+                                  event_index, UINT8_MAX, CARGO_RECEIPT_OK);
+            return false;
+        }
+        cargo_pubs[cargo_count++] = payload;
+        break;
+    case SETTL_EVT_DELIVER_CONSTRUCTION_INPUT:
+        if (payload_len < SETTL_CONSTRUCTION_INPUT_PAYLOAD_SIZE) {
+            settlement_result_set(result, SETTL_IMPORT_REJECT_EVENT,
+                                  event_index, UINT8_MAX, CARGO_RECEIPT_OK);
+            return false;
+        }
+        cargo_count = payload[SETTL_CONSTRUCTION_INPUT_COUNT_OFFSET];
+        if (cargo_count == 0 ||
+            cargo_count > SETTL_MAX_CONSTRUCTION_INPUTS) {
+            settlement_result_set(result, SETTL_IMPORT_REJECT_EVENT,
+                                  event_index, UINT8_MAX, CARGO_RECEIPT_OK);
+            return false;
+        }
+        for (uint8_t i = 0; i < cargo_count; i++)
+            cargo_pubs[i] = payload + 64 + i * 32;
+        break;
+    default:
+        if (evidence && evidence->cargo_count != 0) {
+            settlement_result_set(result, SETTL_IMPORT_REJECT_EVIDENCE_COUNT,
+                                  event_index, UINT8_MAX, CARGO_RECEIPT_OK);
+            return false;
+        }
+        return true;
+    }
+
+    if (!evidence || evidence->cargo_count == 0 || !evidence->cargo) {
+        settlement_result_set(result, SETTL_IMPORT_REJECT_MISSING_EVIDENCE,
+                              event_index, UINT8_MAX, CARGO_RECEIPT_OK);
+        return false;
+    }
+    if (evidence->cargo_count != cargo_count) {
+        settlement_result_set(result, SETTL_IMPORT_REJECT_EVIDENCE_COUNT,
+                              event_index, UINT8_MAX, CARGO_RECEIPT_OK);
+        return false;
+    }
+
+    for (uint8_t i = 0; i < cargo_count; i++) {
+        const settlement_cargo_trust_evidence_t *item =
+            &evidence->cargo[i];
+        if (item->event_id != hdr->event_id) {
+            settlement_result_set(result, SETTL_IMPORT_REJECT_EVIDENCE_EVENT,
+                                  event_index, i, CARGO_RECEIPT_OK);
+            return false;
+        }
+        if (memcmp(item->cargo_pub, cargo_pubs[i], 32) != 0) {
+            settlement_result_set(result, SETTL_IMPORT_REJECT_EVIDENCE_CARGO,
+                                  event_index, i, CARGO_RECEIPT_OK);
+            return false;
+        }
+
+        cargo_receipt_trust_result_t trust = cargo_receipt_trust_verify(
+            item->receipt_chain, item->receipt_count, cargo_pubs[i],
+            item->origin_present ? &item->origin : NULL,
+            item->authority_trust);
+        settlement_import_status_t status =
+            settlement_status_from_trust(trust.status);
+        if (status != SETTL_IMPORT_OK) {
+            settlement_result_set(result, status, event_index, i,
+                                  trust.chain_result);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool settlement_apply_segment_trusted(
+    settlement_state_t *s,
+    const void *events_arg,
+    const uint8_t **payloads,
+    const uint16_t *payload_lens,
+    const settlement_event_trust_evidence_t *evidence,
+    uint32_t event_count,
+    settlement_checkpoint_t *cp_out,
+    settlement_import_result_t *result_out) {
+    const chain_event_header_t *events = (const chain_event_header_t *)events_arg;
+    settlement_result_set(result_out, SETTL_IMPORT_OK, UINT32_MAX,
+                          UINT8_MAX, CARGO_RECEIPT_OK);
+    if (!s || !cp_out ||
+        (event_count > 0 && (!events || !payloads || !payload_lens))) {
+        settlement_result_set(result_out, SETTL_IMPORT_REJECT_BAD_ARGUMENTS,
+                              UINT32_MAX, UINT8_MAX, CARGO_RECEIPT_OK);
+        return false;
+    }
+
+    for (uint32_t i = 0; i < event_count; i++) {
+        const settlement_event_trust_evidence_t *event_evidence =
+            evidence ? &evidence[i] : NULL;
+        if (!settlement_preflight_event(
+                &events[i], payloads[i], payload_lens[i], event_evidence,
+                i, result_out))
+            return false;
+    }
+
+    settlement_state_t next = *s;
+    for (uint32_t i = 0; i < event_count; i++) {
+        if (!settlement_apply_event_preflighted(
+                &next, &events[i], payloads[i], payload_lens[i])) {
+            settlement_result_set(result_out, SETTL_IMPORT_REJECT_EVENT,
+                                  i, UINT8_MAX, CARGO_RECEIPT_OK);
+            return false;
+        }
+        next.last_event_id = events[i].event_id;
+    }
+
+    settlement_checkpoint_t next_cp = {0};
+    settlement_compute_root(s, next_cp.prev_segment_root);
+    next.segment_index++;
+    next_cp.segment_index = next.segment_index;
+    next_cp.event_count = event_count;
+    next_cp.last_event_id = next.last_event_id;
+    settlement_compute_root(&next, next_cp.state_root);
+
+    *s = next;
+    *cp_out = next_cp;
+    return true;
+}
+
 bool settlement_apply_segment(settlement_state_t *s,
                               const void *events_arg,
                               const uint8_t **payloads,
                               const uint16_t *payload_lens,
                               uint32_t event_count,
                               settlement_checkpoint_t *cp_out) {
-    const chain_event_header_t *events = (const chain_event_header_t *)events_arg;
-    settlement_state_t snapshot = *s;
-    uint32_t applied = 0;
-
-    for (uint32_t i = 0; i < event_count; i++) {
-        if (!settlement_apply_event(s, &events[i], payloads[i], payload_lens[i])) {
-            *s = snapshot;
-            return false;
-        }
-        applied++;
-        s->last_event_id = events[i].event_id;
-    }
-
-    s->segment_index++;
-    memset(cp_out, 0, sizeof(*cp_out));
-    cp_out->segment_index = s->segment_index;
-    cp_out->event_count = applied;
-    cp_out->last_event_id = s->last_event_id;
-    settlement_compute_root(s, cp_out->state_root);
-    return true;
+    return settlement_apply_segment_trusted(
+        s, events_arg, payloads, payload_lens, NULL, event_count, cp_out, NULL);
 }

--- a/shared/settlement_engine.h
+++ b/shared/settlement_engine.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "cargo_receipt.h"
 #include "types.h"
 
 #ifdef __cplusplus
@@ -90,11 +91,72 @@ typedef struct {
     uint32_t event_count;
 } settlement_checkpoint_t;
 
+/*
+ * Stable semantic result for a segment import. Receipt-specific failures map
+ * one-to-one from cargo_receipt_trust_verify() so callers never have to infer
+ * whether a rejection came from cryptography, origin binding, or authority
+ * policy.
+ */
+typedef enum {
+    SETTL_IMPORT_OK = 0,
+    SETTL_IMPORT_REJECT_BAD_ARGUMENTS,
+    SETTL_IMPORT_REJECT_PAYLOAD_HASH,
+    SETTL_IMPORT_REJECT_MISSING_EVIDENCE,
+    SETTL_IMPORT_REJECT_EVIDENCE_COUNT,
+    SETTL_IMPORT_REJECT_EVIDENCE_EVENT,
+    SETTL_IMPORT_REJECT_EVIDENCE_CARGO,
+    SETTL_IMPORT_REJECT_TRUST_BAD_ARGUMENTS,
+    SETTL_IMPORT_REJECT_TRUST_CHAIN,
+    SETTL_IMPORT_REJECT_TRUST_MISSING_ORIGIN,
+    SETTL_IMPORT_REJECT_TRUST_ORIGIN_EVENT_TYPE,
+    SETTL_IMPORT_REJECT_TRUST_ORIGIN_CARGO,
+    SETTL_IMPORT_REJECT_TRUST_ORIGIN_PIN,
+    SETTL_IMPORT_REJECT_TRUST_ORIGIN_AUTHORITY,
+    SETTL_IMPORT_REJECT_TRUST_UNKNOWN_AUTHORITY,
+    SETTL_IMPORT_REJECT_TRUST_UNTRUSTED_AUTHORITY,
+    SETTL_IMPORT_REJECT_TRUST_REVOKED_AUTHORITY,
+    SETTL_IMPORT_REJECT_EVENT
+} settlement_import_status_t;
+
+typedef struct {
+    settlement_import_status_t status;
+    uint32_t event_index;              /* UINT32_MAX when no event was reached */
+    uint8_t cargo_index;               /* UINT8_MAX when not cargo-specific */
+    cargo_receipt_result_t chain_result;
+} settlement_import_result_t;
+
+/*
+ * Caller-owned, read-only evidence for one cargo identity in one settlement
+ * event. The origin proof is embedded by value. receipt_chain is borrowed
+ * only for the duration of settlement_apply_segment_trusted(); neither it nor
+ * any origin address is retained in settlement state or checkpoint output.
+ */
+typedef struct {
+    uint64_t event_id;
+    uint8_t cargo_pub[32];
+    const cargo_receipt_t *receipt_chain;
+    uint8_t receipt_count;
+    bool origin_present;
+    cargo_receipt_origin_proof_t origin;
+    cargo_receipt_authority_trust_t authority_trust;
+} settlement_cargo_trust_evidence_t;
+
+typedef struct {
+    const settlement_cargo_trust_evidence_t *cargo;
+    uint8_t cargo_count;
+} settlement_event_trust_evidence_t;
+
 void settlement_state_init(settlement_state_t *s);
 void settlement_compute_root(const settlement_state_t *s, uint8_t root_out[32]);
+const char *settlement_import_status_name(settlement_import_status_t status);
 
-/* Apply one settlement event. hdr points to a chain_event_header_t
- * (from server/chain_log.h — opaque here to avoid include dependency). */
+/*
+ * Apply one non-provenance-sensitive settlement event. hdr points to a
+ * chain_event_header_t (from server/chain_log.h — opaque here to avoid include
+ * dependency). TRANSFER, SELL, and DELIVER_CONSTRUCTION_INPUT deliberately
+ * reject here; import them through settlement_apply_segment_trusted() so trust
+ * evidence cannot be bypassed.
+ */
 bool settlement_apply_event(settlement_state_t *s,
                             const void *hdr,
                             const uint8_t *payload,
@@ -106,6 +168,23 @@ bool settlement_apply_segment(settlement_state_t *s,
                               const uint16_t *payload_lens,
                               uint32_t event_count,
                               settlement_checkpoint_t *cp_out);
+
+/*
+ * Receipt-aware atomic import. evidence is parallel to events and may be NULL
+ * only when the segment contains no provenance-sensitive event. TRANSFER
+ * (0x04), SELL (0x11), and DELIVER_CONSTRUCTION_INPUT (0x21) require exact
+ * event/cargo-bound evidence. The full segment is preflighted before applying
+ * to a private state copy, so rejection leaves both *s and *cp_out untouched.
+ */
+bool settlement_apply_segment_trusted(
+    settlement_state_t *s,
+    const void *events,
+    const uint8_t **payloads,
+    const uint16_t *payload_lens,
+    const settlement_event_trust_evidence_t *evidence,
+    uint32_t event_count,
+    settlement_checkpoint_t *cp_out,
+    settlement_import_result_t *result_out);
 
 #ifdef __cplusplus
 }

--- a/tests/c/test_settlement_engine.c
+++ b/tests/c/test_settlement_engine.c
@@ -2,6 +2,7 @@
 #include "settlement_engine.h"
 #include "../server/chain_log.h"
 #include "sha256.h"
+#include "signal_crypto.h"
 #include <string.h>
 
 /* Build a minimal event header */
@@ -15,6 +16,62 @@ static void make_hdr(chain_event_header_t *hdr, uint8_t type, uint64_t id,
     sha256_init(&ctx);
     sha256_update(&ctx, payload, plen);
     sha256_final(&ctx, hdr->payload_hash);
+}
+
+static void make_receipt_evidence(
+    settlement_cargo_trust_evidence_t *evidence,
+    cargo_receipt_t *receipt,
+    const uint8_t cargo_pub[32],
+    uint64_t event_id,
+    uint8_t seed_tag,
+    cargo_receipt_authority_trust_t authority_trust) {
+    uint8_t seed[32];
+    uint8_t secret[64];
+    for (size_t i = 0; i < sizeof(seed); i++)
+        seed[i] = (uint8_t)(seed_tag + i);
+
+    memset(receipt, 0, sizeof(*receipt));
+    signal_crypto_keypair_from_seed(
+        seed, receipt->authoring_station, secret);
+    memcpy(receipt->cargo_pub, cargo_pub, 32);
+    memset(receipt->recipient_pubkey, (uint8_t)(seed_tag ^ 0x5au), 32);
+    receipt->event_id = event_id;
+    receipt->epoch = event_id + 100;
+    sha256_bytes(cargo_pub, 32, receipt->prev_receipt_hash);
+    uint8_t unsigned_receipt[CARGO_RECEIPT_UNSIGNED_SIZE];
+    cargo_receipt_unsigned_pack(receipt, unsigned_receipt);
+    signal_crypto_sign(receipt->signature, unsigned_receipt,
+                       sizeof(unsigned_receipt), secret);
+
+    memset(evidence, 0, sizeof(*evidence));
+    evidence->event_id = event_id;
+    memcpy(evidence->cargo_pub, cargo_pub, 32);
+    evidence->receipt_chain = receipt;
+    evidence->receipt_count = 1;
+    evidence->origin_present = true;
+    evidence->origin.event_type = CARGO_RECEIPT_ORIGIN_EVENT_SMELT;
+    evidence->origin.event_id = event_id - 1;
+    evidence->origin.epoch = receipt->epoch - 1;
+    memcpy(evidence->origin.event_hash,
+           receipt->prev_receipt_hash, 32);
+    memcpy(evidence->origin.output_cargo_pub, cargo_pub, 32);
+    memcpy(evidence->origin.authority,
+           receipt->authoring_station, 32);
+    evidence->authority_trust = authority_trust;
+
+    memset(secret, 0, sizeof(secret));
+}
+
+static void make_sell_payload(uint8_t payload[112],
+                              const uint8_t cargo_pub[32],
+                              uint8_t player_tag,
+                              int64_t ledger_delta) {
+    memset(payload, 0, 112);
+    memcpy(payload, cargo_pub, 32);
+    memset(payload + 32, player_tag, 32);
+    memset(payload + 64, 0xf0u, 32);
+    memcpy(payload + 96, &ledger_delta, sizeof(ledger_delta));
+    payload[105] = 1; /* direction = SELL */
 }
 
 TEST(test_init_produces_deterministic_root) {
@@ -133,16 +190,11 @@ TEST(test_segment_apply_produces_checkpoint) {
 
     uint8_t payload[112] = {0};
     memset(payload, 0x01, 32);
+    uint8_t payload2[112] = {0};
+    memset(payload2, 0x02, 32);
 
     chain_event_header_t hdrs[2];
     make_hdr(&hdrs[0], 0x01, 1, payload, sizeof(payload));
-    make_hdr(&hdrs[1], 0x01, 2, payload, sizeof(payload));
-    /* Different fragment_pub for second event to avoid duplicate */
-    payload[0] = 0x02;
-    make_hdr(&hdrs[1], 0x01, 2, payload, sizeof(payload));
-    /* Actually, we need different payload for the second event hash */
-    uint8_t payload2[112] = {0};
-    memset(payload2, 0x02, 32);
     make_hdr(&hdrs[1], 0x01, 2, payload2, sizeof(payload2));
 
     const uint8_t *pls[2] = {payload, payload2};
@@ -285,6 +337,328 @@ TEST(test_double_redeem_rejected) {
     ASSERT(!settlement_apply_event(&s, &hdr3, redeem, sizeof(redeem)));
 }
 
+TEST(test_trusted_sell_accepts_current_and_rotated_deterministically) {
+    static const cargo_receipt_authority_trust_t policies[] = {
+        CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT,
+        CARGO_RECEIPT_AUTHORITY_TRUSTED_ROTATED,
+    };
+
+    for (size_t policy = 0; policy < sizeof(policies) / sizeof(policies[0]);
+         policy++) {
+        uint8_t cargo_pub[32];
+        memset(cargo_pub, (uint8_t)(0x61 + policy), sizeof(cargo_pub));
+        uint8_t payload[112];
+        make_sell_payload(payload, cargo_pub, 0x91, 25);
+        chain_event_header_t hdr;
+        make_hdr(&hdr, 0x11, 41, payload, sizeof(payload));
+
+        cargo_receipt_t receipt;
+        settlement_cargo_trust_evidence_t cargo_evidence;
+        make_receipt_evidence(&cargo_evidence, &receipt, cargo_pub,
+                              hdr.event_id, (uint8_t)(0x11 + policy),
+                              policies[policy]);
+        settlement_event_trust_evidence_t event_evidence = {
+            .cargo = &cargo_evidence,
+            .cargo_count = 1,
+        };
+        const uint8_t *payloads[1] = {payload};
+        uint16_t lengths[1] = {sizeof(payload)};
+
+        settlement_state_t a, b;
+        settlement_state_init(&a);
+        settlement_state_init(&b);
+        uint8_t previous_root[32];
+        settlement_compute_root(&a, previous_root);
+        settlement_checkpoint_t cp_a, cp_b;
+        settlement_import_result_t result_a, result_b;
+        ASSERT(settlement_apply_segment_trusted(
+            &a, &hdr, payloads, lengths, &event_evidence, 1,
+            &cp_a, &result_a));
+        ASSERT(settlement_apply_segment_trusted(
+            &b, &hdr, payloads, lengths, &event_evidence, 1,
+            &cp_b, &result_b));
+
+        ASSERT_EQ_INT(result_a.status, SETTL_IMPORT_OK);
+        ASSERT_EQ_INT(result_b.status, SETTL_IMPORT_OK);
+        ASSERT(memcmp(&a, &b, sizeof(a)) == 0);
+        ASSERT(memcmp(&cp_a, &cp_b, sizeof(cp_a)) == 0);
+        ASSERT(memcmp(cp_a.prev_segment_root, previous_root, 32) == 0);
+        ASSERT_EQ_INT(a.station_manifest_counts[0], 1);
+        ASSERT_EQ_INT(a.station_ledger_counts[0], 1);
+        ASSERT_EQ_FLOAT(a.station_ledgers[0][0].balance, 25.0f, 0.001f);
+
+        uint8_t root_before_receipt_destroy[32];
+        uint8_t root_after_receipt_destroy[32];
+        settlement_compute_root(&a, root_before_receipt_destroy);
+        memset(&receipt, 0, sizeof(receipt));
+        memset(&cargo_evidence, 0, sizeof(cargo_evidence));
+        settlement_compute_root(&a, root_after_receipt_destroy);
+        ASSERT(memcmp(root_before_receipt_destroy,
+                      root_after_receipt_destroy, 32) == 0);
+    }
+}
+
+TEST(test_trust_rejections_are_semantic_and_byte_inert) {
+    typedef enum {
+        FAILURE_MISSING_EVIDENCE,
+        FAILURE_CARGO_MISMATCH,
+        FAILURE_MISSING_ORIGIN,
+        FAILURE_UNKNOWN,
+        FAILURE_UNTRUSTED,
+        FAILURE_REVOKED,
+        FAILURE_BAD_SIGNATURE,
+    } failure_kind_t;
+    static const struct {
+        failure_kind_t kind;
+        settlement_import_status_t expected;
+        cargo_receipt_result_t chain_result;
+    } cases[] = {
+        {FAILURE_MISSING_EVIDENCE,
+         SETTL_IMPORT_REJECT_MISSING_EVIDENCE, CARGO_RECEIPT_OK},
+        {FAILURE_CARGO_MISMATCH,
+         SETTL_IMPORT_REJECT_EVIDENCE_CARGO, CARGO_RECEIPT_OK},
+        {FAILURE_MISSING_ORIGIN,
+         SETTL_IMPORT_REJECT_TRUST_MISSING_ORIGIN, CARGO_RECEIPT_OK},
+        {FAILURE_UNKNOWN,
+         SETTL_IMPORT_REJECT_TRUST_UNKNOWN_AUTHORITY, CARGO_RECEIPT_OK},
+        {FAILURE_UNTRUSTED,
+         SETTL_IMPORT_REJECT_TRUST_UNTRUSTED_AUTHORITY, CARGO_RECEIPT_OK},
+        {FAILURE_REVOKED,
+         SETTL_IMPORT_REJECT_TRUST_REVOKED_AUTHORITY, CARGO_RECEIPT_OK},
+        {FAILURE_BAD_SIGNATURE,
+         SETTL_IMPORT_REJECT_TRUST_CHAIN,
+         CARGO_RECEIPT_REJECT_BAD_SIGNATURE},
+    };
+
+    uint8_t cargo_pub[32];
+    memset(cargo_pub, 0x72, sizeof(cargo_pub));
+    uint8_t payload[112];
+    make_sell_payload(payload, cargo_pub, 0x92, 30);
+    chain_event_header_t hdr;
+    make_hdr(&hdr, 0x11, 52, payload, sizeof(payload));
+    const uint8_t *payloads[1] = {payload};
+    uint16_t lengths[1] = {sizeof(payload)};
+
+    settlement_state_t baseline;
+    settlement_state_init(&baseline);
+    baseline.segment_index = 8;
+    baseline.last_event_id = 51;
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        cargo_receipt_t receipt;
+        settlement_cargo_trust_evidence_t cargo_evidence;
+        make_receipt_evidence(
+            &cargo_evidence, &receipt, cargo_pub, hdr.event_id,
+            (uint8_t)(0x30 + i),
+            CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+        settlement_event_trust_evidence_t event_evidence = {
+            .cargo = &cargo_evidence,
+            .cargo_count = 1,
+        };
+        const settlement_event_trust_evidence_t *evidence_ptr =
+            &event_evidence;
+        switch (cases[i].kind) {
+        case FAILURE_MISSING_EVIDENCE:
+            evidence_ptr = NULL;
+            break;
+        case FAILURE_CARGO_MISMATCH:
+            cargo_evidence.cargo_pub[0] ^= 0x80u;
+            break;
+        case FAILURE_MISSING_ORIGIN:
+            cargo_evidence.origin_present = false;
+            break;
+        case FAILURE_UNKNOWN:
+            cargo_evidence.authority_trust =
+                CARGO_RECEIPT_AUTHORITY_UNKNOWN;
+            break;
+        case FAILURE_UNTRUSTED:
+            cargo_evidence.authority_trust =
+                CARGO_RECEIPT_AUTHORITY_UNTRUSTED;
+            break;
+        case FAILURE_REVOKED:
+            cargo_evidence.authority_trust =
+                CARGO_RECEIPT_AUTHORITY_REVOKED;
+            break;
+        case FAILURE_BAD_SIGNATURE:
+            receipt.signature[0] ^= 0x01u;
+            break;
+        }
+
+        settlement_state_t state = baseline;
+        settlement_checkpoint_t checkpoint;
+        memset(&checkpoint, 0xa5, sizeof(checkpoint));
+        settlement_checkpoint_t checkpoint_before = checkpoint;
+        settlement_import_result_t result;
+        ASSERT(!settlement_apply_segment_trusted(
+            &state, &hdr, payloads, lengths, evidence_ptr, 1,
+            &checkpoint, &result));
+        ASSERT_EQ_INT(result.status, cases[i].expected);
+        ASSERT_EQ_INT(result.chain_result, cases[i].chain_result);
+        ASSERT_EQ_INT((int)result.event_index, 0);
+        ASSERT(memcmp(&state, &baseline, sizeof(state)) == 0);
+        ASSERT(memcmp(&checkpoint, &checkpoint_before,
+                      sizeof(checkpoint)) == 0);
+    }
+    ASSERT_STR_EQ(settlement_import_status_name(
+                      SETTL_IMPORT_REJECT_TRUST_REVOKED_AUTHORITY),
+                  "reject_trust_revoked_authority");
+}
+
+TEST(test_later_invalid_trust_event_prevents_earlier_commit) {
+    uint8_t cargo_a[32], cargo_b[32];
+    memset(cargo_a, 0x81, sizeof(cargo_a));
+    memset(cargo_b, 0x82, sizeof(cargo_b));
+    uint8_t payload_a[112], payload_b[112];
+    make_sell_payload(payload_a, cargo_a, 0xa1, 10);
+    make_sell_payload(payload_b, cargo_b, 0xa2, 20);
+    chain_event_header_t hdrs[2];
+    make_hdr(&hdrs[0], 0x11, 61, payload_a, sizeof(payload_a));
+    make_hdr(&hdrs[1], 0x11, 62, payload_b, sizeof(payload_b));
+
+    cargo_receipt_t receipts[2];
+    settlement_cargo_trust_evidence_t cargo_evidence[2];
+    make_receipt_evidence(&cargo_evidence[0], &receipts[0], cargo_a, 61,
+                          0x41, CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+    make_receipt_evidence(&cargo_evidence[1], &receipts[1], cargo_b, 62,
+                          0x42, CARGO_RECEIPT_AUTHORITY_REVOKED);
+    settlement_event_trust_evidence_t event_evidence[2] = {
+        {.cargo = &cargo_evidence[0], .cargo_count = 1},
+        {.cargo = &cargo_evidence[1], .cargo_count = 1},
+    };
+    const uint8_t *payloads[2] = {payload_a, payload_b};
+    uint16_t lengths[2] = {sizeof(payload_a), sizeof(payload_b)};
+
+    settlement_state_t state;
+    settlement_state_init(&state);
+    state.segment_index = 4;
+    state.last_event_id = 60;
+    settlement_state_t before = state;
+    settlement_checkpoint_t checkpoint;
+    memset(&checkpoint, 0x6c, sizeof(checkpoint));
+    settlement_checkpoint_t checkpoint_before = checkpoint;
+    settlement_import_result_t result;
+    ASSERT(!settlement_apply_segment_trusted(
+        &state, hdrs, payloads, lengths, event_evidence, 2,
+        &checkpoint, &result));
+    ASSERT_EQ_INT(result.status,
+                  SETTL_IMPORT_REJECT_TRUST_REVOKED_AUTHORITY);
+    ASSERT_EQ_INT((int)result.event_index, 1);
+    ASSERT(memcmp(&state, &before, sizeof(state)) == 0);
+    ASSERT(memcmp(&checkpoint, &checkpoint_before,
+                  sizeof(checkpoint)) == 0);
+}
+
+TEST(test_payload_hash_rejection_preserves_state_and_checkpoint) {
+    uint8_t payload[112] = {0};
+    memset(payload, 0x31, 32);
+    chain_event_header_t hdr;
+    make_hdr(&hdr, 0x01, 71, payload, sizeof(payload));
+    payload[80] ^= 0x01u;
+    const uint8_t *payloads[1] = {payload};
+    uint16_t lengths[1] = {sizeof(payload)};
+
+    settlement_state_t state;
+    settlement_state_init(&state);
+    state.segment_index = 3;
+    state.last_event_id = 70;
+    settlement_state_t before = state;
+    settlement_checkpoint_t checkpoint;
+    memset(&checkpoint, 0x7d, sizeof(checkpoint));
+    settlement_checkpoint_t checkpoint_before = checkpoint;
+    settlement_import_result_t result;
+    ASSERT(!settlement_apply_segment_trusted(
+        &state, &hdr, payloads, lengths, NULL, 1,
+        &checkpoint, &result));
+    ASSERT_EQ_INT(result.status, SETTL_IMPORT_REJECT_PAYLOAD_HASH);
+    ASSERT(memcmp(&state, &before, sizeof(state)) == 0);
+    ASSERT(memcmp(&checkpoint, &checkpoint_before,
+                  sizeof(checkpoint)) == 0);
+}
+
+TEST(test_construction_input_consumes_only_receipt_backed_units) {
+    settlement_state_t state;
+    settlement_state_init(&state);
+    state.construction_site_count = 1;
+    memset(state.construction_sites[0].scaffold_id, 0x51, 32);
+    memset(state.construction_sites[0].station_pubkey, 0x52, 32);
+    state.construction_sites[0].active = true;
+    state.station_manifest_counts[0] = 2;
+    memset(state.station_manifests[0][0].pub, 0xb1, 32);
+    memset(state.station_manifests[0][1].pub, 0xb2, 32);
+    state.station_manifests[0][0].quantity = 1;
+    state.station_manifests[0][1].quantity = 1;
+
+    uint8_t payload[168] = {0};
+    memcpy(payload, state.construction_sites[0].scaffold_id, 32);
+    memcpy(payload + 32, state.construction_sites[0].station_pubkey, 32);
+    memcpy(payload + 64, state.station_manifests[0][0].pub, 32);
+    memcpy(payload + 96, state.station_manifests[0][1].pub, 32);
+    payload[160] = 2;
+    chain_event_header_t hdr;
+    make_hdr(&hdr, 0x21, 81, payload, sizeof(payload));
+
+    cargo_receipt_t receipts[2];
+    settlement_cargo_trust_evidence_t cargo_evidence[2];
+    make_receipt_evidence(
+        &cargo_evidence[0], &receipts[0], payload + 64, hdr.event_id,
+        0x61, CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+    make_receipt_evidence(
+        &cargo_evidence[1], &receipts[1], payload + 96, hdr.event_id,
+        0x62, CARGO_RECEIPT_AUTHORITY_TRUSTED_ROTATED);
+    settlement_event_trust_evidence_t event_evidence = {
+        .cargo = cargo_evidence,
+        .cargo_count = 2,
+    };
+    const uint8_t *payloads[1] = {payload};
+    uint16_t lengths[1] = {sizeof(payload)};
+    settlement_checkpoint_t checkpoint;
+    settlement_import_result_t result;
+    ASSERT(settlement_apply_segment_trusted(
+        &state, &hdr, payloads, lengths, &event_evidence, 1,
+        &checkpoint, &result));
+    ASSERT_EQ_INT(result.status, SETTL_IMPORT_OK);
+    ASSERT_EQ_INT(state.station_manifest_counts[0], 0);
+    ASSERT_EQ_FLOAT(
+        state.construction_sites[0].build_progress, 0.2f, 0.001f);
+}
+
+TEST(test_all_provenance_event_types_require_evidence) {
+    static const struct {
+        uint8_t type;
+        uint16_t length;
+    } cases[] = {
+        {0x04, 144},
+        {0x11, 112},
+        {0x21, 168},
+    };
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        uint8_t payload[168] = {0};
+        if (cases[i].type == 0x21) payload[160] = 1;
+        chain_event_header_t hdr;
+        make_hdr(&hdr, cases[i].type, (uint64_t)(91 + i),
+                 payload, cases[i].length);
+        const uint8_t *payloads[1] = {payload};
+        uint16_t lengths[1] = {cases[i].length};
+        settlement_state_t state;
+        settlement_state_init(&state);
+        settlement_state_t before = state;
+        ASSERT(!settlement_apply_event(
+            &state, &hdr, payload, cases[i].length));
+        ASSERT(memcmp(&state, &before, sizeof(state)) == 0);
+        settlement_checkpoint_t checkpoint;
+        memset(&checkpoint, 0x8e, sizeof(checkpoint));
+        settlement_checkpoint_t checkpoint_before = checkpoint;
+        settlement_import_result_t result;
+        ASSERT(!settlement_apply_segment_trusted(
+            &state, &hdr, payloads, lengths, NULL, 1,
+            &checkpoint, &result));
+        ASSERT_EQ_INT(result.status, SETTL_IMPORT_REJECT_MISSING_EVIDENCE);
+        ASSERT(memcmp(&state, &before, sizeof(state)) == 0);
+        ASSERT(memcmp(&checkpoint, &checkpoint_before,
+                      sizeof(checkpoint)) == 0);
+    }
+}
+
 
 void register_settlement_engine_tests(void) {
     TEST_SECTION("\nSettlement engine:\n");
@@ -301,4 +675,10 @@ void register_settlement_engine_tests(void) {
     RUN(test_issue_credit_note);
     RUN(test_redeem_credit_note);
     RUN(test_double_redeem_rejected);
+    RUN(test_trusted_sell_accepts_current_and_rotated_deterministically);
+    RUN(test_trust_rejections_are_semantic_and_byte_inert);
+    RUN(test_later_invalid_trust_event_prevents_earlier_commit);
+    RUN(test_payload_hash_rejection_preserves_state_and_checkpoint);
+    RUN(test_construction_input_consumes_only_receipt_backed_units);
+    RUN(test_all_provenance_event_types_require_evidence);
 }


### PR DESCRIPTION
## Summary

- add explicit event/cargo-bound receipt, origin-proof, and authority evidence to settlement segment import
- preflight every payload hash and provenance-sensitive event before applying the segment to a private state copy
- preserve stable semantic rejection results for missing, mismatched, unknown, untrusted, revoked, and cryptographically invalid evidence
- require the trusted segment path for transfer, sell, and construction input, and consume construction inputs from the manifest atomically
- commit state and checkpoint output together, including deterministic previous/current state roots

## Validation

- `./build-test/signal_test --quiet --no-soak` — 1,240/1,240 passed
- ASan/UBSan `./build-san/signal_test --quiet --no-soak` — 1,240/1,240 passed
- `python3 scripts/check_deterministic_build_flags.py build-test/compile_commands.json`
- `python3 scripts/check_replay_repeatability.py ./build-test/signal_replay` — 20 fast scenarios
- `git diff --cached --check`

Closes #640
