### PR TITLE
Refresh deterministic AI episode outcomes

### DIFF
--- a/.github/workflows/replay.yml
+++ b/.github/workflows/replay.yml
@@ -18,6 +18,9 @@ on:
       - 'tools/signal_replay.c'
       - 'scripts/check_deterministic_build_flags.py'
       - 'scripts/ai_eval_corpus.py'
+      - 'scripts/ai_episode_outcomes.py'
+      - 'scripts/analyze_ai_episode_outcomes.py'
+      - 'scripts/test_ai_episode_outcomes.py'
       - 'scripts/build_replay_bundle.py'
       - 'scripts/check_replay_bundles.py'
       - 'scripts/check_replay_repeatability.py'
@@ -39,6 +42,7 @@ on:
           - long
           - ai-eval-fast
           - ai-eval-long
+          - ai-outcomes-fast
 
 permissions:
   contents: read
@@ -88,6 +92,40 @@ jobs:
               emmake cmake --build build-replay-wasm --target signal_replay --parallel
             '
           python3 scripts/check_deterministic_build_flags.py build-replay-wasm/compile_commands.json
+
+      - name: Validate AI episode outcome contracts
+        run: python3 scripts/test_ai_episode_outcomes.py
+
+      - name: Preserve AI outcome facts across native and WASM
+        run: |
+          python3 scripts/build_replay_bundle.py \
+            ./build/signal_replay \
+            replay-bundles/ai-outcomes-linux-x64 \
+            --scenario-set ai-outcomes-fast \
+            --decision-mode teacher
+          python3 scripts/build_replay_bundle.py \
+            ./build-replay-wasm/signal_replay.js \
+            replay-bundles/ai-outcomes-wasm \
+            --scenario-set ai-outcomes-fast \
+            --decision-mode teacher
+          python3 scripts/check_replay_bundles.py \
+            replay-bundles/ai-outcomes-linux-x64 \
+            replay-bundles/ai-outcomes-wasm
+
+      - name: Compare teacher shadow mixed and active outcomes
+        run: |
+          for mode in teacher shadow mixed active; do
+            python3 scripts/build_replay_bundle.py \
+              ./build/signal_replay \
+              "replay-bundles/ai-outcomes-${mode}" \
+              --scenario-set ai-outcomes-fast \
+              --decision-mode "$mode"
+          done
+          python3 scripts/analyze_ai_episode_outcomes.py \
+            teacher=replay-bundles/ai-outcomes-teacher \
+            shadow=replay-bundles/ai-outcomes-shadow \
+            mixed=replay-bundles/ai-outcomes-mixed \
+            active=replay-bundles/ai-outcomes-active
 
       - name: Export Linux x64 native replay bundle
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-web build-server build-test build-san test-san test-san-soak build-msan test-msan build-tsan test-tsan memzero-codegen build-mode-contract client-memory-budget build-flight-trace flight-trace build-signal-replay build-signal-replay-wasm signal-replay replay-repeatability replay-repeatability-long signal-no-omniscience-soak replay-cross-build replay-cross-build-long replay-native-wasm replay-native-wasm-long build-chain-assets chain-assets build-rati-receipt rati-receipt rati-anchor-batch test-rati-anchor-batch rati-anchor-stamp neural-gap-ab signal-client-brain-shadow signal-hnn-shadow assets protocol-check test test-serial test-fast test-soak test-all asteroid-physics-bench smoke smoke-latency smoke-ack-lag smoke-latency-suite relay-traffic-probe ws-backpressure-soak ws-backpressure-soak-short cargo-trust-audit banned-apis deterministic-libm deterministic-build-flags doc-freshness soak-automation vendor-drift fuzz-receipts fuzz-receipts-standalone cppcheck crap profile-machine latency-proxy latency-proxy-high latency-proxy-ack-lag rtc-gateway test-rtc-gateway deploy-fly site clean install-hooks
+.PHONY: all build build-web build-server build-test build-san test-san test-san-soak build-msan test-msan build-tsan test-tsan memzero-codegen build-mode-contract client-memory-budget build-flight-trace flight-trace build-signal-replay build-signal-replay-wasm signal-replay replay-repeatability replay-repeatability-long replay-ai-eval-repeatability replay-ai-eval-repeatability-long replay-ai-eval-native-wasm replay-ai-outcome-repeatability replay-ai-outcome-native-wasm replay-ai-outcome-modes signal-no-omniscience-soak replay-cross-build replay-cross-build-long replay-native-wasm replay-native-wasm-long build-chain-assets chain-assets build-rati-receipt rati-receipt rati-anchor-batch test-rati-anchor-batch rati-anchor-stamp test-rati-anchor-stamp neural-gap-ab signal-client-brain-shadow signal-hnn-shadow assets protocol-check test test-serial test-fast test-soak test-all asteroid-physics-bench smoke smoke-latency smoke-ack-lag smoke-latency-suite relay-traffic-probe ws-backpressure-soak ws-backpressure-soak-short cargo-trust-audit banned-apis deterministic-libm deterministic-build-flags doc-freshness soak-automation vendor-drift fuzz-receipts fuzz-receipts-standalone cppcheck crap profile-machine latency-proxy latency-proxy-high latency-proxy-ack-lag rtc-gateway test-rtc-gateway deploy-fly site clean install-hooks
 
 all: build build-web build-server
 
@@ -132,6 +132,23 @@ replay-ai-eval-repeatability-long: build-signal-replay
 	python3 scripts/check_replay_repeatability.py \
 		./build/signal_replay --scenario-set ai-eval-long
 
+replay-ai-outcome-repeatability: build-signal-replay
+	python3 scripts/test_ai_episode_outcomes.py
+	python3 scripts/check_replay_repeatability.py \
+		./build/signal_replay --scenario-set ai-outcomes-fast
+
+replay-ai-outcome-modes: build-signal-replay
+	@out=$$(mktemp -d /tmp/signal-ai-outcomes.XXXXXX); \
+	for mode in teacher shadow mixed active; do \
+		python3 scripts/build_replay_bundle.py \
+			./build/signal_replay "$$out/$$mode" \
+			--scenario-set ai-outcomes-fast \
+			--decision-mode "$$mode" || exit 1; \
+	done; \
+	python3 scripts/analyze_ai_episode_outcomes.py \
+		teacher="$$out/teacher" shadow="$$out/shadow" \
+		mixed="$$out/mixed" active="$$out/active"
+
 signal-no-omniscience-soak: build-signal-replay
 	python3 scripts/check_no_omniscience_soak.py ./build/signal_replay
 
@@ -179,6 +196,12 @@ replay-ai-eval-native-wasm: build-signal-replay build-signal-replay-wasm
 		./build/signal_replay \
 		./$(SIGNAL_REPLAY_WASM_BUILD)/signal_replay.js \
 		--scenario-set ai-eval-fast
+
+replay-ai-outcome-native-wasm: build-signal-replay build-signal-replay-wasm
+	python3 scripts/check_replay_cross_build.py \
+		./build/signal_replay \
+		./$(SIGNAL_REPLAY_WASM_BUILD)/signal_replay.js \
+		--scenario-set ai-outcomes-fast
 
 # --- Chain asset inventory export ---
 CHAIN_ASSETS_FORMAT ?= json

--- a/docs/intelligence-vision.md
+++ b/docs/intelligence-vision.md
@@ -364,6 +364,12 @@ economy.
 Acceptance:
 
 - native and WASM replay agree over active-worker scenarios
+- replay bundles carry versioned per-head episode outcomes for task
+  completion/failure, safety, route efficiency, stuck/recovery behavior,
+  station need served, and cargo receipt-chain integrity
+- teacher, shadow, mixed, and active reports compare the same stable replay and
+  episode IDs, while requested mode, effective mode, model decisions, and
+  teacher fallbacks remain explicit
 - the fast gate includes selected worker tow, repair, and delivery-proof
   diagnostics, HNN-backed rows, scaffold pickup counters, kit-backed hull
   recovery, cleared NPC delivery shipments, and shared job-family outcome

--- a/docs/replay-harness.md
+++ b/docs/replay-harness.md
@@ -127,7 +127,72 @@ Each row has schema `signal.replay_counterfactual.v1` and includes:
   disconnected station counts, production and consumption edge counts,
   outpost slots, a slot-sensitive topology hash, and a slot-invariant semantic
   topology hash.
+- `outcome_facts`: strict `signal.ai_outcome_facts.v1` evidence used to derive
+  per-head episode outcomes. It records feature-contract versions, bounded
+  completion ticks, player and worker route progress, collision/death/stuck/
+  recovery/loop counters, safety fallbacks, station needs served, and cargo
+  manifest/receipt-chain integrity at both episode boundaries.
 - `authority`: currently `deterministic_seed_prefix_replay`.
+
+## AI Episode Outcome Contract
+
+Every replay bundle uses schema `signal.replay_bundle.v3` and contains a
+strictly validated `outcomes.json` report with schema
+`signal.ai_episode_report.v1`. Each report has one
+`signal.ai_episode_outcome.v1` record per replay row and intelligence head:
+`flight`, `contract`, and `worker`.
+
+Episode boundaries are deliberately narrower than an entire game session:
+
+- a flight episode begins after the shared seed, prefix, and provenance setup,
+  and ends at goal arrival, ship death, or the candidate horizon;
+- a contract episode begins when a contract decision or completion/delivery
+  event is observed, and ends at completion, a terminal rejection, or the
+  horizon; rows with no contract evidence are `not_attempted`;
+- a worker episode begins with a selected assignment and ends when the bounded
+  fixture clears a delivery, completes a scaffold move, finishes a kit-backed
+  repair, defaults a shipment, or reaches the horizon; rows with no assignment
+  evidence are `not_attempted`.
+
+Statuses are `not_attempted`, `in_progress`, `completed`, and `failed`.
+`in_progress` is explicitly marked as truncated; reaching the horizon is never
+silently scored as success or failure. A completed contract or worker episode
+must have a deterministic completion tick or report construction fails.
+
+Replay IDs hash the corpus/version, generator version, scenario index, and
+exact scenario arguments. Episode IDs additionally hash the candidate, head,
+and outcome report version. The four decision modes therefore operate on
+exactly the same episode IDs:
+
+- `teacher` is the authoritative deterministic fallback;
+- `shadow` records the requested comparison mode while teacher decisions
+  remain authoritative;
+- `mixed` and `active` configure the worker brain accordingly, but every
+  episode records effective mode, model decisions, and teacher fallbacks;
+- flight remains a replay counterfactual candidate in all four modes and says
+  so explicitly rather than claiming an active model decision.
+
+Unknown fact/report schemas, encoder-version drift, malformed route metrics,
+non-finite values, or broken cargo lineage fail closed. Attempted-episode
+summaries include completion rate/ticks, collision and death events, stuck and
+recovery counts, repeated route cells, safety overrides, route efficiency,
+behavioral diversity, station need served, and receipt-chain failures.
+`not_attempted` rows are counted but do not pollute those metric totals.
+The short corpus exercises both completed and horizon-truncated flight
+episodes plus completed contract, tow, repair, and delivery-proof episodes.
+
+Run the short deterministic gates with:
+
+```sh
+make replay-ai-outcome-repeatability
+make replay-ai-outcome-native-wasm
+make replay-ai-outcome-modes
+```
+
+The first also runs schema/version unit tests. The native/WASM gate compares
+the raw facts byte-for-byte, including `outcomes.json`. The four-mode gate
+requires identical episode IDs before emitting
+`signal.ai_episode_comparison.v1` summaries.
 
 ## AI Evaluation World Corpus
 
@@ -168,9 +233,10 @@ make replay-ai-eval-repeatability-long
 
 The Deterministic Replay workflow accepts `ai-eval-fast` and `ai-eval-long`
 manual scenario sets. Its weekly scheduled job exports the long native bundle
-as a 30-day artifact. Bundle manifests use `signal.replay_bundle.v2`; every
+as a 30-day artifact. Bundle manifests use `signal.replay_bundle.v3`; every
 scenario entry records the corpus/generator versions and expected invariants,
-and every JSONL row repeats those versions with its measured topology summary.
+every JSONL row repeats those versions with its measured topology summary, and
+the manifest authenticates the versioned `outcomes.json` report.
 
 The fast repeatability gate includes focused active-worker fixtures for
 `worker-tow-hnn`, `worker-repair-hnn`, `worker-delivery-proof-hnn`, and

