### PR TITLE
HUD attention budget and semantic scan zoom

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,6 +311,7 @@ if(NOT EMSCRIPTEN AND NOT BUILD_SERVER_ONLY)
         tests/c/test_signal_field.c
         tests/c/test_gossip.c
         tests/c/test_npc_radio.c
+        tests/c/test_hud_attention.c
         client/identity.c
         client/client_log.c
         ${SIGNAL_SIM_SOURCES}

--- a/client/client.h
+++ b/client/client.h
@@ -393,6 +393,10 @@ typedef struct {
         } rows[16];
         int row_count;
     } scoreboard;
+    /* Healthy build/network telemetry is deliberately hidden during play.
+     * F3 exposes it for diagnostics; actionable connection trouble remains
+     * visible even while this is false. */
+    bool hud_debug_visible;
     /* Per-station manifest summary — [commodity][grade] unit counts.
      * Unified read path for the TRADE UI. Network-authoritative sessions
      * populate it from server manifest-summary broadcasts; the offline
@@ -848,6 +852,7 @@ void draw_ui_meter(float x, float y, float width, float height, float fill, floa
 void get_flight_hud_rects(float* top_x, float* top_y, float* top_w, float* top_h,
     float* bottom_x, float* bottom_y, float* bottom_w, float* bottom_h);
 bool hud_should_draw_message_panel(void);
+const char *hud_attention_current_surface_name(void);
 void get_hud_message_panel_rect(float* x, float* y, float* width, float* height);
 void get_station_panel_rect(float* x, float* y, float* width, float* height);
 

--- a/client/hud.c
+++ b/client/hud.c
@@ -22,6 +22,7 @@
 #include "ui_clarity.h"
 #include "rock_usefulness.h"
 #include "chain_log.h"
+#include "hud_attention.h"
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
@@ -29,6 +30,10 @@
 #define HUD_LATENCY_WARN_MS 100.0f
 #define HUD_LATENCY_BAD_MS 300.0f
 #define HUD_FRAGMENT_NEARBY_RANGE 220.0f
+
+static bool build_hud_message(char *label, size_t label_size,
+                              char *message, size_t message_size,
+                              uint8_t *r, uint8_t *g0, uint8_t *b);
 
 static void hud_append_text(char *out, size_t cap, const char *text) {
     if (!out || cap == 0 || !text) return;
@@ -1095,6 +1100,44 @@ static void hud_draw_alpha_banner_and_connection(float screen_w, bool compact) {
 #else
     const char *client_hash = "dev";
 #endif
+    /* The default play surface reports causes that require attention, not
+     * healthy implementation telemetry. F3 restores the detailed build,
+     * transport, queue, and latency readout for diagnosis. */
+    if (!g.hud_debug_visible) {
+        if (!g.net_authority_enabled) return;
+        if (!net_is_connected()) {
+            sdtx_color3b(PAL_SYNC_OFFLINE);
+            sdtx_puts("offline [P] reconnect");
+            return;
+        }
+        if (!net_is_loopback()) {
+            const char *srv = net_server_hash();
+            if (srv[0] == '\0') {
+                sdtx_color3b(PAL_SYNC_CONNECTING);
+                sdtx_puts("connecting...");
+                return;
+            }
+            if (strcmp(client_hash, srv) != 0) {
+                sdtx_color3b(PAL_SYNC_RESYNCING);
+                sdtx_puts("syncing...");
+                return;
+            }
+            bool ack_fresh = net_latency_stats_fresh(
+                &g.net_ack_latency, g.net_time, NET_LATENCY_STALE_SEC);
+            bool ping_fresh = net_latency_stats_fresh(
+                &g.net_ping_latency, g.net_time, NET_LATENCY_STALE_SEC);
+            float warning_ms = ack_fresh
+                ? net_latency_stats_smoothed_sec(&g.net_ack_latency) * 1000.0f
+                : (ping_fresh
+                    ? net_latency_stats_smoothed_sec(&g.net_ping_latency) * 1000.0f
+                    : 0.0f);
+            if (warning_ms >= HUD_LATENCY_BAD_MS) {
+                sdtx_color3b(PAL_WARNING);
+                sdtx_puts("connection unstable");
+            }
+        }
+        return;
+    }
     if (g.net_authority_enabled && net_is_connected()) {
         const char *srv = net_server_hash();
         bool match = srv[0] != '\0' && strcmp(client_hash, srv) == 0;
@@ -2082,7 +2125,9 @@ static void hud_draw_npc_memory_ticker(const NetInspectSnapshot *snap,
     if (!npc->active) return;
 
     float cell = 8.0f;
-    float px = fmaxf(14.0f, screen_w - 340.0f);
+    /* Keep the card inside the scaled narrow safe edge. Fractional/near-edge
+     * debug-text columns can lose the leading "[ CONTACT" glyphs. */
+    float px = fmaxf(48.0f, screen_w - 340.0f);
     float py = (screen_h < 520.0f) ? 70.0f : 86.0f;
     float bg_x = fmaxf(8.0f, px - 10.0f);
     float bg_y = fmaxf(8.0f, py - 9.0f);
@@ -2185,10 +2230,14 @@ static void hud_draw_npc_memory_ticker(const NetInspectSnapshot *snap,
                  job ? clarity.fg[1] : clarity.dim[1],
                  job ? clarity.fg[2] : clarity.dim[2]);
     if (job) {
-        sdtx_printf("%s %s  home %.10s",
-                    hud_npc_role_label(snap->role),
-                    hud_npc_state_label(snap->state),
-                    home);
+        char role_line[96];
+        char role_fit[96];
+        snprintf(role_line, sizeof(role_line), "%s %s  home %.10s",
+                 hud_npc_role_label(snap->role),
+                 hud_npc_state_label(snap->state),
+                 home);
+        hud_fit_text(role_line, text_chars, role_fit, sizeof(role_fit));
+        sdtx_puts(role_fit);
     } else {
         sdtx_printf("%c MEMORY", stream);
     }
@@ -2318,7 +2367,7 @@ static void hud_draw_inspect_snapshot_pane(float screen_w, float screen_h) {
         if (!np && !g.world.players[target_idx].connected) return;
     }
 
-    float px = fmaxf(16.0f, screen_w - 360.0f);
+    float px = fmaxf(24.0f, screen_w - 360.0f);
     float py = (screen_h < 520.0f) ? 76.0f : 92.0f;
     float cell = 8.0f;
     sdtx_canvas(screen_w, screen_h);
@@ -3019,23 +3068,28 @@ static void hud_draw_scoreboard(float screen_w, float screen_h) {
         order[j + 1] = k;
     }
 
-    float panel_w = 280.0f;
+    bool narrow = screen_w < 520.0f;
+    float panel_w = fminf(narrow ? 358.0f : 360.0f, screen_w - 32.0f);
     float panel_x = (screen_w - panel_w) * 0.5f;
-    float panel_y = screen_h * 0.18f;
+    float panel_y = fmaxf(28.0f, screen_h * 0.16f);
+    int max_rows = (int)((screen_h - panel_y - 64.0f) / 12.0f);
+    if (n > max_rows) n = max_rows;
     sdtx_canvas(screen_w, screen_h);
     sdtx_origin(0.0f, 0.0f);
 
     sdtx_color3b(255, 220, 100);
-    sdtx_pos(panel_x / cell, panel_y / cell);
-    sdtx_puts("== SCOREBOARD ==  [Tab to close]");
+    sdtx_pos((panel_x + 16.0f) / cell, (panel_y + 14.0f) / cell);
+    sdtx_puts(narrow ? "SCOREBOARD // [TAB] CLOSE"
+                     : "SESSION SCOREBOARD // [TAB] CLOSE");
 
     sdtx_color3b(180, 180, 180);
-    sdtx_pos(panel_x / cell, (panel_y + 16.0f) / cell);
-    sdtx_puts("PILOT             K   D   K/D");
+    sdtx_pos((panel_x + 16.0f) / cell, (panel_y + 34.0f) / cell);
+    sdtx_puts(narrow ? "PILOT         K  D  RATIO"
+                     : "PILOT             K   D   K/D");
 
     if (n == 0) {
         sdtx_color3b(140, 140, 140);
-        sdtx_pos(panel_x / cell, (panel_y + 32.0f) / cell);
+        sdtx_pos((panel_x + 16.0f) / cell, (panel_y + 54.0f) / cell);
         sdtx_puts("(no kills or deaths yet)");
         return;
     }
@@ -3055,12 +3109,17 @@ static void hud_draw_scoreboard(float screen_w, float screen_h) {
                       (float)g.scoreboard.rows[idx].deaths;
             snprintf(kdr, sizeof(kdr), "%.2f", r);
         }
-        sdtx_pos(panel_x / cell, (panel_y + 32.0f + (float)rank * 12.0f) / cell);
-        sdtx_printf("%-16s %3d %3d %5s",
-                    label,
-                    g.scoreboard.rows[idx].kills,
-                    g.scoreboard.rows[idx].deaths,
-                    kdr);
+        sdtx_pos((panel_x + 16.0f) / cell,
+                 (panel_y + 54.0f + (float)rank * 12.0f) / cell);
+        if (narrow) {
+            sdtx_printf("%-12.12s %2d %2d %6s", label,
+                        g.scoreboard.rows[idx].kills,
+                        g.scoreboard.rows[idx].deaths, kdr);
+        } else {
+            sdtx_printf("%-16s %3d %3d %5s", label,
+                        g.scoreboard.rows[idx].kills,
+                        g.scoreboard.rows[idx].deaths, kdr);
+        }
     }
 }
 
