### PR TITLE
Eliminate persistence stalls and simulation tick debt loss

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,7 @@ if(NOT EMSCRIPTEN AND NOT BUILD_TESTS_ONLY)
         server/mongoose.c
         server/highscore.c
         server/ws_outbox.c
+        server/persistence_writer.c
         ${SIGNAL_SERVER_PERSISTENCE_SOURCES}
         ${SIGNAL_SIM_SOURCES}
         ${SIGNAL_SIM_HELPERS}
@@ -278,13 +279,14 @@ if(NOT EMSCRIPTEN AND NOT BUILD_TESTS_ONLY)
     )
     signal_apply_sim_profile(signal_server)
     if(NOT MSVC)
-        target_link_libraries(signal_server PRIVATE m)
+        target_link_libraries(signal_server PRIVATE m Threads::Threads)
         target_compile_options(signal_server PRIVATE
             -Wall -Wextra -Wpedantic -Werror -fstack-protector-strong -ffp-contract=off -fno-fast-math)
         # _FORTIFY_SOURCE requires optimization; only set for Release-ish.
         target_compile_definitions(signal_server PRIVATE
             $<$<NOT:$<CONFIG:Debug>>:_FORTIFY_SOURCE=2>)
     else()
+        target_link_libraries(signal_server PRIVATE Threads::Threads)
         # Mirror GCC/Clang -Werror so Windows CI fails on regressions.
         # Selective /wd* mirror the -Wno-* we accept on GCC/Clang:
         #   4127 = constant conditional (common in ASSERT/while(true))
@@ -376,6 +378,7 @@ if(NOT EMSCRIPTEN AND NOT BUILD_SERVER_ONLY)
         tests/c/test_ws_outbox.c
         server/mongoose.c
         server/ws_outbox.c
+        server/persistence_writer.c
         tests/c/test_signal_field.c
         tests/c/test_state_digest.c
         tests/c/test_reconciliation_diagnostics.c

--- a/scripts/test_check_ci_workflow_contract.py
+++ b/scripts/test_check_ci_workflow_contract.py
@@ -459,6 +459,28 @@ class WorkflowContractTests(unittest.TestCase):
             "RELEASE_REF:" in failure for failure in failures
         ), failures)
 