--- a/scripts/ai_episode_outcomes.py
+++ b/scripts/ai_episode_outcomes.py
@@ -1,0 +1,944 @@
+#!/usr/bin/env python3
+"""Build and validate deterministic per-head AI episode outcome reports."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+
+OUTCOME_FACTS_SCHEMA = "signal.ai_outcome_facts.v1"
+OUTCOME_REPORT_SCHEMA = "signal.ai_episode_report.v1"
+OUTCOME_EPISODE_SCHEMA = "signal.ai_episode_outcome.v1"
+OUTCOME_REPORT_VERSION = 1
+OUTCOME_CORPUS_NAME = "signal-ai-outcomes"
+
+DECISION_MODES = ("teacher", "shadow", "mixed", "active")
+HEADS = ("flight", "contract", "worker")
+STATUSES = ("not_attempted", "in_progress", "completed", "failed")
+
+FEATURE_CONTRACTS = {
+    "flight": ("signal-flight-live-v2", 2),
+    "contract": ("signal-contract-live-v2", 2),
+    "worker": ("signal-npc-worker-v2", 2),
+}
+
+AI_OUTCOME_FAST_SCENARIOS = (
+    (
+        "--seed", "65101",
+        "--station", "0",
+        "--history", "W,WA,D",
+        "--horizon-ticks", "120",
+        "--candidates", "NONE,W,WA,WD",
+        "--evaluation-world", "seeded-only",
+        "--hnn-trace",
+    ),
+    (
+        "--seed", "65102",
+        "--station", "127",
+        "--history", "W,WD,A",
+        "--horizon-ticks", "120",
+        "--candidates", "NONE,W,WA,WD",
+        "--evaluation-world", "outpost-high",
+        "--hnn-trace",
+    ),
+    (
+        "--seed", "65103",
+        "--station", "4",
+        "--history", "W,WA,D",
+        "--horizon-ticks", "240",
+        "--candidates", "NONE",
+        "--evaluation-world", "scarcity",
+    ),
+    (
+        "--seed", "65105",
+        "--spawn", "1000,-1000",
+        "--goal", "1000,-1000",
+        "--horizon-ticks", "8",
+        "--candidates", "NONE,W",
+        "--evaluation-world", "seeded-only",
+    ),
+    (
+        "--seed", "6610",
+        "--station", "0",
+        "--horizon-ticks", "1",
+        "--candidates", "NONE",
+        "--active-workers",
+        "--evaluation-world", "seeded-only",
+        "--provenance-script", "worker-tow-hnn",
+    ),
+    (
+        "--seed", "6611",
+        "--station", "0",
+        "--horizon-ticks", "1",
+        "--candidates", "NONE",
+        "--active-workers",
+        "--evaluation-world", "seeded-only",
+        "--provenance-script", "worker-repair-hnn",
+    ),
+    (
+        "--seed", "6612",
+        "--station", "0",
+        "--horizon-ticks", "1",
+        "--candidates", "NONE",
+        "--active-workers",
+        "--evaluation-world", "seeded-only",
+        "--provenance-script", "worker-delivery-proof-hnn",
+    ),
+    (
+        "--seed", "65104",
+        "--station", "4",
+        "--history", "W,WD,A",
+        "--horizon-ticks", "240",
+        "--candidates", "NONE",
+        "--evaluation-world", "route-disrupted",
+    ),
+)
+
+
+class OutcomeReportError(ValueError):
+    """Raised when replay facts or an outcome report fail closed validation."""
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _stable_id(domain: str, value: object) -> str:
+    digest = hashlib.sha256()
+    digest.update(domain.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(_canonical_json(value).encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _require_dict(value: object, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise OutcomeReportError(f"{label} must be an object")
+    return value
+
+
+def _require_list(value: object, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise OutcomeReportError(f"{label} must be an array")
+    return value
+
+
+def _require_str(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise OutcomeReportError(f"{label} must be a non-empty string")
+    return value
+
+
+def _require_bool(value: object, label: str) -> bool:
+    if type(value) is not bool:
+        raise OutcomeReportError(f"{label} must be boolean")
+    return value
+
+
+def _require_int(
+    value: object,
+    label: str,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    if type(value) is not int:
+        raise OutcomeReportError(f"{label} must be an integer")
+    if minimum is not None and value < minimum:
+        raise OutcomeReportError(f"{label} must be >= {minimum}")
+    if maximum is not None and value > maximum:
+        raise OutcomeReportError(f"{label} must be <= {maximum}")
+    return value
+
+
+def _require_number(
+    value: object,
+    label: str,
+    *,
+    minimum: float | None = None,
+) -> float:
+    if type(value) not in (int, float):
+        raise OutcomeReportError(f"{label} must be numeric")
+    number = float(value)
+    if not (-float("inf") < number < float("inf")):
+        raise OutcomeReportError(f"{label} must be finite")
+    if minimum is not None and number < minimum:
+        raise OutcomeReportError(f"{label} must be >= {minimum}")
+    return number
+
+
+def _optional_tick(value: object, label: str) -> int | None:
+    if value is None:
+        return None
+    return _require_int(value, label, minimum=0)
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise OutcomeReportError(f"cannot read replay output {path}: {exc}") from exc
+    for line_number, line in enumerate(lines, 1):
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise OutcomeReportError(
+                f"{path}:{line_number}: invalid JSON: {exc}"
+            ) from exc
+        if not isinstance(value, dict):
+            raise OutcomeReportError(
+                f"{path}:{line_number}: replay row must be an object"
+            )
+        rows.append(value)
+    if not rows:
+        raise OutcomeReportError(f"{path}: replay output has no rows")
+    return rows
+
+
+def _validate_lineage(value: object, label: str) -> dict[str, Any]:
+    lineage = _require_dict(value, label)
+    manifest_count = _require_int(
+        lineage.get("manifest_count"),
+        f"{label}.manifest_count",
+        minimum=0,
+    )
+    receipt_count = _require_int(
+        lineage.get("receipt_count"),
+        f"{label}.receipt_count",
+        minimum=0,
+    )
+    for field in ("missing_receipt_chains", "invalid_receipt_chains"):
+        _require_int(
+            lineage.get(field),
+            f"{label}.{field}",
+            minimum=0,
+            maximum=manifest_count,
+        )
+    parity = _require_bool(
+        lineage.get("receipt_manifest_parity"),
+        f"{label}.receipt_manifest_parity",
+    )
+    if parity != (manifest_count == receipt_count):
+        raise OutcomeReportError(f"{label}.receipt_manifest_parity is inconsistent")
+    identity_hash = _require_str(
+        lineage.get("identity_hash"),
+        f"{label}.identity_hash",
+    )
+    if len(identity_hash) != 64 or any(
+        char not in "0123456789abcdef" for char in identity_hash
+    ):
+        raise OutcomeReportError(f"{label}.identity_hash must be lowercase sha256")
+    return lineage
+
+
+def validate_outcome_facts(value: object) -> dict[str, Any]:
+    facts = _require_dict(value, "outcome_facts")
+    if facts.get("schema") != OUTCOME_FACTS_SCHEMA:
+        raise OutcomeReportError(
+            f"unsupported outcome facts schema: {facts.get('schema')!r}"
+        )
+    if facts.get("report_version") != OUTCOME_REPORT_VERSION:
+        raise OutcomeReportError(
+            f"unsupported outcome report version: {facts.get('report_version')!r}"
+        )
+
+    contracts = _require_dict(
+        facts.get("feature_contracts"),
+        "outcome_facts.feature_contracts",
+    )
+    for head, (feature_set, encoder_version) in FEATURE_CONTRACTS.items():
+        contract = _require_dict(
+            contracts.get(head),
+            f"outcome_facts.feature_contracts.{head}",
+        )
+        if contract.get("feature_set") != feature_set:
+            raise OutcomeReportError(
+                f"{head} feature contract is {contract.get('feature_set')!r}; "
+                f"expected {feature_set!r}"
+            )
+        if contract.get("encoder_version") != encoder_version:
+            raise OutcomeReportError(
+                f"{head} encoder version is {contract.get('encoder_version')!r}; "
+                f"expected {encoder_version}"
+            )
+        _require_bool(
+            contract.get("model_loaded"),
+            f"outcome_facts.feature_contracts.{head}.model_loaded",
+        )
+
+    ticks_executed = _require_int(
+        facts.get("ticks_executed"),
+        "outcome_facts.ticks_executed",
+        minimum=0,
+        maximum=120000,
+    )
+    for field in (
+        "goal_completion_tick",
+        "contract_completion_tick",
+        "worker_completion_tick",
+    ):
+        _optional_tick(facts.get(field), f"outcome_facts.{field}")
+
+    route = _require_dict(facts.get("route"), "outcome_facts.route")
+    for field in ("start_distance", "end_distance", "distance_traveled"):
+        _require_number(route.get(field), f"outcome_facts.route.{field}", minimum=0)
+    _require_number(route.get("progress"), "outcome_facts.route.progress")
+    efficiency = _require_number(
+        route.get("efficiency"),
+        "outcome_facts.route.efficiency",
+        minimum=0,
+    )
+    if efficiency > 1:
+        raise OutcomeReportError("outcome_facts.route.efficiency must be <= 1")
+    for field in ("stuck_ticks", "recovery_events"):
+        _require_int(
+            route.get(field),
+            f"outcome_facts.route.{field}",
+            minimum=0,
+            maximum=ticks_executed,
+        )
+    _require_int(
+        route.get("loop_revisits"),
+        "outcome_facts.route.loop_revisits",
+        minimum=0,
+        maximum=65535,
+    )
+
+    worker_route = _require_dict(
+        facts.get("worker_route"),
+        "outcome_facts.worker_route",
+    )
+    worker_tick_cap = ticks_executed + 1
+    for field in (
+        "assignment_ticks",
+        "motion_ticks",
+        "route_support_ticks",
+        "useful_outcome_ticks",
+        "stuck_ticks",
+        "recovery_events",
+    ):
+        _require_int(
+            worker_route.get(field),
+            f"outcome_facts.worker_route.{field}",
+            minimum=0,
+            maximum=worker_tick_cap,
+        )
+    _require_int(
+        worker_route.get("loop_revisits"),
+        "outcome_facts.worker_route.loop_revisits",
+        minimum=0,
+        maximum=65535,
+    )
+    if worker_route["route_support_ticks"] > worker_route["motion_ticks"]:
+        raise OutcomeReportError(
+            "outcome_facts.worker_route route support exceeds motion"
+        )
+    if worker_route["stuck_ticks"] > worker_route["assignment_ticks"]:
+        raise OutcomeReportError(
+            "outcome_facts.worker_route stuck ticks exceed assignments"
+        )
+    worker_efficiency = _require_number(
+        worker_route.get("efficiency"),
+        "outcome_facts.worker_route.efficiency",
+        minimum=0,
+    )
+    if worker_efficiency > 1:
+        raise OutcomeReportError(
+            "outcome_facts.worker_route.efficiency must be <= 1"
+        )
+    if worker_route["assignment_ticks"] == 0 and worker_efficiency != 0:
+        raise OutcomeReportError(
+            "outcome_facts.worker_route efficiency requires assignments"
+        )
+
+    safety = _require_dict(facts.get("safety"), "outcome_facts.safety")
+    for field in (
+        "collision_events",
+        "death_events",
+        "safety_overrides",
+        "order_rejected_events",
+    ):
+        _require_int(safety.get(field), f"outcome_facts.safety.{field}", minimum=0)
+    _require_number(
+        safety.get("damage_amount"),
+        "outcome_facts.safety.damage_amount",
+        minimum=0,
+    )
+
+    decisions = _require_dict(facts.get("decisions"), "outcome_facts.decisions")
+    for field in (
+        "flight",
+        "contract",
+        "contract_teacher_fallbacks",
+        "worker",
+        "worker_teacher_fallbacks",
+    ):
+        _require_int(decisions.get(field), f"outcome_facts.decisions.{field}", minimum=0)
+    if decisions["flight"] != 1:
+        raise OutcomeReportError("flight replay must have exactly one decision")
+    if decisions["contract_teacher_fallbacks"] > decisions["contract"]:
+        raise OutcomeReportError("contract teacher fallbacks exceed contract decisions")
+    if decisions["worker_teacher_fallbacks"] > decisions["worker"]:
+        raise OutcomeReportError("worker teacher fallbacks exceed worker decisions")
+
+    contract_counts = _require_dict(facts.get("contracts"), "outcome_facts.contracts")
+    for field in ("start_active", "end_active", "completed"):
+        _require_int(
+            contract_counts.get(field),
+            f"outcome_facts.contracts.{field}",
+            minimum=0,
+        )
+
+    station_need = _require_dict(
+        facts.get("station_need"),
+        "outcome_facts.station_need",
+    )
+    for field in (
+        "contract_completions",
+        "sell_events",
+        "sell_value",
+        "delivery_cleared",
+        "repair_events",
+        "scaffolds_placed",
+    ):
+        _require_int(
+            station_need.get(field),
+            f"outcome_facts.station_need.{field}",
+            minimum=0,
+        )
+
+    cargo = _require_dict(facts.get("cargo"), "outcome_facts.cargo")
+    start_lineage = _validate_lineage(
+        cargo.get("start"),
+        "outcome_facts.cargo.start",
+    )
+    end_lineage = _validate_lineage(
+        cargo.get("end"),
+        "outcome_facts.cargo.end",
+    )
+    identity_unchanged = _require_bool(
+        cargo.get("identity_unchanged"),
+        "outcome_facts.cargo.identity_unchanged",
+    )
+    if identity_unchanged != (
+        start_lineage["identity_hash"] == end_lineage["identity_hash"]
+    ):
+        raise OutcomeReportError(
+            "outcome_facts.cargo.identity_unchanged is inconsistent"
+        )
+    integrity_preserved = _require_bool(
+        cargo.get("lineage_integrity_preserved"),
+        "outcome_facts.cargo.lineage_integrity_preserved",
+    )
+    expected_integrity = (
+        start_lineage["receipt_manifest_parity"]
+        and end_lineage["receipt_manifest_parity"]
+        and start_lineage["missing_receipt_chains"] == 0
+        and end_lineage["missing_receipt_chains"] == 0
+        and start_lineage["invalid_receipt_chains"] == 0
+        and end_lineage["invalid_receipt_chains"] == 0
+    )
+    if integrity_preserved != expected_integrity:
+        raise OutcomeReportError(
+            "outcome_facts.cargo.lineage_integrity_preserved is inconsistent"
+        )
+    return facts
+
+
+def validate_outcome_output(path: Path) -> str | None:
+    try:
+        rows = _load_jsonl(path)
+        for row_index, row in enumerate(rows):
+            try:
+                validate_outcome_facts(row.get("outcome_facts"))
+            except OutcomeReportError as exc:
+                return f"row {row_index}: {exc}"
+    except OutcomeReportError as exc:
+        return str(exc)
+    return None
+
+
+def _ai_int(ai: dict[str, Any], field: str) -> int:
+    value = ai.get(field, 0)
+    return value if type(value) is int and value >= 0 else 0
+
+
+def _worker_attempted(facts: dict[str, Any], ai: dict[str, Any]) -> bool:
+    return (
+        facts["decisions"]["worker"] > 0
+        or _ai_int(ai, "worker_assignment_ticks") > 0
+        or _ai_int(ai, "worker_mine_assignment_ticks") > 0
+        or _ai_int(ai, "worker_haul_assignment_ticks") > 0
+        or _ai_int(ai, "worker_tow_assignment_ticks") > 0
+        or _ai_int(ai, "worker_delivery_assignment_ticks") > 0
+        or _ai_int(ai, "worker_scout_assignment_ticks") > 0
+        or _ai_int(ai, "worker_repair_assignment_ticks") > 0
+    )
+
+
+def _status_for(
+    head: str,
+    facts: dict[str, Any],
+    ai: dict[str, Any],
+) -> tuple[str, int | None]:
+    safety = facts["safety"]
+    need = facts["station_need"]
+    if head == "flight":
+        if safety["death_events"] > 0:
+            return "failed", None
+        completion_tick = facts["goal_completion_tick"]
+        if completion_tick is not None:
+            return "completed", completion_tick
+        return "in_progress", None
+
+    if head == "contract":
+        attempted = (
+            facts["decisions"]["contract"] > 0
+            or facts["contracts"]["completed"] > 0
+            or need["delivery_cleared"] > 0
+        )
+        if not attempted:
+            return "not_attempted", None
+        if (
+            safety["order_rejected_events"] > 0
+            and facts["contracts"]["completed"] == 0
+            and need["delivery_cleared"] == 0
+        ):
+            return "failed", None
+        if facts["contracts"]["completed"] > 0 or need["delivery_cleared"] > 0:
+            completion_tick = facts["contract_completion_tick"]
+            if completion_tick is None and need["delivery_cleared"] > 0:
+                completion_tick = facts["worker_completion_tick"]
+            if completion_tick is None:
+                raise OutcomeReportError(
+                    "completed contract episode has no deterministic completion tick"
+                )
+            return "completed", completion_tick
+        return "in_progress", None
+
+    attempted = _worker_attempted(facts, ai)
+    if not attempted:
+        return "not_attempted", None
+    if _ai_int(ai, "npc_delivery_shipments_defaulted") > 0:
+        return "failed", None
+    if (
+        facts["worker_completion_tick"] is not None
+        or need["delivery_cleared"] > 0
+        or need["scaffolds_placed"] > 0
+        or (
+            need["repair_events"] > 0
+            and _ai_int(ai, "worker_repair_assignment_ticks") > 0
+        )
+    ):
+        completion_tick = facts["worker_completion_tick"]
+        if completion_tick is None:
+            raise OutcomeReportError(
+                "completed worker episode has no deterministic completion tick"
+            )
+        return "completed", completion_tick
+    return "in_progress", None
+
+
+def _decision_summary(
+    head: str,
+    mode: str,
+    facts: dict[str, Any],
+) -> dict[str, Any]:
+    decisions = facts["decisions"]
+    if head == "flight":
+        return {
+            "requested_mode": mode,
+            "effective_mode": "replay_counterfactual",
+            "decision_source": "replay_candidate",
+            "decision_count": decisions["flight"],
+            "teacher_fallback_count": 0,
+            "model_decision_count": 0,
+        }
+
+    decision_count = decisions[head]
+    fallback_count = decisions[f"{head}_teacher_fallbacks"]
+    model_count = decision_count - fallback_count
+    if mode in ("teacher", "shadow") or model_count == 0:
+        effective_mode = "teacher"
+    else:
+        effective_mode = mode
+    decision_source = (
+        "teacher_fallback"
+        if fallback_count > 0 and model_count == 0
+        else "model"
+        if model_count > 0
+        else "none"
+    )
+    return {
+        "requested_mode": mode,
+        "effective_mode": effective_mode,
+        "decision_source": decision_source,
+        "decision_count": decision_count,
+        "teacher_fallback_count": fallback_count,
+        "model_decision_count": model_count,
+    }
+
+
+def _worker_diversity(ai: dict[str, Any]) -> int:
+    fields = (
+        "worker_mine_assignment_ticks",
+        "worker_haul_assignment_ticks",
+        "worker_tow_assignment_ticks",
+        "worker_delivery_assignment_ticks",
+        "worker_scout_assignment_ticks",
+        "worker_repair_assignment_ticks",
+    )
+    return sum(1 for field in fields if _ai_int(ai, field) > 0)
+
+
+def _contract_diversity(need: dict[str, Any]) -> int:
+    fields = (
+        "contract_completions",
+        "sell_events",
+        "delivery_cleared",
+        "repair_events",
+    )
+    return sum(1 for field in fields if need[field] > 0)
+
+
+def _flight_diversity(candidate_name: str) -> int:
+    turning = "A" in candidate_name or "D" in candidate_name
+    thrusting = "W" in candidate_name or "S" in candidate_name
+    return int(turning) + int(thrusting)
+
+
+def _episode_from_row(
+    *,
+    mode: str,
+    corpus: str,
+    corpus_version: int,
+    generator_version: int,
+    scenario_index: int,
+    scenario_name: str,
+    scenario_args: list[str],
+    row: dict[str, Any],
+    head: str,
+) -> dict[str, Any]:
+    if row.get("schema") != "signal.replay_counterfactual.v1":
+        raise OutcomeReportError(
+            f"scenario {scenario_index} has unsupported replay schema"
+        )
+    candidate = _require_int(row.get("candidate"), "replay.candidate", minimum=0)
+    candidate_name = _require_str(
+        row.get("candidate_name"),
+        "replay.candidate_name",
+    )
+    facts = validate_outcome_facts(row.get("outcome_facts"))
+    ai_value = row.get("ai", {})
+    ai = ai_value if isinstance(ai_value, dict) else {}
+
+    replay_identity = {
+        "corpus": corpus,
+        "corpus_version": corpus_version,
+        "generator_version": generator_version,
+        "scenario_index": scenario_index,
+        "args": scenario_args,
+    }
+    replay_id = _stable_id("signal-ai-replay-v1", replay_identity)
+    episode_id = _stable_id(
+        "signal-ai-episode-v1",
+        {
+            "replay_id": replay_id,
+            "candidate": candidate,
+            "head": head,
+            "report_version": OUTCOME_REPORT_VERSION,
+        },
+    )
+    status, ticks_to_completion = _status_for(head, facts, ai)
+
+    need = facts["station_need"]
+    if head == "worker":
+        station_need_served = (
+            need["delivery_cleared"]
+            + need["repair_events"]
+            + need["scaffolds_placed"]
+        )
+        diversity = _worker_diversity(ai)
+        route = facts["worker_route"]
+    elif head == "contract":
+        station_need_served = (
+            need["contract_completions"]
+            + need["delivery_cleared"]
+            + need["sell_events"]
+        )
+        diversity = _contract_diversity(need)
+        route = facts["worker_route"]
+    else:
+        station_need_served = 0
+        diversity = _flight_diversity(candidate_name)
+        route = facts["route"]
+
+    if head == "flight":
+        route_distance = route["distance_traveled"]
+        route_progress = route["progress"]
+    else:
+        route_distance = route["motion_ticks"]
+        route_progress = route["useful_outcome_ticks"]
+
+    cargo = facts["cargo"]
+    return {
+        "schema": OUTCOME_EPISODE_SCHEMA,
+        "report_version": OUTCOME_REPORT_VERSION,
+        "episode_id": episode_id,
+        "replay_id": replay_id,
+        "scenario_index": scenario_index,
+        "scenario": scenario_name,
+        "head": head,
+        "candidate": candidate,
+        "candidate_name": candidate_name,
+        "status": status,
+        "ticks_observed": facts["ticks_executed"],
+        "ticks_to_completion": ticks_to_completion,
+        "truncated": status == "in_progress",
+        "decision": _decision_summary(head, mode, facts),
+        "metrics": {
+            "completion": status == "completed",
+            "collision_events": facts["safety"]["collision_events"],
+            "damage_amount": facts["safety"]["damage_amount"],
+            "death_events": facts["safety"]["death_events"],
+            "stuck_ticks": route["stuck_ticks"],
+            "recovery_events": route["recovery_events"],
+            "safety_overrides": facts["safety"]["safety_overrides"],
+            "repeated_loops": route["loop_revisits"],
+            "behavioral_diversity": diversity,
+            "route_distance": route_distance,
+            "route_progress": route_progress,
+            "route_efficiency": route["efficiency"],
+            "station_need_served": station_need_served,
+            "cargo_identity_unchanged": cargo["identity_unchanged"],
+            "provenance_preserved": cargo["lineage_integrity_preserved"],
+            "start_manifest_count": cargo["start"]["manifest_count"],
+            "end_manifest_count": cargo["end"]["manifest_count"],
+            "missing_receipt_chains": cargo["end"]["missing_receipt_chains"],
+            "invalid_receipt_chains": cargo["end"]["invalid_receipt_chains"],
+            "receipt_manifest_parity": cargo["end"]["receipt_manifest_parity"],
+        },
+        "feature_contract": facts["feature_contracts"][head],
+    }
+
+
+def build_episode_report(
+    *,
+    decision_mode: str,
+    corpus: str,
+    corpus_version: int,
+    generator_version: int,
+    scenario_entries: Iterable[tuple[dict[str, Any], Path]],
+) -> dict[str, Any]:
+    if decision_mode not in DECISION_MODES:
+        raise OutcomeReportError(f"unsupported decision mode: {decision_mode!r}")
+    _require_str(corpus, "corpus")
+    _require_int(corpus_version, "corpus_version", minimum=1)
+    _require_int(generator_version, "generator_version", minimum=1)
+
+    episodes: list[dict[str, Any]] = []
+    replays: list[dict[str, Any]] = []
+    for entry, path in scenario_entries:
+        scenario_index = _require_int(
+            entry.get("index"),
+            "scenario.index",
+            minimum=0,
+        )
+        raw_args = _require_list(entry.get("args"), "scenario.args")
+        scenario_args = [
+            _require_str(value, f"scenario.args[{index}]")
+            for index, value in enumerate(raw_args)
+        ]
+        evaluation = _require_dict(entry.get("evaluation"), "scenario.evaluation")
+        scenario_name = _require_str(
+            evaluation.get("name"),
+            "scenario.evaluation.name",
+        )
+        replay_id = _stable_id(
+            "signal-ai-replay-v1",
+            {
+                "corpus": corpus,
+                "corpus_version": corpus_version,
+                "generator_version": generator_version,
+                "scenario_index": scenario_index,
+                "args": scenario_args,
+            },
+        )
+        rows = _load_jsonl(path)
+        replays.append(
+            {
+                "replay_id": replay_id,
+                "scenario_index": scenario_index,
+                "scenario": scenario_name,
+                "args": scenario_args,
+                "candidate_count": len(rows),
+            }
+        )
+        for row in rows:
+            for head in HEADS:
+                episodes.append(
+                    _episode_from_row(
+                        mode=decision_mode,
+                        corpus=corpus,
+                        corpus_version=corpus_version,
+                        generator_version=generator_version,
+                        scenario_index=scenario_index,
+                        scenario_name=scenario_name,
+                        scenario_args=scenario_args,
+                        row=row,
+                        head=head,
+                    )
+                )
+
+    if not episodes:
+        raise OutcomeReportError("outcome report has no episodes")
+    episodes.sort(
+        key=lambda episode: (
+            episode["scenario_index"],
+            episode["candidate"],
+            HEADS.index(episode["head"]),
+        )
+    )
+    replays.sort(key=lambda replay: replay["scenario_index"])
+    report_core = {
+        "schema": OUTCOME_REPORT_SCHEMA,
+        "report_version": OUTCOME_REPORT_VERSION,
+        "decision_mode": decision_mode,
+        "corpus": corpus,
+        "corpus_version": corpus_version,
+        "generator_version": generator_version,
+        "replays": replays,
+        "episodes": episodes,
+    }
+    report_core["report_id"] = _stable_id(
+        "signal-ai-episode-report-v1",
+        report_core,
+    )
+    validate_episode_report(report_core, expected_mode=decision_mode)
+    return report_core
+
+
+def validate_episode_report(
+    value: object,
+    *,
+    expected_mode: str | None = None,
+) -> dict[str, Any]:
+    report = _require_dict(value, "outcome report")
+    if report.get("schema") != OUTCOME_REPORT_SCHEMA:
+        raise OutcomeReportError(
+            f"unsupported outcome report schema: {report.get('schema')!r}"
+        )
+    if report.get("report_version") != OUTCOME_REPORT_VERSION:
+        raise OutcomeReportError(
+            f"unsupported outcome report version: {report.get('report_version')!r}"
+        )
+    mode = report.get("decision_mode")
+    if mode not in DECISION_MODES:
+        raise OutcomeReportError(f"unsupported outcome report mode: {mode!r}")
+    if expected_mode is not None and mode != expected_mode:
+        raise OutcomeReportError(
+            f"outcome report mode is {mode!r}; expected {expected_mode!r}"
+        )
+    _require_str(report.get("corpus"), "outcome report.corpus")
+    _require_int(report.get("corpus_version"), "outcome report.corpus_version", minimum=1)
+    _require_int(
+        report.get("generator_version"),
+        "outcome report.generator_version",
+        minimum=1,
+    )
+    report_id = _require_str(report.get("report_id"), "outcome report.report_id")
+    if len(report_id) != 64:
+        raise OutcomeReportError("outcome report.report_id must be sha256")
+
+    replays = _require_list(report.get("replays"), "outcome report.replays")
+    episodes = _require_list(report.get("episodes"), "outcome report.episodes")
+    if not replays or not episodes:
+        raise OutcomeReportError("outcome report must contain replays and episodes")
+    replay_ids: set[str] = set()
+    for replay_index, replay_value in enumerate(replays):
+        replay = _require_dict(replay_value, f"outcome report.replays[{replay_index}]")
+        replay_id = _require_str(
+            replay.get("replay_id"),
+            f"outcome report.replays[{replay_index}].replay_id",
+        )
+        if replay_id in replay_ids:
+            raise OutcomeReportError(f"duplicate replay_id: {replay_id}")
+        replay_ids.add(replay_id)
+
+    episode_ids: set[str] = set()
+    for episode_index, episode_value in enumerate(episodes):
+        label = f"outcome report.episodes[{episode_index}]"
+        episode = _require_dict(episode_value, label)
+        if episode.get("schema") != OUTCOME_EPISODE_SCHEMA:
+            raise OutcomeReportError(f"{label} has unsupported schema")
+        if episode.get("report_version") != OUTCOME_REPORT_VERSION:
+            raise OutcomeReportError(f"{label} has unsupported report version")
+        episode_id = _require_str(episode.get("episode_id"), f"{label}.episode_id")
+        if episode_id in episode_ids:
+            raise OutcomeReportError(f"duplicate episode_id: {episode_id}")
+        episode_ids.add(episode_id)
+        if episode.get("replay_id") not in replay_ids:
+            raise OutcomeReportError(f"{label} references an unknown replay_id")
+        if episode.get("head") not in HEADS:
+            raise OutcomeReportError(f"{label} has an unsupported head")
+        if episode.get("status") not in STATUSES:
+            raise OutcomeReportError(f"{label} has an unsupported status")
+        _require_bool(episode.get("truncated"), f"{label}.truncated")
+        status = episode["status"]
+        if episode["truncated"] != (status == "in_progress"):
+            raise OutcomeReportError(f"{label}.truncated disagrees with status")
+        ticks_to_completion = episode.get("ticks_to_completion")
+        if status == "completed":
+            if ticks_to_completion is None:
+                raise OutcomeReportError(
+                    f"{label}.ticks_to_completion is required when completed"
+                )
+            _optional_tick(ticks_to_completion, f"{label}.ticks_to_completion")
+        elif ticks_to_completion is not None:
+            raise OutcomeReportError(
+                f"{label}.ticks_to_completion must be null unless completed"
+            )
+        decision = _require_dict(episode.get("decision"), f"{label}.decision")
+        if decision.get("requested_mode") != mode:
+            raise OutcomeReportError(f"{label} requested mode does not match report")
+        metrics = _require_dict(episode.get("metrics"), f"{label}.metrics")
+        _require_bool(metrics.get("provenance_preserved"), f"{label}.metrics.provenance_preserved")
+        _require_int(
+            metrics.get("repeated_loops"),
+            f"{label}.metrics.repeated_loops",
+            minimum=0,
+        )
+        feature_contract = _require_dict(
+            episode.get("feature_contract"),
+            f"{label}.feature_contract",
+        )
+        expected_contract = FEATURE_CONTRACTS[episode["head"]]
+        if (
+            feature_contract.get("feature_set") != expected_contract[0]
+            or feature_contract.get("encoder_version") != expected_contract[1]
+        ):
+            raise OutcomeReportError(f"{label} feature contract mismatch")
+    return report
+
+
+def load_episode_report(
+    path: Path,
+    *,
+    expected_mode: str | None = None,
+) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise OutcomeReportError(f"cannot load outcome report {path}: {exc}") from exc
+    return validate_episode_report(value, expected_mode=expected_mode)
+
+
+def serialize_episode_report(report: dict[str, Any]) -> bytes:
+    validate_episode_report(report)
+    return (json.dumps(report, indent=2, sort_keys=True) + "\n").encode("utf-8")

--- a/scripts/analyze_ai_episode_outcomes.py
+++ b/scripts/analyze_ai_episode_outcomes.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Compare teacher, shadow, mixed, and active AI episode outcome bundles."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from ai_episode_outcomes import (
+    DECISION_MODES,
+    HEADS,
+    OUTCOME_REPORT_VERSION,
+    STATUSES,
+    OutcomeReportError,
+    load_episode_report,
+)
+from check_replay_bundles import BUNDLE_SCHEMA, load_bundle
+
+
+COMPARISON_SCHEMA = "signal.ai_episode_comparison.v1"
+COMPARISON_VERSION = 1
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare deterministic AI episode outcomes across the four "
+            "decision modes."
+        )
+    )
+    parser.add_argument(
+        "bundles",
+        nargs="+",
+        metavar="MODE=PATH",
+        help="one bundle for each of teacher, shadow, mixed, and active",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit the machine-readable comparison report",
+    )
+    return parser.parse_args()
+
+
+def parse_bundle_specs(specs: list[str]) -> dict[str, Path]:
+    bundles: dict[str, Path] = {}
+    for spec in specs:
+        if "=" not in spec:
+            raise OutcomeReportError(f"bundle must use MODE=PATH syntax: {spec!r}")
+        mode, raw_path = spec.split("=", 1)
+        if mode not in DECISION_MODES:
+            raise OutcomeReportError(f"unsupported decision mode: {mode!r}")
+        if mode in bundles:
+            raise OutcomeReportError(f"duplicate bundle for mode: {mode}")
+        if not raw_path:
+            raise OutcomeReportError(f"bundle path is empty for mode: {mode}")
+        bundles[mode] = Path(raw_path).resolve()
+    missing = [mode for mode in DECISION_MODES if mode not in bundles]
+    if missing:
+        raise OutcomeReportError(
+            f"missing decision-mode bundles: {', '.join(missing)}"
+        )
+    return bundles
+
+
+def load_mode_bundle(
+    mode: str,
+    path: Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    loaded = load_bundle(path)
+    if loaded is None:
+        raise OutcomeReportError(f"invalid replay bundle for {mode}: {path}")
+    manifest, _outputs = loaded
+    if manifest.get("schema") != BUNDLE_SCHEMA:
+        raise OutcomeReportError(f"{mode} bundle has unsupported schema")
+    if manifest.get("decision_mode") != mode:
+        raise OutcomeReportError(
+            f"{mode} bundle declares {manifest.get('decision_mode')!r}"
+        )
+    outcome_entry = manifest["outcomes"]
+    report = load_episode_report(
+        path / outcome_entry["file"],
+        expected_mode=mode,
+    )
+    return manifest, report
+
+
+def _episode_identity(episode: dict[str, Any]) -> tuple[object, ...]:
+    return (
+        episode["episode_id"],
+        episode["replay_id"],
+        episode["scenario_index"],
+        episode["scenario"],
+        episode["head"],
+        episode["candidate"],
+        episode["candidate_name"],
+    )
+
+
+def _round(value: float) -> float:
+    return round(value, 6)
+
+
+def summarize_head(episodes: list[dict[str, Any]]) -> dict[str, Any]:
+    status_counts = {status: 0 for status in STATUSES}
+    route_efficiencies: list[float] = []
+    ticks_to_completion: list[int] = []
+    totals = {
+        "collision_events": 0,
+        "death_events": 0,
+        "stuck_ticks": 0,
+        "recovery_events": 0,
+        "safety_overrides": 0,
+        "repeated_loops": 0,
+        "station_need_served": 0,
+        "behavioral_diversity": 0,
+        "provenance_failures": 0,
+        "invalid_receipt_chains": 0,
+        "missing_receipt_chains": 0,
+    }
+    for episode in episodes:
+        status_counts[episode["status"]] += 1
+        if episode["status"] == "not_attempted":
+            continue
+        metrics = episode["metrics"]
+        route_efficiencies.append(float(metrics["route_efficiency"]))
+        if episode["ticks_to_completion"] is not None:
+            ticks_to_completion.append(int(episode["ticks_to_completion"]))
+        for field in totals:
+            if field == "provenance_failures":
+                totals[field] += int(not metrics["provenance_preserved"])
+            else:
+                totals[field] += int(metrics[field])
+
+    attempted = len(episodes) - status_counts["not_attempted"]
+    completed = status_counts["completed"]
+    completion_rate = completed / attempted if attempted else None
+    return {
+        "episodes": len(episodes),
+        "attempted": attempted,
+        "status": status_counts,
+        "completion_rate": (
+            _round(completion_rate) if completion_rate is not None else None
+        ),
+        "average_route_efficiency": (
+            _round(sum(route_efficiencies) / len(route_efficiencies))
+            if route_efficiencies
+            else None
+        ),
+        "average_ticks_to_completion": (
+            _round(sum(ticks_to_completion) / len(ticks_to_completion))
+            if ticks_to_completion
+            else None
+        ),
+        **totals,
+    }
+
+
+def build_comparison(
+    bundles: dict[str, Path],
+    manifests: dict[str, dict[str, Any]],
+    reports: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    baseline_mode = DECISION_MODES[0]
+    baseline_manifest = manifests[baseline_mode]
+    baseline_report = reports[baseline_mode]
+    metadata_fields = ("corpus", "corpus_version", "generator_version")
+    for mode in DECISION_MODES[1:]:
+        for field in metadata_fields:
+            if reports[mode].get(field) != baseline_report.get(field):
+                raise OutcomeReportError(
+                    f"{mode} report {field} differs from {baseline_mode}"
+                )
+
+    baseline_episodes = {
+        episode["episode_id"]: episode
+        for episode in baseline_report["episodes"]
+    }
+    baseline_ids = set(baseline_episodes)
+    for mode in DECISION_MODES[1:]:
+        candidate_episodes = {
+            episode["episode_id"]: episode
+            for episode in reports[mode]["episodes"]
+        }
+        candidate_ids = set(candidate_episodes)
+        if candidate_ids != baseline_ids:
+            missing = len(baseline_ids - candidate_ids)
+            extra = len(candidate_ids - baseline_ids)
+            raise OutcomeReportError(
+                f"{mode} episode IDs differ: missing={missing} extra={extra}"
+            )
+        for episode_id, baseline_episode in baseline_episodes.items():
+            if (
+                _episode_identity(candidate_episodes[episode_id])
+                != _episode_identity(baseline_episode)
+            ):
+                raise OutcomeReportError(
+                    f"{mode} semantic identity differs for episode {episode_id}"
+                )
+
+    modes: dict[str, Any] = {}
+    for mode in DECISION_MODES:
+        episodes = reports[mode]["episodes"]
+        modes[mode] = {
+            "bundle": str(bundles[mode]),
+            "report_id": reports[mode]["report_id"],
+            "heads": {
+                head: summarize_head(
+                    [episode for episode in episodes if episode["head"] == head]
+                )
+                for head in HEADS
+            },
+        }
+
+    core = {
+        "schema": COMPARISON_SCHEMA,
+        "comparison_version": COMPARISON_VERSION,
+        "outcome_report_version": OUTCOME_REPORT_VERSION,
+        "corpus": baseline_report["corpus"],
+        "corpus_version": baseline_report["corpus_version"],
+        "generator_version": baseline_report["generator_version"],
+        "scenario_set": baseline_manifest["scenario_set"],
+        "episode_count_per_mode": len(baseline_ids),
+        "shared_episode_ids": True,
+        "modes": modes,
+    }
+    digest = hashlib.sha256(
+        json.dumps(core, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    core["comparison_id"] = digest
+    return core
+
+
+def print_text(comparison: dict[str, Any]) -> None:
+    print(
+        f"schema={comparison['schema']} "
+        f"corpus={comparison['corpus']} "
+        f"episodes_per_mode={comparison['episode_count_per_mode']} "
+        f"shared_ids={str(comparison['shared_episode_ids']).lower()}"
+    )
+    for mode in DECISION_MODES:
+        for head in HEADS:
+            summary = comparison["modes"][mode]["heads"][head]
+            status = summary["status"]
+            print(
+                f"{mode}/{head}: attempted={summary['attempted']} "
+                f"completed={status['completed']} failed={status['failed']} "
+                f"in_progress={status['in_progress']} "
+                f"not_attempted={status['not_attempted']} "
+                f"collisions={summary['collision_events']} "
+                f"stuck={summary['stuck_ticks']} "
+                f"provenance_failures={summary['provenance_failures']} "
+                f"route_efficiency={summary['average_route_efficiency']}"
+            )
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        bundle_paths = parse_bundle_specs(args.bundles)
+        manifests: dict[str, dict[str, Any]] = {}
+        reports: dict[str, dict[str, Any]] = {}
+        for mode in DECISION_MODES:
+            manifests[mode], reports[mode] = load_mode_bundle(
+                mode,
+                bundle_paths[mode],
+            )
+        comparison = build_comparison(bundle_paths, manifests, reports)
+    except OutcomeReportError as exc:
+        print(f"AI episode outcome comparison failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(comparison, indent=2, sort_keys=True))
+    else:
+        print_text(comparison)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_replay_bundle.py
+++ b/scripts/build_replay_bundle.py
@@ -6,9 +6,17 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import sys
 from pathlib import Path
 
+from ai_episode_outcomes import (
+    DECISION_MODES,
+    OUTCOME_CORPUS_NAME,
+    OutcomeReportError,
+    build_episode_report,
+    serialize_episode_report,
+)
 from ai_eval_corpus import (
     CORPUS_NAME,
     CORPUS_VERSION,
@@ -25,7 +33,7 @@ from check_replay_repeatability import (
 )
 
 
-BUNDLE_SCHEMA = "signal.replay_bundle.v2"
+BUNDLE_SCHEMA = "signal.replay_bundle.v3"
 
 
 def parse_args() -> argparse.Namespace:
@@ -37,7 +45,20 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--scenario-set",
         default="fast",
-        choices=("fast", "long", "all", "ai-eval-fast", "ai-eval-long"),
+        choices=(
+            "fast",
+            "long",
+            "all",
+            "ai-eval-fast",
+            "ai-eval-long",
+            "ai-outcomes-fast",
+        ),
+    )
+    parser.add_argument(
+        "--decision-mode",
+        default="teacher",
+        choices=DECISION_MODES,
+        help="label and configure the decision policy used for outcome reports",
     )
     return parser.parse_args()
 
@@ -64,11 +85,16 @@ def main() -> int:
     output_dir.mkdir(parents=True, exist_ok=True)
     manifest_scenarios: list[dict[str, object]] = []
     evaluation_outputs: dict[str, Path] = {}
+    run_env = os.environ.copy()
+    run_env["SIGNAL_NPC_WORKER_BRAIN_MODE"] = (
+        "shadow" if args.decision_mode in ("teacher", "shadow")
+        else args.decision_mode
+    )
 
     for index, scenario_args in enumerate(scenarios):
         filename = f"scenario-{index:03d}.jsonl"
         output = output_dir / filename
-        if not run_once(binary, scenario_args, output):
+        if not run_once(binary, scenario_args, output, env=run_env):
             print(
                 f"signal_replay scenario {index} failed while building bundle",
                 file=sys.stderr,
@@ -130,14 +156,42 @@ def main() -> int:
         )
         return 1
 
+    if args.scenario_set == "ai-outcomes-fast":
+        corpus = OUTCOME_CORPUS_NAME
+    elif args.scenario_set.startswith("ai-eval-"):
+        corpus = CORPUS_NAME
+    else:
+        corpus = "signal-replay-default"
+    try:
+        outcome_report = build_episode_report(
+            decision_mode=args.decision_mode,
+            corpus=corpus,
+            corpus_version=CORPUS_VERSION,
+            generator_version=GENERATOR_VERSION,
+            scenario_entries=(
+                (entry, output_dir / str(entry["file"]))
+                for entry in manifest_scenarios
+            ),
+        )
+        outcome_bytes = serialize_episode_report(outcome_report)
+    except OutcomeReportError as exc:
+        print(f"AI episode outcome report failed: {exc}", file=sys.stderr)
+        return 1
+    outcome_filename = "outcomes.json"
+    (output_dir / outcome_filename).write_bytes(outcome_bytes)
+
     manifest = {
-        "corpus": (
-            CORPUS_NAME
-            if args.scenario_set.startswith("ai-eval-")
-            else "signal-replay-default"
-        ),
+        "corpus": corpus,
         "corpus_version": CORPUS_VERSION,
+        "decision_mode": args.decision_mode,
         "generator_version": GENERATOR_VERSION,
+        "outcomes": {
+            "file": outcome_filename,
+            "report_version": outcome_report["report_version"],
+            "schema": outcome_report["schema"],
+            "sha256": hashlib.sha256(outcome_bytes).hexdigest(),
+            "size": len(outcome_bytes),
+        },
         "scenario_set": args.scenario_set,
         "scenarios": manifest_scenarios,
         "schema": BUNDLE_SCHEMA,

--- a/scripts/check_replay_bundles.py
+++ b/scripts/check_replay_bundles.py
@@ -9,11 +9,18 @@ import json
 import sys
 from pathlib import Path
 
+from ai_episode_outcomes import (
+    DECISION_MODES,
+    OUTCOME_REPORT_SCHEMA,
+    OUTCOME_REPORT_VERSION,
+    OutcomeReportError,
+    load_episode_report,
+)
 from ai_eval_corpus import CORPUS_VERSION, GENERATOR_VERSION
 from check_replay_cross_build import first_diff
 
 
-BUNDLE_SCHEMA = "signal.replay_bundle.v2"
+BUNDLE_SCHEMA = "signal.replay_bundle.v3"
 
 
 def parse_args() -> argparse.Namespace:
@@ -43,6 +50,13 @@ def load_bundle(path: Path) -> tuple[dict[str, object], dict[str, bytes]] | None
     ):
         print(
             f"replay bundle version mismatch in {manifest_path}",
+            file=sys.stderr,
+        )
+        return None
+    decision_mode = manifest.get("decision_mode")
+    if decision_mode not in DECISION_MODES:
+        print(
+            f"replay bundle decision mode missing in {manifest_path}",
             file=sys.stderr,
         )
         return None
@@ -91,6 +105,48 @@ def load_bundle(path: Path) -> tuple[dict[str, object], dict[str, bytes]] | None
             print(f"replay scenario digest mismatch: {output_path}", file=sys.stderr)
             return None
         outputs[filename] = output_bytes
+
+    outcome_entry = manifest.get("outcomes")
+    if not isinstance(outcome_entry, dict):
+        print(f"replay bundle outcomes missing in {manifest_path}", file=sys.stderr)
+        return None
+    outcome_filename = outcome_entry.get("file")
+    if (
+        not isinstance(outcome_filename, str)
+        or Path(outcome_filename).name != outcome_filename
+        or not outcome_filename.endswith(".json")
+    ):
+        print(
+            f"unsafe outcome filename in {manifest_path}: {outcome_filename}",
+            file=sys.stderr,
+        )
+        return None
+    if (
+        outcome_entry.get("schema") != OUTCOME_REPORT_SCHEMA
+        or outcome_entry.get("report_version") != OUTCOME_REPORT_VERSION
+    ):
+        print(
+            f"replay bundle outcome version mismatch in {manifest_path}",
+            file=sys.stderr,
+        )
+        return None
+    outcome_path = path / outcome_filename
+    if not outcome_path.is_file():
+        print(f"replay outcome report not found: {outcome_path}", file=sys.stderr)
+        return None
+    outcome_bytes = outcome_path.read_bytes()
+    if (
+        hashlib.sha256(outcome_bytes).hexdigest() != outcome_entry.get("sha256")
+        or len(outcome_bytes) != outcome_entry.get("size")
+    ):
+        print(f"replay outcome digest mismatch: {outcome_path}", file=sys.stderr)
+        return None
+    try:
+        load_episode_report(outcome_path, expected_mode=decision_mode)
+    except OutcomeReportError as exc:
+        print(f"invalid replay outcome report {outcome_path}: {exc}", file=sys.stderr)
+        return None
+    outputs[outcome_filename] = outcome_bytes
     return manifest, outputs
 
 
@@ -133,7 +189,9 @@ def main() -> int:
                 )
             return 1
 
-    scenario_count = len(baseline_outputs)
+    scenario_count = len(
+        [filename for filename in baseline_outputs if filename.endswith(".jsonl")]
+    )
     print(
         f"signal replay bundle check passed "
         f"({len(loaded)} runners, {scenario_count} scenarios)"

--- a/scripts/check_replay_cross_build.py
+++ b/scripts/check_replay_cross_build.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 import subprocess
 import sys
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 
+from ai_episode_outcomes import validate_outcome_output
 from ai_eval_corpus import (
     evaluation_world,
     validate_evaluation_output,
@@ -29,7 +31,13 @@ def runner_for(binary: Path) -> list[str]:
     return [str(binary)]
 
 
-def run_once(binary: Path, args: tuple[str, ...], out: Path) -> bool:
+def run_once(
+    binary: Path,
+    args: tuple[str, ...],
+    out: Path,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> bool:
     cmd = [*runner_for(binary), *args, "--out", str(out)]
     result = subprocess.run(
         cmd,
@@ -37,6 +45,7 @@ def run_once(binary: Path, args: tuple[str, ...], out: Path) -> bool:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        env=env,
     )
     if result.returncode != 0 or not out.exists():
         print(
@@ -84,7 +93,8 @@ def main() -> int:
     if len(args) != 2:
         print(
             "usage: check_replay_cross_build.py LEFT_SIGNAL_REPLAY RIGHT_SIGNAL_REPLAY "
-            "[--scenario-set fast|long|all|ai-eval-fast|ai-eval-long]",
+            "[--scenario-set fast|long|all|ai-eval-fast|ai-eval-long|"
+            "ai-outcomes-fast]",
             file=sys.stderr,
         )
         return 2
@@ -138,6 +148,14 @@ def main() -> int:
                 return 1
             if not left_bytes:
                 print(f"signal_replay scenario {i} produced no output", file=sys.stderr)
+                return 1
+            outcome_failure = validate_outcome_output(left)
+            if outcome_failure is not None:
+                print(
+                    f"signal_replay scenario {i} failed outcome facts: "
+                    f"{outcome_failure}",
+                    file=sys.stderr,
+                )
                 return 1
             evaluation_failure = validate_evaluation_output(left, scenario_args)
             if evaluation_failure is not None:

--- a/scripts/check_replay_repeatability.py
+++ b/scripts/check_replay_repeatability.py
@@ -9,6 +9,10 @@ import tempfile
 import json
 from pathlib import Path
 
+from ai_episode_outcomes import (
+    AI_OUTCOME_FAST_SCENARIOS,
+    validate_outcome_output,
+)
 from ai_eval_corpus import (
     AI_EVAL_FAST_SCENARIOS,
     AI_EVAL_LONG_SCENARIOS,
@@ -226,6 +230,7 @@ SCENARIO_SETS = {
     "all": FAST_SCENARIOS + LONG_SCENARIOS,
     "ai-eval-fast": AI_EVAL_FAST_SCENARIOS,
     "ai-eval-long": AI_EVAL_LONG_SCENARIOS,
+    "ai-outcomes-fast": AI_OUTCOME_FAST_SCENARIOS,
 }
 
 
@@ -417,7 +422,8 @@ def main() -> int:
     if len(args) > 1:
         print(
             "usage: check_replay_repeatability.py [SIGNAL_REPLAY] "
-            "[--scenario-set fast|long|all|ai-eval-fast|ai-eval-long]",
+            "[--scenario-set fast|long|all|ai-eval-fast|ai-eval-long|"
+            "ai-outcomes-fast]",
             file=sys.stderr,
         )
         return 2
@@ -451,6 +457,14 @@ def main() -> int:
                 return 1
             if not left_bytes:
                 print(f"signal_replay scenario {i} produced no output", file=sys.stderr)
+                return 1
+            outcome_failure = validate_outcome_output(left)
+            if outcome_failure is not None:
+                print(
+                    f"signal_replay scenario {i} failed outcome facts: "
+                    f"{outcome_failure}",
+                    file=sys.stderr,
+                )
                 return 1
             evaluation_failure = validate_evaluation_output(left, scenario_args)
             if evaluation_failure is not None:

--- a/scripts/test_ai_episode_outcomes.py
+++ b/scripts/test_ai_episode_outcomes.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Unit tests for deterministic AI episode outcome report contracts."""
+
+from __future__ import annotations
+
+import copy
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from ai_episode_outcomes import (
+    FEATURE_CONTRACTS,
+    OUTCOME_FACTS_SCHEMA,
+    OUTCOME_REPORT_VERSION,
+    OutcomeReportError,
+    build_episode_report,
+    validate_episode_report,
+    validate_outcome_facts,
+)
+
+
+def lineage() -> dict[str, object]:
+    return {
+        "manifest_count": 0,
+        "receipt_count": 0,
+        "missing_receipt_chains": 0,
+        "invalid_receipt_chains": 0,
+        "receipt_manifest_parity": True,
+        "identity_hash": "12" * 32,
+    }
+
+
+def facts() -> dict[str, object]:
+    return {
+        "schema": OUTCOME_FACTS_SCHEMA,
+        "report_version": OUTCOME_REPORT_VERSION,
+        "feature_contracts": {
+            head: {
+                "feature_set": contract[0],
+                "encoder_version": contract[1],
+                "model_loaded": head == "flight",
+            }
+            for head, contract in FEATURE_CONTRACTS.items()
+        },
+        "ticks_executed": 24,
+        "goal_completion_tick": None,
+        "contract_completion_tick": None,
+        "worker_completion_tick": None,
+        "route": {
+            "start_distance": 1000.0,
+            "end_distance": 800.0,
+            "distance_traveled": 250.0,
+            "progress": 200.0,
+            "efficiency": 0.8,
+            "stuck_ticks": 0,
+            "recovery_events": 0,
+            "loop_revisits": 0,
+        },
+        "worker_route": {
+            "assignment_ticks": 0,
+            "motion_ticks": 0,
+            "route_support_ticks": 0,
+            "useful_outcome_ticks": 0,
+            "efficiency": 0.0,
+            "stuck_ticks": 0,
+            "recovery_events": 0,
+            "loop_revisits": 0,
+        },
+        "safety": {
+            "collision_events": 0,
+            "damage_amount": 0.0,
+            "death_events": 0,
+            "safety_overrides": 0,
+            "order_rejected_events": 0,
+        },
+        "decisions": {
+            "flight": 1,
+            "contract": 0,
+            "contract_teacher_fallbacks": 0,
+            "worker": 0,
+            "worker_teacher_fallbacks": 0,
+        },
+        "contracts": {
+            "start_active": 0,
+            "end_active": 0,
+            "completed": 0,
+        },
+        "station_need": {
+            "contract_completions": 0,
+            "sell_events": 0,
+            "sell_value": 0,
+            "delivery_cleared": 0,
+            "repair_events": 0,
+            "scaffolds_placed": 0,
+        },
+        "cargo": {
+            "start": lineage(),
+            "end": lineage(),
+            "identity_unchanged": True,
+            "lineage_integrity_preserved": True,
+        },
+    }
+
+
+def replay_row(
+    candidate: int,
+    outcome_facts: dict[str, object],
+    *,
+    ai: dict[str, object] | None = None,
+) -> dict[str, object]:
+    row: dict[str, object] = {
+        "schema": "signal.replay_counterfactual.v1",
+        "candidate": candidate,
+        "candidate_name": ("NONE", "W", "A", "D")[candidate],
+        "outcome_facts": outcome_facts,
+    }
+    if ai is not None:
+        row["ai"] = ai
+    return row
+
+
+def scenario_entry() -> dict[str, object]:
+    return {
+        "index": 0,
+        "args": ["--seed", "651", "--candidates", "NONE,W,A,D"],
+        "evaluation": {"name": "seeded-only"},
+        "file": "scenario-000.jsonl",
+    }
+
+
+class EpisodeOutcomeTests(unittest.TestCase):
+    def build(
+        self,
+        rows: list[dict[str, object]],
+        *,
+        mode: str = "teacher",
+    ) -> dict[str, object]:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scenario-000.jsonl"
+            path.write_text(
+                "".join(json.dumps(row) + "\n" for row in rows),
+                encoding="utf-8",
+            )
+            return build_episode_report(
+                decision_mode=mode,
+                corpus="signal-ai-outcomes",
+                corpus_version=1,
+                generator_version=1,
+                scenario_entries=[(scenario_entry(), path)],
+            )
+
+    def test_statuses_distinguish_completion_failure_and_truncation(self) -> None:
+        completed = facts()
+        completed["goal_completion_tick"] = 7
+        failed = facts()
+        failed["safety"]["death_events"] = 1
+        contract = facts()
+        contract["decisions"]["contract"] = 1
+        contract["decisions"]["contract_teacher_fallbacks"] = 1
+        contract["contracts"]["completed"] = 1
+        contract["contract_completion_tick"] = 11
+        worker = facts()
+        report = self.build(
+            [
+                replay_row(0, completed),
+                replay_row(1, failed),
+                replay_row(2, contract),
+                replay_row(
+                    3,
+                    worker,
+                    ai={"worker_assignment_ticks": 4},
+                ),
+            ]
+        )
+        by_key = {
+            (episode["candidate"], episode["head"]): episode
+            for episode in report["episodes"]
+        }
+        self.assertEqual(by_key[(0, "flight")]["status"], "completed")
+        self.assertEqual(by_key[(0, "flight")]["ticks_to_completion"], 7)
+        self.assertEqual(by_key[(1, "flight")]["status"], "failed")
+        self.assertEqual(by_key[(2, "contract")]["status"], "completed")
+        self.assertEqual(by_key[(3, "worker")]["status"], "in_progress")
+        self.assertTrue(by_key[(3, "worker")]["truncated"])
+        self.assertEqual(by_key[(0, "worker")]["status"], "not_attempted")
+
+    def test_episode_ids_are_mode_invariant(self) -> None:
+        rows = [replay_row(0, facts()), replay_row(1, facts())]
+        teacher = self.build(rows, mode="teacher")
+        active = self.build(rows, mode="active")
+        self.assertEqual(
+            {episode["episode_id"] for episode in teacher["episodes"]},
+            {episode["episode_id"] for episode in active["episodes"]},
+        )
+        self.assertNotEqual(teacher["report_id"], active["report_id"])
+
+    def test_provenance_failure_is_preserved_in_metrics(self) -> None:
+        broken = facts()
+        broken["cargo"]["end"]["manifest_count"] = 1
+        broken["cargo"]["end"]["receipt_count"] = 1
+        broken["cargo"]["end"]["invalid_receipt_chains"] = 1
+        broken["cargo"]["end"]["identity_hash"] = "34" * 32
+        broken["cargo"]["identity_unchanged"] = False
+        broken["cargo"]["lineage_integrity_preserved"] = False
+        report = self.build([replay_row(0, broken)])
+        for episode in report["episodes"]:
+            self.assertFalse(episode["metrics"]["provenance_preserved"])
+            self.assertEqual(episode["metrics"]["invalid_receipt_chains"], 1)
+
+    def test_bounded_route_counter_change_fails_closed(self) -> None:
+        unbounded = facts()
+        unbounded["worker_route"]["loop_revisits"] = 65536
+        with self.assertRaisesRegex(OutcomeReportError, "must be <= 65535"):
+            validate_outcome_facts(unbounded)
+
+    def test_inconsistent_lineage_claim_fails_closed(self) -> None:
+        inconsistent = facts()
+        inconsistent["cargo"]["end"]["manifest_count"] = 1
+        inconsistent["cargo"]["end"]["receipt_count"] = 1
+        inconsistent["cargo"]["end"]["missing_receipt_chains"] = 1
+        with self.assertRaisesRegex(
+            OutcomeReportError,
+            "lineage_integrity_preserved is inconsistent",
+        ):
+            validate_outcome_facts(inconsistent)
+
+    def test_outcome_facts_schema_change_fails_closed(self) -> None:
+        stale = facts()
+        stale["schema"] = "signal.ai_outcome_facts.v0"
+        with self.assertRaisesRegex(OutcomeReportError, "unsupported outcome facts"):
+            validate_outcome_facts(stale)
+
+    def test_report_version_change_fails_closed(self) -> None:
+        report = self.build([replay_row(0, facts())])
+        stale = copy.deepcopy(report)
+        stale["report_version"] = OUTCOME_REPORT_VERSION + 1
+        with self.assertRaisesRegex(OutcomeReportError, "unsupported outcome report"):
+            validate_episode_report(stale)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/signal_replay.c
+++ b/tools/signal_replay.c
@@ -9,6 +9,7 @@
  */
 #include <errno.h>
 #include <inttypes.h>
