### PR TITLE
Receipt trust surfaces: semantic inspection, CLI, and replay vectors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,6 +396,23 @@ if(BUILD_TOOLS AND NOT EMSCRIPTEN)
         target_compile_definitions(signal_rati_receipt PRIVATE _CRT_SECURE_NO_WARNINGS)
     endif()
 
+    add_executable(signal_receipt_verify
+        tools/signal_receipt_verify.c
+        shared/cargo_receipt.c
+        ${SIGNAL_CRYPTO_SOURCES}
+    )
+    target_include_directories(signal_receipt_verify PRIVATE
+        ${SIGNAL_INCLUDE_DIRS}
+        ${SIGNAL_CRYPTO_INCLUDE_DIR})
+    if(NOT MSVC)
+        target_compile_options(signal_receipt_verify PRIVATE
+            -Wall -Wextra -Wpedantic -Werror -ffp-contract=off -fno-fast-math)
+    else()
+        target_compile_options(signal_receipt_verify PRIVATE
+            /W4 /WX /wd4127 /wd4459 /wd4996 /wd5287)
+        target_compile_definitions(signal_receipt_verify PRIVATE _CRT_SECURE_NO_WARNINGS)
+    endif()
+
     add_executable(flight_trace
         tools/flight_trace.c
         ${SIGNAL_SIM_SOURCES}

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ for the `swarm.rati.chat` avatar sync workflow.
   server/operator setup, station copy sync, chain health, and troubleshooting.
 - [`docs/decentralization.md`](docs/decentralization.md): station identity,
   signed chain logs, cargo receipts, and the off-chain trust model.
+- [`docs/cargo-receipt-trust.md`](docs/cargo-receipt-trust.md): what portable
+  receipts prove, station-policy limits, and semantic CLI verification.
 - [`docs/cargo-architecture.md`](docs/cargo-architecture.md): canonical cargo
   vocabulary — fragments, bulk float, crates, manifests, and lineage.
 - [`docs/holographic-gossip-network.md`](docs/holographic-gossip-network.md):

--- a/client/hud.c
+++ b/client/hud.c
@@ -1478,41 +1478,9 @@ static bool hud_market_source_chain_label(const NetInspectSnapshotRow *row,
 static const char *hud_cargo_trust_label(
     const NetInspectSnapshotRow *row) {
     if (!row || !row->trust_evaluated) return "";
-    if (row->trust_accepted) {
-        switch ((cargo_receipt_trust_status_t)row->trust_status) {
-        case CARGO_RECEIPT_TRUST_VALID_TRUSTED:
-            return "trusted";
-        case CARGO_RECEIPT_TRUST_VALID_TRUSTED_ROTATED:
-            return "trusted/rotated";
-        case CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY:
-            return "accepted/unknown";
-        case CARGO_RECEIPT_TRUST_REJECT_UNTRUSTED_AUTHORITY:
-            return "accepted/untrusted";
-        default:
-            return "accepted";
-        }
-    }
-    switch ((cargo_receipt_trust_status_t)row->trust_status) {
-    case CARGO_RECEIPT_TRUST_REJECT_CHAIN:
-        return "rejected/chain";
-    case CARGO_RECEIPT_TRUST_REJECT_MISSING_ORIGIN:
-        return "rejected/no-origin";
-    case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_EVENT_TYPE:
-    case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_CARGO:
-    case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_PIN:
-        return "rejected/origin";
-    case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_AUTHORITY:
-        return "rejected/authority";
-    case CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY:
-        return "rejected/unknown";
-    case CARGO_RECEIPT_TRUST_REJECT_UNTRUSTED_AUTHORITY:
-        return "rejected/untrusted";
-    case CARGO_RECEIPT_TRUST_REJECT_REVOKED_AUTHORITY:
-        return "rejected/revoked";
-    case CARGO_RECEIPT_TRUST_REJECT_BAD_ARGUMENTS:
-    default:
-        return "rejected";
-    }
+    return cargo_receipt_trust_semantic_label(
+        (cargo_receipt_trust_status_t)row->trust_status,
+        row->trust_accepted);
 }
 
 static void hud_job_reason_label(const NetInspectSnapshotRow *row,

--- a/docs/cargo-receipt-trust.md
+++ b/docs/cargo-receipt-trust.md
@@ -1,0 +1,55 @@
+# Cargo receipt trust
+
+Signal separates three questions that are easy to blur:
+
+1. **Witness chain:** are the portable custody receipts correctly signed,
+   cargo-bound, and linked?
+2. **Origin:** does the oldest receipt pin an actual `SMELT` or `CRAFT` event
+   that produced this cargo identity?
+3. **Seal policy:** does the evaluating station currently accept the producing
+   authority, accept it as a rotated historical key, or classify it as unknown,
+   untrusted, or revoked?
+
+A valid witness chain alone does not prove production origin or local trust.
+Station policy is local: a lawful station can reject an unknown issuer while a
+black market accepts it. Revoked issuers are rejected everywhere.
+
+## Standalone verification
+
+`signal_receipt_verify` consumes a binary receipt chain made by concatenating
+canonical 208-byte `cargo_receipt_t` records in chronological order. The
+origin proof and authority lifecycle decision are explicit inputs:
+
+```sh
+./build/signal_receipt_verify \
+  --report=json \
+  --cargo-pub=<cargo-identity-hex> \
+  --origin-event=smelt \
+  --origin-hash=<producing-event-header-sha256> \
+  --origin-authority=<station-pubkey-hex-or-base58> \
+  --origin-event-id=42 \
+  --origin-epoch=12000 \
+  --authority-trust=current \
+  receipt-chain.bin
+```
+
+Use `--origin-event=missing` when history is unavailable; do not synthesize an
+origin hash. Accepted authority values are `current`, `rotated`, `unknown`,
+`untrusted`, and `revoked`.
+
+Text output leads with semantic copy such as `accepted/trusted`,
+`rejected/no-origin`, or `rejected/revoked`. JSON output uses the stable
+`signal.cargo_receipt_trust.v1` schema and includes:
+
+- `accepted`, the final policy result;
+- stable numeric and string verdict, chain, origin-event, and authority fields;
+- an `audit` object retaining cargo identity, exact origin hash and authority,
+  event coordinates, first receipt authority, and receipt-head hash.
+
+Exit status is 0 for an accepted proof, 1 for a semantic rejection, and 2 for
+malformed arguments or binary input.
+
+The CLI, cargo inspection HUD, gameplay gates, and settlement import all call
+the same `cargo_receipt_trust_verify()` verdict contract. The short semantic
+label also comes from the shared receipt layer, so audit and gameplay wording
+cannot silently drift apart.

--- a/docs/operator-onboarding.md
+++ b/docs/operator-onboarding.md
@@ -354,6 +354,12 @@ presented chain from a peer or foreign operator. The shared handoff ticket
 format can bind those proofs to cross-zone ship state; the remaining federation
 gap is consuming that ticket during an actual authority handoff.
 
+For an offline cargo decision, run `signal_receipt_verify` with the packed
+receipt chain, resolved producing-event proof, and your explicit authority
+lifecycle decision. See [cargo receipt trust](cargo-receipt-trust.md) for the
+binary input, stable JSON schema, and the boundary between a valid witness
+chain and station-local acceptance policy.
+
 Until #480 lands, federation is "informal" against Byzantine operators. The
 off-chain receipt chain can prove cargo history, but without a public
 chain-tip anchor an operator can still fork their own history for different

--- a/docs/replay-harness.md
+++ b/docs/replay-harness.md
@@ -78,8 +78,9 @@ Each row has schema `signal.replay_counterfactual.v1` and includes:
 - Motion metrics: end position, velocity, speed, angle, goal distance, progress,
   and scalar utility.
 - `receipt_trust`: an always-on `signal.receipt_trust.v1` contract vector for
-  trusted SMELT/CRAFT origins, an accepted historical rotated key, unknown and
-  revoked authorities, a missing origin proof, and a tampered receipt chain.
+  trusted SMELT/CRAFT origins, an accepted historical rotated key, unknown,
+  untrusted, and revoked authorities, a missing origin proof, and a tampered
+  receipt chain.
   Replay aborts if any vector produces a different semantic verdict; the
   native/WASM and cross-runner gates compare the emitted codes exactly.
 - Optional `hnn` object when `--hnn-trace` is set: flat trace contract,

--- a/shared/cargo_receipt.c
+++ b/shared/cargo_receipt.c
@@ -218,6 +218,47 @@ const char *cargo_receipt_trust_status_name(
     }
 }
 
+const char *cargo_receipt_trust_semantic_label(
+    cargo_receipt_trust_status_t status,
+    bool accepted) {
+    if (accepted) {
+        switch (status) {
+        case CARGO_RECEIPT_TRUST_VALID_TRUSTED:
+            return "accepted/trusted";
+        case CARGO_RECEIPT_TRUST_VALID_TRUSTED_ROTATED:
+            return "accepted/rotated";
+        case CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY:
+            return "accepted/unknown";
+        case CARGO_RECEIPT_TRUST_REJECT_UNTRUSTED_AUTHORITY:
+            return "accepted/untrusted";
+        default:
+            return "accepted";
+        }
+    }
+    switch (status) {
+    case CARGO_RECEIPT_TRUST_REJECT_CHAIN:
+        return "rejected/witness";
+    case CARGO_RECEIPT_TRUST_REJECT_MISSING_ORIGIN:
+        return "rejected/no-origin";
+    case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_EVENT_TYPE:
+    case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_CARGO:
+    case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_PIN:
+        return "rejected/origin";
+    case CARGO_RECEIPT_TRUST_REJECT_ORIGIN_AUTHORITY:
+        return "rejected/seal";
+    case CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY:
+        return "rejected/unknown";
+    case CARGO_RECEIPT_TRUST_REJECT_UNTRUSTED_AUTHORITY:
+        return "rejected/untrusted";
+    case CARGO_RECEIPT_TRUST_REJECT_REVOKED_AUTHORITY:
+        return "rejected/revoked";
+    case CARGO_RECEIPT_TRUST_REJECT_BAD_ARGUMENTS:
+        return "rejected/evidence";
+    default:
+        return "rejected";
+    }
+}
+
 /* ---------------- ship_receipts_t storage --------------------------- */
 
 bool ship_receipts_init(ship_receipts_t *r, uint16_t cap) {

--- a/shared/cargo_receipt.h
+++ b/shared/cargo_receipt.h
@@ -216,6 +216,11 @@ cargo_receipt_trust_result_t cargo_receipt_trust_verify(
 const char *cargo_receipt_trust_status_name(
     cargo_receipt_trust_status_t status);
 
+/* Compact semantic copy shared by gameplay inspection and audit tools. */
+const char *cargo_receipt_trust_semantic_label(
+    cargo_receipt_trust_status_t status,
+    bool accepted);
+
 /* ---------------- ship_receipts_t ---------------------------------- */
 
 /* Per-cargo receipt store running parallel to ship_t.manifest.

--- a/tests/c/test_cross_station_settlement.c
+++ b/tests/c/test_cross_station_settlement.c
@@ -379,6 +379,8 @@ TEST(test_receipt_trust_accepts_smelt_craft_and_rotated_authority) {
     ASSERT_EQ_INT(result.origin_event, CARGO_RECEIPT_ORIGIN_EVENT_SMELT);
     ASSERT_STR_EQ(cargo_receipt_trust_status_name(result.status),
                   "valid_trusted");
+    ASSERT_STR_EQ(cargo_receipt_trust_semantic_label(result.status, true),
+                  "accepted/trusted");
 
     proof.event_type = CARGO_RECEIPT_ORIGIN_EVENT_CRAFT;
     result = cargo_receipt_trust_verify(
@@ -394,6 +396,8 @@ TEST(test_receipt_trust_accepts_smelt_craft_and_rotated_authority) {
                   CARGO_RECEIPT_TRUST_VALID_TRUSTED_ROTATED);
     ASSERT_STR_EQ(cargo_receipt_trust_status_name(result.status),
                   "valid_trusted_rotated");
+    ASSERT_STR_EQ(cargo_receipt_trust_semantic_label(result.status, true),
+                  "accepted/rotated");
     crs_teardown();
 }
 
@@ -415,6 +419,8 @@ TEST(test_receipt_trust_distinguishes_origin_proof_failures) {
         CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
     ASSERT_EQ_INT(result.status,
                   CARGO_RECEIPT_TRUST_REJECT_MISSING_ORIGIN);
+    ASSERT_STR_EQ(cargo_receipt_trust_semantic_label(result.status, false),
+                  "rejected/no-origin");
 
     cargo_receipt_origin_proof_t proof = valid;
     proof.event_type = CARGO_RECEIPT_ORIGIN_EVENT_NONE;
@@ -423,6 +429,8 @@ TEST(test_receipt_trust_distinguishes_origin_proof_failures) {
         CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
     ASSERT_EQ_INT(result.status,
                   CARGO_RECEIPT_TRUST_REJECT_ORIGIN_EVENT_TYPE);
+    ASSERT_STR_EQ(cargo_receipt_trust_semantic_label(result.status, false),
+                  "rejected/origin");
 
     proof = valid;
     proof.output_cargo_pub[0] ^= 0x80u;
@@ -445,6 +453,8 @@ TEST(test_receipt_trust_distinguishes_origin_proof_failures) {
         CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
     ASSERT_EQ_INT(result.status,
                   CARGO_RECEIPT_TRUST_REJECT_ORIGIN_AUTHORITY);
+    ASSERT_STR_EQ(cargo_receipt_trust_semantic_label(result.status, false),
+                  "rejected/seal");
 
     ASSERT(memcmp(&receipt, &receipt_before, sizeof(receipt)) == 0);
     ASSERT(memcmp(&valid, &proof_before, sizeof(valid)) == 0);
@@ -468,11 +478,15 @@ TEST(test_receipt_trust_distinguishes_authority_policy) {
                   CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY);
     ASSERT_STR_EQ(cargo_receipt_trust_status_name(result.status),
                   "reject_unknown_authority");
+    ASSERT_STR_EQ(cargo_receipt_trust_semantic_label(result.status, false),
+                  "rejected/unknown");
 
     result = cargo_receipt_trust_verify(
         &receipt, 1, cargo_pk, &proof, CARGO_RECEIPT_AUTHORITY_UNTRUSTED);
     ASSERT_EQ_INT(result.status,
                   CARGO_RECEIPT_TRUST_REJECT_UNTRUSTED_AUTHORITY);
+    ASSERT_STR_EQ(cargo_receipt_trust_semantic_label(result.status, false),
+                  "rejected/untrusted");
 
     result = cargo_receipt_trust_verify(
         &receipt, 1, cargo_pk, &proof, CARGO_RECEIPT_AUTHORITY_REVOKED);
@@ -480,6 +494,8 @@ TEST(test_receipt_trust_distinguishes_authority_policy) {
                   CARGO_RECEIPT_TRUST_REJECT_REVOKED_AUTHORITY);
     ASSERT_STR_EQ(cargo_receipt_trust_status_name(result.status),
                   "reject_revoked_authority");
+    ASSERT_STR_EQ(cargo_receipt_trust_semantic_label(result.status, false),
+                  "rejected/revoked");
 
     result = cargo_receipt_trust_verify(
         &receipt, 1, cargo_pk, &proof,
@@ -510,6 +526,8 @@ TEST(test_receipt_trust_preserves_cryptographic_chain_failure) {
         CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
     ASSERT_EQ_INT(result.status, CARGO_RECEIPT_TRUST_REJECT_CHAIN);
     ASSERT_EQ_INT(result.chain_result, CARGO_RECEIPT_REJECT_BAD_SIGNATURE);
+    ASSERT_STR_EQ(cargo_receipt_trust_semantic_label(result.status, false),
+                  "rejected/witness");
 
     result = cargo_receipt_trust_verify(
         &receipt, 1, NULL, &proof,
@@ -518,6 +536,46 @@ TEST(test_receipt_trust_preserves_cryptographic_chain_failure) {
                   CARGO_RECEIPT_TRUST_REJECT_BAD_ARGUMENTS);
     ASSERT_EQ_INT(result.chain_result, CARGO_RECEIPT_OK);
     crs_teardown();
+}
+
+TEST(test_receipt_trust_semantic_labels_cover_stable_verdict_contract) {
+    static const struct {
+        cargo_receipt_trust_status_t status;
+        bool accepted;
+        const char *label;
+    } vectors[] = {
+        {CARGO_RECEIPT_TRUST_VALID_TRUSTED, true, "accepted/trusted"},
+        {CARGO_RECEIPT_TRUST_VALID_TRUSTED_ROTATED, true,
+         "accepted/rotated"},
+        {CARGO_RECEIPT_TRUST_REJECT_BAD_ARGUMENTS, false,
+         "rejected/evidence"},
+        {CARGO_RECEIPT_TRUST_REJECT_CHAIN, false, "rejected/witness"},
+        {CARGO_RECEIPT_TRUST_REJECT_MISSING_ORIGIN, false,
+         "rejected/no-origin"},
+        {CARGO_RECEIPT_TRUST_REJECT_ORIGIN_EVENT_TYPE, false,
+         "rejected/origin"},
+        {CARGO_RECEIPT_TRUST_REJECT_ORIGIN_CARGO, false,
+         "rejected/origin"},
+        {CARGO_RECEIPT_TRUST_REJECT_ORIGIN_PIN, false,
+         "rejected/origin"},
+        {CARGO_RECEIPT_TRUST_REJECT_ORIGIN_AUTHORITY, false,
+         "rejected/seal"},
+        {CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY, false,
+         "rejected/unknown"},
+        {CARGO_RECEIPT_TRUST_REJECT_UNTRUSTED_AUTHORITY, false,
+         "rejected/untrusted"},
+        {CARGO_RECEIPT_TRUST_REJECT_REVOKED_AUTHORITY, false,
+         "rejected/revoked"},
+        {CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY, true,
+         "accepted/unknown"},
+        {CARGO_RECEIPT_TRUST_REJECT_UNTRUSTED_AUTHORITY, true,
+         "accepted/untrusted"},
+    };
+    for (size_t i = 0; i < sizeof(vectors) / sizeof(vectors[0]); i++) {
+        ASSERT_STR_EQ(cargo_receipt_trust_semantic_label(
+                          vectors[i].status, vectors[i].accepted),
+                      vectors[i].label);
+    }
 }
 
 static cargo_unit_t crs_test_ingot(const uint8_t cargo_pk[32]) {
@@ -1769,6 +1827,7 @@ void register_cross_station_settlement_tests(void) {
     RUN(test_receipt_trust_distinguishes_origin_proof_failures);
     RUN(test_receipt_trust_distinguishes_authority_policy);
     RUN(test_receipt_trust_preserves_cryptographic_chain_failure);
+    RUN(test_receipt_trust_semantic_labels_cover_stable_verdict_contract);
     RUN(test_station_trust_evaluator_accepts_current_and_local_origin);
     RUN(test_station_trust_evaluator_accepts_rotated_origin_key);
     RUN(test_station_trust_evaluator_applies_unknown_untrusted_and_revoked_policy);

--- a/tests/c/test_signal_verify.c
+++ b/tests/c/test_signal_verify.c
@@ -15,7 +15,9 @@
 #include "chain_log.h"
 #include "station_authority.h"
 #include "game_sim.h"
+#include "cargo_receipt.h"
 #include "sha256.h"
+#include "signal_crypto.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -425,6 +427,25 @@ static const char *sv_find_signal_rati_receipt_bin(void) {
     return NULL;
 }
 
+static const char *sv_find_signal_receipt_verify_bin(void) {
+    static const char *candidates[] = {
+        "build-test/signal_receipt_verify",
+        "build-coverage/signal_receipt_verify",
+        "build/signal_receipt_verify",
+        "./signal_receipt_verify",
+        "../build-test/signal_receipt_verify",
+        "../build-coverage/signal_receipt_verify",
+        "../build/signal_receipt_verify",
+    };
+    for (size_t i = 0; i < sizeof(candidates) / sizeof(candidates[0]); i++) {
+        FILE *f = fopen(candidates[i], "rb");
+        if (!f) continue;
+        fclose(f);
+        return candidates[i];
+    }
+    return NULL;
+}
+
 static void sv_hex32(const uint8_t in[32], char out[65]) {
     static const char h[] = "0123456789abcdef";
     for (int i = 0; i < 32; i++) {
@@ -748,6 +769,126 @@ TEST(test_signal_rati_receipt_cli_emits_smelt_receipt) {
 
     sv_teardown();
 }
+
+TEST(test_signal_receipt_verify_cli_semantic_vectors) {
+    const char *verify_bin = sv_find_signal_receipt_verify_bin();
+    if (!verify_bin) {
+        TEST_WARN("signal_receipt_verify binary not built; skipping CLI vectors");
+        return;
+    }
+
+    uint8_t seed[32];
+    uint8_t cargo_pub[32];
+    for (int i = 0; i < 32; i++) {
+        seed[i] = (uint8_t)(0x21 + i);
+        cargo_pub[i] = (uint8_t)(0x71 + i);
+    }
+    uint8_t authority[32], secret[64], origin_hash[32];
+    signal_crypto_keypair_from_seed(seed, authority, secret);
+    sha256_bytes(cargo_pub, sizeof(cargo_pub), origin_hash);
+
+    cargo_receipt_t receipt = {0};
+    memcpy(receipt.cargo_pub, cargo_pub, 32);
+    memcpy(receipt.authoring_station, authority, 32);
+    memset(receipt.recipient_pubkey, 0x44, 32);
+    receipt.event_id = 8;
+    receipt.epoch = 12;
+    memcpy(receipt.prev_receipt_hash, origin_hash, 32);
+    uint8_t unsigned_receipt[CARGO_RECEIPT_UNSIGNED_SIZE];
+    cargo_receipt_unsigned_pack(&receipt, unsigned_receipt);
+    signal_crypto_sign(receipt.signature, unsigned_receipt,
+                       sizeof(unsigned_receipt), secret);
+
+    char chain_path[256];
+    snprintf(chain_path, sizeof(chain_path), "%s_receipt-trust.bin",
+             TMP("receipt"));
+    uint8_t packed[CARGO_RECEIPT_SIZE];
+    cargo_receipt_pack(&receipt, packed);
+    FILE *chain_file = fopen(chain_path, "wb");
+    ASSERT(chain_file != NULL);
+    ASSERT(fwrite(packed, 1, sizeof(packed), chain_file) == sizeof(packed));
+    ASSERT(fclose(chain_file) == 0);
+
+    char cargo_hex[65], origin_hex[65], authority_hex[65];
+    sv_hex32(cargo_pub, cargo_hex);
+    sv_hex32(origin_hash, origin_hex);
+    sv_hex32(authority, authority_hex);
+    char base[1536];
+    snprintf(base, sizeof(base),
+             "%s --report=json --cargo-pub=%s --origin-event=smelt "
+             "--origin-hash=%s --origin-authority=%s "
+             "--origin-event-id=7 --origin-epoch=11",
+             verify_bin, cargo_hex, origin_hex, authority_hex);
+
+    static const struct {
+        const char *policy;
+        unsigned status_code;
+        bool accepted;
+        const char *semantic;
+    } policy_vectors[] = {
+        {"current", 0, true, "accepted/trusted"},
+        {"rotated", 1, true, "accepted/rotated"},
+        {"unknown", 9, false, "rejected/unknown"},
+        {"untrusted", 10, false, "rejected/untrusted"},
+        {"revoked", 11, false, "rejected/revoked"},
+    };
+    for (size_t i = 0;
+         i < sizeof(policy_vectors) / sizeof(policy_vectors[0]); i++) {
+        char cmd[2048];
+        snprintf(cmd, sizeof(cmd), "%s --authority-trust=%s %s 2>/dev/null",
+                 base, policy_vectors[i].policy, chain_path);
+        FILE *p = popen(cmd, "r");
+        ASSERT(p != NULL);
+        char output[8192] = {0};
+        ASSERT(fread(output, 1, sizeof(output) - 1, p) > 0);
+        (void)pclose(p);
+        char status_field[64];
+        snprintf(status_field, sizeof(status_field),
+                 "\"status_code\":%u", policy_vectors[i].status_code);
+        ASSERT(strstr(output,
+                      "\"schema\":\"signal.cargo_receipt_trust.v1\"") != NULL);
+        ASSERT(strstr(output, status_field) != NULL);
+        ASSERT(strstr(output, policy_vectors[i].accepted
+                                 ? "\"accepted\":true"
+                                 : "\"accepted\":false") != NULL);
+        ASSERT(strstr(output, policy_vectors[i].semantic) != NULL);
+        ASSERT(strstr(output, cargo_hex) != NULL);
+        ASSERT(strstr(output, origin_hex) != NULL);
+        ASSERT(strstr(output, authority_hex) != NULL);
+    }
+
+    char cmd[2048];
+    snprintf(cmd, sizeof(cmd),
+             "%s --report=json --cargo-pub=%s --origin-event=missing "
+             "--authority-trust=current %s 2>/dev/null",
+             verify_bin, cargo_hex, chain_path);
+    FILE *p = popen(cmd, "r");
+    ASSERT(p != NULL);
+    char output[8192] = {0};
+    ASSERT(fread(output, 1, sizeof(output) - 1, p) > 0);
+    (void)pclose(p);
+    ASSERT(strstr(output, "\"status_code\":4") != NULL);
+    ASSERT(strstr(output, "rejected/no-origin") != NULL);
+    ASSERT(strstr(output, "\"origin_hash\":null") != NULL);
+
+    receipt.signature[0] ^= 0x01u;
+    cargo_receipt_pack(&receipt, packed);
+    chain_file = fopen(chain_path, "wb");
+    ASSERT(chain_file != NULL);
+    ASSERT(fwrite(packed, 1, sizeof(packed), chain_file) == sizeof(packed));
+    ASSERT(fclose(chain_file) == 0);
+    snprintf(cmd, sizeof(cmd), "%s --authority-trust=current %s 2>/dev/null",
+             base, chain_path);
+    p = popen(cmd, "r");
+    ASSERT(p != NULL);
+    memset(output, 0, sizeof(output));
+    ASSERT(fread(output, 1, sizeof(output) - 1, p) > 0);
+    (void)pclose(p);
+    ASSERT(strstr(output, "\"status_code\":3") != NULL);
+    ASSERT(strstr(output, "\"chain_code\":3") != NULL);
+    ASSERT(strstr(output, "rejected/witness") != NULL);
+    memset(secret, 0, sizeof(secret));
+}
 #endif
 
 void register_signal_verify_tests(void);
@@ -765,5 +906,6 @@ void register_signal_verify_tests(void) {
     RUN(test_signal_verify_tower_chain_invariant_detects_orphan);
     RUN(test_signal_chain_assets_lineage_cli_prints_craft_tree);
     RUN(test_signal_rati_receipt_cli_emits_smelt_receipt);
+    RUN(test_signal_receipt_verify_cli_semantic_vectors);
 #endif
 }

--- a/tools/signal_receipt_verify.c
+++ b/tools/signal_receipt_verify.c
@@ -1,0 +1,368 @@
+/*
+ * signal_receipt_verify -- semantic verifier for portable cargo receipts.
+ *
+ * Input is a raw concatenation of canonical 208-byte cargo_receipt_t records
+ * in chronological order. Origin facts and authority policy are explicit CLI
+ * inputs so the tool cannot imply that a self-consistent signature chain also
+ * proves production origin or local issuer trust.
+ */
+
+#include "base58.h"
+#include "cargo_receipt.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef enum { REPORT_TEXT, REPORT_JSON } report_format_t;
+
+typedef struct {
+    const char *chain_path;
+    report_format_t report;
+    bool cargo_set;
+    uint8_t cargo_pub[32];
+    bool origin_event_set;
+    cargo_receipt_origin_event_t origin_event;
+    bool origin_hash_set;
+    uint8_t origin_hash[32];
+    bool origin_authority_set;
+    uint8_t origin_authority[32];
+    uint64_t origin_event_id;
+    uint64_t origin_epoch;
+    bool authority_trust_set;
+    cargo_receipt_authority_trust_t authority_trust;
+} cli_opts_t;
+
+static void usage(FILE *out) {
+    fprintf(out,
+        "usage: signal_receipt_verify [options] <receipt-chain.bin>\n"
+        "\n"
+        "Required:\n"
+        "  --cargo-pub=<hex|base58>\n"
+        "  --origin-event=<smelt|craft|missing>\n"
+        "  --authority-trust=<current|rotated|unknown|untrusted|revoked>\n"
+        "\n"
+        "Required unless origin-event=missing:\n"
+        "  --origin-hash=<hex>          SHA-256 of producing event header\n"
+        "  --origin-authority=<hex|base58>\n"
+        "\n"
+        "Optional:\n"
+        "  --origin-event-id=<n>        Audit detail (default 0)\n"
+        "  --origin-epoch=<n>           Audit detail (default 0)\n"
+        "  --report=<text|json>         Default text\n"
+        "  -h, --help\n"
+        "\n"
+        "Exit: 0 accepted, 1 rejected, 2 malformed input.\n");
+}
+
+static int hex_nibble(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return 10 + c - 'a';
+    if (c >= 'A' && c <= 'F') return 10 + c - 'A';
+    return -1;
+}
+
+static bool parse_hex32(const char *text, uint8_t out[32]) {
+    if (!text || strlen(text) != 64u) return false;
+    for (size_t i = 0; i < 32u; i++) {
+        int hi = hex_nibble(text[i * 2u]);
+        int lo = hex_nibble(text[i * 2u + 1u]);
+        if (hi < 0 || lo < 0) return false;
+        out[i] = (uint8_t)((hi << 4) | lo);
+    }
+    return true;
+}
+
+static bool parse_pub(const char *text, uint8_t out[32]) {
+    return parse_hex32(text, out) || base58_decode(text, out, 32) == 32;
+}
+
+static bool parse_u64(const char *text, uint64_t *out) {
+    if (!text || !*text || !out) return false;
+    uint64_t value = 0;
+    for (const char *p = text; *p; p++) {
+        if (*p < '0' || *p > '9') return false;
+        uint64_t digit = (uint64_t)(*p - '0');
+        if (value > (UINT64_MAX - digit) / 10u) return false;
+        value = value * 10u + digit;
+    }
+    *out = value;
+    return true;
+}
+
+static bool parse_origin_event(const char *text,
+                               cargo_receipt_origin_event_t *out) {
+    if (strcmp(text, "missing") == 0) {
+        *out = CARGO_RECEIPT_ORIGIN_EVENT_NONE;
+        return true;
+    }
+    if (strcmp(text, "smelt") == 0) {
+        *out = CARGO_RECEIPT_ORIGIN_EVENT_SMELT;
+        return true;
+    }
+    if (strcmp(text, "craft") == 0) {
+        *out = CARGO_RECEIPT_ORIGIN_EVENT_CRAFT;
+        return true;
+    }
+    return false;
+}
+
+static bool parse_authority_trust(
+    const char *text, cargo_receipt_authority_trust_t *out) {
+    if (strcmp(text, "current") == 0) {
+        *out = CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT;
+        return true;
+    }
+    if (strcmp(text, "rotated") == 0) {
+        *out = CARGO_RECEIPT_AUTHORITY_TRUSTED_ROTATED;
+        return true;
+    }
+    if (strcmp(text, "unknown") == 0) {
+        *out = CARGO_RECEIPT_AUTHORITY_UNKNOWN;
+        return true;
+    }
+    if (strcmp(text, "untrusted") == 0) {
+        *out = CARGO_RECEIPT_AUTHORITY_UNTRUSTED;
+        return true;
+    }
+    if (strcmp(text, "revoked") == 0) {
+        *out = CARGO_RECEIPT_AUTHORITY_REVOKED;
+        return true;
+    }
+    return false;
+}
+
+static bool parse_args(int argc, char **argv, cli_opts_t *opts) {
+    memset(opts, 0, sizeof(*opts));
+    opts->report = REPORT_TEXT;
+    for (int i = 1; i < argc; i++) {
+        const char *arg = argv[i];
+        if (strcmp(arg, "-h") == 0 || strcmp(arg, "--help") == 0) {
+            usage(stdout);
+            exit(0);
+        } else if (strncmp(arg, "--cargo-pub=", 12) == 0) {
+            opts->cargo_set = parse_pub(arg + 12, opts->cargo_pub);
+            if (!opts->cargo_set) return false;
+        } else if (strncmp(arg, "--origin-event=", 15) == 0) {
+            opts->origin_event_set =
+                parse_origin_event(arg + 15, &opts->origin_event);
+            if (!opts->origin_event_set) return false;
+        } else if (strncmp(arg, "--origin-hash=", 14) == 0) {
+            opts->origin_hash_set =
+                parse_hex32(arg + 14, opts->origin_hash);
+            if (!opts->origin_hash_set) return false;
+        } else if (strncmp(arg, "--origin-authority=", 19) == 0) {
+            opts->origin_authority_set =
+                parse_pub(arg + 19, opts->origin_authority);
+            if (!opts->origin_authority_set) return false;
+        } else if (strncmp(arg, "--origin-event-id=", 18) == 0) {
+            if (!parse_u64(arg + 18, &opts->origin_event_id)) return false;
+        } else if (strncmp(arg, "--origin-epoch=", 15) == 0) {
+            if (!parse_u64(arg + 15, &opts->origin_epoch)) return false;
+        } else if (strncmp(arg, "--authority-trust=", 18) == 0) {
+            opts->authority_trust_set =
+                parse_authority_trust(arg + 18, &opts->authority_trust);
+            if (!opts->authority_trust_set) return false;
+        } else if (strcmp(arg, "--report=json") == 0) {
+            opts->report = REPORT_JSON;
+        } else if (strcmp(arg, "--report=text") == 0) {
+            opts->report = REPORT_TEXT;
+        } else if (arg[0] == '-') {
+            return false;
+        } else if (!opts->chain_path) {
+            opts->chain_path = arg;
+        } else {
+            return false;
+        }
+    }
+    if (!opts->chain_path || !opts->cargo_set ||
+        !opts->origin_event_set || !opts->authority_trust_set)
+        return false;
+    if (opts->origin_event != CARGO_RECEIPT_ORIGIN_EVENT_NONE &&
+        (!opts->origin_hash_set || !opts->origin_authority_set))
+        return false;
+    return true;
+}
+
+static bool load_chain(const char *path,
+                       cargo_receipt_t chain[CARGO_RECEIPT_CHAIN_MAX_LEN],
+                       size_t *count_out) {
+    FILE *file = fopen(path, "rb");
+    if (!file) return false;
+    size_t count = 0;
+    for (;;) {
+        uint8_t packed[CARGO_RECEIPT_SIZE];
+        size_t got = fread(packed, 1, sizeof(packed), file);
+        if (got == 0 && feof(file)) break;
+        if (got != sizeof(packed) ||
+            count >= CARGO_RECEIPT_CHAIN_MAX_LEN ||
+            !cargo_receipt_unpack(packed, &chain[count])) {
+            fclose(file);
+            return false;
+        }
+        count++;
+    }
+    fclose(file);
+    *count_out = count;
+    return true;
+}
+
+static void hex32(const uint8_t bytes[32], char out[65]) {
+    static const char digits[] = "0123456789abcdef";
+    for (size_t i = 0; i < 32; i++) {
+        out[i * 2u] = digits[bytes[i] >> 4];
+        out[i * 2u + 1u] = digits[bytes[i] & 0x0fu];
+    }
+    out[64] = '\0';
+}
+
+static const char *chain_result_name(cargo_receipt_result_t result) {
+    switch (result) {
+    case CARGO_RECEIPT_OK: return "ok";
+    case CARGO_RECEIPT_REJECT_EMPTY: return "reject_empty";
+    case CARGO_RECEIPT_REJECT_TOO_LONG: return "reject_too_long";
+    case CARGO_RECEIPT_REJECT_BAD_SIGNATURE: return "reject_bad_signature";
+    case CARGO_RECEIPT_REJECT_BROKEN_LINKAGE: return "reject_broken_linkage";
+    case CARGO_RECEIPT_REJECT_CARGO_MISMATCH: return "reject_cargo_mismatch";
+    case CARGO_RECEIPT_REJECT_ZERO_AUTHORITY: return "reject_zero_authority";
+    case CARGO_RECEIPT_REJECT_ZERO_ORIGIN: return "reject_zero_origin";
+    default: return "unknown";
+    }
+}
+
+static const char *origin_event_name(cargo_receipt_origin_event_t event) {
+    switch (event) {
+    case CARGO_RECEIPT_ORIGIN_EVENT_SMELT: return "smelt";
+    case CARGO_RECEIPT_ORIGIN_EVENT_CRAFT: return "craft";
+    default: return "missing";
+    }
+}
+
+static const char *authority_trust_name(
+    cargo_receipt_authority_trust_t trust) {
+    switch (trust) {
+    case CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT: return "current";
+    case CARGO_RECEIPT_AUTHORITY_TRUSTED_ROTATED: return "rotated";
+    case CARGO_RECEIPT_AUTHORITY_UNKNOWN: return "unknown";
+    case CARGO_RECEIPT_AUTHORITY_UNTRUSTED: return "untrusted";
+    case CARGO_RECEIPT_AUTHORITY_REVOKED: return "revoked";
+    default: return "invalid";
+    }
+}
+
+static bool trust_accepted(cargo_receipt_trust_status_t status) {
+    return status == CARGO_RECEIPT_TRUST_VALID_TRUSTED ||
+           status == CARGO_RECEIPT_TRUST_VALID_TRUSTED_ROTATED;
+}
+
+static void print_json(const cli_opts_t *opts,
+                       const cargo_receipt_t *chain,
+                       size_t count,
+                       const cargo_receipt_trust_result_t *result) {
+    char cargo[65], origin_hash[65] = {0}, origin_authority[65] = {0};
+    char first_authority[65] = {0}, head_hash[65] = {0};
+    hex32(opts->cargo_pub, cargo);
+    if (opts->origin_hash_set) hex32(opts->origin_hash, origin_hash);
+    if (opts->origin_authority_set)
+        hex32(opts->origin_authority, origin_authority);
+    if (count > 0) {
+        uint8_t hash[32];
+        hex32(chain[0].authoring_station, first_authority);
+        cargo_receipt_hash(&chain[count - 1u], hash);
+        hex32(hash, head_hash);
+    }
+    bool accepted = trust_accepted(result->status);
+    printf("{\n");
+    printf("  \"schema\":\"signal.cargo_receipt_trust.v1\",\n");
+    printf("  \"accepted\":%s,\n", accepted ? "true" : "false");
+    printf("  \"verdict\":{\"status_code\":%u,\"status\":\"%s\","
+           "\"semantic\":\"%s\",\"chain_code\":%u,\"chain\":\"%s\","
+           "\"origin_event_code\":%u,\"origin_event\":\"%s\","
+           "\"authority_trust_code\":%u,\"authority_trust\":\"%s\"},\n",
+           (unsigned)result->status,
+           cargo_receipt_trust_status_name(result->status),
+           cargo_receipt_trust_semantic_label(result->status, accepted),
+           (unsigned)result->chain_result,
+           chain_result_name(result->chain_result),
+           (unsigned)result->origin_event,
+           origin_event_name(result->origin_event),
+           (unsigned)result->authority_trust,
+           authority_trust_name(result->authority_trust));
+    printf("  \"audit\":{\"cargo_pub\":\"%s\",\"receipt_count\":%zu,",
+           cargo, count);
+    if (opts->origin_event == CARGO_RECEIPT_ORIGIN_EVENT_NONE) {
+        printf("\"origin_hash\":null,\"origin_authority\":null,");
+    } else {
+        printf("\"origin_hash\":\"%s\",\"origin_authority\":\"%s\",",
+               origin_hash, origin_authority);
+    }
+    printf("\"origin_event_id\":%llu,\"origin_epoch\":%llu,",
+           (unsigned long long)opts->origin_event_id,
+           (unsigned long long)opts->origin_epoch);
+    if (count > 0)
+        printf("\"first_receipt_authority\":\"%s\","
+               "\"receipt_head_hash\":\"%s\"}\n",
+               first_authority, head_hash);
+    else
+        printf("\"first_receipt_authority\":null,"
+               "\"receipt_head_hash\":null}\n");
+    printf("}\n");
+}
+
+static void print_text(const cli_opts_t *opts,
+                       size_t count,
+                       const cargo_receipt_trust_result_t *result) {
+    bool accepted = trust_accepted(result->status);
+    printf("Receipt: %s\n",
+           cargo_receipt_trust_semantic_label(result->status, accepted));
+    printf("Origin: %s (%s)\n",
+           origin_event_name(result->origin_event),
+           result->status == CARGO_RECEIPT_TRUST_REJECT_MISSING_ORIGIN
+               ? "proof missing" : "proof evaluated");
+    printf("Seal: %s\n", authority_trust_name(result->authority_trust));
+    printf("Witnesses: %zu signed receipt link%s\n",
+           count, count == 1 ? "" : "s");
+    printf("Audit: status=%u:%s chain=%u:%s event_id=%llu epoch=%llu\n",
+           (unsigned)result->status,
+           cargo_receipt_trust_status_name(result->status),
+           (unsigned)result->chain_result,
+           chain_result_name(result->chain_result),
+           (unsigned long long)opts->origin_event_id,
+           (unsigned long long)opts->origin_epoch);
+}
+
+int main(int argc, char **argv) {
+    cli_opts_t opts;
+    if (!parse_args(argc, argv, &opts)) {
+        usage(stderr);
+        return 2;
+    }
+
+    cargo_receipt_t chain[CARGO_RECEIPT_CHAIN_MAX_LEN];
+    size_t count = 0;
+    if (!load_chain(opts.chain_path, chain, &count)) {
+        fprintf(stderr, "signal_receipt_verify: malformed receipt chain\n");
+        return 2;
+    }
+
+    cargo_receipt_origin_proof_t origin = {
+        .event_type = opts.origin_event,
+        .event_id = opts.origin_event_id,
+        .epoch = opts.origin_epoch,
+    };
+    memcpy(origin.event_hash, opts.origin_hash, 32);
+    memcpy(origin.output_cargo_pub, opts.cargo_pub, 32);
+    memcpy(origin.authority, opts.origin_authority, 32);
+    cargo_receipt_trust_result_t result = cargo_receipt_trust_verify(
+        chain, count, opts.cargo_pub,
+        opts.origin_event == CARGO_RECEIPT_ORIGIN_EVENT_NONE ? NULL : &origin,
+        opts.authority_trust);
+
+    if (opts.report == REPORT_JSON)
+        print_json(&opts, chain, count, &result);
+    else
+        print_text(&opts, count, &result);
+    return trust_accepted(result.status) ? 0 : 1;
+}

--- a/tools/signal_replay.c
+++ b/tools/signal_replay.c
@@ -215,6 +215,7 @@ typedef struct {
     cargo_receipt_trust_status_t trusted_craft;
     cargo_receipt_trust_status_t trusted_rotated;
     cargo_receipt_trust_status_t unknown_authority;
+    cargo_receipt_trust_status_t untrusted_authority;
     cargo_receipt_trust_status_t revoked_authority;
     cargo_receipt_trust_status_t missing_origin;
     cargo_receipt_trust_status_t tampered_chain;
@@ -316,6 +317,9 @@ static bool sr_receipt_trust_known_vector(
     out->unknown_authority = cargo_receipt_trust_verify(
         &receipt, 1, cargo_pub, &proof,
         CARGO_RECEIPT_AUTHORITY_UNKNOWN).status;
+    out->untrusted_authority = cargo_receipt_trust_verify(
+        &receipt, 1, cargo_pub, &proof,
+        CARGO_RECEIPT_AUTHORITY_UNTRUSTED).status;
     out->revoked_authority = cargo_receipt_trust_verify(
         &receipt, 1, cargo_pub, &proof,
         CARGO_RECEIPT_AUTHORITY_REVOKED).status;
@@ -334,6 +338,8 @@ static bool sr_receipt_trust_known_vector(
                CARGO_RECEIPT_TRUST_VALID_TRUSTED_ROTATED &&
            out->unknown_authority ==
                CARGO_RECEIPT_TRUST_REJECT_UNKNOWN_AUTHORITY &&
+           out->untrusted_authority ==
+               CARGO_RECEIPT_TRUST_REJECT_UNTRUSTED_AUTHORITY &&
            out->revoked_authority ==
                CARGO_RECEIPT_TRUST_REJECT_REVOKED_AUTHORITY &&
            out->missing_origin ==
@@ -3960,6 +3966,7 @@ static void sr_write_row(FILE *out, const sr_config_t *config, const sr_result_t
             "\"trusted_craft\":%d,"
             "\"trusted_rotated\":%d,"
             "\"unknown_authority\":%d,"
+            "\"untrusted_authority\":%d,"
             "\"revoked_authority\":%d,"
             "\"missing_origin\":%d,"
             "\"tampered_chain\":%d}",
@@ -3967,6 +3974,7 @@ static void sr_write_row(FILE *out, const sr_config_t *config, const sr_result_t
             (int)r->receipt_trust.trusted_craft,
             (int)r->receipt_trust.trusted_rotated,
             (int)r->receipt_trust.unknown_authority,
+            (int)r->receipt_trust.untrusted_authority,
             (int)r->receipt_trust.revoked_authority,
             (int)r->receipt_trust.missing_origin,
             (int)r->receipt_trust.tampered_chain);


### PR DESCRIPTION
## Summary

- add `signal_receipt_verify` with explicit origin proof and authority policy inputs, semantic text output, and stable `signal.cargo_receipt_trust.v1` JSON audit fields
- share semantic verdict labels across the cargo inspection HUD and verifier
- extend deterministic native/WASM replay vectors with untrusted authority coverage and document the receipt proof/policy boundary

## Validation

- strict native build
- native suite: 1241/1241 passed before final label-table addition; focused final receipt-trust suite: 5/5 passed
- ASan/UBSan suite: 1250/1250 passed; focused final receipt-trust suite: 5/5 passed
- deterministic compile flags: native and WASM passed
- replay repeatability: 20/20 fast scenarios passed
- native vs WASM replay: 20/20 fast scenarios byte-identical
- scope audit: `server/main.c` and fuzz corpus untouched

Closes #636