@@ -3075,7 +3134,6 @@ static void hud_draw_shared_panels(float screen_w, float screen_h, float sig_qua
     hud_draw_kill_feed(screen_w, screen_h);
     hud_draw_kill_confirm(screen_w, screen_h);
     hud_draw_kill_counter(screen_w);
-    hud_draw_scoreboard(screen_w, screen_h);
     /* Hit feedback vignette — drawn last so it sits above the HUD
      * readouts, but the inset rectangle in the middle leaves the
      * action row + flight readouts unobscured. */
@@ -3344,10 +3402,34 @@ void get_flight_hud_rects(float* top_x, float* top_y, float* top_w, float* top_h
     *bottom_h = bottom_height;
 }
 
+static bool hud_inspect_surface_active(void) {
+    return g.inspect_station >= 0 ||
+        (g.inspect_snapshot_timer > 0.0f &&
+         g.inspect_snapshot.target_type != INSPECT_TARGET_NONE);
+}
+
 bool hud_should_draw_message_panel(void) {
     if (episode_is_active(&g.episode)) return false;
-    return !LOCAL_PLAYER.docked || !g.onboarding.complete || !g.onboarding.welcomed ||
-           (g.notice_timer > 0.0f) || (g.collection_feedback_timer > 0.0f);
+    if (g.scoreboard.show) return false;
+    if (hud_inspect_surface_active()) return false;
+    char label[32];
+    char message[320];
+    uint8_t r = 0, g0 = 0, b = 0;
+    return build_hud_message(label, sizeof(label), message, sizeof(message),
+                             &r, &g0, &b);
+}
+
+const char *hud_attention_current_surface_name(void) {
+    hud_attention_flags_t flags = {
+        .death = g.death_screen_timer > 0.0f ||
+                 g.death_cinematic.active ||
+                 g.death_cinematic.menu_alpha > 0.001f,
+        .docked = LOCAL_PLAYER.docked && g.dock_settle_timer <= 0.0f,
+        .inspect = hud_inspect_surface_active(),
+        .scoreboard = g.scoreboard.show,
+        .message = hud_should_draw_message_panel(),
+    };
+    return hud_attention_surface_name(hud_attention_select(flags));
 }
 
 void get_hud_message_panel_rect(float* x, float* y, float* width, float* height) {
@@ -5352,6 +5434,24 @@ void draw_hud_panels(void) {
         return;
     }
     draw_hull_warning_overlay();
+    if (hud_inspect_surface_active() && !LOCAL_PLAYER.docked)
+        return;
+    if (g.scoreboard.show && !LOCAL_PLAYER.docked) {
+        float screen_w = ui_screen_width();
+        float screen_h = ui_screen_height();
+        float panel_w = fminf(screen_w < 520.0f ? 358.0f : 360.0f,
+                              screen_w - 32.0f);
+        float panel_x = (screen_w - panel_w) * 0.5f;
+        float panel_y = fmaxf(28.0f, screen_h * 0.16f);
+        int rows = g.scoreboard.row_count;
+        if (rows < 1) rows = 1;
+        if (rows > 16) rows = 16;
+        float panel_h = fminf(screen_h - panel_y - 24.0f,
+                              70.0f + (float)rows * 12.0f);
+        draw_ui_scrim(0.42f);
+        draw_ui_panel(panel_x, panel_y, panel_w, panel_h, 0.18f);
+        return;
+    }
     float top_x = 0.0f, top_y = 0.0f, top_w = 0.0f, top_h = 0.0f;
     float bottom_x = 0.0f, bottom_y = 0.0f, bottom_w = 0.0f, bottom_h = 0.0f;
     get_flight_hud_rects(&top_x, &top_y, &top_w, &top_h, &bottom_x, &bottom_y, &bottom_w, &bottom_h);
@@ -5602,6 +5702,25 @@ void draw_hud(void) {
 
     /* Death-screen overlay short-circuits the rest of the HUD. */
     if (draw_death_overlay(screen_w, screen_h)) return;
+    if (hud_inspect_surface_active() && !LOCAL_PLAYER.docked) {
+        sdtx_canvas(screen_w / ui_text_zoom(), screen_h / ui_text_zoom());
+        sdtx_font(0);
+        sdtx_origin(0.0f, 0.0f);
+        sdtx_home();
+        hud_draw_module_inspect_pane(screen_w);
+        hud_draw_inspect_snapshot_pane(screen_w, screen_h);
+        float sig_quality = signal_strength_at(&g.world, LOCAL_PLAYER.ship->pos);
+        hud_draw_signal_lost_warning(screen_w, screen_h, sig_quality);
+        draw_damage_flash(screen_w, screen_h);
+        return;
+    }
+    /* The scoreboard is a deliberate modal glance, not another layer on top
+     * of flight, tutorial, inspect, and connection chrome. */
+    if (g.scoreboard.show && !LOCAL_PLAYER.docked) {
+        hud_draw_scoreboard(screen_w, screen_h);
+        draw_damage_flash(screen_w, screen_h);
+        return;
+    }
 
     bool compact = ui_is_compact();
     float top_x = 0.0f;
@@ -5668,7 +5787,8 @@ void draw_hud(void) {
     sdtx_font(0);
     sdtx_origin(0.0f, 0.0f);
     sdtx_home();
-    if (hud_should_draw_message_panel()) {
+    bool message_panel_visible = hud_should_draw_message_panel();
+    if (message_panel_visible) {
         int message_cols = 0;
         get_hud_message_panel_rect(&message_x, &message_y, &message_w, &message_h);
         build_hud_message(message_label, sizeof(message_label), message_text, sizeof(message_text), &message_r, &message_g, &message_b);
@@ -5733,20 +5853,22 @@ void draw_hud(void) {
             sdtx_pos(top_text_x, top_row_2);
             if (LOCAL_PLAYER.in_dock_range) {
                 sdtx_color3b(PAL_SIGNAL_MINT);
-                sdtx_puts("DOCK RANGE // E dock");
+                sdtx_puts(message_panel_visible
+                    ? "DOCK RANGE"
+                    : "DOCK RANGE // E dock");
             } else {
                 sdtx_color3b(PAL_NAV_BLUE);
                 sdtx_printf("%s %d u // %d %s", nav_role, station_distance, bearing_degrees, bearing_mark);
             }
 
-            sdtx_pos(top_text_x, top_row_3);
-            {
+            if (!message_panel_visible) {
+                sdtx_pos(top_text_x, top_row_3);
                 hud_action_t act = hud_classify_action(cargo_units, cargo_capacity, sig_quality);
                 hud_render_action_compact(&act, dock_role);
             }
         }
 
-        if (!LOCAL_PLAYER.docked && hud_should_draw_message_panel()) {
+        if (!LOCAL_PLAYER.docked && message_panel_visible) {
             /* Subtitle: up to HUD_MSG_LINES wrapped lines, stacked bottom-up. */
             float cell = HUD_CELL * ui_text_zoom();
             int first_line_with_content = -1;
@@ -5823,7 +5945,9 @@ void draw_hud(void) {
         sdtx_printf("%s // docked // E launch", current_station->name);
     } else if (LOCAL_PLAYER.in_dock_range) {
         sdtx_color3b(PAL_SIGNAL_MINT);
-        sdtx_puts("In dock range. [E] to dock.");
+        sdtx_puts(message_panel_visible
+            ? "In dock range."
+            : "In dock range. [E] to dock.");
     } else {
         sdtx_color3b(PAL_NAV_BLUE);
         sdtx_printf("%s %d u // %d deg %s",
@@ -5833,8 +5957,8 @@ void draw_hud(void) {
             bearing_side);
     }
 
-    sdtx_pos(top_text_x, top_row_3);
-    {
+    if (!message_panel_visible) {
+        sdtx_pos(top_text_x, top_row_3);
         hud_action_t act = hud_classify_action(cargo_units, cargo_capacity, sig_quality);
         hud_render_action_wide(&act, current_station);
     }
@@ -5930,7 +6054,7 @@ void draw_hud(void) {
         sdtx_pos(cur_x / cell, msg_y / cell);
         sdtx_color4b(total_r, total_g, total_b, (uint8_t)(alpha * 255.0f));
         sdtx_puts(" ]");
-    } else if (hud_should_draw_message_panel()) {
+    } else if (message_panel_visible) {
         float cell = 8.0f;
         bool is_hull_warn = (message_r == 255 && message_g == 60);
         uint8_t r8 = message_r, g8 = message_g, b8 = message_b;

--- a/client/hud_attention.h
+++ b/client/hud_attention.h
@@ -1,0 +1,65 @@
+/*
+ * hud_attention.h -- Pure HUD attention policy.
+ *
+ * Keep the precedence and semantic-zoom budgets independent from rendering so
+ * they can be tested without a graphics context.
+ */
+#ifndef SIGNAL_HUD_ATTENTION_H
+#define SIGNAL_HUD_ATTENTION_H
+
+#include <stdbool.h>
+
+typedef enum {
+    HUD_ATTENTION_FLIGHT = 0,
+    HUD_ATTENTION_MESSAGE,
+    HUD_ATTENTION_SCOREBOARD,
+    HUD_ATTENTION_INSPECT,
+    HUD_ATTENTION_STATION,
+    HUD_ATTENTION_DEATH,
+} hud_attention_surface_t;
+
+typedef struct {
+    bool death;
+    bool docked;
+    bool inspect;
+    bool scoreboard;
+    bool message;
+} hud_attention_flags_t;
+
+static inline hud_attention_surface_t
+hud_attention_select(hud_attention_flags_t flags) {
+    if (flags.death) return HUD_ATTENTION_DEATH;
+    if (flags.docked) return HUD_ATTENTION_STATION;
+    if (flags.inspect) return HUD_ATTENTION_INSPECT;
+    if (flags.scoreboard) return HUD_ATTENTION_SCOREBOARD;
+    if (flags.message) return HUD_ATTENTION_MESSAGE;
+    return HUD_ATTENTION_FLIGHT;
+}
+
+static inline const char *
+hud_attention_surface_name(hud_attention_surface_t surface) {
+    switch (surface) {
+    case HUD_ATTENTION_DEATH:      return "death";
+    case HUD_ATTENTION_STATION:    return "station";
+    case HUD_ATTENTION_INSPECT:    return "inspect";
+    case HUD_ATTENTION_SCOREBOARD: return "scoreboard";
+    case HUD_ATTENTION_MESSAGE:    return "message";
+    case HUD_ATTENTION_FLIGHT:
+    default:                       return "flight";
+    }
+}
+
+static inline int hud_scan_asteroid_budget(float viewport_width) {
+    /* viewport_width is the scaled HUD canvas, not raw window pixels. */
+    if (viewport_width < 360.0f) return 4;
+    if (viewport_width < 720.0f) return 6;
+    return 8;
+}
+
+static inline int hud_scan_npc_budget(float viewport_width) {
+    if (viewport_width < 360.0f) return 2;
+    if (viewport_width < 720.0f) return 3;
+    return 4;
+}
+
+#endif

--- a/client/main.c
+++ b/client/main.c
@@ -25,6 +25,7 @@
 #include "net_input_lead.h"
 #include "net_clock.h"
 #include "client_log.h"
+#include "hud_attention.h"
 
 
 #ifdef __EMSCRIPTEN__
@@ -1640,6 +1641,12 @@ static void sim_step(float dt) {
         music_next_track(&g.music);
     if (g.input.key_pressed[SAPP_KEYCODE_LEFT_BRACKET] && g.music.playing)
         music_prev_track(&g.music);
+    if (g.input.key_pressed[SAPP_KEYCODE_F3]) {
+        g.hud_debug_visible = !g.hud_debug_visible;
+        set_notice(g.hud_debug_visible
+            ? "Network/build telemetry shown."
+            : "Network/build telemetry hidden.");
+    }
 
     step_notice_timer(dt);
     update_sell_fx(dt);
@@ -1673,6 +1680,12 @@ static void sim_step(float dt) {
     /* Tab while undocked opens/pages visible inspect provenance first. Without
      * an active scan pane it keeps its older session-scoreboard behavior.
      * Docked Tab is already taken for station panels. */
+    bool inspect_surface_active =
+        g.inspect_station >= 0 ||
+        (g.inspect_snapshot_timer > 0.0f &&
+         g.inspect_snapshot.target_type != INSPECT_TARGET_NONE);
+    if (inspect_surface_active)
+        g.scoreboard.show = false;
     if (!LOCAL_PLAYER.docked && g.input.key_pressed[SAPP_KEYCODE_TAB]) {
         if (g.inspect_snapshot_timer > 0.0f &&
             g.inspect_snapshot.target_type != INSPECT_TARGET_NONE) {
@@ -4741,6 +4754,26 @@ EMSCRIPTEN_KEEPALIVE
 const char *signal_station_panel_label(void) {
     const station_panel_descriptor_t *panel = mobile_active_station_panel();
     return (panel && panel->label) ? panel->label : "";
+}
+
+EMSCRIPTEN_KEEPALIVE
+const char *signal_hud_attention_surface(void) {
+    return hud_attention_current_surface_name();
+}
+
+EMSCRIPTEN_KEEPALIVE
+int signal_hud_debug_visible(void) {
+    return g.hud_debug_visible ? 1 : 0;
+}
+
+EMSCRIPTEN_KEEPALIVE
+int signal_hud_scan_asteroid_budget(void) {
+    return hud_scan_asteroid_budget(ui_screen_width());
+}
+
+EMSCRIPTEN_KEEPALIVE
+int signal_hud_scan_npc_budget(void) {
+    return hud_scan_npc_budget(ui_screen_width());
 }
 
 EMSCRIPTEN_KEEPALIVE

--- a/client/world_draw.c
+++ b/client/world_draw.c
@@ -20,6 +20,7 @@
 #include "sim_ship.h"
 #include "tractor.h"
 #include "npc_radio.h"
+#include "hud_attention.h"
 #include <stddef.h>  /* ptrdiff_t for station index */
 #include <stdlib.h>
 
@@ -4195,6 +4196,7 @@ void draw_npc_chatter(void) {
 
     hail_asteroid_tag_t tags[HAIL_SCAN_ASTEROID_TAG_LIMIT];
     int tag_count = 0;
+    int asteroid_budget = hud_scan_asteroid_budget(ui_screen_width());
 
     for (int i = 0; i < MAX_ASTEROIDS; i++) {
         const asteroid_t *a = &g.world.asteroids[i];
@@ -4207,13 +4209,13 @@ void draw_npc_chatter(void) {
         if (reveal <= 0.01f) continue;
         float relevance = hail_asteroid_relevance(a, i, dist_sq);
 
-        if (tag_count < HAIL_SCAN_ASTEROID_TAG_LIMIT) {
+        if (tag_count < asteroid_budget) {
             tags[tag_count++] = (hail_asteroid_tag_t){
                 i, dist_sq, reveal, relevance
             };
         } else {
             int worst = 0;
-            for (int j = 1; j < HAIL_SCAN_ASTEROID_TAG_LIMIT; j++) {
+            for (int j = 1; j < asteroid_budget; j++) {
                 if (tags[j].relevance < tags[worst].relevance) worst = j;
             }
             if (relevance > tags[worst].relevance) {
@@ -4271,13 +4273,43 @@ void draw_npc_chatter(void) {
         }
     }
 
+    typedef struct {
+        int index;
+        float relevance;
+    } hail_npc_tag_t;
+    hail_npc_tag_t npc_tags[4];
+    int npc_tag_count = 0;
+    int npc_budget = hud_scan_npc_budget(ui_screen_width());
     for (int i = 0; i < MAX_NPC_SHIPS; i++) {
         const npc_ship_t *npc = &g.world.npc_ships[i];
         if (!npc->active) continue;
         if (!on_screen(npc->ship->pos.x, npc->ship->pos.y, 50.0f)) continue;
-        if (v2_dist_sq(npc->ship->pos, g.hail_ping_origin) > hail_range_sq) continue;
+        float dist_sq = v2_dist_sq(npc->ship->pos, g.hail_ping_origin);
+        if (dist_sq > hail_range_sq) continue;
+        if (hail_scan_reveal_alpha(npc->ship->pos) <= 0.01f) continue;
+        float relevance = hail_range_sq - dist_sq;
+        if (LOCAL_PLAYER.scan_target_type == INSPECT_TARGET_NPC &&
+            LOCAL_PLAYER.scan_target_index == i)
+            relevance += hail_range_sq * 4.0f;
+        if (hail_conversation_entry_for_npc(i))
+            relevance += hail_range_sq * 2.0f;
+        if (npc_tag_count < npc_budget) {
+            npc_tags[npc_tag_count++] = (hail_npc_tag_t){i, relevance};
+        } else {
+            int worst = 0;
+            for (int j = 1; j < npc_budget; j++) {
+                if (npc_tags[j].relevance < npc_tags[worst].relevance)
+                    worst = j;
+            }
+            if (relevance > npc_tags[worst].relevance)
+                npc_tags[worst] = (hail_npc_tag_t){i, relevance};
+        }
+    }
+
+    for (int tag = 0; tag < npc_tag_count; tag++) {
+        int i = npc_tags[tag].index;
+        const npc_ship_t *npc = &g.world.npc_ships[i];
         float reveal = hail_scan_reveal_alpha(npc->ship->pos);
-        if (reveal <= 0.01f) continue;
 
         const hail_conversation_entry_t *entry =
             hail_conversation_entry_for_npc(i);

--- a/docs/perception-review-checklist.md
+++ b/docs/perception-review-checklist.md
@@ -35,3 +35,20 @@ pixel assertions:
 If a semantic assertion fails, the browser error names the player question it
 violated. If a visual review fails, record the scenario, viewport, and artifact
 name on the sprint tracker before changing presentation.
+
+## HUD attention-budget review
+
+The same browser lane captures a deterministic attention pass:
+
+| State | Expected primary surface | Review attachment |
+| --- | --- | --- |
+| Docked, desktop | Station terminal; healthy build/network diagnostics absent | `perception-hud-attention-station-desktop` |
+| Onboarding message, narrow | One tutorial/notice instruction; competing flight action absent | `perception-hud-attention-message-narrow` |
+| Undocked scoreboard, narrow | Scoreboard only; no flight panel or tutorial subtitle beneath it | `perception-hud-attention-scoreboard-narrow` |
+| Selected NPC scan, narrow | Inspect/contact card; stale scoreboard and tutorial subtitle suppressed | `perception-hud-attention-inspect-narrow` |
+
+The gate also asserts that F3 is the explicit diagnostic toggle and that scan
+budgets contract from eight asteroid/four NPC labels on desktop to four
+asteroid/two NPC labels on narrow screens. Critical connection states remain
+visible without F3; healthy version, latency, queue, and replay telemetry does
+not.

--- a/docs/ui-design-direction.md
+++ b/docs/ui-design-direction.md
@@ -61,6 +61,10 @@ These items moved from direction to implemented baseline:
   shipyard, dock, storage, or service consequences.
 - Fragment usefulness first pass: tracked contract fit, direct station demand,
   and rare grade fallback in the target/tow HUD.
+- HUD attention budget: death, station, inspect, scoreboard, message, and
+  flight surfaces have deterministic precedence; scoreboard is modal, scan
+  labels contract with viewport width, and healthy build/network telemetry is
+  available on F3 instead of occupying the play surface.
 
 The next work should not repaint those shipped cues. It should stabilize NPC
 motive, summarize station memory, and deepen rock value beyond direct demand.

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -460,6 +460,37 @@ async function hudActionText(page: Page): Promise<string> {
   });
 }
 
+async function hudAttentionSurface(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const mod = (window as unknown as {
+      Module?: { ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => string };
+    }).Module;
+    if (!mod || typeof mod.ccall !== 'function') return '';
+    return mod.ccall('signal_hud_attention_surface', 'string', [], []) || '';
+  });
+}
+
+async function hudAttentionTelemetry(page: Page): Promise<{
+  debugVisible: number;
+  asteroidBudget: number;
+  npcBudget: number;
+}> {
+  return page.evaluate(() => {
+    const mod = (window as unknown as {
+      Module?: { ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => number };
+    }).Module;
+    const read = (name: string) => {
+      if (!mod || typeof mod.ccall !== 'function') return 0;
+      return mod.ccall(name, 'number', [], []) | 0;
+    };
+    return {
+      debugVisible: read('signal_hud_debug_visible'),
+      asteroidBudget: read('signal_hud_scan_asteroid_budget'),
+      npcBudget: read('signal_hud_scan_npc_budget'),
+    };
+  });
+}
+
 async function laserRefitSummary(page: Page): Promise<string> {
   return page.evaluate(() => {
     const mod = (window as unknown as {
@@ -1978,6 +2009,49 @@ test.describe('Browser smoke tests', () => {
       .poll(async () => (await readCanvasStats(canvas)).nonBlackRatio, { timeout: 5_000 })
       .toBeGreaterThan(0.05);
 
+    expectNoFatalErrors(logs);
+  });
+
+  rootBundleSmokeTest('HUD attention keeps one primary surface and semantic scan budgets on desktop and narrow layouts', async ({ page }, testInfo) => {
+    const logs = installFatalCollectors(page);
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const canvas = await loadGame(page, false, { singleplayer: true });
+
+    await expect.poll(async () => hudAttentionSurface(page)).toBe('station');
+    expect(await hudAttentionTelemetry(page)).toEqual({
+      debugVisible: 0,
+      asteroidBudget: 8,
+      npcBudget: 4,
+    });
+    await attachPerceptionReview(testInfo, canvas, 'hud-attention-station', 'desktop');
+
+    await page.setViewportSize({ width: 390, height: 760 });
+    await setSmokeLoopState(page, smokeLoopState.narrowCameraOffset);
+    await expect.poll(async () => hudAttentionSurface(page)).toBe('message');
+    expect(await hudAttentionTelemetry(page)).toEqual({
+      debugVisible: 0,
+      asteroidBudget: 4,
+      npcBudget: 2,
+    });
+    await attachPerceptionReview(testInfo, canvas, 'hud-attention-message', 'narrow');
+
+    await canvas.click();
+    await tap(page, 'Tab');
+    await expect.poll(async () => hudAttentionSurface(page)).toBe('scoreboard');
+    await attachPerceptionReview(testInfo, canvas, 'hud-attention-scoreboard', 'narrow');
+
+    await tap(page, 'F3');
+    await expect.poll(async () => (await hudAttentionTelemetry(page)).debugVisible).toBe(1);
+    await tap(page, 'F3');
+    await expect.poll(async () => (await hudAttentionTelemetry(page)).debugVisible).toBe(0);
+
+    await setSmokeLoopState(page, smokeLoopState.npcMotiveCrisp);
+    await expect.poll(async () => hudAttentionSurface(page)).toBe('inspect');
+    await attachPerceptionReview(testInfo, canvas, 'hud-attention-inspect', 'narrow');
+
+    await expect
+      .poll(async () => (await readCanvasStats(canvas)).nonBlackRatio, { timeout: 5_000 })
+      .toBeGreaterThan(0.05);
     expectNoFatalErrors(logs);
   });
 

--- a/tests/c/test_hud_attention.c
+++ b/tests/c/test_hud_attention.c
@@ -1,0 +1,50 @@
+#include "test_harness.h"
+#include "hud_attention.h"
+#include <string.h>
+
+TEST(test_hud_attention_uses_one_deterministic_primary_surface) {
+    hud_attention_flags_t flags = {
+        .message = true,
+        .scoreboard = true,
+        .inspect = true,
+        .docked = true,
+        .death = true,
+    };
+    ASSERT_EQ_INT(hud_attention_select(flags), HUD_ATTENTION_DEATH);
+
+    flags.death = false;
+    ASSERT_EQ_INT(hud_attention_select(flags), HUD_ATTENTION_STATION);
+    flags.docked = false;
+    ASSERT_EQ_INT(hud_attention_select(flags), HUD_ATTENTION_INSPECT);
+    flags.inspect = false;
+    ASSERT_EQ_INT(hud_attention_select(flags), HUD_ATTENTION_SCOREBOARD);
+    flags.scoreboard = false;
+    ASSERT_EQ_INT(hud_attention_select(flags), HUD_ATTENTION_MESSAGE);
+    flags.message = false;
+    ASSERT_EQ_INT(hud_attention_select(flags), HUD_ATTENTION_FLIGHT);
+}
+
+TEST(test_hud_attention_surface_names_are_stable_for_browser_review) {
+    ASSERT(strcmp(hud_attention_surface_name(HUD_ATTENTION_FLIGHT), "flight") == 0);
+    ASSERT(strcmp(hud_attention_surface_name(HUD_ATTENTION_MESSAGE), "message") == 0);
+    ASSERT(strcmp(hud_attention_surface_name(HUD_ATTENTION_SCOREBOARD), "scoreboard") == 0);
+    ASSERT(strcmp(hud_attention_surface_name(HUD_ATTENTION_INSPECT), "inspect") == 0);
+    ASSERT(strcmp(hud_attention_surface_name(HUD_ATTENTION_STATION), "station") == 0);
+    ASSERT(strcmp(hud_attention_surface_name(HUD_ATTENTION_DEATH), "death") == 0);
+}
+
+TEST(test_hud_scan_budget_tracks_semantic_zoom) {
+    ASSERT_EQ_INT(hud_scan_asteroid_budget(269.0f), 4);
+    ASSERT_EQ_INT(hud_scan_npc_budget(269.0f), 2);
+    ASSERT_EQ_INT(hud_scan_asteroid_budget(600.0f), 6);
+    ASSERT_EQ_INT(hud_scan_npc_budget(600.0f), 3);
+    ASSERT_EQ_INT(hud_scan_asteroid_budget(800.0f), 8);
+    ASSERT_EQ_INT(hud_scan_npc_budget(800.0f), 4);
+}
+
+void register_hud_attention_tests(void) {
+    TEST_SECTION("\nHUD attention:\n");
+    RUN(test_hud_attention_uses_one_deterministic_primary_surface);
+    RUN(test_hud_attention_surface_names_are_stable_for_browser_review);
+    RUN(test_hud_scan_budget_tracks_semantic_zoom);
+}

--- a/tests/c/test_main.c
+++ b/tests/c/test_main.c
@@ -84,6 +84,7 @@ void register_settlement_engine_tests(void);
 void register_signal_field_tests(void);
 void register_gossip_tests(void);
 void register_npc_radio_tests(void);
+void register_hud_attention_tests(void);
 
 static int parse_shard_arg(const char *arg, int *out_index, int *out_total) {
     char *slash = NULL;
@@ -213,6 +214,7 @@ int main(int argc, char **argv) {
     register_signal_field_tests();
     register_gossip_tests();
     register_npc_radio_tests();
+    register_hud_attention_tests();
 
     printf("\n%d tests run, %d passed, %d failed", tests_run, tests_passed, tests_failed);
     if (g_warnings > 0) printf(", %d warnings", g_warnings);


### PR DESCRIPTION
Closes #619

## What changed

- added a pure, testable HUD attention policy for death, station, inspect, scoreboard, message, and flight surfaces
- made the scoreboard a narrow-safe modal instead of stacking it over flight and tutorial chrome
- gave inspect/contact cards exclusive ownership of the HUD frame and bounded narrow text
- hid healthy version/build/latency/queue telemetry by default while preserving actionable connection warnings; F3 toggles the full diagnostic surface
- reduced hail/scan clutter with viewport-aware asteroid and NPC label budgets while preserving selected contacts and active conversations
- made tutorial, notice, hull, plan, docking, autopilot, and construction messages suppress competing flight commands
- added native policy tests, browser exports, deterministic desktop/narrow screenshots, and review documentation

## Why

Recent legibility work added truthful cues without a central arbitration rule. The renderer independently drew flight status, onboarding messages, inspect cards, scoreboard content, scan labels, and connection diagnostics, so valid information competed for the same sparse screen. The new policy chooses one primary surface and uses semantic zoom for secondary world labels.

## Player impact

Players get one readable next action at a time. Scan and contact views retain the most relevant targets without low-priority label floods, scoreboard and inspect states no longer inherit unrelated HUD instructions, and routine implementation telemetry no longer occupies the play surface.

The policy remains honest to the simulation: selection only ranks already-revealed contacts and existing evidence. It does not expose undiscovered state.

## Validation

- `./build/signal_test --quiet` — 1,219 passed, 0 failed
- `cmake --build build --target signal -j4` — native client build passed
- `make build-web` — WebAssembly build and deterministic flag gate passed
- complete `tests/browser-smoke.spec.ts` — 13 passed, 9 environment-specific live/online cases skipped
- perception acceptance + HUD attention gates — 2 passed, including desktop station and narrow message/scoreboard/inspect artifacts
- `git diff --check` and staged diff check passed

Unrelated `server/main.c` and fuzz corpus files were not modified.

## CI dependency

The fuzz job fails before compiling this branch because the desktop client
requires ALSA in the headless fuzz configuration. This is the inherited #631
infrastructure defect; draft PR #632 fixes it and has a green fuzz job. Replay
checks for this branch are green, and the main native safety job is still
running.