+#include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -42,6 +43,7 @@
 #include "sim_ai.h"
 #include "sim_asteroid.h"
 #include "sim_construction.h"
+#include "signal_intelligence.h"
 #include "sim_nav.h"
 #include "sim_physics.h"
 #include "station_authority.h"
@@ -50,6 +52,7 @@
 
 #define SR_SCHEMA "signal.replay_counterfactual.v1"
 #define SR_AI_EVAL_SCHEMA "signal.ai_eval_world.v1"
+#define SR_OUTCOME_FACTS_SCHEMA "signal.ai_outcome_facts.v1"
 #define SR_AI_EVAL_CORPUS_VERSION 1u
 #define SR_AI_EVAL_GENERATOR_VERSION 1u
 #define SR_PUBLIC_STATE_HASH_SCHEMA "signal.replay.public_state_hash"
@@ -59,10 +62,15 @@
 #define SR_PUBLIC_EVENT_HASH_VERSION 3u
 #define SR_PUBLIC_EVENT_HASH_DOMAIN \
     "signal-replay-events-v3-public-actor"
+#define SR_OUTCOME_REPORT_VERSION 1u
 #define SR_ACTION_COUNT 9
 #define SR_MAX_PREFIX 4096
 #define SR_MAX_HORIZON_TICKS 120000
 #define SR_EVAL_MAX_OUTPOSTS 8
