### PR TITLE
Harden native sanitizer and secret lifecycles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ on:
       - 'Makefile'
       - '.github/workflows/ci.yml'
   workflow_dispatch:
+  schedule:
+    - cron: '23 8 * * 2'
 
 permissions:
   contents: read
@@ -59,3 +61,28 @@ jobs:
           name: fuzz-cargo-receipt-artifacts
           path: tests/fuzz/artifacts/
           if-no-files-found: ignore
+
+  memory-sanitizer:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install MemorySanitizer toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build
+      - name: Check instrumentable native core for uninitialized reads
+        run: make memzero-codegen test-msan
+
+  thread-sanitizer:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install ThreadSanitizer toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build
+      - name: Check reentrant simulation and HNN state
+        run: make test-tsan

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,14 @@ if(NOT SIGNAL_CRYPTO_BACKEND STREQUAL "tweetnacl")
         "use 'tweetnacl'.")
 endif()
 
-set(SIGNAL_CRYPTO_SOURCES
+set(SIGNAL_CRYPTO_VENDOR_SOURCES
     vendor/tweetnacl/tweetnacl.c
     vendor/tweetnacl/randombytes.c
     vendor/tweetnacl/signal_crypto_tweetnacl.c
+)
+set(SIGNAL_CRYPTO_SOURCES
+    shared/signal_memzero.c
+    ${SIGNAL_CRYPTO_VENDOR_SOURCES}
 )
 set(SIGNAL_CRYPTO_INCLUDE_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/vendor/tweetnacl"
@@ -38,10 +42,10 @@ set(SIGNAL_CRYPTO_INCLUDE_DIR
 # the project's own code remains under full UBSan scrutiny.
 # `-fno-sanitize=...` is silently accepted in non-sanitized builds.
 if(MSVC)
-    set_source_files_properties(${SIGNAL_CRYPTO_SOURCES}
+    set_source_files_properties(${SIGNAL_CRYPTO_VENDOR_SOURCES}
         PROPERTIES COMPILE_OPTIONS "/W0")
 else()
-    set_source_files_properties(${SIGNAL_CRYPTO_SOURCES}
+    set_source_files_properties(${SIGNAL_CRYPTO_VENDOR_SOURCES}
         PROPERTIES COMPILE_OPTIONS "-w;-fno-sanitize=shift;-fno-sanitize=signed-integer-overflow")
 endif()
 
@@ -311,6 +315,7 @@ if(NOT EMSCRIPTEN AND NOT BUILD_SERVER_ONLY)
         tests/c/test_signal_field.c
         tests/c/test_gossip.c
         tests/c/test_npc_radio.c
+        tests/c/test_native_safety.c
         client/identity.c
         client/client_log.c
         ${SIGNAL_SIM_SOURCES}
@@ -322,6 +327,8 @@ if(NOT EMSCRIPTEN AND NOT BUILD_SERVER_ONLY)
         ${SIGNAL_INCLUDE_DIRS}
         ${SIGNAL_CRYPTO_INCLUDE_DIR})
     signal_apply_sim_profile(signal_test)
+    find_package(Threads REQUIRED)
+    target_link_libraries(signal_test PRIVATE Threads::Threads)
     if(NOT MSVC)
         target_link_libraries(signal_test PRIVATE m)
         target_compile_options(signal_test PRIVATE -Wall -Wextra -Wpedantic -Werror -ffp-contract=off -fno-fast-math)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-web build-server build-test build-san test-san test-tsan build-flight-trace flight-trace build-signal-replay build-signal-replay-wasm signal-replay replay-repeatability replay-repeatability-long signal-no-omniscience-soak replay-cross-build replay-cross-build-long replay-native-wasm replay-native-wasm-long build-chain-assets chain-assets build-rati-receipt rati-receipt rati-anchor-batch test-rati-anchor-batch rati-anchor-stamp test-rati-anchor-stamp neural-gap-ab signal-client-brain-shadow signal-hnn-shadow assets protocol-check test test-serial test-fast test-soak test-all smoke smoke-latency smoke-ack-lag smoke-latency-suite relay-traffic-probe banned-apis deterministic-libm deterministic-build-flags doc-freshness fuzz-receipts fuzz-receipts-standalone cppcheck crap profile-machine latency-proxy latency-proxy-high latency-proxy-ack-lag rtc-gateway deploy-fly site clean install-hooks
+.PHONY: all build build-web build-server build-test build-san test-san build-msan test-msan build-tsan test-tsan memzero-codegen build-flight-trace flight-trace build-signal-replay build-signal-replay-wasm signal-replay replay-repeatability replay-repeatability-long signal-no-omniscience-soak replay-cross-build replay-cross-build-long replay-native-wasm replay-native-wasm-long build-chain-assets chain-assets build-rati-receipt rati-receipt rati-anchor-batch test-rati-anchor-batch rati-anchor-stamp test-rati-anchor-stamp neural-gap-ab signal-client-brain-shadow signal-hnn-shadow assets protocol-check test test-serial test-fast test-soak test-all smoke smoke-latency smoke-ack-lag smoke-latency-suite relay-traffic-probe banned-apis deterministic-libm deterministic-build-flags doc-freshness fuzz-receipts fuzz-receipts-standalone cppcheck crap profile-machine latency-proxy latency-proxy-high latency-proxy-ack-lag rtc-gateway deploy-fly site clean install-hooks
 
 all: build build-web build-server
 
@@ -400,6 +400,13 @@ test-serial: build-test
 SANITIZER ?= address,undefined
 SAN_BUILD_DIR ?= build-san
 SAN_TEST_FLAGS ?= --quiet --no-soak
+ifeq ($(UNAME_S),Linux)
+ASAN_DETECT_LEAKS ?= 1
+else
+# LeakSanitizer is not available in Apple's ASan runtime. Linux CI is the
+# authoritative leak gate; keep local macOS ASan/UBSan usable.
+ASAN_DETECT_LEAKS ?= 0
+endif
 
 build-san:
 	cmake $(GENERATOR) -S . -B $(SAN_BUILD_DIR) -DCMAKE_BUILD_TYPE=Debug \
@@ -410,26 +417,64 @@ build-san:
 	cmake --build $(SAN_BUILD_DIR) --parallel
 
 test-san: TEST_BIN=./$(SAN_BUILD_DIR)/signal_test
-# Legacy fixtures frequently clear seeded station/NPC arrays with memset,
-# discarding fixture-owned manifests before WORLD_DECL cleanup runs. Keep this
-# gate focused on address/undefined behavior until those fixture leaks are
-# migrated to cleanup-aware reset helpers.
-test-san: TEST_ENV=ASAN_OPTIONS=detect_leaks=0:halt_on_error=1 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
+test-san: TEST_ENV=ASAN_OPTIONS=detect_leaks=$(ASAN_DETECT_LEAKS):halt_on_error=1 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
 test-san: TEST_PREFIX=$(TEST_STACK_PREFIX)
 test-san: build-san
 	$(call RUN_PARALLEL_TESTS,$(SAN_TEST_FLAGS))
 
-test-tsan: TEST_BIN=./build-tsan/signal_test
-test-tsan: TEST_ENV=TSAN_OPTIONS=halt_on_error=1
-test-tsan: TEST_PREFIX=$(TEST_STACK_PREFIX)
-test-tsan:
-	cmake $(GENERATOR) -S . -B build-tsan -DCMAKE_BUILD_TYPE=Debug \
+MSAN_CC ?= clang
+MSAN_BUILD_DIR ?= build-msan
+MSAN_TEST_FILTERS ?= memzero identity station_authority signed_action
+
+build-msan:
+	cmake $(GENERATOR) -S . -B $(MSAN_BUILD_DIR) \
+		-DCMAKE_C_COMPILER=$(MSAN_CC) -DCMAKE_BUILD_TYPE=Debug \
 		-DBUILD_TESTS_ONLY=ON -DGIT_HASH=$(GIT_HASH) $(SIM_PROFILE_CMAKE) \
-		-DCMAKE_C_FLAGS="-O1 -g -fsanitize=thread -fno-omit-frame-pointer" \
-		-DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread"
-	@ln -sf build-tsan/compile_commands.json compile_commands.json
-	cmake --build build-tsan --parallel
-	$(call RUN_PARALLEL_TESTS,$(SAN_TEST_FLAGS))
+		-DCMAKE_C_FLAGS="-O1 -g -fsanitize=memory -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer -fPIE" \
+		-DCMAKE_EXE_LINKER_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2 -pie"
+	@ln -sf $(MSAN_BUILD_DIR)/compile_commands.json compile_commands.json
+	cmake --build $(MSAN_BUILD_DIR) --target signal_test --parallel
+
+test-msan: build-msan
+	@set -e; \
+	for filter in $(MSAN_TEST_FILTERS); do \
+		echo "MSan: $$filter"; \
+		$(TEST_STACK_PREFIX) MSAN_OPTIONS=halt_on_error=1:exit_code=86:poison_in_dtor=1 \
+			./$(MSAN_BUILD_DIR)/signal_test --quiet --no-soak \
+			--filter=$$filter; \
+	done
+
+MEMZERO_CC ?= clang
+MEMZERO_IR ?= build-safety/signal_memzero.ll
+
+memzero-codegen:
+	@mkdir -p $(@D) $(dir $(MEMZERO_IR))
+	$(MEMZERO_CC) -std=c11 -O3 -S -emit-llvm -Ishared \
+		shared/signal_memzero.c -o $(MEMZERO_IR)
+	@grep -Eq 'store volatile i8 0,' $(MEMZERO_IR) || { \
+		echo "explicit wipe fallback lost its volatile byte stores"; \
+		exit 1; \
+	}
+
+TSAN_CC ?= clang
+TSAN_BUILD_DIR ?= build-tsan
+TSAN_TEST_FLAGS ?= --quiet --no-soak --filter=native_safety_thread
+
+build-tsan:
+	cmake $(GENERATOR) -S . -B $(TSAN_BUILD_DIR) \
+		-DCMAKE_C_COMPILER=$(TSAN_CC) -DCMAKE_BUILD_TYPE=Debug \
+		-DBUILD_TESTS_ONLY=ON -DGIT_HASH=$(GIT_HASH) $(SIM_PROFILE_CMAKE) \
+		-DCMAKE_C_FLAGS="-O1 -g -fsanitize=thread -fno-omit-frame-pointer -fPIE" \
+		-DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread -pie"
+	@ln -sf $(TSAN_BUILD_DIR)/compile_commands.json compile_commands.json
+	cmake --build $(TSAN_BUILD_DIR) --target signal_test --parallel
+
+test-tsan: TEST_BIN=./$(TSAN_BUILD_DIR)/signal_test
+test-tsan: TEST_ENV=TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1
+test-tsan: TEST_PREFIX=$(TEST_STACK_PREFIX)
+test-tsan: TEST_SHARDS=1
+test-tsan: build-tsan
+	$(call RUN_PARALLEL_TESTS,$(TSAN_TEST_FLAGS))
 
 # libFuzzer harness for untrusted receipt/handoff decode paths.
 # Requires a clang that ships the libFuzzer runtime — Xcode CLT clang

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ for the `swarm.rati.chat` avatar sync workflow.
   multiplayer relay deployment on Fly.io.
 - [`docs/replay-harness.md`](docs/replay-harness.md): deterministic
   seed+prefix counterfactual replay harness for agent experiments.
+- [`docs/c_safety_policy.md`](docs/c_safety_policy.md): native ownership,
+  sanitizer lanes, vendor scope, and explicit secret-wipe policy.
 - [`docs/anime-integration-plan.md`](docs/anime-integration-plan.md): current
   in-engine milestone-video playback architecture and remaining work.
 - [`docs/space-mining-3d-v1.md`](docs/space-mining-3d-v1.md): draft v1

--- a/client/identity.c
+++ b/client/identity.c
@@ -19,6 +19,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "signal_memzero.h"
+
 #if defined(__EMSCRIPTEN__)
   #include <emscripten.h>
 #elif defined(_WIN32)
@@ -118,10 +120,12 @@ static bool read_secret_file(const char *path,
     int eof = feof(fp);
     fclose(fp);
     if (got != SIGNAL_CRYPTO_SECRET_BYTES || !eof) {
+        signal_memzero_explicit(buf, sizeof(buf));
         *out_corrupt = true;
         return false;
     }
     memcpy(out, buf, SIGNAL_CRYPTO_SECRET_BYTES);
+    signal_memzero_explicit(buf, sizeof(buf));
     return true;
 }
 
@@ -265,14 +269,16 @@ bool identity_save_to(const player_identity_t *id, const char *path) {
     (void)path;
     char enc[128];
     b64_encode(id->secret, SIGNAL_CRYPTO_SECRET_BYTES, enc);
-    return signal_localstorage_save(enc) == 1;
+    bool saved = signal_localstorage_save(enc) == 1;
+    signal_memzero_explicit(enc, sizeof(enc));
+    return saved;
 #else
     return write_secret_file(path, id->secret);
 #endif
 }
 
 bool identity_load_or_generate_at(player_identity_t *out, const char *path) {
-    memset(out, 0, sizeof(*out));
+    signal_memzero_explicit(out, sizeof(*out));
 
 #if defined(__EMSCRIPTEN__)
     (void)path;
@@ -288,27 +294,33 @@ bool identity_load_or_generate_at(player_identity_t *out, const char *path) {
                    out->secret + (SIGNAL_CRYPTO_SECRET_BYTES -
                                   SIGNAL_CRYPTO_PUBKEY_BYTES),
                    SIGNAL_CRYPTO_PUBKEY_BYTES);
+            signal_memzero_explicit(dec, sizeof(dec));
+            signal_memzero_explicit(enc, sizeof(enc));
             return true;
         }
+        signal_memzero_explicit(dec, sizeof(dec));
         /* Corrupt — preserve as .bad before regenerating. */
         fprintf(stderr,
                 "[identity] localStorage entry corrupt; "
                 "moving to signal:identity.bad\n");
         signal_localstorage_rename_bad();
     }
+    signal_memzero_explicit(enc, sizeof(enc));
     signal_crypto_keypair(out->pubkey, out->secret);
     return identity_save_to(out, path);
 #else
     bool corrupt = false;
-    uint8_t secret[SIGNAL_CRYPTO_SECRET_BYTES];
+    uint8_t secret[SIGNAL_CRYPTO_SECRET_BYTES] = {0};
     if (read_secret_file(path, secret, &corrupt)) {
         memcpy(out->secret, secret, SIGNAL_CRYPTO_SECRET_BYTES);
         memcpy(out->pubkey,
                out->secret + (SIGNAL_CRYPTO_SECRET_BYTES -
                               SIGNAL_CRYPTO_PUBKEY_BYTES),
                SIGNAL_CRYPTO_PUBKEY_BYTES);
+        signal_memzero_explicit(secret, sizeof(secret));
         return true;
     }
+    signal_memzero_explicit(secret, sizeof(secret));
     if (corrupt) {
         fprintf(stderr,
                 "[identity] %s is not 64 bytes; moving to %s.bad\n",
@@ -337,4 +349,10 @@ bool identity_load_or_generate(player_identity_t *out) {
     }
     return identity_load_or_generate_at(out, path);
 #endif
+}
+
+void identity_clear(player_identity_t *id) {
+    if (!id) return;
+    signal_memzero_explicit(id->secret, sizeof(id->secret));
+    memset(id->pubkey, 0, sizeof(id->pubkey));
 }

--- a/client/identity.h
+++ b/client/identity.h
@@ -52,6 +52,9 @@ bool identity_load_or_generate(player_identity_t *out);
 bool identity_load_or_generate_at(player_identity_t *out, const char *path);
 bool identity_save_to(const player_identity_t *id, const char *path);
 
+/* Wipe the in-memory keypair at application/test lifecycle boundaries. */
+void identity_clear(player_identity_t *id);
+
 #ifdef __cplusplus
 }
 #endif

--- a/client/main.c
+++ b/client/main.c
@@ -4529,6 +4529,8 @@ static void cleanup(void) {
     if (g.net_authority_enabled) {
         net_shutdown();
     }
+    net_clear_identity();
+    identity_clear(&g.identity);
     saudio_shutdown();
     sdtx_shutdown();
     hull_fog_shutdown();

--- a/client/net.c
+++ b/client/net.c
@@ -10,6 +10,7 @@
 #include "manifest.h"
 #include "pubkey_proof.h"
 #include "signal_crypto.h"
+#include "signal_memzero.h"
 #include "net_clock.h"
 #include "wire_codec.h"
 
@@ -446,6 +447,7 @@ bool net_init_loopback(const NetCallbacks* callbacks, uint8_t local_id) {
     memset(&net_state, 0, sizeof(net_state));
     restore_identity(saved_pubkey, saved_secret,
                      saved_pub_ready, saved_secret_ready);
+    signal_memzero_explicit(saved_secret, sizeof(saved_secret));
     if (callbacks) net_state.callbacks = *callbacks;
     net_state.local_id = local_id;
     net_state.connected = true;
@@ -704,12 +706,21 @@ void net_set_identity_pubkey(const uint8_t pubkey[32]) {
 
 void net_set_identity_secret(const uint8_t secret[64]) {
     if (!secret) {
-        memset(net_state.identity_secret, 0, sizeof(net_state.identity_secret));
+        signal_memzero_explicit(net_state.identity_secret,
+                                sizeof(net_state.identity_secret));
         net_state.identity_secret_ready = false;
         return;
     }
     memcpy(net_state.identity_secret, secret, 64);
     net_state.identity_secret_ready = true;
+}
+
+void net_clear_identity(void) {
+    signal_memzero_explicit(net_state.identity_secret,
+                            sizeof(net_state.identity_secret));
+    memset(net_state.identity_pubkey, 0, sizeof(net_state.identity_pubkey));
+    net_state.identity_secret_ready = false;
+    net_state.identity_pubkey_ready = false;
 }
 
 bool net_has_identity_secret(void) {
@@ -783,6 +794,7 @@ bool net_send_signed_action(uint8_t action_type,
     int total = SIGNED_ACTION_HEADER_SIZE + (int)payload_len +
                 (int)SIGNED_ACTION_SIG_SIZE;
     ws_send_binary(buf, total);
+    signal_memzero_explicit(buf, sizeof(buf));
     return true;
 }
 
@@ -806,6 +818,9 @@ bool net_send_claim_legacy_save(const char *token_basename) {
     memcpy(&buf[2], token_basename, hex_len);
     memcpy(&buf[2 + hex_len], sig, SIGNAL_CRYPTO_SIG_BYTES);
     ws_send_binary(buf, (int)(2 + hex_len + SIGNAL_CRYPTO_SIG_BYTES));
+    signal_memzero_explicit(msg, sizeof(msg));
+    signal_memzero_explicit(sig, sizeof(sig));
+    signal_memzero_explicit(buf, sizeof(buf));
     printf("[net] sent legacy-save claim for %s\n", token_basename);
     return true;
 }
@@ -3398,6 +3413,7 @@ bool net_init(const char* url, const NetCallbacks* callbacks) {
     memcpy(net_state.identity_secret, saved_secret, sizeof(saved_secret));
     net_state.identity_pubkey_ready = saved_pub_ready;
     net_state.identity_secret_ready = saved_secret_ready;
+    signal_memzero_explicit(saved_secret, sizeof(saved_secret));
 
     if (!url || url[0] == '\0') {
         printf("[net] no server URL provided, multiplayer disabled\n");
@@ -3579,6 +3595,7 @@ bool net_init(const char* url, const NetCallbacks* callbacks) {
     memcpy(net_state.identity_secret, saved_secret, sizeof(saved_secret));
     net_state.identity_pubkey_ready = saved_pub_ready;
     net_state.identity_secret_ready = saved_secret_ready;
+    signal_memzero_explicit(saved_secret, sizeof(saved_secret));
 
     if (!url || url[0] == '\0') {
         printf("[net] no server URL provided, multiplayer disabled\n");

--- a/client/net.h
+++ b/client/net.h
@@ -592,6 +592,9 @@ bool net_has_identity_pubkey(void);
  * signatures + pubkey. */
 void net_set_identity_secret(const uint8_t secret[64]);
 
+/* Clear the long-lived in-memory identity copy during final client teardown. */
+void net_clear_identity(void);
+
 /* Send a signed state-changing action.
  *
  * Returns true if the message was queued onto the wire; false if the

--- a/docs/c_safety_policy.md
+++ b/docs/c_safety_policy.md
@@ -10,8 +10,12 @@ parsing, sanitizer runs, static analysis, and review rules.
 - Linux, macOS, and Windows native builds run in GitHub Actions.
 - `make test` rebuilds and runs fast `signal_test` shards.
 - `make test-soak` runs the long-horizon sim tests.
-- `make test-san` runs `signal_test` with ASan+UBSan locally.
-- `make test-tsan` is available for threaded changes.
+- `make test-san` runs `signal_test` with ASan+UBSan and enables
+  LeakSanitizer on Linux.
+- `make test-msan` runs the instrumentable crypto, identity, station-authority,
+  and signed-action subset with Clang MemorySanitizer.
+- `make test-tsan` runs the bounded concurrent HNN/simulation regression. CI
+  runs it weekly and on manual dispatch.
 - `make banned-apis` fails on banned libc calls in owned C source.
 - `make cppcheck`, scan-build, and clang-tidy run in CI static analysis.
 - Nightly Valgrind checks run against the non-soak test suite.
@@ -67,6 +71,60 @@ documented sentinel.
 a different contract.
 - Every fixed memory or bounds bug gets a regression test.
 
+## Sanitizer Scope
+
+Linux CI is authoritative for leak detection. Its normal sanitizer job sets
+`ASAN_OPTIONS=detect_leaks=1:halt_on_error=1`. Apple's ASan runtime does not
+support LeakSanitizer, so the same target uses `detect_leaks=0` on macOS while
+retaining address and undefined-behavior coverage.
+
+Fixture code must preserve production ownership rules. Use `SHIP_DECL`,
+`STATION_DECL`, `STATION_ARRAY`, and `WORLD_DECL` for owned test objects. Use
+`ship_reset()`, `station_reset()`, and the world slot-reset helpers instead of
+overwriting a live object with `memset`; a live manifest must be cleaned before
+its owning object is reset.
+
+MemorySanitizer requires a consistently Clang-instrumented executable. Its CI
+lane therefore covers a useful native-core subset that does not depend on
+graphical or audio system libraries. This is an explicit supported scope, not
+a source-file suppression.
+
+The scheduled ThreadSanitizer lane runs a purpose-built regression with four
+threads. Each thread initializes HNN key/feature caches and advances an
+independent player-only simulation. HNN caches are thread-local: they retain
+the single-thread hot-path cache without sharing mutable key-generation state
+between simulation workers.
+
+TweetNaCl is vendored upstream code. Its warning and signed-overflow/shift
+sanitizer compatibility flags apply only to `SIGNAL_CRYPTO_VENDOR_SOURCES` in
+`CMakeLists.txt`. Project-owned crypto glue, explicit wiping, identity, and
+authority code remain fully instrumented.
+
+## Secret Wiping
+
+Use `signal_memzero_explicit()` for secret keys, secret-derived seeds, signing
+scratch buffers, and lifecycle teardown. Ordinary `memset` is not a secret
+wipe because an optimizer may remove dead stores.
+
+The implementation selects:
+
+- C23 `memset_explicit` when the compiler advertises C23;
+- Windows `SecureZeroMemory`;
+- a reviewed C11 volatile-byte-store fallback elsewhere.
+
+The fallback's volatile stores are observable side effects and cannot be
+elided. `make memzero-codegen` compiles the C11 fallback to optimized LLVM IR
+and requires its volatile byte stores to remain. The runtime contract test
+also calls the separately compiled wipe function, checks every byte, accepts
+null/zero-length calls, and reports the selected backend. Keep clearing
+centralized in this API so compiler and platform changes have one review
+point.
+
+Lifecycle boundaries currently include station cleanup/reset, authority-root
+replacement and shutdown, identity teardown, network identity teardown,
+secret-file/base64 temporaries, derived station seeds, and signing/verification
+scratch buffers.
+
 ## Review Checklist
 
 - Who owns every pointer crossing this function boundary?
@@ -76,3 +134,6 @@ a different contract.
 - Are parser failures tested, including short input and malformed input?
 - Does ASan+UBSan pass for code touching parsing, serialization, save/load, or
 network state?
+- Does a lifecycle boundary wipe long-lived or temporary key material through
+  `signal_memzero_explicit()`?
+- Does fixture reset clean owned manifests before overwriting the object?

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -1687,8 +1687,7 @@ static bool world_ship_slot_activate(world_t *w, int ship_slot) {
     ship_slot_t *slot = &w->ships[ship_slot];
     if (slot->active) return true;
     uint16_t generation = ship_slot_next_generation(slot->generation);
-    ship_cleanup(&slot->component);
-    memset(&slot->component, 0, sizeof(slot->component));
+    ship_reset(&slot->component);
     if (!ship_manifest_bootstrap(&slot->component)) return false;
     slot->generation = generation;
     slot->active = true;
@@ -1700,8 +1699,7 @@ static void world_ship_slot_release(world_t *w, int ship_slot) {
     ship_slot_t *slot = &w->ships[ship_slot];
     if (slot->active)
         world_tow_links_clear_source(w, world_ship_ref_for_slot(w, ship_slot));
-    if (slot->active) ship_cleanup(&slot->component);
-    memset(&slot->component, 0, sizeof(slot->component));
+    ship_reset(&slot->component);
     slot->active = false;
 }
 
@@ -4168,11 +4166,10 @@ static void apply_ship_damage(world_t *w, server_player_t *sp, float damage) {
 /* Ship collision                                                     */
 /* ================================================================== */
 
-static int ship_collision_count; /* per-frame overlap counter for crush detection */
-
-static void resolve_ship_circle(world_t *w, server_player_t *sp, vec2 center, float radius) {
+static void resolve_ship_circle(world_t *w, server_player_t *sp, vec2 center,
+                                float radius, int *collision_count) {
     float impact = resolve_ship_circle_pushback(sp->ship, center, radius);
-    if (impact > 0.0f) ship_collision_count++;
+    if (impact > 0.0f) (*collision_count)++;
     if (impact <= 0.0f || sp->docked || w->player_only_mode) return;
     float dmg = collision_damage_for(impact, 1.0f);
     if (dmg > 0.0f) {
@@ -4192,7 +4189,9 @@ static void resolve_ship_circle(world_t *w, server_player_t *sp, vec2 center, fl
  *      on the rebound.
  *   3. Damage scales with rock radius. An XL rock hits ~2.5× harder
  *      than an S-tier fragment. Free signal that bigger rocks matter. */
-static void resolve_ship_asteroid_collision(world_t *w, server_player_t *sp, asteroid_t *a) {
+static void resolve_ship_asteroid_collision(world_t *w, server_player_t *sp,
+                                            asteroid_t *a,
+                                            int *collision_count) {
     /* Geometric push-out + mass-equal bounce live in sim_ship now;
      * player-only attribution / self-damage suppression sits on top. */
     vec2 asteroid_vel_before = a->vel;
@@ -4203,7 +4202,7 @@ static void resolve_ship_asteroid_collision(world_t *w, server_player_t *sp, ast
         a->net_dirty = asteroid_dirty_before;
     }
     if (impact <= 0.0f) return;
-    ship_collision_count++;
+    (*collision_count)++;
     if (w->player_only_mode) return;
 
     /* Self-damage skip: your own ballistic rock can't hurt you. The
@@ -5469,7 +5468,9 @@ static bool ship_near_station_collision_envelope(const server_player_t *sp,
     return v2_dist_sq(sp->ship->pos, st->pos) <= reach * reach;
 }
 
-static void resolve_module_collisions(world_t *w, server_player_t *sp, const station_t *st) {
+static void resolve_module_collisions(world_t *w, server_player_t *sp,
+                                      const station_t *st,
+                                      int *collision_count) {
     station_geom_t geom;
     station_build_geom(st, &geom);
     float ship_r = ship_hull_def(sp->ship)->ship_radius;
@@ -5479,7 +5480,8 @@ static void resolve_module_collisions(world_t *w, server_player_t *sp, const sta
 
     /* Module circles */
     for (int i = 0; i < geom.circle_count; i++)
-        resolve_ship_circle(w, sp, geom.circles[i].center, geom.circles[i].radius);
+        resolve_ship_circle(w, sp, geom.circles[i].center,
+                            geom.circles[i].radius, collision_count);
 
     /* Near-module suppression: if ship is angularly close to any module
      * on a corridor's ring, skip corridor tests (module circle takes priority,
@@ -5516,13 +5518,13 @@ static bool is_already_towed(world_t *w, const server_player_t *sp,
                              int asteroid_idx);
 
 static void resolve_world_collisions(world_t *w, server_player_t *sp) {
-    ship_collision_count = 0;
+    int collision_count = 0;
     for (int i = 0; i < MAX_STATIONS; i++) {
         if (!station_collides(&w->stations[i])) continue;
         if (!ship_near_station_collision_envelope(sp, &w->stations[i])) continue;
         /* Skip collision with docking target during approach lerp */
         if (sp->docking_approach && i == sp->nearby_station) continue;
-        resolve_module_collisions(w, sp, &w->stations[i]);
+        resolve_module_collisions(w, sp, &w->stations[i], &collision_count);
     }
     for (int i = 0; i < MAX_ASTEROIDS; i++) {
         if (!w->asteroids[i].active) continue;
@@ -5534,12 +5536,13 @@ static void resolve_world_collisions(world_t *w, server_player_t *sp) {
          * damage; a tractored fragment dragged INTO a third ship hits
          * normally. The owner's own tow doesn't self-damage thanks to
          * the session-token check in resolve_ship_asteroid_collision. */
-        resolve_ship_asteroid_collision(w, sp, &w->asteroids[i]);
+        resolve_ship_asteroid_collision(w, sp, &w->asteroids[i],
+                                        &collision_count);
     }
     /* Crush: pinched between 3+ bodies simultaneously (2 adjacent modules
      * on the same ring is normal, only crush when truly trapped) */
-    if (!w->player_only_mode && !sp->docked && ship_collision_count >= 3) {
-        float crush = (float)(ship_collision_count - 2) * 2.0f;
+    if (!w->player_only_mode && !sp->docked && collision_count >= 3) {
+        float crush = (float)(collision_count - 2) * 2.0f;
         apply_ship_damage(w, sp, crush);
     }
 }
@@ -13584,7 +13587,7 @@ void world_sim_step_player_only(world_t *w, int player_idx, float dt) {
 void world_cleanup(world_t *w) {
     if (!w) return;
     for (int i = 0; i < WORLD_SHIP_CAP; i++)
-        if (w->ships[i].active) ship_cleanup(&w->ships[i].component);
+        ship_cleanup(&w->ships[i].component);
     for (int i = 0; i < MAX_SHIP_ASSETS; i++)
         ship_cleanup(&w->ship_assets[i].stored_ship);
     for (int i = 0; i < MAX_STATIONS; i++)
@@ -13627,8 +13630,7 @@ void world_ensure_seeded_freeport(world_t *w) {
     station_t *st = &w->stations[SIGNAL_FREEPORT_STATION_INDEX];
     if (station_exists(st)) return;
 
-    station_cleanup(st);
-    memset(st, 0, sizeof(*st));
+    station_reset(st);
     (void)station_manifest_bootstrap(st);
     station_authority_init_seeded(st, w->belt_seed,
                                   (uint32_t)SIGNAL_FREEPORT_STATION_INDEX);
@@ -13814,7 +13816,7 @@ void world_reset(world_t *w) {
     uint32_t seed = w->rng;  /* caller may pre-set seed; 0 = default */
     float *sig_buf = w->signal_cache.strength; /* preserve heap allocation */
     for (int i = 0; i < WORLD_SHIP_CAP; i++)
-        if (w->ships[i].active) ship_cleanup(&w->ships[i].component);
+        ship_cleanup(&w->ships[i].component);
     for (int i = 0; i < MAX_SHIP_ASSETS; i++)
         ship_cleanup(&w->ship_assets[i].stored_ship);
     for (int i = 0; i < MAX_STATIONS; i++)

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -2849,13 +2849,17 @@ bool player_save(const server_player_t *sp, const char *dir, int slot) {
     FILE *f = fopen(tmp_path, "wb");
     if (!f) return false;
     encode_v4_ship(&ship_disk, sp->ship);
-    player_save_data_t data = {
-        .magic = PLAYER_MAGIC,
-        .ship = ship_disk,
-        .last_station = sp->current_station,
-        .last_pos = sp->ship->pos,
-        .last_angle = sp->ship->angle,
-    };
+    /*
+     * This legacy fixed-width record is checksummed and written as raw bytes,
+     * including ABI padding. A designated initializer initializes members but
+     * not padding, so start from a fully defined representation.
+     */
+    player_save_data_t data = {0};
+    data.magic = PLAYER_MAGIC;
+    data.ship = ship_disk;
+    data.last_station = sp->current_station;
+    data.last_pos = sp->ship->pos;
+    data.last_angle = sp->ship->angle;
     bool ok = fwrite(&data, sizeof(data), 1, f) == 1;
     uint32_t crc = ok ? crc32_update(0, &data, sizeof(data)) : 0;
     /* Manifest tail (PLY5). Count + entries; CRC accumulates both. */

--- a/server/station_authority.c
+++ b/server/station_authority.c
@@ -6,11 +6,13 @@
 #include "station_authority.h"
 
 #include <assert.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "base58.h"
 #include "sha256.h"
 #include "signal_crypto.h"
+#include "signal_memzero.h"
 
 /* Domain-separation strings. Bumping these (e.g. "-v2") would
  * invalidate every previously-derived station pubkey, so keep them
@@ -24,6 +26,7 @@ static const char DEV_SECRET[]           = "signal-dev-station-authority-secret"
 
 static uint8_t station_auth_secret_root[32];
 static bool station_auth_secret_ready = false;
+static bool station_auth_cleanup_registered = false;
 
 static void station_authority_hash_secret(const char *secret,
                                           uint8_t out_root[32]) {
@@ -32,18 +35,33 @@ static void station_authority_hash_secret(const char *secret,
     sha256_update(&c, SECRET_SEED_DOMAIN, sizeof(SECRET_SEED_DOMAIN) - 1);
     sha256_update(&c, secret, strlen(secret));
     sha256_final(&c, out_root);
+    signal_memzero_explicit(&c, sizeof(c));
 }
 
 bool station_authority_configure_secret(const char *secret) {
     if (!secret || secret[0] == '\0') return false;
-    station_authority_hash_secret(secret, station_auth_secret_root);
+    if (!station_auth_cleanup_registered) {
+        station_auth_cleanup_registered =
+            atexit(station_authority_clear_secret) == 0;
+    }
+    uint8_t next_root[32];
+    station_authority_hash_secret(secret, next_root);
+    signal_memzero_explicit(station_auth_secret_root,
+                            sizeof(station_auth_secret_root));
+    memcpy(station_auth_secret_root, next_root, sizeof(next_root));
+    signal_memzero_explicit(next_root, sizeof(next_root));
     station_auth_secret_ready = true;
     return true;
 }
 
+void station_authority_clear_secret(void) {
+    signal_memzero_explicit(station_auth_secret_root,
+                            sizeof(station_auth_secret_root));
+    station_auth_secret_ready = false;
+}
+
 void station_authority_use_dev_secret(void) {
-    station_authority_hash_secret(DEV_SECRET, station_auth_secret_root);
-    station_auth_secret_ready = true;
+    (void)station_authority_configure_secret(DEV_SECRET);
 }
 
 static const uint8_t *station_authority_secret_root(void) {
@@ -112,6 +130,7 @@ void station_authority_init_seeded(station_t *s,
     uint8_t seed[32];
     station_authority_seeded_seed(world_seed, station_index, seed);
     signal_crypto_keypair_from_seed(seed, s->station_pubkey, s->station_secret);
+    signal_memzero_explicit(seed, sizeof(seed));
     /* Seeded stations have no founder / planted_tick provenance. */
     memset(s->outpost_founder_pubkey, 0, sizeof(s->outpost_founder_pubkey));
     s->outpost_planted_tick = 0;
@@ -130,6 +149,7 @@ void station_authority_init_outpost(station_t *s,
     station_authority_outpost_seed(s->outpost_founder_pubkey, s->name,
                                     planted_tick, seed);
     signal_crypto_keypair_from_seed(seed, s->station_pubkey, s->station_secret);
+    signal_memzero_explicit(seed, sizeof(seed));
 }
 
 bool station_authority_rederive_secret(station_t *s,
@@ -148,6 +168,7 @@ bool station_authority_rederive_secret(station_t *s,
     }
     uint8_t derived_pub[32];
     signal_crypto_keypair_from_seed(seed, derived_pub, s->station_secret);
+    signal_memzero_explicit(seed, sizeof(seed));
     /* If the saved pubkey is zero (pre-v40 save with no station
      * identity field), stamp the rederived pubkey so the station has a
      * usable identity. If a non-zero saved pubkey no longer matches the

--- a/server/station_authority.h
+++ b/server/station_authority.h
@@ -42,6 +42,11 @@ extern "C" {
  * NULL/empty input and leaves the previous secret unchanged. */
 bool station_authority_configure_secret(const char *secret);
 
+/* Explicitly clear the process-level operator-secret root. The next seeded
+ * derivation falls back to the development secret unless a new secret is
+ * configured first. */
+void station_authority_clear_secret(void);
+
 /* Reset to the deterministic development secret used by local tests and
  * non-production local runs. Production servers should configure a real
  * secret before world_reset/world_load. */

--- a/shared/holographic_nn.c
+++ b/shared/holographic_nn.c
@@ -25,11 +25,19 @@ typedef struct {
     float vec[HNN_DIM];
 } hnn_key_cache_entry_t;
 
+#if defined(_MSC_VER)
+#define SIGNAL_THREAD_LOCAL __declspec(thread)
+#else
+#define SIGNAL_THREAD_LOCAL _Thread_local
+#endif
+
 /* A tiny PRNG for deterministic key generation (xorshift32). */
-static uint32_t hnn_rand_state;
-static hnn_key_cache_entry_t g_hnn_key_cache[HNN_KEY_CACHE_SIZE];
-static float g_hnn_feature_keys[HNN_FEATURE_COUNT][HNN_DIM];
-static bool g_hnn_feature_keys_initialized = false;
+static SIGNAL_THREAD_LOCAL uint32_t hnn_rand_state;
+static SIGNAL_THREAD_LOCAL hnn_key_cache_entry_t
+    g_hnn_key_cache[HNN_KEY_CACHE_SIZE];
+static SIGNAL_THREAD_LOCAL float
+    g_hnn_feature_keys[HNN_FEATURE_COUNT][HNN_DIM];
+static SIGNAL_THREAD_LOCAL bool g_hnn_feature_keys_initialized = false;
 
 typedef struct {
     const char *name;

--- a/shared/manifest.c
+++ b/shared/manifest.c
@@ -1,5 +1,6 @@
 #include "manifest.h"
 #include "cargo_receipt.h"  /* Layer D of #479 — ship receipt store */
+#include "signal_memzero.h"
 #include "wire_codec.h"
 
 #include <assert.h>
@@ -496,6 +497,12 @@ void ship_cleanup(ship_t *ship) {
     cargo_store_cleanup(&ship->cargo_store);
 }
 
+void ship_reset(ship_t *ship) {
+    if (!ship) return;
+    ship_cleanup(ship);
+    memset(ship, 0, sizeof(*ship));
+}
+
 bool ship_manifest_bootstrap(ship_t *ship) {
     return ship && cargo_store_bootstrap(
         &ship->cargo_store, SHIP_MANIFEST_DEFAULT_CAP);
@@ -538,6 +545,14 @@ int ship_manifest_consume_by_commodity(ship_t *ship, commodity_t c, int n) {
 void station_cleanup(station_t *station) {
     if (!station) return;
     cargo_store_cleanup(&station->cargo_store);
+    signal_memzero_explicit(station->station_secret,
+                            sizeof(station->station_secret));
+}
+
+void station_reset(station_t *station) {
+    if (!station) return;
+    station_cleanup(station);
+    memset(station, 0, sizeof(*station));
 }
 
 bool station_manifest_bootstrap(station_t *station) {

--- a/shared/manifest.h
+++ b/shared/manifest.h
@@ -122,6 +122,9 @@ void ship_finished_sync(ship_t *ship, commodity_t c);
 int ship_finished_drain(ship_t *ship, commodity_t c, int n);
 
 void ship_cleanup(ship_t *ship);
+
+/* Release owned cargo/receipt storage and return the whole value to zero. */
+void ship_reset(ship_t *ship);
 bool ship_manifest_bootstrap(ship_t *ship);
 bool ship_copy(ship_t *dst, const ship_t *src);
 
@@ -139,6 +142,9 @@ bool ship_manifest_remove_with_chain(ship_t *ship, uint16_t index,
                                      cargo_receipt_chain_t *out_chain);
 int ship_manifest_consume_by_commodity(ship_t *ship, commodity_t c, int n);
 void station_cleanup(station_t *station);
+
+/* Release owned cargo/receipt storage, wipe the signing key, and zero state. */
+void station_reset(station_t *station);
 bool station_manifest_bootstrap(station_t *station);
 bool station_copy(station_t *dst, const station_t *src);
 ship_receipts_t *station_get_receipts(station_t *station);

--- a/shared/signal_memzero.c
+++ b/shared/signal_memzero.c
@@ -1,0 +1,35 @@
+#include "signal_memzero.h"
+
+#include <string.h>
+
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
+void signal_memzero_explicit(void *ptr, size_t len) {
+    if (!ptr || len == 0) return;
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+    memset_explicit(ptr, 0, len);
+#elif defined(_WIN32)
+    SecureZeroMemory(ptr, len);
+#else
+    /*
+     * C11 fallback: stores through a volatile-qualified lvalue are observable
+     * side effects and therefore cannot be removed as dead stores. Keep this
+     * small and local so every non-C23 platform follows one reviewed path.
+     */
+    volatile unsigned char *bytes = (volatile unsigned char *)ptr;
+    while (len-- > 0) *bytes++ = 0;
+#endif
+}
+
+const char *signal_memzero_backend(void) {
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+    return "c23-memset-explicit";
+#elif defined(_WIN32)
+    return "windows-secure-zero-memory";
+#else
+    return "c11-volatile-store";
+#endif
+}

--- a/shared/signal_memzero.h
+++ b/shared/signal_memzero.h
@@ -1,0 +1,26 @@
+/*
+ * signal_memzero.h -- non-elidable clearing for secret material.
+ *
+ * Ordinary memset calls may be removed when the compiler proves that a
+ * buffer is dead. Use this API for keys, secret-derived seeds, and signing
+ * scratch at lifecycle boundaries. It is not a general object reset helper.
+ */
+#ifndef SHARED_SIGNAL_MEMZERO_H
+#define SHARED_SIGNAL_MEMZERO_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void signal_memzero_explicit(void *ptr, size_t len);
+
+/* Stable diagnostic string used by tests and operator documentation. */
+const char *signal_memzero_backend(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SHARED_SIGNAL_MEMZERO_H */

--- a/tests/c/test_commodity.c
+++ b/tests/c/test_commodity.c
@@ -101,7 +101,7 @@ TEST(test_commodity_color_u8_all_branches) {
 }
 
 TEST(test_ship_total_cargo) {
-    ship_t ship = {0};
+    SHIP_DECL(ship);
     ASSERT(ship_manifest_bootstrap(&ship));
     ship.cargo[COMMODITY_FERRITE_ORE] = 10.0f;
     uint8_t origin[8] = {0};
@@ -114,7 +114,7 @@ TEST(test_ship_total_cargo) {
 }
 
 TEST(test_ship_cargo_amount) {
-    ship_t ship = {0};
+    SHIP_DECL(ship);
     ASSERT(ship_manifest_bootstrap(&ship));
     ship.cargo[COMMODITY_CUPRITE_ORE] = 42.0f;
     ASSERT_EQ_FLOAT(ship_cargo_amount(&ship, COMMODITY_CUPRITE_ORE), 42.0f, 0.01f);

--- a/tests/c/test_construction.c
+++ b/tests/c/test_construction.c
@@ -530,7 +530,7 @@ TEST(test_module_delivery_emits_construction_chain_event) {
     m->scaffold = true;
     m->build_progress = 0.0f;
 
-    ship_t ship = {0};
+    SHIP_DECL(ship);
     ASSERT(manifest_init(&ship.manifest, 4));
     ship.cargo[COMMODITY_FRAME] = 1.0f;
     cargo_unit_t unit = {0};
@@ -686,6 +686,7 @@ TEST(test_docked_buy_one_unit_per_intent) {
     sp->docked = true;
     sp->current_station = 1;
     memset(sp->session_token, 0xAA, sizeof(sp->session_token));
+    manifest_free(&sp->ship->manifest);
     ASSERT(manifest_init(&sp->ship->manifest, 16));
     ledger_credit_supply(st, sp->session_token, 5000.0f);
     float bal_before = ledger_balance(st, sp->session_token);
@@ -3848,7 +3849,7 @@ TEST(test_module_flow_diag_slow_feed) {
 }
 
 TEST(test_module_flow_diag_storage_consumer_full) {
-    station_t st = {0};
+    STATION_DECL(st);
     st.signal_range = 1.0f;
     st.module_count = 2;
     st.modules[0] = (station_module_t){
@@ -4202,8 +4203,7 @@ TEST(test_pair_satisfied_cross_ring) {
     world_reset(w);
 
     station_t *st = &w->stations[5]; /* unused slot, completely empty */
-    station_cleanup(st);
-    memset(st, 0, sizeof(*st));
+    station_reset(st);
     st->signal_range = 1.0f;
 
     /* Empty station — no hoppers, LASER_FAB cannot be paired. */
@@ -4219,8 +4219,7 @@ TEST(test_pair_satisfied_cross_ring) {
 
     /* FURNACE accepts ANY ore, but the hopper has to sit on an adjacent ring. */
     station_t *st2 = &w->stations[6];
-    station_cleanup(st2);
-    memset(st2, 0, sizeof(*st2));
+    station_reset(st2);
     st2->signal_range = 1.0f;
     ASSERT(!station_pair_satisfied(st2, 2, 0, MODULE_FURNACE));
     add_hopper_for(st2, 2, 1, COMMODITY_FERRITE_ORE);

--- a/tests/c/test_crypto.c
+++ b/tests/c/test_crypto.c
@@ -4,6 +4,17 @@
 
 #include "base64.h"
 #include "signal_crypto.h"
+#include "signal_memzero.h"
+
+TEST(test_signal_memzero_explicit_runtime_contract) {
+    uint8_t secret[96];
+    memset(secret, 0xa5, sizeof(secret));
+    signal_memzero_explicit(secret, sizeof(secret));
+    for (size_t i = 0; i < sizeof(secret); i++) ASSERT_EQ_INT(secret[i], 0);
+    ASSERT(signal_memzero_backend() != NULL);
+    ASSERT(signal_memzero_backend()[0] != '\0');
+    signal_memzero_explicit(NULL, 0);
+}
 
 TEST(test_crypto_keypair_distinct) {
     uint8_t pub_a[SIGNAL_CRYPTO_PUBKEY_BYTES];
@@ -89,6 +100,17 @@ TEST(test_crypto_verify_rejects_pub_tamper) {
     ASSERT(!signal_crypto_verify(sig, msg, sizeof(msg), pub));
 }
 
+TEST(test_crypto_rejects_overflowing_message_length) {
+    uint8_t sig[SIGNAL_CRYPTO_SIG_BYTES];
+    uint8_t sec[SIGNAL_CRYPTO_SECRET_BYTES] = {0};
+    uint8_t pub[SIGNAL_CRYPTO_PUBKEY_BYTES] = {0};
+    memset(sig, 0xa5, sizeof(sig));
+
+    signal_crypto_sign(sig, NULL, SIZE_MAX, sec);
+    for (size_t i = 0; i < sizeof(sig); i++) ASSERT_EQ_INT(sig[i], 0);
+    ASSERT(!signal_crypto_verify(sig, NULL, SIZE_MAX, pub));
+}
+
 TEST(test_base64_decode_rejects_short_output_buffer) {
     const uint8_t raw[3] = {1, 2, 3};
     char encoded[8];
@@ -105,11 +127,13 @@ TEST(test_base64_decode_rejects_short_output_buffer) {
 void register_crypto_tests(void);
 void register_crypto_tests(void) {
     TEST_SECTION("\nCrypto (Ed25519) tests:\n");
+    RUN(test_signal_memzero_explicit_runtime_contract);
     RUN(test_crypto_keypair_distinct);
     RUN(test_crypto_random_bytes_distinct_and_nonzero);
     RUN(test_crypto_sign_verify_roundtrip);
     RUN(test_crypto_verify_rejects_msg_tamper);
     RUN(test_crypto_verify_rejects_sig_tamper);
     RUN(test_crypto_verify_rejects_pub_tamper);
+    RUN(test_crypto_rejects_overflowing_message_length);
     RUN(test_base64_decode_rejects_short_output_buffer);
 }

--- a/tests/c/test_economy.c
+++ b/tests/c/test_economy.c
@@ -387,7 +387,7 @@ static void test_setup_delivery_player(world_t *w, server_player_t **out_sp) {
 }
 
 TEST(test_station_production_yard_makes_frames) {
-    station_t station = {0};
+    STATION_DECL(station);
     station.modules[station.module_count++] = (station_module_t){ .type = MODULE_FRAME_PRESS };
     ASSERT(test_set_station_finished_units(&station, COMMODITY_FERRITE_INGOT, 5));
     step_station_production(&station, 1, 1.0f);
@@ -402,7 +402,7 @@ TEST(test_station_production_yard_makes_frames) {
 }
 
 TEST(test_station_production_beamworks_makes_modules) {
-    station_t station = {0};
+    STATION_DECL(station);
     station.modules[station.module_count++] = (station_module_t){ .type = MODULE_LASER_FAB };
     station.modules[station.module_count++] = (station_module_t){ .type = MODULE_TRACTOR_FAB };
     ASSERT(test_set_station_finished_units(&station, COMMODITY_CUPRITE_INGOT, 5));
@@ -1625,7 +1625,7 @@ TEST(test_dynamic_ore_price_deficit) {
 }
 
 TEST(test_product_price_tracks_ore) {
-    station_t st = {0};
+    STATION_DECL(st);
     st.base_price[COMMODITY_FRAME] = 20.0f;
     /* Sell price: empty=2× base, full=1× base */
     ASSERT_EQ_FLOAT(station_sell_price(&st, COMMODITY_FRAME), 40.0f, 0.1f);
@@ -3316,7 +3316,7 @@ TEST(test_commodity_volume_kit_dense) {
 
 TEST(test_ship_total_cargo_kit_density) {
     /* 100 kits + 5 frames = 100 * 0.1 + 5 * 1.0 = 15 cargo units. */
-    ship_t ship = {0};
+    SHIP_DECL(ship);
     ASSERT(ship_manifest_bootstrap(&ship));
     uint8_t origin[8] = {0};
     float legacy[COMMODITY_COUNT] = {0};

--- a/tests/c/test_furnace_color.c
+++ b/tests/c/test_furnace_color.c
@@ -32,7 +32,7 @@ static void make_station(station_t *st,
                          const module_type_t *types,
                          const uint8_t *rings,
                          int count) {
-    memset(st, 0, sizeof(*st));
+    station_reset(st);
     st->module_count = (uint16_t)count;
     for (int i = 0; i < count; i++) {
         st->modules[i].type = types[i];

--- a/tests/c/test_gossip.c
+++ b/tests/c/test_gossip.c
@@ -1477,8 +1477,9 @@ TEST(test_ship_contact_gossip_exchanges_memory_and_holograms) {
                               SIGNAL_FIELD_KIND_HOLOGRAM, 0) > 0.0f);
 }
 
-static void test_reset_holographic_pilot(npc_ship_t *npc) {
-    memset(npc, 0, sizeof(*npc));
+static npc_ship_t *test_reset_holographic_pilot(world_t *w, int npc_slot) {
+    if (!test_world_npc_slot_reset(w, npc_slot)) return NULL;
+    npc_ship_t *npc = &w->npc_ships[npc_slot];
     npc->active = true;
     npc->brain_mode = SERVER_BRAIN_MODE_HOLOGRAPHIC;
     npc->home_station = 0;
@@ -1486,6 +1487,7 @@ static void test_reset_holographic_pilot(npc_ship_t *npc) {
     npc->hnn_experience_uploaded_station = 0xffu;
     npc->hnn_experience_uploaded_source_station = 0xffu;
     hnn_memory_init(&npc->hnn_mem);
+    return npc;
 }
 
 static void test_reset_station_hnn_experience(station_t *st) {
@@ -1510,8 +1512,8 @@ TEST(test_holographic_pilot_uploads_experience_once) {
     WORLD_DECL;
     world_reset(&w);
 
-    npc_ship_t *npc = &w.npc_ships[0];
-    test_reset_holographic_pilot(npc);
+    npc_ship_t *npc = test_reset_holographic_pilot(&w, 0);
+    ASSERT(npc != NULL);
     test_store_hnn_trace(&npc->hnn_mem, 0x1234u, 0x5678u);
     npc->hnn_experience_local_version++;
     ASSERT_EQ_INT(npc->hnn_mem.experience_count, 1);
@@ -1541,8 +1543,8 @@ TEST(test_holographic_pilot_transports_station_cell) {
     WORLD_DECL;
     world_reset(&w);
 
-    npc_ship_t *npc = &w.npc_ships[0];
-    test_reset_holographic_pilot(npc);
+    npc_ship_t *npc = test_reset_holographic_pilot(&w, 0);
+    ASSERT(npc != NULL);
     test_store_hnn_trace(&npc->hnn_mem, 0x2234u, 0x6678u);
     npc->hnn_experience_local_version++;
 
@@ -1569,8 +1571,8 @@ TEST(test_holographic_pilot_rejects_unproven_trace_cargo) {
     WORLD_DECL;
     world_reset(&w);
 
-    npc_ship_t *npc = &w.npc_ships[0];
-    test_reset_holographic_pilot(npc);
+    npc_ship_t *npc = test_reset_holographic_pilot(&w, 0);
+    ASSERT(npc != NULL);
     test_store_hnn_trace(&npc->hnn_mem, 0x3234u, 0x7678u);
     npc->hnn_experience_station = 0;
     npc->hnn_experience_version = 2;
@@ -1594,8 +1596,8 @@ TEST(test_holographic_pilot_rejects_low_fidelity_trace_cargo) {
     WORLD_DECL;
     world_reset(&w);
 
-    npc_ship_t *npc = &w.npc_ships[0];
-    test_reset_holographic_pilot(npc);
+    npc_ship_t *npc = test_reset_holographic_pilot(&w, 0);
+    ASSERT(npc != NULL);
     test_store_hnn_trace(&npc->hnn_mem, 0x4234u, 0x8678u);
     npc->hnn_mem.last_retrieval_similarity = -1.0f;
     npc->hnn_mem.last_margin = 0.0f;

--- a/tests/c/test_harness.h
+++ b/tests/c/test_harness.h
@@ -74,6 +74,11 @@ void test_prepare_case(const char *name);
 extern int g_soak_enabled;
 extern int g_only_soak;
 
+typedef struct {
+    station_t *stations;
+    size_t count;
+} station_array_cleanup_t;
+
 /* Auto-cleanup for world_t — frees the heap-allocated signal cache grid.
  * Uses __attribute__((cleanup)) on GCC/Clang; on MSVC, leaks are
  * acceptable in tests (no cleanup on early ASSERT return). */
@@ -83,6 +88,7 @@ extern int g_only_soak;
 #define WORLD_HEAP world_t *
 #define SHIP_DECL(name) ship_t name = {0}
 #define STATION_DECL(name) station_t name = {0}
+#define STATION_ARRAY(name, count) station_t name[(count)] = {0}
 #define SERVER_PLAYER_DECL(name) \
     ship_t name##_ship_backing = {0}; \
     server_connection_t name##_connection_backing = {0}; \
@@ -119,6 +125,11 @@ static inline void world_ptr_auto_cleanup(world_t **wp) {
 }
 static inline void ship_auto_cleanup(ship_t *ship) { ship_cleanup(ship); }
 static inline void station_auto_cleanup(station_t *station) { station_cleanup(station); }
+static inline void station_array_auto_cleanup(station_array_cleanup_t *guard) {
+    if (!guard || !guard->stations) return;
+    for (size_t i = 0; i < guard->count; i++)
+        station_cleanup(&guard->stations[i]);
+}
 static inline void server_player_auto_cleanup(server_player_t *sp) {
     if (sp && sp->ship) ship_cleanup(sp->ship);
 }
@@ -130,6 +141,10 @@ static inline void npc_ship_auto_cleanup(npc_ship_t *npc) {
 #define WORLD_HEAP __attribute__((cleanup(world_ptr_auto_cleanup))) world_t *
 #define SHIP_DECL(name) ship_t __attribute__((cleanup(ship_auto_cleanup))) name = {0}
 #define STATION_DECL(name) station_t __attribute__((cleanup(station_auto_cleanup))) name = {0}
+#define STATION_ARRAY(name, count) \
+    station_t name[(count)] = {0}; \
+    station_array_cleanup_t name##_cleanup \
+        __attribute__((cleanup(station_array_auto_cleanup))) = {name, (count)}
 #define SERVER_PLAYER_DECL(name) \
     ship_t name##_ship_backing = {0}; \
     server_connection_t name##_connection_backing = {0}; \
@@ -172,6 +187,20 @@ static inline void test_world_bind_ship_slots(world_t *w) {
     }
     for (int i = 0; i < MAX_NPC_SHIPS; i++)
         (void)world_npc_ship_slot_activate(w, i);
+}
+
+static inline bool test_world_npc_slot_reset(world_t *w, int npc_slot) {
+    if (!w || npc_slot < 0 || npc_slot >= MAX_NPC_SHIPS) return false;
+    world_npc_ship_slot_release(w, npc_slot);
+    memset(&w->npc_ships[npc_slot], 0, sizeof(w->npc_ships[npc_slot]));
+    return world_npc_ship_slot_activate(w, npc_slot);
+}
+
+static inline void test_world_clear_npcs(world_t *w) {
+    if (!w) return;
+    for (int i = 0; i < MAX_NPC_SHIPS; i++)
+        world_npc_ship_slot_release(w, i);
+    memset(w->npc_ships, 0, sizeof(w->npc_ships));
 }
 
 #if defined(_MSC_VER)

--- a/tests/c/test_identity.c
+++ b/tests/c/test_identity.c
@@ -78,9 +78,22 @@ TEST(test_identity_corrupt_file_renamed_to_bad) {
     remove(bad_path);
 }
 
+TEST(test_identity_clear_wipes_private_material) {
+    player_identity_t id;
+    signal_crypto_keypair(id.pubkey, id.secret);
+    uint8_t zero_secret[SIGNAL_CRYPTO_SECRET_BYTES] = {0};
+    uint8_t zero_pub[SIGNAL_CRYPTO_PUBKEY_BYTES] = {0};
+
+    ASSERT(memcmp(id.secret, zero_secret, sizeof(zero_secret)) != 0);
+    identity_clear(&id);
+    ASSERT(memcmp(id.secret, zero_secret, sizeof(zero_secret)) == 0);
+    ASSERT(memcmp(id.pubkey, zero_pub, sizeof(zero_pub)) == 0);
+}
+
 void register_identity_tests(void);
 void register_identity_tests(void) {
     TEST_SECTION("\nIdentity (player keypair) tests:\n");
     RUN(test_identity_save_then_load);
     RUN(test_identity_corrupt_file_renamed_to_bad);
+    RUN(test_identity_clear_wipes_private_material);
 }

--- a/tests/c/test_main.c
+++ b/tests/c/test_main.c
@@ -84,6 +84,7 @@ void register_settlement_engine_tests(void);
 void register_signal_field_tests(void);
 void register_gossip_tests(void);
 void register_npc_radio_tests(void);
+void register_native_safety_tests(void);
 
 static int parse_shard_arg(const char *arg, int *out_index, int *out_total) {
     char *slash = NULL;
@@ -213,6 +214,7 @@ int main(int argc, char **argv) {
     register_signal_field_tests();
     register_gossip_tests();
     register_npc_radio_tests();
+    register_native_safety_tests();
 
     printf("\n%d tests run, %d passed, %d failed", tests_run, tests_passed, tests_failed);
     if (g_warnings > 0) printf(", %d warnings", g_warnings);

--- a/tests/c/test_manifest.c
+++ b/tests/c/test_manifest.c
@@ -263,7 +263,7 @@ TEST(test_manifest_rarity_tint_blends_grade_average) {
 }
 
 TEST(test_station_manifest_receipts_track_push_remove) {
-    station_t st = {0};
+    STATION_DECL(st);
     cargo_unit_t first = {0};
     cargo_unit_t second = {0};
     cargo_receipt_chain_t chain = {0};
@@ -301,7 +301,7 @@ TEST(test_station_manifest_receipts_track_push_remove) {
 }
 
 TEST(test_station_manifest_rejects_unverified_receipt_chain) {
-    station_t st = {0};
+    STATION_DECL(st);
     cargo_unit_t unit = {0};
     cargo_receipt_chain_t chain = {0};
 

--- a/tests/c/test_native_safety.c
+++ b/tests/c/test_native_safety.c
@@ -1,0 +1,152 @@
+#include "test_harness.h"
+
+#include "holographic_nn.h"
+
+#ifndef _WIN32
+#include <pthread.h>
+#include <stdatomic.h>
+
+enum {
+    NATIVE_SAFETY_THREAD_COUNT = 4,
+    NATIVE_SAFETY_STEPS = 32,
+};
+
+typedef struct {
+    atomic_int ready;
+    atomic_bool go;
+} native_safety_start_t;
+
+typedef struct {
+    native_safety_start_t *start;
+    world_t *world;
+    float key[HNN_DIM];
+    float state[HNN_DIM];
+    vec2 final_pos;
+} native_safety_thread_t;
+
+static void *native_safety_thread_main(void *opaque) {
+    native_safety_thread_t *ctx = opaque;
+    hnn_pilot_features_t features = {
+        .target_dist = 0.75f,
+        .heading_error = -0.25f,
+        .heading_cos = 0.96875f,
+        .heading_sin = -0.25f,
+        .speed = 0.40f,
+        .forward_speed = 0.35f,
+        .lateral_speed = 0.05f,
+        .brake_distance = 0.10f,
+        .fwd_clear = 0.80f,
+        .left_clear = 0.60f,
+        .right_clear = 0.70f,
+        .signal_quality = 0.90f,
+        .hull_ratio = 1.0f,
+        .path_count = 0.25f,
+        .path_current = 0.125f,
+    };
+
+    atomic_fetch_add_explicit(&ctx->start->ready, 1, memory_order_release);
+    while (!atomic_load_explicit(&ctx->start->go, memory_order_acquire)) {
+    }
+
+    /*
+     * Each worker enters key/cache and feature-key initialization with a
+     * fresh thread-local cache. TSan therefore covers the old mutable-global
+     * race while the value comparison below preserves deterministic output.
+     */
+    hnn_key_vector(0x6245afe123456789ull, ctx->key);
+    hnn_encode_state(&features, ctx->state);
+
+    for (int i = 0; i < NATIVE_SAFETY_STEPS; i++)
+        world_sim_step_player_only(ctx->world, 0, SIM_DT);
+    ctx->final_pos = ctx->world->players[0].ship->pos;
+    return NULL;
+}
+#endif
+
+TEST(test_native_safety_thread_reentrant_hnn_and_simulation) {
+#ifdef _WIN32
+    /* The scheduled TSan lane is Linux-only. Keep Windows test builds valid. */
+    ASSERT(true);
+#else
+    native_safety_start_t start;
+    atomic_init(&start.ready, 0);
+    atomic_init(&start.go, false);
+
+    pthread_t threads[NATIVE_SAFETY_THREAD_COUNT];
+    native_safety_thread_t workers[NATIVE_SAFETY_THREAD_COUNT] = {0};
+    int created = 0;
+    int thread_error = 0;
+    bool results_match = true;
+
+    for (int i = 0; i < NATIVE_SAFETY_THREAD_COUNT; i++) {
+        workers[i].start = &start;
+        workers[i].world = calloc(1, sizeof(*workers[i].world));
+        if (!workers[i].world) {
+            for (int j = 0; j < i; j++) {
+                world_cleanup(workers[j].world);
+                free(workers[j].world);
+            }
+            ASSERT(workers[i].world != NULL);
+        }
+        world_reset(workers[i].world);
+
+        server_player_t *sp = &workers[i].world->players[0];
+        player_init_ship(sp, workers[i].world);
+        sp->connected = true;
+        sp->session_ready = true;
+        sp->docked = false;
+        sp->current_station = -1;
+        sp->ship->pos = v2(120.0f, -80.0f);
+        sp->ship->vel = v2(12.0f, -3.0f);
+        sp->input.thrust = 0.5f;
+        sp->input.turn = -0.25f;
+
+    }
+
+    for (int i = 0; i < NATIVE_SAFETY_THREAD_COUNT; i++) {
+        thread_error = pthread_create(&threads[i], NULL,
+                                      native_safety_thread_main, &workers[i]);
+        if (thread_error != 0) break;
+        created++;
+    }
+
+    while (thread_error == 0 &&
+           atomic_load_explicit(&start.ready, memory_order_acquire) !=
+               NATIVE_SAFETY_THREAD_COUNT) {
+    }
+    atomic_store_explicit(&start.go, true, memory_order_release);
+
+    for (int i = 0; i < created; i++) {
+        if (pthread_join(threads[i], NULL) != 0 && thread_error == 0)
+            thread_error = -1;
+    }
+
+    if (thread_error == 0) {
+        for (int i = 1; i < NATIVE_SAFETY_THREAD_COUNT; i++) {
+            results_match =
+                results_match &&
+                memcmp(workers[0].key, workers[i].key,
+                       sizeof(workers[0].key)) == 0 &&
+                memcmp(workers[0].state, workers[i].state,
+                       sizeof(workers[0].state)) == 0 &&
+                fabsf(workers[0].final_pos.x - workers[i].final_pos.x) <=
+                    0.000001f &&
+                fabsf(workers[0].final_pos.y - workers[i].final_pos.y) <=
+                    0.000001f;
+        }
+    }
+
+    for (int i = 0; i < NATIVE_SAFETY_THREAD_COUNT; i++) {
+        world_cleanup(workers[i].world);
+        free(workers[i].world);
+    }
+    ASSERT_EQ_INT(thread_error, 0);
+    ASSERT(results_match);
+#endif
+}
+
+void register_native_safety_tests(void);
+void register_native_safety_tests(void) {
+    TEST_SECTION("\nNative safety:\n");
+    RUN(test_native_safety_thread_reentrant_hnn_and_simulation);
+}

--- a/tests/c/test_npc_radio.c
+++ b/tests/c/test_npc_radio.c
@@ -52,8 +52,7 @@ static npc_ship_t *place_npc(world_t *w,
                              vec2 pos) {
     if (!w || index < 0 || index >= MAX_NPC_SHIPS) return NULL;
     npc_ship_t *npc = &w->npc_ships[index];
-    memset(npc, 0, sizeof(*npc));
-    if (!world_npc_ship_slot_activate(w, index)) return NULL;
+    if (!test_world_npc_slot_reset(w, index)) return NULL;
     npc->active = true;
     npc->role = role;
     npc->ship->pos = pos;
@@ -202,7 +201,7 @@ TEST(test_npc_radio_formats_supply_route_and_scaffold_memories) {
 TEST(test_npc_radio_choice_prompt_and_response_apply) {
     WORLD_DECL;
     world_reset(&w);
-    memset(w.npc_ships, 0, sizeof(w.npc_ships));
+    test_world_clear_npcs(&w);
 
     npc_ship_t *hauler = place_npc(&w, 2, NPC_ROLE_HAULER, v2(10.0f, 0.0f));
     ASSERT(hauler != NULL);
@@ -265,7 +264,7 @@ TEST(test_npc_radio_choice_prompt_and_response_apply) {
 TEST(test_npc_radio_choice_prompt_varies_by_hail_request) {
     WORLD_DECL;
     world_reset(&w);
-    memset(w.npc_ships, 0, sizeof(w.npc_ships));
+    test_world_clear_npcs(&w);
 
     npc_ship_t *hauler = place_npc(&w, 2, NPC_ROLE_HAULER, v2(10.0f, 0.0f));
     ASSERT(hauler != NULL);
@@ -305,7 +304,7 @@ TEST(test_npc_radio_choice_prompt_varies_by_hail_request) {
 TEST(test_npc_radio_choice_prompt_omits_ungrounded_example_keys) {
     WORLD_DECL;
     world_reset(&w);
-    memset(w.npc_ships, 0, sizeof(w.npc_ships));
+    test_world_clear_npcs(&w);
 
     npc_ship_t *ungrounded =
         place_npc(&w, 1, NPC_ROLE_HAULER, v2(10.0f, 0.0f));
@@ -364,7 +363,7 @@ TEST(test_npc_radio_player_choices_apply) {
 TEST(test_npc_radio_hail_conversation_orders_by_proximity) {
     WORLD_DECL;
     world_reset(&w);
-    memset(w.npc_ships, 0, sizeof(w.npc_ships));
+    test_world_clear_npcs(&w);
 
     npc_ship_t *far_miner = place_npc(&w, 4, NPC_ROLE_MINER, v2(50.0f, 0.0f));
     ASSERT(far_miner != NULL);
@@ -403,7 +402,7 @@ TEST(test_npc_radio_hail_conversation_orders_by_proximity) {
 TEST(test_npc_radio_hail_conversation_caps_nearest_four) {
     WORLD_DECL;
     world_reset(&w);
-    memset(w.npc_ships, 0, sizeof(w.npc_ships));
+    test_world_clear_npcs(&w);
 
     for (int i = 0; i < 6; i++) {
         npc_ship_t *npc = place_npc(&w, i, NPC_ROLE_MINER,

--- a/tests/c/test_prefix_class_pricing.c
+++ b/tests/c/test_prefix_class_pricing.c
@@ -65,7 +65,7 @@ TEST(test_prefix_pricing_rati_class_50x) {
  * the buy curve is 1 - 0.5*0.5 = 0.75×; under RATi prefix the
  * combined factor is 0.75 × 50 = 37.5. */
 TEST(test_prefix_pricing_compose_with_stock_curve) {
-    station_t st = {0};
+    STATION_DECL(st);
     st.base_price[COMMODITY_FERRITE_INGOT] = 24.0f;
     /* Half-full PRODUCT stockpile (capacity = MAX_PRODUCT_STOCK). */
     ASSERT(test_set_station_finished_units(

--- a/tests/c/test_protocol.c
+++ b/tests/c/test_protocol.c
@@ -5630,8 +5630,7 @@ TEST(test_roundtrip_inspect_snapshot_npc_manifest_chain) {
     npc.home_station = 0;
     npc.dest_station = 1;
 
-    ship_t ship;
-    memset(&ship, 0, sizeof(ship));
+    SHIP_DECL(ship);
     ASSERT(ship_manifest_bootstrap(&ship));
 
     cargo_unit_t unit;
@@ -5696,8 +5695,7 @@ TEST(test_inspect_snapshot_npc_expands_matching_receipt_chain) {
     npc.home_station = 0;
     npc.dest_station = 1;
 
-    ship_t ship;
-    memset(&ship, 0, sizeof(ship));
+    SHIP_DECL(ship);
     ASSERT(ship_manifest_bootstrap(&ship));
 
     cargo_unit_t unit;
@@ -5806,8 +5804,7 @@ TEST(test_inspect_snapshot_npc_retrieves_matching_station_receipt_chain) {
     npc.home_station = 0;
     npc.dest_station = 1;
 
-    ship_t ship;
-    memset(&ship, 0, sizeof(ship));
+    SHIP_DECL(ship);
     ASSERT(ship_manifest_bootstrap(&ship));
 
     WORLD_DECL;
@@ -5979,8 +5976,7 @@ TEST(test_inspect_snapshot_npc_includes_market_memory_diagnostics) {
     }
     memcpy(item->payload, &memory, sizeof(memory));
 
-    ship_t ship;
-    memset(&ship, 0, sizeof(ship));
+    SHIP_DECL(ship);
     ASSERT(ship_manifest_bootstrap(&ship));
 
     uint8_t buf[INSPECT_SNAPSHOT_MAX_SIZE];
@@ -6080,8 +6076,7 @@ TEST(test_inspect_snapshot_npc_expands_matching_job_source_memory) {
     }
     memcpy(item->payload, &route, sizeof(route));
 
-    ship_t ship;
-    memset(&ship, 0, sizeof(ship));
+    SHIP_DECL(ship);
     ASSERT(ship_manifest_bootstrap(&ship));
 
     uint8_t buf[INSPECT_SNAPSHOT_MAX_SIZE];
@@ -6157,8 +6152,7 @@ TEST(test_inspect_snapshot_npc_includes_job_offer_diagnostics) {
     npc.job_diag_commodity[1] = (uint8_t)COMMODITY_FERRITE_ORE;
     npc.job_diag_hint[1] = 6;
 
-    ship_t ship;
-    memset(&ship, 0, sizeof(ship));
+    SHIP_DECL(ship);
     ASSERT(ship_manifest_bootstrap(&ship));
 
     uint8_t buf[INSPECT_SNAPSHOT_MAX_SIZE];
@@ -6232,8 +6226,7 @@ TEST(test_inspect_snapshot_npc_includes_hnn_trace_diagnostics) {
 
     hnn_memory_contract_t contract = hnn_memory_contract(&npc.hnn_mem);
 
-    ship_t ship;
-    memset(&ship, 0, sizeof(ship));
+    SHIP_DECL(ship);
     ASSERT(ship_manifest_bootstrap(&ship));
 
     uint8_t buf[INSPECT_SNAPSHOT_MAX_SIZE];
@@ -6287,8 +6280,7 @@ TEST(test_inspect_snapshot_groups_anonymous_ingots_by_grade) {
     npc.home_station = 0;
     npc.dest_station = 1;
 
-    ship_t ship;
-    memset(&ship, 0, sizeof(ship));
+    SHIP_DECL(ship);
     ASSERT(ship_manifest_bootstrap(&ship));
 
     uint8_t fragment_pub[32] = {0};
@@ -6358,8 +6350,7 @@ TEST(test_inspect_snapshot_groups_finished_goods_by_grade) {
     npc.home_station = 0;
     npc.dest_station = 1;
 
-    ship_t ship;
-    memset(&ship, 0, sizeof(ship));
+    SHIP_DECL(ship);
     ASSERT(ship_manifest_bootstrap(&ship));
 
     const struct {
@@ -6425,8 +6416,7 @@ TEST(test_inspect_snapshot_keeps_named_ingots_individual) {
     npc.home_station = 0;
     npc.dest_station = 1;
 
-    ship_t ship;
-    memset(&ship, 0, sizeof(ship));
+    SHIP_DECL(ship);
     ASSERT(ship_manifest_bootstrap(&ship));
 
     uint8_t fragment_pub[32] = {0};
@@ -6480,8 +6470,7 @@ TEST(test_inspect_snapshot_keeps_named_ingots_individual) {
 }
 
 TEST(test_roundtrip_stations) {
-    station_t stations[MAX_STATIONS];
-    memset(stations, 0, sizeof(stations));
+    STATION_ARRAY(stations, MAX_STATIONS);
 
     /* Mark station 0 as active so it gets serialized */
     stations[0].signal_range = 2200.0f;
@@ -6512,8 +6501,7 @@ TEST(test_roundtrip_stations) {
 }
 
 TEST(test_payload_cache_suppresses_unchanged_world_stations_per_connection) {
-    station_t stations[MAX_STATIONS];
-    memset(stations, 0, sizeof(stations));
+    STATION_ARRAY(stations, MAX_STATIONS);
     stations[0].signal_range = 2200.0f;
     stations[0]._inventory_cache[COMMODITY_FERRITE_ORE] = 45.5f;
     ASSERT(station_manifest_bootstrap(&stations[0]));
@@ -6543,8 +6531,7 @@ TEST(test_payload_cache_suppresses_unchanged_world_stations_per_connection) {
 }
 
 TEST(test_world_stations_q_omits_zero_inventory_slots) {
-    station_t stations[MAX_STATIONS];
-    memset(stations, 0, sizeof(stations));
+    STATION_ARRAY(stations, MAX_STATIONS);
     stations[0].signal_range = 2200.0f;
     stations[0]._inventory_cache[COMMODITY_FERRITE_ORE] = 45.5f;
     ASSERT(station_manifest_bootstrap(&stations[0]));
@@ -6580,8 +6567,7 @@ TEST(test_world_stations_q_omits_zero_inventory_slots) {
 }
 
 TEST(test_station_identity_serializes_module_commodities) {
-    station_t st;
-    memset(&st, 0, sizeof(st));
+    STATION_DECL(st);
     st.services = STATION_SERVICE_REPAIR;
     st.pos = v2(10.0f, -20.0f);
     st.radius = 60.0f;
@@ -6631,8 +6617,7 @@ TEST(test_station_identity_serializes_module_commodities) {
 }
 
 TEST(test_station_identity_serializes_operator_text) {
-    station_t st;
-    memset(&st, 0, sizeof(st));
+    STATION_DECL(st);
     st.signal_range = 1000.0f;
     snprintf(st.name, sizeof(st.name), "Voice Test");
     snprintf(st.hail_message, sizeof(st.hail_message), "station motd");
@@ -6669,8 +6654,7 @@ TEST(test_station_identity_serializes_operator_text) {
 }
 
 TEST(test_station_identity_q_compacts_sparse_text_and_lists) {
-    station_t st;
-    memset(&st, 0, sizeof(st));
+    STATION_DECL(st);
     st.services = 0x12345678u;
     st.signal_range = 1000.0f;
     st.pos = v2(10.0f, -20.0f);
@@ -7019,8 +7003,7 @@ TEST(test_bug92_station_record_size_matches_buffer) {
      * STATION_RECORD_SIZE is validated at compile time via _Static_assert,
      * but verify at runtime that serialize_stations writes exactly the
      * expected number of bytes. */
-    station_t stations[MAX_STATIONS];
-    memset(stations, 0, sizeof(stations));
+    STATION_ARRAY(stations, MAX_STATIONS);
     /* Empty stations should produce 0 records */
     uint8_t buf[2 + MAX_STATIONS * STATION_RECORD_SIZE];
     int len = serialize_stations(buf, stations);
@@ -7423,7 +7406,7 @@ TEST(test_bug93_hint_mines_small_shard_with_minor_desync) {
     WORLD_DECL;
     world_reset(&w);
     memset(w.asteroids, 0, sizeof(w.asteroids));
-    memset(w.npc_ships, 0, sizeof(w.npc_ships));
+    test_world_clear_npcs(&w);
 
     player_init_ship(&w.players[0], &w);
     w.players[0].connected = true;
@@ -7492,8 +7475,7 @@ TEST(test_roundtrip_player_ship) {
 }
 
 TEST(test_manifest_detail_serializes_full_cargo_identity) {
-    station_t st;
-    memset(&st, 0, sizeof(st));
+    STATION_DECL(st);
     ASSERT(station_manifest_bootstrap(&st));
 
     cargo_unit_t unit = {0};

--- a/tests/c/test_station_authority.c
+++ b/tests/c/test_station_authority.c
@@ -10,6 +10,7 @@
 
 #include "station_authority.h"
 #include "signal_crypto.h"
+#include "signal_memzero.h"
 #include "net_protocol.h"
 
 TEST(test_station_authority_seeded_determinism) {
@@ -80,8 +81,7 @@ TEST(test_station_authority_outpost_derivation) {
     /* Place an outpost (manually constructed to avoid driving the full
      * scaffold-tow flow) and assert the pubkey matches an independent
      * recomputation from the same (founder, name, tick) triple. */
-    station_t st;
-    memset(&st, 0, sizeof(st));
+    STATION_DECL(st);
     snprintf(st.name, sizeof(st.name), "Outpost Alpha");
     uint8_t founder[32];
     for (int i = 0; i < 32; i++) founder[i] = (uint8_t)(0x10 + i);
@@ -100,6 +100,28 @@ TEST(test_station_authority_outpost_derivation) {
     /* Provenance fields stamped for save/load rederivation. */
     ASSERT(memcmp(st.outpost_founder_pubkey, founder, 32) == 0);
     ASSERT_EQ_INT((int)st.outpost_planted_tick, (int)tick);
+    signal_memzero_explicit(expected_seed, sizeof(expected_seed));
+    signal_memzero_explicit(expected_secret, sizeof(expected_secret));
+}
+
+TEST(test_station_authority_cleanup_wipes_private_material) {
+    STATION_DECL(st);
+    station_authority_init_seeded(&st, 4242u, 0);
+    uint8_t zero_secret[sizeof(st.station_secret)] = {0};
+    ASSERT(memcmp(st.station_secret, zero_secret, sizeof(zero_secret)) != 0);
+
+    station_cleanup(&st);
+    ASSERT(memcmp(st.station_secret, zero_secret, sizeof(zero_secret)) == 0);
+
+    station_authority_configure_secret("temporary-operator-secret");
+    station_authority_clear_secret();
+    uint8_t cleared_seed[32], dev_seed[32];
+    station_authority_seeded_seed(4242u, 0, cleared_seed);
+    station_authority_use_dev_secret();
+    station_authority_seeded_seed(4242u, 0, dev_seed);
+    ASSERT(memcmp(cleared_seed, dev_seed, sizeof(dev_seed)) == 0);
+    signal_memzero_explicit(cleared_seed, sizeof(cleared_seed));
+    signal_memzero_explicit(dev_seed, sizeof(dev_seed));
 }
 
 TEST(test_station_authority_sign_verify_roundtrip) {
@@ -254,6 +276,7 @@ void register_station_authority_tests(void) {
     RUN(test_station_authority_seeded_distinct_seeds);
     RUN(test_station_authority_operator_secret_affects_pubkey);
     RUN(test_station_authority_outpost_derivation);
+    RUN(test_station_authority_cleanup_wipes_private_material);
     RUN(test_station_authority_sign_verify_roundtrip);
     RUN(test_station_authority_save_load_rederives_secret);
     RUN(test_station_authority_wire_omits_secret);

--- a/tests/c/test_world_sim.c
+++ b/tests/c/test_world_sim.c
@@ -3286,7 +3286,7 @@ TEST(test_frontier_outpost_roster_respects_virtual_logistics_budget) {
     frontier_virtual_pilots_set(w, 0);
     int zero_budget_station = SIGNAL_FIRST_OUTPOST_INDEX;
     station_t *zero_budget = &w->stations[zero_budget_station];
-    memset(zero_budget, 0, sizeof(*zero_budget));
+    station_reset(zero_budget);
     snprintf(zero_budget->name, sizeof(zero_budget->name),
              "Zero Budget Outpost");
     zero_budget->pos = v2(5200.0f, 2500.0f);
@@ -3325,7 +3325,7 @@ TEST(test_frontier_outpost_roster_respects_virtual_logistics_budget) {
          s < SIGNAL_FIRST_OUTPOST_INDEX + 7 && s < MAX_STATIONS;
          s++) {
         station_t *st = &w->stations[s];
-        memset(st, 0, sizeof(*st));
+        station_reset(st);
         snprintf(st->name, sizeof(st->name), "Budget Outpost %d", s);
         st->pos = v2(6000.0f + (float)(s - SIGNAL_FIRST_OUTPOST_INDEX) * 900.0f,
                      3000.0f);
@@ -3563,7 +3563,7 @@ TEST(test_world_sim_step_laser_scans_cargo_pod) {
     WORLD_DECL;
     world_reset(&w);
     memset(w.asteroids, 0, sizeof(w.asteroids));
-    memset(w.npc_ships, 0, sizeof(w.npc_ships));
+    test_world_clear_npcs(&w);
 
     server_player_t *sp = &w.players[0];
     player_init_ship(sp, &w);
@@ -4933,9 +4933,7 @@ TEST(test_holographic_npc_bootstrap_gate_blocks_forward_thrust) {
     signal_brain_holographic_init();
 
     npc_ship_t *npc = &w.npc_ships[0];
-    world_npc_ship_slot_release(&w, 0);
-    memset(npc, 0, sizeof(*npc));
-    ASSERT(world_npc_ship_slot_activate(&w, 0));
+    ASSERT(test_world_npc_slot_reset(&w, 0));
 
     station_t *st = &w.stations[0];
     ASSERT(station_exists(st));

--- a/vendor/tweetnacl/signal_crypto_tweetnacl.c
+++ b/vendor/tweetnacl/signal_crypto_tweetnacl.c
@@ -8,6 +8,7 @@
  * Public domain. Layer A.1 of #479.
  */
 #include "signal_crypto.h"
+#include "signal_memzero.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -40,6 +41,10 @@ void signal_crypto_sign(uint8_t sig[SIGNAL_CRYPTO_SIG_BYTES],
                         const uint8_t secret[SIGNAL_CRYPTO_SECRET_BYTES]) {
     /* crypto_sign writes (sig||msg) into a buffer of size len + 64. */
     unsigned long long smlen = 0;
+    if (len > SIZE_MAX - SIGNAL_CRYPTO_SIG_BYTES) {
+        memset(sig, 0, SIGNAL_CRYPTO_SIG_BYTES);
+        return;
+    }
     /* Stack alloc up to a small bound; otherwise heap. The signing
      * buffer is bounded by message size + 64. */
     uint8_t  stack_buf[1024];
@@ -50,6 +55,7 @@ void signal_crypto_sign(uint8_t sig[SIGNAL_CRYPTO_SIG_BYTES],
     }
     crypto_sign(sm, &smlen, msg, (unsigned long long)len, secret);
     memcpy(sig, sm, SIGNAL_CRYPTO_SIG_BYTES);
+    signal_memzero_explicit(sm, len + SIGNAL_CRYPTO_SIG_BYTES);
     if (sm != stack_buf) free(sm);
 }
 
@@ -57,6 +63,7 @@ bool signal_crypto_verify(const uint8_t sig[SIGNAL_CRYPTO_SIG_BYTES],
                           const uint8_t *msg, size_t len,
                           const uint8_t pub[SIGNAL_CRYPTO_PUBKEY_BYTES]) {
     /* Re-build a (sig || msg) buffer for crypto_sign_open. */
+    if (len > SIZE_MAX - SIGNAL_CRYPTO_SIG_BYTES) return false;
     uint8_t  stack_sm[1024];
     uint8_t  stack_m [1024];
     uint8_t *sm = stack_sm;
@@ -74,6 +81,8 @@ bool signal_crypto_verify(const uint8_t sig[SIGNAL_CRYPTO_SIG_BYTES],
     int rc = crypto_sign_open(m, &mlen,
                               sm, (unsigned long long)smlen_in,
                               pub);
+    signal_memzero_explicit(sm, smlen_in);
+    signal_memzero_explicit(m, smlen_in);
     if (sm != stack_sm) { free(sm); free(m); }
     return rc == 0;
 }


### PR DESCRIPTION
Closes #624

## What changed

- re-enable Linux LeakSanitizer with cleanup-aware ship, station, NPC, and fixture reset paths
- add a scoped Clang MemorySanitizer lane and weekly/manual ThreadSanitizer lane
- add a concurrent HNN plus independent-simulation regression; make HNN caches thread-local
- remove the TSan-discovered process-global ship collision counter in favor of per-call state
- add `signal_memzero_explicit()` with C23, Windows, and reviewed C11 backends plus optimized-IR and runtime proofs
- wipe station authority roots/seeds, station/player keys, identity/network copies, and crypto signing scratch at lifecycle boundaries
- keep sanitizer compatibility flags scoped to vendored TweetNaCl sources
- document sanitizer scope, ownership rules, and secret-wipe policy

## Validation

Final head `c270f24`:

- Linux CI ASan/UBSan/LSan with `detect_leaks=1` — 1221/1221 tests and all policy gates passed
- Linux CI MemorySanitizer — scoped memzero, identity, station-authority, and signed-action suites passed
- `make test TEST_SHARDS=4` — 1221/1221 locally
- `make test-san SAN_BUILD_DIR=build-san-624 TEST_SHARDS=4` — 1221/1221 ASan/UBSan locally
- `make test-tsan TSAN_CC=/opt/homebrew/opt/llvm/bin/clang TSAN_BUILD_DIR=build-tsan-624` — 1/1, no races
- `make test-soak TEST_SHARDS=4` — 9/9
- native client and headless server compile checks
- Linux x64, macOS ARM, and WASM cross-runner replay bundles — byte-identical across 20 scenarios
- receipt/handoff fuzz — 9354 local executions, no crash
- banned APIs, deterministic libm/build flags, docs freshness, cppcheck, actionlint, and memzero optimized-IR gate

## Known inherited CI dependency

The fuzz job still stops during desktop dependency configuration because the base branch requires ALSA before reaching the decoder targets. This repository-wide defect is #631 and its headless configuration fix is ready in draft PR #632. It is unrelated to this PR; the existing corpus and `server/main.c` remain untouched.