+    def test_release_cannot_drop_cargo_trust_caller_audit(self) -> None:
+        failures = self.failures(
+            workflow="release.yml",
+            before="make cargo-trust-audit banned-apis",
+            after="make banned-apis",
+        )
+        self.assertTrue(any(
+            "release.yml" in failure and "cargo trust" in failure
+            for failure in failures
+        ), failures)
+
+    def test_deploy_cannot_drop_cargo_trust_caller_audit(self) -> None:
+        failures = self.failures(
+            workflow="deploy-fly.yml",
+            before="make cargo-trust-audit banned-apis",
+            after="make banned-apis",
+        )
+        self.assertTrue(any(
+            "deploy-fly.yml" in failure and "cargo trust" in failure
+            for failure in failures
+        ), failures)
+
     def test_floating_third_party_action_is_rejected(self) -> None:
         failures = self.failures(
             workflow="deploy-fly.yml",

--- a/server/main.c
+++ b/server/main.c
@@ -33,6 +33,7 @@
 #include "public_actor_resolver.h"
 #include "legacy_save_recovery.h"
 #include "persistence_generation.h"
+#include "persistence_writer.h"
 #include "ws_outbox.h"
 #include <math.h>       /* lroundf */
 
@@ -64,11 +65,14 @@
 /* ------------------------------------------------------------------ */
 
 static world_t world;
-static bool running = true;
+static volatile sig_atomic_t running = 1;
+static persistence_writer_t *persistence_writer = NULL;
 static const char *allowed_origin = NULL;
 static const char *internal_token = NULL;
 
 static void server_sensitive_state_cleanup(void) {
+    persistence_writer_destroy(persistence_writer);
+    persistence_writer = NULL;
     world_cleanup(&world);
     station_authority_clear_secret();
 }
@@ -1004,7 +1008,7 @@ static uint32_t signal_build_id_u32(void) {
 
 static void signal_handler(int sig) {
     (void)sig;
-    running = false;
+    running = 0;
 }
 
 /* ------------------------------------------------------------------ */
@@ -3660,6 +3664,7 @@ static bool ws_rate_bucket_allow(ws_rate_bucket_t *bucket, uint64_t now,
 
 static void select_generation_players(
     bool save_player_slot[MAX_PLAYERS]);
+static void wait_for_persistence_writer_result(uint64_t now);
 static void reject_ws_authentication(
     struct mg_connection *c, int pid, const char *reason);
 static bool complete_ws_session_bootstrap_if_ready(
@@ -3719,7 +3724,7 @@ static void abort_legacy_recovery_session(
                 "[FATAL] recovery claimant %d acquired authoritative state "
                 "before commit\n", pid);
         persistence_recovery_invariant_failed = true;
-        running = false;
+        running = 0;
         return;
     }
     persistence_save_requested = true;
@@ -3800,6 +3805,7 @@ static void handle_verified_legacy_recovery(
     }
 
     bool save_player_slot[MAX_PLAYERS];
+    wait_for_persistence_writer_result(now);
     select_generation_players(save_player_slot);
     save_player_slot[pid] = true;
     persistence_generation_paths_t published = {0};
@@ -3820,7 +3826,7 @@ static void handle_verified_legacy_recovery(
             (size_t)n >= sizeof(active_player_save_dir)) {
             fprintf(stderr,
                     "[FATAL] recovered player generation path is too long\n");
-            running = false;
+            running = 0;
         }
         for (int p = 0; p < MAX_PLAYERS; p++) {
             server_player_t *player = &world.players[p];
@@ -8223,7 +8229,6 @@ static bool run_sim_ticks(float *sim_accum, float elapsed, uint64_t now) {
         steps++;
     }
     flush_pending_input_acks(pending_input_acks);
-    if (*sim_accum > SIM_DT) *sim_accum = 0.0f; /* prevent spiral */
     return false;
 }
 
@@ -8421,7 +8426,8 @@ static int server_poll_timeout_ms(uint64_t now,
     next = min_due_ms(next, last_world, WORLD_TICK_MS);
     next = min_due_ms(next, last_ship, SHIP_TICK_MS);
     next = min_due_ms(next, last_analytics, ANALYTICS_EMF_INTERVAL_MS);
-    if (!legacy_recovery_offer_active(now)) {
+    if (!legacy_recovery_offer_active(now) &&
+        !persistence_writer_active(persistence_writer)) {
         if (persistence_save_requested) {
             if (persistence_retry_not_before_ms < next)
                 next = persistence_retry_not_before_ms;
@@ -8453,6 +8459,72 @@ static void select_generation_players(
     }
 }
 
+static bool adopt_published_generation(
+    const persistence_generation_paths_t *published
+) {
+    if (!published) return false;
+    int n = snprintf(active_player_save_dir,
+                     sizeof(active_player_save_dir), "%s",
+                     published->player_dir);
+    if (n <= 0 || (size_t)n >= sizeof(active_player_save_dir)) {
+        fprintf(stderr,
+                "[FATAL] published player generation path is too long\n");
+        running = 0;
+        return false;
+    }
+    printf("[save] published persistence generation %" PRIu64 "\n",
+           published->generation);
+    return true;
+}
+
+static void apply_persistence_writer_result(
+    persistence_writer_state_t state,
+    const persistence_generation_paths_t *published,
+    uint64_t now,
+    uint64_t *last_save
+) {
+    if (state == PERSISTENCE_WRITER_SUCCEEDED) {
+        if (adopt_published_generation(published)) {
+            persistence_retry_not_before_ms = 0;
+            if (last_save) *last_save = now;
+        } else {
+            persistence_save_requested = true;
+            persistence_retry_not_before_ms = now + PERSISTENCE_RETRY_MS;
+        }
+    } else if (state == PERSISTENCE_WRITER_FAILED) {
+        fprintf(stderr,
+                "[save] background generation was not published\n");
+        persistence_save_requested = true;
+        persistence_retry_not_before_ms = now + PERSISTENCE_RETRY_MS;
+    }
+}
+
+static void wait_for_persistence_writer_result(uint64_t now) {
+    if (!persistence_writer) return;
+    persistence_generation_paths_t published = {0};
+    persistence_writer_state_t state =
+        persistence_writer_wait(persistence_writer, &published);
+    apply_persistence_writer_result(state, &published, now, NULL);
+}
+
+static bool start_persistent_state_save(void) {
+    if (!persistence_writer || persistence_recovery_invariant_failed)
+        return false;
+    bool save_player_slot[MAX_PLAYERS];
+    select_generation_players(save_player_slot);
+    if (!persistence_writer_start(
+            persistence_writer,
+            PERSISTENCE_GENERATION_DIR,
+            PLAYER_SAVE_DIR,
+            &world,
+            save_player_slot)) {
+        return false;
+    }
+    /* New mutations may set this again while the immutable snapshot saves. */
+    persistence_save_requested = false;
+    return true;
+}
+
 static bool save_persistent_state(void) {
     if (persistence_recovery_invariant_failed) {
         fprintf(stderr,
@@ -8474,18 +8546,7 @@ static bool save_persistent_state(void) {
                 strerror(errno));
         return false;
     }
-    int n = snprintf(active_player_save_dir,
-                     sizeof(active_player_save_dir), "%s",
-                     published.player_dir);
-    if (n <= 0 || (size_t)n >= sizeof(active_player_save_dir)) {
-        fprintf(stderr,
-                "[FATAL] published player generation path is too long\n");
-        running = false;
-        return false;
-    }
-    printf("[save] published persistence generation %" PRIu64 "\n",
-           published.generation);
-    return true;
+    return adopt_published_generation(&published);
 }
 
 /* ------------------------------------------------------------------ */
@@ -8515,6 +8576,12 @@ int main(void) {
     if (!enter_persistence_data_dir()) return 1;
     ensure_persistence_dirs();
     if (!load_world_state()) return 1;
+    persistence_writer = persistence_writer_create();
+    if (!persistence_writer) {
+        fprintf(stderr,
+                "[FATAL] failed to create background persistence writer\n");
+        return 1;
+    }
     if (!server_apply_npc_worker_trace_fixture()) return 1;
     if (!server_apply_ws_backpressure_fixture()) return 1;
     frontier_virtual_pilots_set(&world, frontier_virtual_pilot_target);
@@ -8651,6 +8718,12 @@ int main(void) {
             last_analytics, last_save));
         uint64_t now = mg_millis();
         service_legacy_recovery_offers(now);
+        persistence_generation_paths_t background_published = {0};
+        persistence_writer_state_t background_state =
+            persistence_writer_poll(
+                persistence_writer, &background_published);
+        apply_persistence_writer_result(
+            background_state, &background_published, now, &last_save);
 
         if (now - last_sim >= SIM_TICK_MS) {
             float elapsed = (float)(now - last_sim) / 1000.0f;
@@ -8706,14 +8779,11 @@ int main(void) {
             !recovery_offer_in_flight &&
             persistence_save_requested &&
             now >= persistence_retry_not_before_ms;
-        if (autosave_due || requested_save_due) {
-            if (save_persistent_state()) {
-                persistence_save_requested = false;
-                persistence_retry_not_before_ms = 0;
-                last_save = now;
-            } else {
-                /* Keep disconnect/auth dirty intent and retry at a bounded
-                 * cadence instead of either losing it or fsync-spinning. */
+        if (!persistence_writer_active(persistence_writer) &&
+            (autosave_due || requested_save_due)) {
+            if (!start_persistent_state_save()) {
+                /* Keep dirty intent and retry at a bounded cadence instead
+                 * of either losing it or fsync-spinning. */
                 persistence_save_requested = true;
                 persistence_retry_not_before_ms =
                     now + PERSISTENCE_RETRY_MS;
@@ -8722,6 +8792,7 @@ int main(void) {
     }
 
     mg_mgr_free(&mgr);
+    wait_for_persistence_writer_result(mg_millis());
     if (save_persistent_state()) {
         printf("[server] world saved\n");
     } else {

--- a/server/persistence_writer.c
+++ b/server/persistence_writer.c
@@ -1,0 +1,213 @@
+#include "persistence_writer.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <pthread.h>
+#endif
+
+struct persistence_writer {
+#ifdef _WIN32
+    HANDLE thread;
+    CRITICAL_SECTION lock;
+#else
+    pthread_t thread;
+    pthread_mutex_t lock;
+#endif
+    bool thread_joinable;
+    persistence_writer_state_t state;
+    world_t *snapshot;
+    char root_dir[PERSISTENCE_GENERATION_PATH_MAX];
+    char legacy_player_dir[PERSISTENCE_GENERATION_PATH_MAX];
+    bool save_player_slot[MAX_PLAYERS];
+    persistence_generation_paths_t published;
+};
+
+static void writer_lock(persistence_writer_t *writer) {
+#ifdef _WIN32
+    EnterCriticalSection(&writer->lock);
+#else
+    (void)pthread_mutex_lock(&writer->lock);
+#endif
+}
+
+static void writer_unlock(persistence_writer_t *writer) {
+#ifdef _WIN32
+    LeaveCriticalSection(&writer->lock);
+#else
+    (void)pthread_mutex_unlock(&writer->lock);
+#endif
+}
+
+static void persistence_writer_run(persistence_writer_t *writer) {
+    persistence_generation_paths_t published = {0};
+    bool ok = persistence_generation_commit(
+        writer->root_dir,
+        writer->legacy_player_dir,
+        writer->snapshot,
+        writer->save_player_slot,
+        PERSISTENCE_GENERATION_FAULT_NONE,
+        &published);
+    world_snapshot_clone_destroy(writer->snapshot);
+    writer->snapshot = NULL;
+
+    writer_lock(writer);
+    if (ok) writer->published = published;
+    writer->state = ok
+        ? PERSISTENCE_WRITER_SUCCEEDED
+        : PERSISTENCE_WRITER_FAILED;
+    writer_unlock(writer);
+}
+
+#ifdef _WIN32
+static DWORD WINAPI persistence_writer_thread(void *context) {
+    persistence_writer_run((persistence_writer_t *)context);
+    return 0;
+}
+#else
+static void *persistence_writer_thread(void *context) {
+    persistence_writer_run((persistence_writer_t *)context);
+    return NULL;
+}
+#endif
+
+persistence_writer_t *persistence_writer_create(void) {
+    persistence_writer_t *writer = calloc(1, sizeof(*writer));
+    if (!writer) return NULL;
+#ifdef _WIN32
+    InitializeCriticalSection(&writer->lock);
+#else
+    if (pthread_mutex_init(&writer->lock, NULL) != 0) {
+        free(writer);
+        return NULL;
+    }
+#endif
+    return writer;
+}
+
+static void persistence_writer_join(persistence_writer_t *writer) {
+    if (!writer || !writer->thread_joinable) return;
+#ifdef _WIN32
+    (void)WaitForSingleObject(writer->thread, INFINITE);
+    (void)CloseHandle(writer->thread);
+    writer->thread = NULL;
+#else
+    (void)pthread_join(writer->thread, NULL);
+#endif
+    writer->thread_joinable = false;
+}
+
+void persistence_writer_destroy(persistence_writer_t *writer) {
+    if (!writer) return;
+    persistence_writer_join(writer);
+    world_snapshot_clone_destroy(writer->snapshot);
+#ifdef _WIN32
+    DeleteCriticalSection(&writer->lock);
+#else
+    (void)pthread_mutex_destroy(&writer->lock);
+#endif
+    free(writer);
+}
+
+bool persistence_writer_start(
+    persistence_writer_t *writer,
+    const char *root_dir,
+    const char *legacy_player_dir,
+    const world_t *world,
+    const bool save_player_slot[MAX_PLAYERS]
+) {
+    if (!writer || !root_dir || !legacy_player_dir || !world ||
+        !save_player_slot || writer->thread_joinable) {
+        return false;
+    }
+    int root_len = snprintf(writer->root_dir, sizeof(writer->root_dir),
+                            "%s", root_dir);
+    int legacy_len = snprintf(writer->legacy_player_dir,
+                              sizeof(writer->legacy_player_dir),
+                              "%s", legacy_player_dir);
+    if (root_len <= 0 || (size_t)root_len >= sizeof(writer->root_dir) ||
+        legacy_len <= 0 ||
+        (size_t)legacy_len >= sizeof(writer->legacy_player_dir)) {
+        return false;
+    }
+    writer->snapshot = world_snapshot_clone_create(world);
+    if (!writer->snapshot) return false;
+    memcpy(writer->save_player_slot, save_player_slot,
+           sizeof(writer->save_player_slot));
+    memset(&writer->published, 0, sizeof(writer->published));
+    writer->state = PERSISTENCE_WRITER_RUNNING;
+
+#ifdef _WIN32
+    writer->thread = CreateThread(
+        NULL, 0, persistence_writer_thread, writer, 0, NULL);
+    if (!writer->thread) {
+#else
+    if (pthread_create(
+            &writer->thread, NULL,
+            persistence_writer_thread, writer) != 0) {
+#endif
+        world_snapshot_clone_destroy(writer->snapshot);
+        writer->snapshot = NULL;
+        writer->state = PERSISTENCE_WRITER_IDLE;
+        return false;
+    }
+    writer->thread_joinable = true;
+    return true;
+}
+
+bool persistence_writer_active(persistence_writer_t *writer) {
+    /* A completed OS thread is still busy until poll/wait joins it and
+     * consumes its result; start() enforces the same single-writer rule. */
+    return writer && writer->thread_joinable;
+}
+
+static persistence_writer_state_t persistence_writer_collect(
+    persistence_writer_t *writer,
+    persistence_generation_paths_t *published,
+    bool wait
+) {
+    if (!writer) return PERSISTENCE_WRITER_IDLE;
+    writer_lock(writer);
+    persistence_writer_state_t state = writer->state;
+    writer_unlock(writer);
+    if (!wait && state == PERSISTENCE_WRITER_RUNNING)
+        return state;
+    if (writer->thread_joinable) {
+        persistence_writer_join(writer);
+        writer_lock(writer);
+        state = writer->state;
+        writer_unlock(writer);
+    }
+    if (state != PERSISTENCE_WRITER_SUCCEEDED &&
+        state != PERSISTENCE_WRITER_FAILED) {
+        return state;
+    }
+    writer_lock(writer);
+    if (state == PERSISTENCE_WRITER_SUCCEEDED && published)
+        *published = writer->published;
+    writer->state = PERSISTENCE_WRITER_IDLE;
+    memset(&writer->published, 0, sizeof(writer->published));
+    writer_unlock(writer);
+    return state;
+}
+
+persistence_writer_state_t persistence_writer_poll(
+    persistence_writer_t *writer,
+    persistence_generation_paths_t *published
+) {
+    return persistence_writer_collect(writer, published, false);
+}
+
+persistence_writer_state_t persistence_writer_wait(
+    persistence_writer_t *writer,
+    persistence_generation_paths_t *published
+) {
+    return persistence_writer_collect(writer, published, true);
+}

--- a/server/persistence_writer.h
+++ b/server/persistence_writer.h
@@ -1,0 +1,37 @@
+/* Single-worker background generation persistence. */
+#ifndef SIGNAL_PERSISTENCE_WRITER_H
+#define SIGNAL_PERSISTENCE_WRITER_H
+
+#include "persistence_generation.h"
+
+typedef struct persistence_writer persistence_writer_t;
+
+typedef enum {
+    PERSISTENCE_WRITER_IDLE = 0,
+    PERSISTENCE_WRITER_RUNNING,
+    PERSISTENCE_WRITER_SUCCEEDED,
+    PERSISTENCE_WRITER_FAILED,
+} persistence_writer_state_t;
+
+persistence_writer_t *persistence_writer_create(void);
+void persistence_writer_destroy(persistence_writer_t *writer);
+
+/* Takes an immutable deep snapshot before returning to the simulation loop. */
+bool persistence_writer_start(
+    persistence_writer_t *writer,
+    const char *root_dir,
+    const char *legacy_player_dir,
+    const world_t *world,
+    const bool save_player_slot[MAX_PLAYERS]);
+
+bool persistence_writer_active(persistence_writer_t *writer);
+
+/* Completed results are consumed by poll/wait and the writer returns idle. */
+persistence_writer_state_t persistence_writer_poll(
+    persistence_writer_t *writer,
+    persistence_generation_paths_t *published);
+persistence_writer_state_t persistence_writer_wait(
+    persistence_writer_t *writer,
+    persistence_generation_paths_t *published);
+
+#endif

--- a/shared/station_cells.h
+++ b/shared/station_cells.h
@@ -27,6 +27,7 @@ static inline cell_role_t station_cell_role_for_module(module_type_t type) {
     case MODULE_FRAME_PRESS:
     case MODULE_LASER_FAB:
     case MODULE_TRACTOR_FAB:
+    case MODULE_ENGINE_FAB:
     case MODULE_SHIPYARD:    return CELL_ROLE_SYSTEM;
     default:                 return CELL_ROLE_SYSTEM;
     }

--- a/tests/c/test_cross_station_settlement.c
+++ b/tests/c/test_cross_station_settlement.c
@@ -873,6 +873,67 @@ TEST(test_station_trust_evaluator_accepts_current_and_local_origin) {
     crs_teardown();
 }
 
+TEST(test_physical_origin_evaluator_preserves_black_market_policy) {
+    crs_setup("physical_origin_black_market");
+    WORLD_HEAP w = calloc(1, sizeof(world_t));
+    ASSERT(w != NULL);
+    crs_world_init(w, 0xD10A);
+
+    uint8_t cargo_pk[32];
+    fill_test_cargo_pubkey(cargo_pk, 0x4A);
+    cargo_unit_t unit = crs_test_ingot_at(cargo_pk, 2);
+    chain_payload_smelt_t smelt = {0};
+    ASSERT(chain_payload_smelt_bind_output(
+        &smelt, unit.parent_merkle, 0, &unit));
+    ASSERT(chain_log_emit(
+        w, &w->stations[2], CHAIN_EVT_SMELT,
+        &smelt, sizeof(smelt)) != 0);
+
+    station_t *origin = &w->stations[2];
+    origin->policy_generation = 1;
+    origin->policy_tick = w->tick + 1;
+    origin->policy_card_count = 1;
+    origin->policy_card_ids[0] =
+        (uint8_t)STATION_POLICY_CARD_BLACK_MARKET;
+    origin->policy_card_domains[0] =
+        (uint8_t)STATION_POLICY_DOMAIN_TRADE;
+    origin->policy_card_costs[0] = 20;
+    origin->policy_card_scores[0] = 1.0f;
+
+    station_t *viewer = &w->stations[1];
+    viewer->policy_generation = 1;
+    viewer->policy_tick = w->tick + 1;
+    viewer->policy_card_count = 1;
+    viewer->policy_card_ids[0] =
+        (uint8_t)STATION_POLICY_CARD_PROVENANCE_SCREENING;
+    viewer->policy_card_domains[0] =
+        (uint8_t)STATION_POLICY_DOMAIN_TRADE;
+    viewer->policy_card_costs[0] = 25;
+    viewer->policy_card_scores[0] = 1.0f;
+
+    cargo_receipt_station_evaluation_t physical =
+        cargo_receipt_evaluate_physical_origin_at_station(
+            w, 1, &unit);
+
+    ASSERT_EQ_INT(physical.origin_status,
+                  CARGO_RECEIPT_ORIGIN_RESOLVE_VERIFIED);
+    ASSERT_EQ_INT(physical.trust.authority_trust,
+                  CARGO_RECEIPT_AUTHORITY_TRUSTED_CURRENT);
+    ASSERT(!physical.accepted);
+    ASSERT_EQ_INT(physical.legality.status,
+                  CARGO_LEGALITY_CONTRABAND);
+    ASSERT_EQ_INT(physical.legality.black_market_station, 2);
+    ASSERT((physical.legality.reasons &
+            CARGO_LEGALITY_REASON_BLACK_MARKET_AUTHORITY) != 0);
+    cargo_receipt_station_evaluation_t tolerated =
+        cargo_receipt_evaluate_physical_origin_at_station(
+            w, 2, &unit);
+    ASSERT(tolerated.accepted);
+    ASSERT((tolerated.legality.reasons &
+            CARGO_LEGALITY_REASON_POLICY_TOLERATES) != 0);
+    crs_teardown();
+}
+
 TEST(test_station_trust_evaluator_accepts_rotated_origin_and_link_keys) {
     crs_setup("station_eval_rotated");
     WORLD_HEAP w = calloc(1, sizeof(world_t));
@@ -3757,6 +3818,7 @@ void register_cross_station_settlement_tests(void) {
     RUN(test_receipt_trust_preserves_cryptographic_chain_failure);
     RUN(test_receipt_trust_status_names_cover_every_verdict);
     RUN(test_station_trust_evaluator_accepts_current_and_local_origin);
+    RUN(test_physical_origin_evaluator_preserves_black_market_policy);
     RUN(test_station_trust_evaluator_accepts_rotated_origin_and_link_keys);
     RUN(test_station_trust_evaluator_applies_intermediate_author_policy);
     RUN(test_tolerant_station_applies_origin_author_distrust_semantically);

--- a/tests/c/test_manifest.c
+++ b/tests/c/test_manifest.c
@@ -450,6 +450,7 @@ TEST(test_recipe_ratios_match_economy_ladder) {
     const recipe_def_t *frame = recipe_get(RECIPE_FRAME_BASIC);
     const recipe_def_t *laser = recipe_get(RECIPE_LASER_BASIC);
     const recipe_def_t *tractor = recipe_get(RECIPE_TRACTOR_COIL);
+    const recipe_def_t *engine = recipe_get(RECIPE_ENGINE_BASIC);
     const recipe_def_t *kits = recipe_get(RECIPE_REPAIR_KIT_FAB);
 
     ASSERT(frame != NULL);
@@ -468,6 +469,14 @@ TEST(test_recipe_ratios_match_economy_ladder) {
     ASSERT_EQ_INT(tractor->input_commodities[0], COMMODITY_CUPRITE_INGOT);
     ASSERT_EQ_INT(tractor->input_commodities[1], COMMODITY_FRAME);
     ASSERT_EQ_INT(tractor->output_count, 1);
+
+    ASSERT(engine != NULL);
+    ASSERT_EQ_INT(engine->input_count, 3);
+    ASSERT_EQ_INT(engine->input_commodities[0], COMMODITY_FRAME);
+    ASSERT_EQ_INT(engine->input_commodities[1], COMMODITY_CUPRITE_INGOT);
+    ASSERT_EQ_INT(engine->input_commodities[2], COMMODITY_CRYSTAL_INGOT);
+    ASSERT_EQ_INT(engine->output_commodity, COMMODITY_ENGINE_MODULE);
+    ASSERT_EQ_INT(engine->output_count, 1);
 
     ASSERT(kits != NULL);
     ASSERT_EQ_INT(kits->input_count, 3);
@@ -699,6 +708,37 @@ TEST(test_hash_product_accepts_repair_kit_three_finished_inputs) {
     ASSERT_EQ_INT(kit.grade, MINING_GRADE_COMMON);
     ASSERT_EQ_INT(kit.recipe_id, RECIPE_REPAIR_KIT_FAB);
     ASSERT(!hash_product(RECIPE_REPAIR_KIT_FAB, inputs, 2, 0, &kit));
+}
+
+TEST(test_hash_product_accepts_engine_three_material_inputs) {
+    cargo_unit_t inputs[RECIPE_INPUT_MAX] = {0};
+    cargo_unit_t engine = {0};
+    const commodity_t commodities[3] = {
+        COMMODITY_FRAME,
+        COMMODITY_CUPRITE_INGOT,
+        COMMODITY_CRYSTAL_INGOT,
+    };
+    const cargo_kind_t kinds[3] = {
+        CARGO_KIND_FRAME,
+        CARGO_KIND_INGOT,
+        CARGO_KIND_INGOT,
+    };
+    for (int i = 0; i < 3; i++) {
+        inputs[i].kind = (uint8_t)kinds[i];
+        inputs[i].commodity = (uint8_t)commodities[i];
+        inputs[i].grade = (uint8_t)(i == 2
+            ? MINING_GRADE_RARE : MINING_GRADE_FINE);
+        inputs[i].quantity = 1u;
+        for (int b = 0; b < 32; b++)
+            inputs[i].pub[b] = (uint8_t)(0x20 * (i + 1) + b);
+    }
+
+    ASSERT(hash_product(RECIPE_ENGINE_BASIC, inputs, 3, 0, &engine));
+    ASSERT_EQ_INT(engine.kind, CARGO_KIND_ENGINE);
+    ASSERT_EQ_INT(engine.commodity, COMMODITY_ENGINE_MODULE);
+    ASSERT_EQ_INT(engine.grade, MINING_GRADE_FINE);
+    ASSERT_EQ_INT(engine.recipe_id, RECIPE_ENGINE_BASIC);
+    ASSERT(!hash_product(RECIPE_ENGINE_BASIC, inputs, 2, 0, &engine));
 }
 
 TEST(test_fracture_claim_resolves_best_verified_grade) {
@@ -1287,6 +1327,7 @@ void register_manifest_tests(void) {
     RUN(test_hash_ingot_matches_known_vector);
     RUN(test_hash_product_matches_known_vector_and_min_grade);
     RUN(test_hash_product_accepts_repair_kit_three_finished_inputs);
+    RUN(test_hash_product_accepts_engine_three_material_inputs);
     RUN(test_fracture_claim_resolves_best_verified_grade);
     RUN(test_fracture_claim_fallback_resolves_without_claims);
     RUN(test_fracture_claim_rejects_past_deadline);

--- a/tests/c/test_persistence_generation.c
+++ b/tests/c/test_persistence_generation.c
@@ -2,6 +2,7 @@
 
 #include "cargo_receipt_issue.h"
 #include "persistence_generation.h"
+#include "persistence_writer.h"
 
 #include <errno.h>
 #include <stdio.h>
@@ -607,7 +608,50 @@ TEST(test_persistence_generation_rejects_symlinked_legacy_namespace) {
 }
 #endif
 
+TEST(test_persistence_writer_commits_immutable_snapshot) {
+    char root[PERSISTENCE_GENERATION_PATH_MAX];
+    char legacy[PERSISTENCE_GENERATION_PATH_MAX];
+    ASSERT(snprintf(root, sizeof(root), "%s/%s",
+                    test_tmp_dir(), "generation_async_snapshot") > 0);
+    ASSERT(snprintf(legacy, sizeof(legacy), "%s/%s",
+                    test_tmp_dir(), "generation_async_legacy") > 0);
+    static const uint8_t token[8] =
+        {0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38};
+    WORLD_HEAP world = calloc(1, sizeof(*world));
+    ASSERT(world != NULL);
+    ASSERT(test_prepare_generation_world(
+        world, token, 12.0f, 44.0f, 75.0f));
+    bool save_slots[MAX_PLAYERS] = {0};
+    save_slots[0] = true;
+
+    persistence_writer_t *writer = persistence_writer_create();
+    ASSERT(writer != NULL);
+    ASSERT(persistence_writer_start(
+        writer, root, legacy, world, save_slots));
+    ASSERT(!persistence_writer_start(
+        writer, root, legacy, world, save_slots));
+
+    /* These changes happen after snapshot capture and must not leak into the
+     * generation being serialized by the worker. */
+    world->time = 99.0f;
+    world->players[0].ship->hull = 9.0f;
+    persistence_generation_paths_t published = {0};
+    ASSERT_EQ_INT(
+        persistence_writer_wait(writer, &published),
+        PERSISTENCE_WRITER_SUCCEEDED);
+    ASSERT(!persistence_writer_active(writer));
+    persistence_writer_destroy(writer);
+
+    WORLD_HEAP loaded = calloc(1, sizeof(*loaded));
+    ASSERT(loaded != NULL);
+    ASSERT(test_load_generation_world(&published, loaded));
+    ASSERT_EQ_FLOAT(loaded->time, 12.0f, 0.001f);
+    ASSERT(test_load_generation_player(&published, loaded, token));
+    ASSERT_EQ_FLOAT(loaded->players[0].ship->hull, 44.0f, 0.001f);
+}
+
 void register_persistence_generation_tests(void) {
+    RUN(test_persistence_writer_commits_immutable_snapshot);
     RUN(test_persistence_generation_publish_boundaries_and_player_carry);
     RUN(test_persistence_generation_prunes_bounded_history_after_publish);
     RUN(test_persistence_generation_recovery_follows_published_lineage);

--- a/tests/c/test_world_sim.c
+++ b/tests/c/test_world_sim.c
@@ -5261,6 +5261,168 @@ TEST(test_frame_press_accepts_player_towed_ingot_pod_at_press) {
     ASSERT(v2_dot(w.cargo_pods[input_pod].vel, to_hopper) > 0.0f);
 }
 
+TEST(test_kepler_frame_press_consumes_prospect_ingot_pod_after_intake) {
+    WORLD_DECL;
+    world_reset(&w);
+    station_t *kepler = &w.stations[1];
+    server_player_t *sp = &w.players[0];
+    cargo_unit_t input = {0};
+    cargo_unit_t second_input = {0};
+    cargo_unit_t shell = {0};
+    uint8_t fragment_a[32] = {0};
+    uint8_t fragment_b[32] = {0};
+    const uint8_t shell_origin[8] = {
+        'P','R','O','S','P','O','D','1'
+    };
+    int press_idx = -1;
+    int hopper_idx = station_find_hopper_for(
+        kepler, COMMODITY_FERRITE_INGOT);
+
+    fragment_a[31] = 0x29;
+    for (int i = 0; i < kepler->module_count; i++) {
+        if (kepler->modules[i].type == MODULE_FRAME_PRESS) {
+            press_idx = i;
+            break;
+        }
+    }
+    ASSERT(press_idx >= 0);
+    ASSERT(hopper_idx >= 0);
+
+    manifest_clear(&kepler->manifest);
+    memset(kepler->_inventory_cache, 0,
+           sizeof(kepler->_inventory_cache));
+    for (int m = 0; m < MAX_MODULES_PER_STATION; m++) {
+        kepler->modules[m].input_buffer = 0.0f;
+        kepler->modules[m].output_buffer = 0.0f;
+    }
+    memset(w.cargo_pods, 0, sizeof(w.cargo_pods));
+
+    ASSERT(hash_ingot(COMMODITY_FERRITE_INGOT, MINING_GRADE_FINE,
+                      fragment_a, 0, &input));
+    ASSERT(test_anchor_smelt_unit(&w, 0, &input));
+    ASSERT(hash_legacy_migrate_unit(
+        shell_origin, COMMODITY_FRAME, 0, &shell));
+    ASSERT(test_anchor_legacy_cargo_unit(&w, 0, &shell));
+
+    /* Reproduce the live screenshot: the idle ring has drifted until the
+     * press and its outer ingot hopper are on opposite sides of Kepler. The
+     * physical ingot is beside the press, not beside the remote hopper. */
+    kepler->arm_rotation[1] = 0.0f;
+    kepler->arm_rotation[2] = PI_F;
+    vec2 press_pos = module_world_pos_ring(
+        kepler, kepler->modules[press_idx].ring,
+        kepler->modules[press_idx].slot);
+    vec2 hopper_pos = module_world_pos_ring(
+        kepler, kepler->modules[hopper_idx].ring,
+        kepler->modules[hopper_idx].slot);
+    ASSERT(v2_dist_sq(press_pos, hopper_pos) >
+           HOPPER_PULL_RANGE * HOPPER_PULL_RANGE);
+    int input_pod = spawn_cargo_pod_with_manifest(
+        &w, v2_add(press_pos, v2(24.0f, 0.0f)),
+        v2(0.0f, 0.0f),
+        COMMODITY_FERRITE_INGOT, &input, 1,
+        CARGO_POD_CARGO);
+    ASSERT(input_pod >= 0);
+    cargo_pod_set_shell_frame(&w.cargo_pods[input_pod], &shell);
+
+    player_init_ship(sp, &w);
+    sp->id = 0;
+    sp->connected = true;
+    sp->session_ready = true;
+    memset(sp->session_token, 0x29,
+           sizeof(sp->session_token));
+    kepler->base_price[COMMODITY_FERRITE_INGOT] = 10.0f;
+    float balance_before = ledger_balance(
+        kepler, sp->session_token);
+    float earned_before = sp->ship->stat_credits_earned;
+    ASSERT(world_cargo_pod_set_player_tractor(
+        &w, input_pod, 0));
+
+    /* Player ownership and proximity are not enough. The foreign unit has no
+     * station custody until the ordinary intake handoff below completes. */
+    ASSERT_EQ_INT(test_count_exact_pod_units(
+                      &w, COMMODITY_FERRITE_INGOT), 1);
+    ASSERT_EQ_INT(cargo_pod_custody_station(
+                      &w.cargo_pods[input_pod]), -1);
+
+    step_station_cargo_pod_tractors(&w, SIM_DT);
+
+    ASSERT_EQ_INT(sp->ship->towed_pod_count, 0);
+    ASSERT_EQ_INT(cargo_pod_player_tractor(
+                      &w.cargo_pods[input_pod]), -1);
+    ASSERT(cargo_pod_is_tractored_by_module(
+        &w.cargo_pods[input_pod], 1, press_idx));
+    ASSERT_EQ_INT(cargo_pod_custody_station(
+                      &w.cargo_pods[input_pod]), 1);
+    ASSERT(ledger_balance(kepler, sp->session_token) > balance_before);
+    ASSERT(sp->ship->stat_credits_earned > earned_before);
+    ASSERT(w.cargo_pods[input_pod].has_shell_frame);
+    ASSERT(memcmp(w.cargo_pods[input_pod].shell_frame.pub,
+                  shell.pub, 32) == 0);
+
+    vec2 hold = v2(0.0f, 0.0f);
+    ASSERT(cargo_pod_module_tractor_anchor(
+        &w, &w.cargo_pods[input_pod], 1,
+        press_idx, &hold));
+    w.cargo_pods[input_pod].pos = hold;
+    w.cargo_pods[input_pod].vel = station_ring_point_velocity(
+        kepler, kepler->modules[press_idx].ring, hold);
+    kepler->modules[press_idx].craft_progress = 1.0f;
+
+    sim_step_station_production(&w, 0.0f);
+
+    ASSERT_EQ_INT(test_count_exact_pod_units(
+                      &w, COMMODITY_FERRITE_INGOT), 0);
+    const cargo_pod_t *frames = test_first_exact_pod_with_units(
+        &w, COMMODITY_FRAME, CELL_STRUTS_PER_INGOT - 1);
+    ASSERT(frames != NULL);
+    ASSERT(frames->has_shell_frame);
+    ASSERT_EQ_INT(frames->manifest_units[0].origin_station, 1);
+    ASSERT_EQ_INT(frames->manifest_units[0].recipe_id,
+                  RECIPE_FRAME_BASIC);
+
+    /* Emptying the paid Prospect pod unfolds its carrier without laundering
+     * Kepler's custody. That foreign-authored frame remains valid physical
+     * stock and can package the next press batch. */
+    ASSERT(w.cargo_pods[input_pod].active);
+    ASSERT_EQ_INT(w.cargo_pods[input_pod].commodity, COMMODITY_FRAME);
+    ASSERT_EQ_INT(w.cargo_pods[input_pod].manifest_count, 1);
+    ASSERT(!w.cargo_pods[input_pod].has_shell_frame);
+    ASSERT_EQ_INT(cargo_pod_custody_station(
+                      &w.cargo_pods[input_pod]), 1);
+    ASSERT(memcmp(w.cargo_pods[input_pod].manifest_units[0].pub,
+                  shell.pub, 32) == 0);
+
+    int first_output = (int)(frames - w.cargo_pods);
+    ASSERT(first_output >= 0 && first_output < MAX_CARGO_PODS);
+    ASSERT(world_cargo_pod_set_player_tractor(
+        &w, first_output, 0));
+
+    fragment_b[31] = 0x2a;
+    ASSERT(hash_ingot(COMMODITY_FERRITE_INGOT, MINING_GRADE_FINE,
+                      fragment_b, 0, &second_input));
+    ASSERT(test_anchor_smelt_unit(&w, 1, &second_input));
+    int second_pod = spawn_cargo_pod_with_manifest(
+        &w, hold, station_ring_point_velocity(
+                      kepler, kepler->modules[press_idx].ring, hold),
+        COMMODITY_FERRITE_INGOT, &second_input, 1,
+        CARGO_POD_CARGO);
+    ASSERT(second_pod >= 0);
+    ASSERT(world_cargo_pod_set_module_tractor(
+        &w, second_pod, 1, press_idx));
+    kepler->modules[press_idx].craft_progress = 1.0f;
+
+    sim_step_station_production(&w, 0.0f);
+
+    ASSERT(!w.cargo_pods[input_pod].active);
+    const cargo_pod_t *reused = test_first_exact_pod_with_units(
+        &w, COMMODITY_FRAME, CELL_STRUTS_PER_INGOT);
+    ASSERT(reused != NULL);
+    ASSERT(reused->has_shell_frame);
+    ASSERT(memcmp(reused->shell_frame.pub, shell.pub, 32) == 0);
+    ASSERT_EQ_INT(cargo_pod_custody_station(reused), 1);
+}
+
 TEST(test_station_hopper_accepts_player_towed_ingot_pod) {
     WORLD_DECL;
     world_reset(&w);
@@ -5864,6 +6026,99 @@ TEST(test_station_production_fills_existing_laser_output_pod) {
     ASSERT(cargo_pod_is_tractored_by_module(&w.cargo_pods[output_pod],
                                             2, output_hopper));
     ASSERT(test_first_exact_pod_with_units(&w, COMMODITY_LASER_MODULE, 1) == NULL);
+}
+
+TEST(test_engine_fab_consumes_frame_pod_and_both_ingot_pods) {
+    WORLD_DECL;
+    world_reset(&w);
+    station_t *st = &w.stations[2];
+    int engine_idx = -1;
+    for (int i = 0; i < st->module_count; i++) {
+        if (!st->modules[i].scaffold &&
+            st->modules[i].type == MODULE_ENGINE_FAB) {
+            engine_idx = i;
+            break;
+        }
+    }
+    ASSERT(engine_idx >= 0);
+
+    manifest_clear(&st->manifest);
+    memset(st->_inventory_cache, 0, sizeof(st->_inventory_cache));
+    for (int m = 0; m < MAX_MODULES_PER_STATION; m++) {
+        st->modules[m].input_buffer = 0.0f;
+        st->modules[m].output_buffer = 0.0f;
+        st->modules[m].craft_progress = 0.0f;
+    }
+    memset(w.cargo_pods, 0, sizeof(w.cargo_pods));
+
+    const commodity_t inputs[3] = {
+        COMMODITY_FRAME,
+        COMMODITY_CUPRITE_INGOT,
+        COMMODITY_CRYSTAL_INGOT,
+    };
+    int pods[3] = {-1, -1, -1};
+    cargo_unit_t recipe_inputs[3] = {{0}};
+    for (int input = 0; input < 3; input++) {
+        int hopper = station_find_hopper_for(st, inputs[input]);
+        ASSERT(hopper >= 0);
+        vec2 pos = module_world_pos_ring(
+            st, st->modules[hopper].ring, st->modules[hopper].slot);
+        uint16_t count = inputs[input] == COMMODITY_FRAME ? 2u : 1u;
+        pods[input] = test_spawn_exact_pod(&w, pos, inputs[input], count);
+        ASSERT(pods[input] >= 0);
+        ASSERT(test_anchor_pod_legacy_cargo(&w, 2, pods[input]));
+        recipe_inputs[input] =
+            w.cargo_pods[pods[input]].manifest_units[count - 1u];
+        ASSERT(world_cargo_pod_set_module_tractor(
+            &w, pods[input], 2, hopper));
+        ASSERT(cargo_pod_module_tractor_anchor(
+            &w, &w.cargo_pods[pods[input]], 2, hopper, &pos));
+        w.cargo_pods[pods[input]].pos = pos;
+        w.cargo_pods[pods[input]].vel = station_ring_point_velocity(
+            st, st->modules[hopper].ring, pos);
+        ASSERT(cargo_pod_module_tractor_arrived(
+            &w, &w.cargo_pods[pods[input]], 2, hopper));
+    }
+
+    cargo_unit_t expected = {0};
+    ASSERT(hash_product(
+        RECIPE_ENGINE_BASIC, recipe_inputs, 3, 0, &expected));
+    step_station_cargo_pod_tractors(&w, 0.0f);
+    for (int input = 0; input < 3; input++) {
+        ASSERT(cargo_pod_is_tractored_by_module(
+            &w.cargo_pods[pods[input]], 2, engine_idx));
+        vec2 engine_anchor = {0};
+        ASSERT(cargo_pod_module_tractor_anchor(
+            &w, &w.cargo_pods[pods[input]], 2, engine_idx,
+            &engine_anchor));
+        w.cargo_pods[pods[input]].pos = engine_anchor;
+        w.cargo_pods[pods[input]].vel = station_ring_point_velocity(
+            st, st->modules[engine_idx].ring, engine_anchor);
+        ASSERT(cargo_pod_module_tractor_arrived(
+            &w, &w.cargo_pods[pods[input]], 2, engine_idx));
+    }
+    sim_step_station_production(&w, 2.0f);
+    const cargo_pod_t *output = test_first_exact_pod_with_units(
+        &w, COMMODITY_ENGINE_MODULE, 1);
+
+    ASSERT(output != NULL);
+    for (int input = 0; input < 3; input++)
+        ASSERT(!w.cargo_pods[pods[input]].active);
+    ASSERT(output->has_shell_frame);
+    ASSERT_EQ_INT(output->shell_frame.commodity, COMMODITY_FRAME);
+    ASSERT_EQ_INT(output->manifest_units[0].kind, CARGO_KIND_ENGINE);
+    ASSERT_EQ_INT(output->manifest_units[0].recipe_id,
+                  RECIPE_ENGINE_BASIC);
+    ASSERT(memcmp(output->manifest_units[0].pub,
+                  expected.pub, sizeof(expected.pub)) == 0);
+    ASSERT(memcmp(output->manifest_units[0].parent_merkle,
+                  expected.parent_merkle,
+                  sizeof(expected.parent_merkle)) == 0);
+    int output_hopper = station_find_output_hopper_for_module(
+        st, &st->modules[engine_idx]);
+    ASSERT(output_hopper >= 0);
+    ASSERT(cargo_pod_is_tractored_by_module(
+        output, 2, output_hopper));
 }
 
 /* Manifest-as-truth invariant: production refuses to mint orphan
@@ -12040,6 +12295,7 @@ void register_world_sim_basic_tests(void) {
     RUN(test_station_physical_stock_counts_payload_and_frame_shell);
     RUN(test_station_physical_craft_append_failure_is_inert);
     RUN(test_frame_press_accepts_player_towed_ingot_pod_at_press);
+    RUN(test_kepler_frame_press_consumes_prospect_ingot_pod_after_intake);
     RUN(test_station_hopper_accepts_player_towed_ingot_pod);
     RUN(test_frame_press_consumes_dock_held_ingot_pod);
     RUN(test_frame_press_reclaims_dock_held_frame_pod_as_output_crate);
@@ -12051,6 +12307,7 @@ void register_world_sim_basic_tests(void) {
     RUN(test_furnace_tractor_holds_frame_pod_outside_module);
     RUN(test_station_production_ejects_laser_pod);
     RUN(test_station_production_fills_existing_laser_output_pod);
+    RUN(test_engine_fab_consumes_frame_pod_and_both_ingot_pods);
     RUN(test_station_production_without_manifest_inputs_refuses_to_mint);
     RUN(test_world_sim_step_events_emitted);
     RUN(test_world_sim_step_npc_miners_work);


### PR DESCRIPTION
Closes #693.

## What changed
- Move persistence generation commits to a single background writer using immutable world snapshots.
- Preserve accumulated simulation time after the per-poll step cap instead of discarding remaining tick debt.
- Join background persistence safely for recovery and shutdown, with bounded retry behavior.
- Add live-world regressions for Kepler frame pressing, reusable frame shells, Engine Fab inputs, and station trust policy.
- Add workflow mutation checks protecting the cargo-trust audit.

## Root cause and impact
Asteroid collision planning is inexpensive at current world densities. The more plausible jank sources were synchronous save I/O on the simulation and network poll thread and silent loss of accumulated simulation time after a busy poll. This keeps disk latency off gameplay and lets the fixed-step simulation catch up over subsequent polls without an unbounded single-poll spiral.

## Validation
- Canonical release command: 1641/1641 tests passed
- Native suite: 1641/1641
- ASan and UBSan: 1641/1641
- ThreadSanitizer: 1/1 bounded concurrency regression
- Functional soak: 9/9
- Production server strict build
- cppcheck
- Cargo trust, banned API, deterministic libm, documentation freshness, soak automation, vendor drift, and workflow contract gates
- Governance gate passed at exact head ded12244314711fa96d4b7f7a17028efe6857a21