+#define SR_ROUTE_CELL_CAP 256
+#define SR_ROUTE_CELL_SIZE 256.0f
+#define SR_STUCK_TICK_THRESHOLD 120
+#define SR_GOAL_COMPLETION_RADIUS 250.0f
 
 typedef enum {
     SR_PROVENANCE_SCRIPT_NONE = 0,
@@ -104,6 +112,16 @@ typedef struct {
 } sr_action_def_t;
 
 typedef struct {
+    int x;
+    int y;
+} sr_route_cell_t;
+
+typedef struct {
+    int npc_slot;
+    sr_route_cell_t cell;
+} sr_worker_route_visit_t;
+
+typedef struct {
     uint32_t seed;
     int station;
     bool spawn_set;
@@ -139,6 +157,12 @@ typedef struct {
     int fracture_events;
     int outpost_placed_events;
     int scaffold_ready_events;
+    int contract_complete_events;
+    int order_rejected_events;
+    uint32_t first_contract_complete_tick;
+    bool first_contract_complete_tick_set;
+    uint32_t first_repair_tick;
+    bool first_repair_tick_set;
     int pickup_fragments;
     float pickup_ore;
     float damage_amount;
@@ -166,6 +190,11 @@ typedef struct {
     int worker_scaffold_motion_ticks;
     int worker_delivery_shipment_ticks;
     int worker_useful_outcome_ticks;
+    int first_worker_completion_tick;
+    int worker_stuck_ticks;
+    int worker_recovery_events;
+    int worker_loop_revisits;
+    bool worker_stuck_latched;
 } sr_ai_branch_summary_t;
 
 typedef struct {
@@ -288,6 +317,15 @@ typedef struct {
 } sr_receipt_trust_eval_t;
 
 typedef struct {
+    int manifest_count;
+    int receipt_count;
+    int missing_receipt_chains;
+    int invalid_receipt_chains;
+    bool receipt_manifest_parity;
+    uint8_t identity_hash[32];
+} sr_lineage_summary_t;
+
+typedef struct {
     bool ok;
     int candidate;
     int prefix_ticks;
@@ -311,6 +349,24 @@ typedef struct {
     float end_angle;
     bool end_docked;
     int end_current_station;
+    int ticks_executed;
+    int goal_completion_tick;
+    int contract_completion_tick;
+    int repair_completion_tick;
+    float route_start_dist;
+    float travel_distance;
+    float route_efficiency;
+    int stuck_ticks;
+    int recovery_events;
+    int loop_revisits;
+    int start_active_contracts;
+    int end_active_contracts;
+    uint64_t contract_decisions;
+    uint64_t contract_teacher_decisions;
+    uint64_t worker_decisions;
+    uint64_t worker_teacher_decisions;
+    sr_lineage_summary_t start_lineage;
+    sr_lineage_summary_t end_lineage;
     uint16_t end_manifest_count;
     sr_event_counts_t events;
     sr_ai_summary_t ai;
@@ -2181,6 +2237,136 @@ static void sr_hash_ship_cargo_identity(sha256_ctx_t *ctx, const ship_t *ship)
     sr_hash_receipts(ctx, &ship->manifest, ship_get_receipts_const(ship));
 }
 
+static void sr_collect_lineage_summary(const ship_t *ship,
+                                       sr_lineage_summary_t *summary)
+{
+    sha256_ctx_t ctx;
+    const ship_receipts_t *receipts;
+    if (!summary) return;
+    memset(summary, 0, sizeof(*summary));
+    sha256_init(&ctx);
+    sha256_update(&ctx, "signal-ai-outcome-lineage-v1",
+                  sizeof("signal-ai-outcome-lineage-v1") - 1u);
+    if (!ship) {
+        sha256_final(&ctx, summary->identity_hash);
+        return;
+    }
+
+    sr_hash_ship_cargo_identity(&ctx, ship);
+    sha256_final(&ctx, summary->identity_hash);
+
+    summary->manifest_count = ship->manifest.count;
+    receipts = ship_get_receipts_const(ship);
+    summary->receipt_count = receipts ? receipts->count : 0;
+    summary->receipt_manifest_parity =
+        summary->manifest_count == summary->receipt_count;
+    for (int i = 0; i < summary->manifest_count; i++) {
+        if (!receipts || !receipts->chains || i >= receipts->count ||
+            receipts->chains[i].len == 0) {
+            summary->missing_receipt_chains++;
+            continue;
+        }
+        const cargo_receipt_chain_t *chain = &receipts->chains[i];
+        if (cargo_receipt_chain_verify(
+                chain->links, chain->len, ship->manifest.units[i].pub) !=
+            CARGO_RECEIPT_OK) {
+            summary->invalid_receipt_chains++;
+        }
+    }
+}
+
+static int sr_active_contract_count(const world_t *w)
+{
+    int count = 0;
+    if (!w) return 0;
+    for (int i = 0; i < MAX_CONTRACTS; i++) {
+        if (w->contracts[i].active) count++;
+    }
+    return count;
+}
+
+static sr_route_cell_t sr_route_cell_for(vec2 pos)
+{
+    return (sr_route_cell_t){
+        .x = (int)floorf(pos.x / SR_ROUTE_CELL_SIZE),
+        .y = (int)floorf(pos.y / SR_ROUTE_CELL_SIZE),
+    };
+}
+
+static bool sr_route_cell_equal(sr_route_cell_t left, sr_route_cell_t right)
+{
+    return left.x == right.x && left.y == right.y;
+}
+
+static bool sr_route_observe_cell(sr_route_cell_t cells[SR_ROUTE_CELL_CAP],
+                                  int *cell_count,
+                                  sr_route_cell_t cell)
+{
+    if (!cells || !cell_count) return false;
+    for (int i = 0; i < *cell_count; i++) {
+        if (sr_route_cell_equal(cells[i], cell)) return true;
+    }
+    if (*cell_count < SR_ROUTE_CELL_CAP) {
+        cells[*cell_count] = cell;
+        (*cell_count)++;
+    }
+    return false;
+}
+
+static bool sr_npc_has_selected_assignment(const npc_ship_t *npc)
+{
+    if (!npc || !npc->active) return false;
+    int diag_count = npc->job_diag_count;
+    if (diag_count > 4) diag_count = 4;
+    for (int i = 0; i < diag_count; i++) {
+        if (npc->job_diag_selected[i] >= 200) return true;
+    }
+    return false;
+}
+
+static void sr_observe_worker_routes(
+    const world_t *w,
+    sr_worker_route_visit_t visits[SR_ROUTE_CELL_CAP],
+    int *visit_count,
+    sr_route_cell_t previous_cells[MAX_NPC_SHIPS],
+    bool previous_cell_set[MAX_NPC_SHIPS],
+    sr_ai_branch_summary_t *summary)
+{
+    if (!w || !visits || !visit_count || !previous_cells ||
+        !previous_cell_set || !summary) {
+        return;
+    }
+    for (int i = 0; i < MAX_NPC_SHIPS; i++) {
+        const npc_ship_t *npc = &w->npc_ships[i];
+        if (!sr_npc_has_selected_assignment(npc) || !npc->ship) continue;
+        sr_route_cell_t cell = sr_route_cell_for(npc->ship->pos);
+        if (previous_cell_set[i] &&
+            sr_route_cell_equal(previous_cells[i], cell)) {
+            continue;
+        }
+
+        bool revisited = false;
+        for (int j = 0; j < *visit_count; j++) {
+            if (visits[j].npc_slot == i &&
+                sr_route_cell_equal(visits[j].cell, cell)) {
+                revisited = true;
+                break;
+            }
+        }
+        if (revisited && summary->worker_loop_revisits < 65535) {
+            summary->worker_loop_revisits++;
+        } else if (!revisited && *visit_count < SR_ROUTE_CELL_CAP) {
+            visits[*visit_count] = (sr_worker_route_visit_t){
+                .npc_slot = i,
+                .cell = cell,
+            };
+            (*visit_count)++;
+        }
+        previous_cells[i] = cell;
+        previous_cell_set[i] = true;
+    }
+}
+
 static void sr_hash_station_ledger(sha256_ctx_t *ctx, const station_t *st)
 {
     int count = st->ledger_count;
@@ -2849,6 +3035,12 @@ static void sr_hash_event(sha256_ctx_t *ctx, const sim_event_t *ev)
         sr_hash_i32(ctx, ev->scaffold_ready.station);
         sr_hash_i32(ctx, ev->scaffold_ready.module_type);
         break;
+    case SIM_EVENT_CONTRACT_COMPLETE:
+        sr_hash_u8(ctx, (uint8_t)ev->contract_complete.action);
+        break;
+    case SIM_EVENT_ORDER_REJECTED:
+        sr_hash_u8(ctx, ev->order_rejected.reason);
+        break;
     case SIM_EVENT_MINING_TICK:
         break;
     case SIM_EVENT_REPAIR:
@@ -3066,6 +3258,10 @@ static void sr_accumulate_events(const world_t *w,
             counts->sell_bonus += ev->sell.bonus_cr;
             break;
         case SIM_EVENT_REPAIR:
+            if (!counts->first_repair_tick_set) {
+                counts->first_repair_tick = w->tick;
+                counts->first_repair_tick_set = true;
+            }
             counts->repair_events++;
             break;
         case SIM_EVENT_MINING_TICK:
@@ -3079,6 +3275,16 @@ static void sr_accumulate_events(const world_t *w,
             break;
         case SIM_EVENT_SCAFFOLD_READY:
             counts->scaffold_ready_events++;
+            break;
+        case SIM_EVENT_CONTRACT_COMPLETE:
+            if (!counts->first_contract_complete_tick_set) {
+                counts->first_contract_complete_tick = w->tick;
+                counts->first_contract_complete_tick_set = true;
+            }
+            counts->contract_complete_events++;
+            break;
+        case SIM_EVENT_ORDER_REJECTED:
+            counts->order_rejected_events++;
             break;
         default:
             break;
@@ -3663,7 +3869,8 @@ static void sr_count_selected_job(sr_ai_summary_t *out,
 }
 
 static void sr_ai_branch_observe(sr_ai_summary_t *out,
-                                 const sr_ai_summary_t *sample)
+                                 const sr_ai_summary_t *sample,
+                                 int relative_tick)
 {
     if (!out || !sample || !sample->enabled) return;
     sr_ai_branch_summary_t *b = &out->branch;
@@ -3737,6 +3944,18 @@ static void sr_ai_branch_observe(sr_ai_summary_t *out,
     if (scaffold_motion > 0) b->worker_scaffold_motion_ticks++;
     if (delivery_work > 0) b->worker_delivery_shipment_ticks++;
     if (useful > 0) b->worker_useful_outcome_ticks++;
+    if (assignments > 0 && motion == 0 && useful == 0) {
+        b->worker_stuck_ticks++;
+        b->worker_stuck_latched = true;
+    } else if (b->worker_stuck_latched && (motion > 0 || useful > 0)) {
+        b->worker_recovery_events++;
+        b->worker_stuck_latched = false;
+    }
+    if (b->first_worker_completion_tick < 0 &&
+        (sample->npc_delivery_shipments_cleared > 0 ||
+         sample->scaffolds_placed > 0)) {
+        b->first_worker_completion_tick = relative_tick;
+    }
 }
 
 static int sr_station_remote_known_contracts(
@@ -4289,12 +4508,32 @@ static bool sr_run_branch(const sr_config_t *config, int candidate, sr_result_t 
     sha256_ctx_t event_hash;
     sr_chain_fixture_t chain_fixture = {0};
     bool world_ready = false;
+    sr_route_cell_t route_cells[SR_ROUTE_CELL_CAP];
+    sr_route_cell_t previous_cell = {0};
+    sr_worker_route_visit_t worker_route_visits[SR_ROUTE_CELL_CAP];
+    sr_route_cell_t worker_previous_cells[MAX_NPC_SHIPS];
+    bool worker_previous_cell_set[MAX_NPC_SHIPS] = {false};
+    vec2 previous_pos = v2(0.0f, 0.0f);
+    float previous_dist = 0.0f;
+    int route_cell_count = 0;
+    int worker_route_visit_count = 0;
+    int consecutive_stuck_ticks = 0;
+    bool stuck_latched = false;
+    uint32_t episode_start_tick = 0;
+    uint64_t contract_decisions_start = 0;
+    uint64_t contract_teacher_start = 0;
+    uint64_t worker_decisions_start = 0;
+    uint64_t worker_teacher_start = 0;
     bool ok = false;
 
     memset(out, 0, sizeof(*out));
     out->candidate = candidate;
     out->prefix_ticks = config->prefix_count;
     out->horizon_ticks = config->horizon_ticks;
+    out->goal_completion_tick = -1;
+    out->contract_completion_tick = -1;
+    out->repair_completion_tick = -1;
+    out->ai.branch.first_worker_completion_tick = -1;
 
     w = (world_t *)calloc(1, sizeof(*w));
     if (!w) return false;
@@ -4336,6 +4575,17 @@ static bool sr_run_branch(const sr_config_t *config, int candidate, sr_result_t 
     out->start_hull = sp->ship->hull;
     out->start_cargo = ship_total_cargo(sp->ship);
     out->start_balance = sr_player_station_balance(w, sp);
+    out->start_active_contracts = sr_active_contract_count(w);
+    sr_collect_lineage_summary(sp->ship, &out->start_lineage);
+    episode_start_tick = w->tick;
+    contract_decisions_start =
+        signal_intelligence_contract_decision_count();
+    contract_teacher_start =
+        signal_intelligence_contract_teacher_decision_count();
+    worker_decisions_start =
+        signal_intelligence_npc_worker_decision_count();
+    worker_teacher_start =
+        signal_intelligence_npc_worker_teacher_decision_count();
     sr_state_hash(w, sp, out->prefix_state_hash);
     signal_authoritative_state_digest(w, out->prefix_state_root);
 
@@ -4345,25 +4595,80 @@ static bool sr_run_branch(const sr_config_t *config, int candidate, sr_result_t 
     if (!sr_run_provenance_script(config, w, sp, &out->events, &event_hash)) {
         goto cleanup;
     }
+    if (config->provenance_script == SR_PROVENANCE_SCRIPT_WORKER_TOW_HNN ||
+        config->provenance_script == SR_PROVENANCE_SCRIPT_WORKER_REPAIR_HNN) {
+        out->ai.branch.first_worker_completion_tick =
+            (int)(w->tick - episode_start_tick);
+    }
     if (config->hnn_trace) {
         sr_hnn_evaluate_branch(w, sp, goal, candidate,
                                hnn_mem_ptr, hnn_net_ptr, hnn_actions_ptr,
                                config->hnn_cleanup_steps,
                                &out->hnn);
     }
+    previous_pos = sp->ship->pos;
+    previous_dist = v2_len(v2_sub(goal, previous_pos));
+    out->route_start_dist = previous_dist;
+    previous_cell = sr_route_cell_for(previous_pos);
+    route_cells[route_cell_count++] = previous_cell;
+    if (previous_dist <= SR_GOAL_COMPLETION_RADIUS)
+        out->goal_completion_tick = 0;
     if (config->active_workers) {
         sr_ai_summary_t sample;
         sr_collect_ai_summary(w, &sample);
-        sr_ai_branch_observe(&out->ai, &sample);
+        sr_ai_branch_observe(
+            &out->ai, &sample, (int)(w->tick - episode_start_tick));
+        sr_observe_worker_routes(
+            w, worker_route_visits, &worker_route_visit_count,
+            worker_previous_cells, worker_previous_cell_set,
+            &out->ai.branch);
     }
     for (int i = 0; i < config->horizon_ticks; i++) {
         sr_apply_action(sp, candidate);
         world_sim_step(w, SIM_DT);
+        out->ticks_executed = i + 1;
         sr_accumulate_events(w, &out->events, &event_hash);
+        vec2 current_pos = sp->ship->pos;
+        float step_distance = v2_len(v2_sub(current_pos, previous_pos));
+        float current_dist = v2_len(v2_sub(goal, current_pos));
+        out->travel_distance += step_distance;
+        if (step_distance <= 0.05f &&
+            fabsf(current_dist - previous_dist) <= 0.05f) {
+            consecutive_stuck_ticks++;
+            if (consecutive_stuck_ticks >= SR_STUCK_TICK_THRESHOLD) {
+                out->stuck_ticks++;
+                stuck_latched = true;
+            }
+        } else {
+            if (stuck_latched && step_distance > 0.5f)
+                out->recovery_events++;
+            consecutive_stuck_ticks = 0;
+            stuck_latched = false;
+        }
+        sr_route_cell_t current_cell = sr_route_cell_for(current_pos);
+        if (!sr_route_cell_equal(current_cell, previous_cell)) {
+            if (sr_route_observe_cell(
+                    route_cells, &route_cell_count, current_cell) &&
+                out->loop_revisits < 65535) {
+                out->loop_revisits++;
+            }
+            previous_cell = current_cell;
+        }
+        if (out->goal_completion_tick < 0 &&
+            current_dist <= SR_GOAL_COMPLETION_RADIUS) {
+            out->goal_completion_tick = i + 1;
+        }
+        previous_pos = current_pos;
+        previous_dist = current_dist;
         if (config->active_workers) {
             sr_ai_summary_t sample;
             sr_collect_ai_summary(w, &sample);
-            sr_ai_branch_observe(&out->ai, &sample);
+            sr_ai_branch_observe(
+                &out->ai, &sample, (int)(w->tick - episode_start_tick));
+            sr_observe_worker_routes(
+                w, worker_route_visits, &worker_route_visit_count,
+                worker_previous_cells, worker_previous_cell_set,
+                &out->ai.branch);
         }
         if (out->events.death_events > 0 || sp->ship->hull <= 0.0f) {
             break;
@@ -4385,6 +4690,37 @@ static bool sr_run_branch(const sr_config_t *config, int candidate, sr_result_t 
     out->end_docked = sp->docked;
     out->end_current_station = sp->current_station;
     out->end_manifest_count = sp->ship->manifest.count;
+    out->end_active_contracts = sr_active_contract_count(w);
+    sr_collect_lineage_summary(sp->ship, &out->end_lineage);
+    out->contract_decisions =
+        signal_intelligence_contract_decision_count() -
+        contract_decisions_start;
+    out->contract_teacher_decisions =
+        signal_intelligence_contract_teacher_decision_count() -
+        contract_teacher_start;
+    out->worker_decisions =
+        signal_intelligence_npc_worker_decision_count() -
+        worker_decisions_start;
+    out->worker_teacher_decisions =
+        signal_intelligence_npc_worker_teacher_decision_count() -
+        worker_teacher_start;
+    if (out->events.first_contract_complete_tick_set) {
+        out->contract_completion_tick =
+            (int)(out->events.first_contract_complete_tick -
+                  episode_start_tick);
+    }
+    if (out->events.first_repair_tick_set) {
+        out->repair_completion_tick =
+            (int)(out->events.first_repair_tick - episode_start_tick);
+    }
+    {
+        float route_progress = out->route_start_dist - out->end_dist;
+        if (route_progress > 0.0f && out->travel_distance > 0.0001f) {
+            out->route_efficiency =
+                sr_feature_clamp(
+                    route_progress / out->travel_distance, 0.0f, 1.0f);
+        }
+    }
     out->utility = ((double)out->progress / 1000.0) -
                    ((double)out->hull_loss * 0.45) -
                    ((double)out->events.damage_amount * 0.25) -
@@ -4712,6 +5048,171 @@ static void sr_write_eval_summary(FILE *out,
     fprintf(out, "}");
 }
 
+static void sr_write_optional_tick(FILE *out, int tick)
+{
+    if (tick >= 0) fprintf(out, "%d", tick);
+    else fprintf(out, "null");
+}
+
+static void sr_write_lineage_summary(FILE *out,
+                                     const sr_lineage_summary_t *lineage)
+{
+    fprintf(out,
+            "{\"manifest_count\":%d,"
+            "\"receipt_count\":%d,"
+            "\"missing_receipt_chains\":%d,"
+            "\"invalid_receipt_chains\":%d,"
+            "\"receipt_manifest_parity\":%s,",
+            lineage->manifest_count,
+            lineage->receipt_count,
+            lineage->missing_receipt_chains,
+            lineage->invalid_receipt_chains,
+            lineage->receipt_manifest_parity ? "true" : "false");
+    sr_json_hash(out, "identity_hash", lineage->identity_hash);
+    fprintf(out, "}");
+}
+
+static void sr_write_outcome_facts(FILE *out, const sr_result_t *r)
+{
+    bool lineage_integrity_preserved =
+        r->start_lineage.receipt_manifest_parity &&
+        r->end_lineage.receipt_manifest_parity &&
+        r->start_lineage.invalid_receipt_chains == 0 &&
+        r->end_lineage.invalid_receipt_chains == 0 &&
+        r->start_lineage.missing_receipt_chains == 0 &&
+        r->end_lineage.missing_receipt_chains == 0;
+    bool identity_unchanged =
+        memcmp(r->start_lineage.identity_hash,
+               r->end_lineage.identity_hash,
+               sizeof(r->start_lineage.identity_hash)) == 0;
+    int safety_overrides = r->events.order_rejected_events;
+    int worker_completion_tick =
+        r->ai.branch.first_worker_completion_tick;
+    float worker_route_efficiency = 0.0f;
+    if (r->repair_completion_tick >= 0 &&
+        (worker_completion_tick < 0 ||
+         r->repair_completion_tick < worker_completion_tick)) {
+        worker_completion_tick = r->repair_completion_tick;
+    }
+    if (r->hnn.enabled && !r->hnn.candidate_allowed)
+        safety_overrides++;
+    if (r->ai.branch.worker_assignment_ticks > 0) {
+        worker_route_efficiency = sr_feature_clamp(
+            (float)r->ai.branch.worker_useful_outcome_ticks /
+                (float)r->ai.branch.worker_assignment_ticks,
+            0.0f, 1.0f);
+    }
+
+    fprintf(out,
+            ",\"outcome_facts\":{\"schema\":\"%s\","
+            "\"report_version\":%u,"
+            "\"feature_contracts\":{"
+            "\"flight\":{\"feature_set\":\"%s\","
+            "\"encoder_version\":%u,\"model_loaded\":%s},"
+            "\"contract\":{\"feature_set\":\"%s\","
+            "\"encoder_version\":%u,\"model_loaded\":%s},"
+            "\"worker\":{\"feature_set\":\"%s\","
+            "\"encoder_version\":%u,\"model_loaded\":%s}},"
+            "\"ticks_executed\":%d,"
+            "\"goal_completion_tick\":",
+            SR_OUTCOME_FACTS_SCHEMA,
+            SR_OUTCOME_REPORT_VERSION,
+            signal_intelligence_flight_feature_set(),
+            signal_intelligence_flight_feature_encoder_version(),
+            signal_intelligence_flight_loaded() ? "true" : "false",
+            SIGNAL_CONTRACT_FEATURE_SET,
+            (unsigned)SIGNAL_CONTRACT_FEATURE_ENCODER_VERSION,
+            signal_intelligence_contract_loaded() ? "true" : "false",
+            SIGNAL_NPC_WORKER_FEATURE_SET,
+            (unsigned)SIGNAL_NPC_WORKER_FEATURE_ENCODER_VERSION,
+            signal_intelligence_npc_worker_loaded() ? "true" : "false",
+            r->ticks_executed);
+    sr_write_optional_tick(out, r->goal_completion_tick);
+    fprintf(out, ",\"contract_completion_tick\":");
+    sr_write_optional_tick(out, r->contract_completion_tick);
+    fprintf(out, ",\"worker_completion_tick\":");
+    sr_write_optional_tick(out, worker_completion_tick);
+    fprintf(out,
+            ",\"route\":{\"start_distance\":%.3f,"
+            "\"end_distance\":%.3f,"
+            "\"distance_traveled\":%.3f,"
+            "\"progress\":%.3f,"
+            "\"efficiency\":%.9f,"
+            "\"stuck_ticks\":%d,"
+            "\"recovery_events\":%d,"
+            "\"loop_revisits\":%d},"
+            "\"worker_route\":{\"assignment_ticks\":%d,"
+            "\"motion_ticks\":%d,"
+            "\"route_support_ticks\":%d,"
+            "\"useful_outcome_ticks\":%d,"
+            "\"efficiency\":%.9f,"
+            "\"stuck_ticks\":%d,"
+            "\"recovery_events\":%d,"
+            "\"loop_revisits\":%d},"
+            "\"safety\":{\"collision_events\":%d,"
+            "\"damage_amount\":%.3f,"
+            "\"death_events\":%d,"
+            "\"safety_overrides\":%d,"
+            "\"order_rejected_events\":%d},"
+            "\"decisions\":{\"flight\":1,"
+            "\"contract\":%" PRIu64 ","
+            "\"contract_teacher_fallbacks\":%" PRIu64 ","
+            "\"worker\":%" PRIu64 ","
+            "\"worker_teacher_fallbacks\":%" PRIu64 "},"
+            "\"contracts\":{\"start_active\":%d,"
+            "\"end_active\":%d,"
+            "\"completed\":%d},"
+            "\"station_need\":{\"contract_completions\":%d,"
+            "\"sell_events\":%d,"
+            "\"sell_value\":%d,"
+            "\"delivery_cleared\":%d,"
+            "\"repair_events\":%d,"
+            "\"scaffolds_placed\":%d},"
+            "\"cargo\":{\"start\":",
+            r->route_start_dist,
+            r->end_dist,
+            r->travel_distance,
+            r->route_start_dist - r->end_dist,
+            r->route_efficiency,
+            r->stuck_ticks,
+            r->recovery_events,
+            r->loop_revisits,
+            r->ai.branch.worker_assignment_ticks,
+            r->ai.branch.worker_motion_ticks,
+            r->ai.branch.worker_route_support_ticks,
+            r->ai.branch.worker_useful_outcome_ticks,
+            worker_route_efficiency,
+            r->ai.branch.worker_stuck_ticks,
+            r->ai.branch.worker_recovery_events,
+            r->ai.branch.worker_loop_revisits,
+            r->events.damage_events,
+            r->events.damage_amount,
+            r->events.death_events,
+            safety_overrides,
+            r->events.order_rejected_events,
+            r->contract_decisions,
+            r->contract_teacher_decisions,
+            r->worker_decisions,
+            r->worker_teacher_decisions,
+            r->start_active_contracts,
+            r->end_active_contracts,
+            r->events.contract_complete_events,
+            r->events.contract_complete_events,
+            r->events.sell_events,
+            r->events.sell_base,
+            r->ai.npc_delivery_shipments_cleared,
+            r->events.repair_events,
+            r->ai.scaffolds_placed);
+    sr_write_lineage_summary(out, &r->start_lineage);
+    fprintf(out, ",\"end\":");
+    sr_write_lineage_summary(out, &r->end_lineage);
+    fprintf(out,
+            ",\"identity_unchanged\":%s,"
+            "\"lineage_integrity_preserved\":%s}}",
+            identity_unchanged ? "true" : "false",
+            lineage_integrity_preserved ? "true" : "false");
+}
+
 static void sr_write_row(FILE *out, const sr_config_t *config, const sr_result_t *r)
 {
     fprintf(out,
@@ -4870,6 +5371,7 @@ static void sr_write_row(FILE *out, const sr_config_t *config, const sr_result_t
             (int)r->receipt_trust.unknown_authority,
             (int)r->receipt_trust.untrusted_authority,
             (int)r->receipt_trust.revoked_authority);
+    sr_write_outcome_facts(out, r);
     fprintf(out, ",\"authority\":\"deterministic_seed_prefix_replay\"}\n");
 }
 


### PR DESCRIPTION
Closes #651

Supersedes #655.

## Summary
- Adds strict, versioned outcome facts and episode records for flight, contract, and worker intelligence heads.
- Measures completion, safety, route efficiency, bounded stuck/recovery behavior, station need served, and cargo receipt lineage.
- Compares teacher, shadow, mixed, and active modes across 45 shared episode IDs.
- Extends replay-bundle v3 with authenticated outcome data and fail-closed schema validation.

## Stack refresh
The original PR was stacked on the AI feature and evaluation-corpus branches. Both dependencies are now on main, so this replacement contains one issue-specific commit on deployed main while preserving the current public-state hashes, receipt-trust vectors, and centralized replay workflow.

## Validation
- Full aggregate suite: 1651 of 1651 passed.
- Outcome contract tests: 7 of 7 passed.
- Outcome repeatability: 8 scenarios passed.
- Native and WebAssembly outcome parity: 8 scenarios passed.
- Legacy replay repeatability: 21 scenarios passed.
- AI evaluation repeatability: 10 scenarios passed.
- Teacher, shadow, mixed, and active reports share all 45 episode IDs.
- CI workflow contracts, path classification, documentation freshness, script syntax, and diff integrity passed.