### PR TITLE
Make station payouts durable and at-most-once

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -23,27 +23,49 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The test runner shards by test index. Eight buckets cut the
-        # long-tail Valgrind shards roughly in half versus the old 4-way
-        # post-deploy sweep while preserving full non-soak coverage.
-        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+        # The test runner shards by test index. Sixteen buckets keep the
+        # slowest persistence/simulation bucket below the one-hour job limit
+        # while preserving full non-soak coverage.
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
     steps:
       - uses: actions/checkout@v6
 
       - name: Install valgrind
         run: sudo apt-get update && sudo apt-get install -y valgrind
 
-      - name: Valgrind memcheck (shard ${{ matrix.shard }}/8)
+      - name: Valgrind memcheck (shard ${{ matrix.shard }}/16)
         run: |
           set -o pipefail
           cmake -S . -B build-valgrind -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS_ONLY=ON
           cmake --build build-valgrind --parallel
           # `--track-origins=yes` dropped per #525 — leaks still detected
-          # by `--leak-check=full`. `--quiet` cuts stdout so valgrind's
-          # interleaved logs don't dominate runtime via I/O.
+          # by `--leak-check=full`. Keep memcheck diagnostics separate from
+          # the intentionally quiet test stream so the actual first error is
+          # visible and retained as a failure artifact.
+          set +e
           scripts/run_signal_test.sh valgrind --error-exitcode=1 \
             --leak-check=full \
             --show-leak-kinds=definite \
             --errors-for-leak-kinds=definite \
             --main-stacksize=67108864 \
-            ./build-valgrind/signal_test --quiet --no-soak --shard=${{ matrix.shard }}/8 2>&1 | tail -30
+            --log-file=valgrind-${{ matrix.shard }}.log \
+            ./build-valgrind/signal_test --quiet --no-soak \
+            --shard=${{ matrix.shard }}/16 \
+            > test-${{ matrix.shard }}.log 2>&1
+          status=$?
+          set -e
+          tail -30 test-${{ matrix.shard }}.log
+          if [ -s valgrind-${{ matrix.shard }}.log ]; then
+            tail -200 valgrind-${{ matrix.shard }}.log
+          fi
+          exit "$status"
+
+      - name: Upload Valgrind failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: valgrind-${{ matrix.shard }}-${{ github.sha }}
+          path: |
+            valgrind-${{ matrix.shard }}.log
+            test-${{ matrix.shard }}.log
+          if-no-files-found: error

--- a/scripts/check_ci_workflow_contract.py
+++ b/scripts/check_ci_workflow_contract.py
@@ -470,10 +470,24 @@ def contract_failures(
                 f"({marker!r})"
             )
 
-    if "set -o pipefail" not in sources.get("valgrind.yml", ""):
+    valgrind = sources.get("valgrind.yml", "")
+    if "set -o pipefail" not in valgrind:
         failures.append(
-            "valgrind.yml: truncated memcheck pipeline must enable pipefail"
+            "valgrind.yml: memcheck diagnostics must enable pipefail"
         )
+    valgrind_requirements = {
+        "--log-file=valgrind-${{ matrix.shard }}.log":
+            "a dedicated memcheck diagnostic log",
+        "if: failure()": "failure-only diagnostic retention",
+        "uses: actions/upload-artifact@v4":
+            "uploaded Valgrind failure diagnostics",
+        "test-${{ matrix.shard }}.log": "a retained test-output log",
+    }
+    for marker, description in valgrind_requirements.items():
+        if marker not in valgrind:
+            failures.append(
+                f"valgrind.yml: workflow lacks {description} ({marker!r})"
+            )
 
     programs = job_block(ci, "programs")
     for manifest in (

--- a/scripts/test_check_ci_workflow_contract.py
+++ b/scripts/test_check_ci_workflow_contract.py
@@ -282,7 +282,29 @@ class WorkflowContractTests(unittest.TestCase):
             after="",
         )
         self.assertTrue(any(
-            "memcheck pipeline must enable pipefail" in failure
+            "memcheck diagnostics must enable pipefail" in failure
+            for failure in failures
+        ), failures)
+
+    def test_valgrind_cannot_drop_diagnostic_log(self) -> None:
+        failures = self.failures(
+            workflow="valgrind.yml",
+            before="            --log-file=valgrind-${{ matrix.shard }}.log \\\n",
+            after="",
+        )
+        self.assertTrue(any(
+            "dedicated memcheck diagnostic log" in failure
+            for failure in failures
+        ), failures)
+
+    def test_valgrind_cannot_drop_failure_artifact_upload(self) -> None:
+        failures = self.failures(
+            workflow="valgrind.yml",
+            before="        uses: actions/upload-artifact@v4\n",
+            after="        uses: actions/checkout@v4\n",
+        )
+        self.assertTrue(any(
+            "uploaded Valgrind failure diagnostics" in failure
             for failure in failures
         ), failures)
 

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -480,8 +480,9 @@ static bool station_payout_journal_reserve(world_t *w, uint32_t needed) {
         }
         capacity *= 2u;
     }
-    if (capacity < needed ||
-        (size_t)capacity > SIZE_MAX / sizeof(*w->payout_journal.entries)) {
+    /* The hard journal cap keeps the allocation below SIZE_MAX even on
+     * 32-bit targets, so no second multiplication-overflow guard is needed. */
+    if (capacity < needed) {
         return false;
     }
     station_payout_receipt_t *entries = realloc(
@@ -570,7 +571,7 @@ bool station_payout_commit(world_t *w,
 
 bool station_payout_credit_batch_prepare(
     world_t *w, int station_idx, station_payout_action_t action,
-    const uint8_t (*source_identities)[32], const float *amounts,
+    uint8_t (*source_identities)[32], const float *amounts,
     uint16_t count, const uint8_t recipient_pubkey[32],
     station_payout_credit_batch_stage_t *out) {
     if (out) memset(out, 0, sizeof(*out));

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -135,6 +135,7 @@ void ledger_pubkey_from_token(const uint8_t token[8], uint8_t out[32]) {
 
 static bool secure_bytes_nonzero(const uint8_t *bytes, size_t len);
 static bool pubkey_is_zero(const uint8_t pk[32]);
+static bool bytes_any(const uint8_t *bytes, size_t len);
 
 static float ledger_sanitize_float(float value) {
     if (!isfinite(value)) return 0.0f;
@@ -341,6 +342,369 @@ static bool ledger_stage_pod_sale_by_pubkey(
         ledger_saturating_u32_sum(
             out->row.lifetime_ore_units, units);
     out->row.top_commodity = commodity;
+    return true;
+}
+
+static bool ledger_stage_supply_credit_by_pubkey(
+    const station_t *st, const uint8_t pubkey[32], float ore_value,
+    uint32_t ore_units, uint8_t commodity,
+    ledger_earn_stage_t *out, float *out_credited) {
+    if (out_credited) *out_credited = 0.0f;
+    if (!isfinite(ore_value) || ore_value <= 0.0f ||
+        !out || !out_credited) {
+        return false;
+    }
+    float credited = ore_value * 0.65f;
+    if (!isfinite(credited) || credited < 0.01f ||
+        !ledger_stage_earn_by_pubkey(st, pubkey, credited, out)) {
+        return false;
+    }
+    float lifetime_before = ledger_sanitize_float(out->row.lifetime_supply);
+    float lifetime_after = ledger_sanitize_float(lifetime_before + ore_value);
+    if (!isfinite(lifetime_after) ||
+        fabsf((lifetime_after - lifetime_before) - ore_value) > 0.001f) {
+        memset(out, 0, sizeof(*out));
+        return false;
+    }
+    out->row.lifetime_supply = lifetime_after;
+    if (ore_units > 0) {
+        out->row.lifetime_ore_units = ledger_saturating_u32_sum(
+            out->row.lifetime_ore_units, ore_units);
+        out->row.top_commodity = commodity;
+    }
+    *out_credited = credited;
+    return true;
+}
+
+static bool server_player_ledger_identity(const server_player_t *sp,
+                                          uint8_t out[32]) {
+    if (!sp || !out) return false;
+    if (server_player_copy_verified_pubkey(sp, out)) return true;
+    ledger_pubkey_from_token(sp->session_token, out);
+    return bytes_any(out, 32);
+}
+
+/* ---- Durable payout idempotence (#686) --------------------------- */
+
+enum {
+    STATION_PAYOUT_JOURNAL_INITIAL_CAPACITY = 64,
+};
+
+static bool bytes_any(const uint8_t *bytes, size_t len) {
+    if (!bytes) return false;
+    uint8_t any = 0;
+    for (size_t i = 0; i < len; i++) any |= bytes[i];
+    return any != 0;
+}
+
+static SIGNAL_MAYBE_UNUSED const char *station_payout_action_name(
+    station_payout_action_t action) {
+    switch (action) {
+    case STATION_PAYOUT_POD_INTAKE: return "pod-intake";
+    case STATION_PAYOUT_CONTRACT_CARGO: return "contract-cargo";
+    case STATION_PAYOUT_CONTRACT_FRAGMENT: return "contract-fragment";
+    case STATION_PAYOUT_BOUND_FREIGHT: return "bound-freight";
+    case STATION_PAYOUT_BOUND_FREIGHT_ORIGIN:
+        return "bound-freight-origin";
+    case STATION_PAYOUT_BLACK_MARKET: return "black-market";
+    case STATION_PAYOUT_SMELT_TOWER: return "smelt-tower";
+    case STATION_PAYOUT_SMELT_FRACTURER: return "smelt-fracturer";
+    case STATION_PAYOUT_BUILD_DELIVERY: return "build-delivery";
+    default: return "invalid";
+    }
+}
+
+bool station_payout_identity(const station_t *station,
+                             station_payout_action_t action,
+                             const uint8_t source_identity[32],
+                             uint8_t out[32]) {
+    static const uint8_t domain[] = "signal/station-payout/v1";
+    if (out) memset(out, 0, 32);
+    if (!station || !out || !source_identity ||
+        action <= STATION_PAYOUT_NONE || action >= STATION_PAYOUT_COUNT ||
+        station->id == 0 ||
+        !bytes_any(station->station_actor_id,
+                   sizeof(station->station_actor_id)) ||
+        !bytes_any(station->station_pubkey,
+                   sizeof(station->station_pubkey)) ||
+        !bytes_any(source_identity, 32)) {
+        return false;
+    }
+
+    uint8_t header[6] = {0};
+    wire_write_u32_le(header, station->id);
+    header[4] = (uint8_t)action;
+    header[5] = station->authority_registry_version;
+    sha256_ctx_t hash;
+    sha256_init(&hash);
+    sha256_update(&hash, domain, sizeof(domain) - 1u);
+    sha256_update(&hash, header, sizeof(header));
+    sha256_update(&hash, station->station_actor_id,
+                  sizeof(station->station_actor_id));
+    sha256_update(&hash, station->station_pubkey,
+                  sizeof(station->station_pubkey));
+    sha256_update(&hash, source_identity, 32);
+    sha256_final(&hash, out);
+    return true;
+}
+
+const station_payout_receipt_t *station_payout_find(
+    const world_t *w, const uint8_t payout_id[32]) {
+    if (!w || !payout_id ||
+        w->payout_journal.count > w->payout_journal.capacity ||
+        (w->payout_journal.count > 0 && !w->payout_journal.entries)) {
+        return NULL;
+    }
+    for (uint32_t i = 0; i < w->payout_journal.count; i++) {
+        if (memcmp(w->payout_journal.entries[i].payout_id,
+                   payout_id, 32) == 0) {
+            return &w->payout_journal.entries[i];
+        }
+    }
+    return NULL;
+}
+
+static bool station_payout_journal_reserve(world_t *w, uint32_t needed) {
+    if (!w || needed > STATION_PAYOUT_JOURNAL_MAX_ENTRIES ||
+        w->payout_journal.count > w->payout_journal.capacity ||
+        (w->payout_journal.count > 0 && !w->payout_journal.entries)) {
+        return false;
+    }
+    if (needed <= w->payout_journal.capacity) return true;
+    uint32_t capacity = w->payout_journal.capacity;
+    if (capacity == 0) capacity = STATION_PAYOUT_JOURNAL_INITIAL_CAPACITY;
+    while (capacity < needed) {
+        if (capacity > STATION_PAYOUT_JOURNAL_MAX_ENTRIES / 2u) {
+            capacity = STATION_PAYOUT_JOURNAL_MAX_ENTRIES;
+            break;
+        }
+        capacity *= 2u;
+    }
+    if (capacity < needed ||
+        (size_t)capacity > SIZE_MAX / sizeof(*w->payout_journal.entries)) {
+        return false;
+    }
+    station_payout_receipt_t *entries = realloc(
+        w->payout_journal.entries,
+        (size_t)capacity * sizeof(*entries));
+    if (!entries) return false;
+    if (capacity > w->payout_journal.capacity) {
+        memset(entries + w->payout_journal.capacity, 0,
+               (size_t)(capacity - w->payout_journal.capacity) *
+                   sizeof(*entries));
+    }
+    w->payout_journal.entries = entries;
+    w->payout_journal.capacity = capacity;
+    return true;
+}
+
+station_payout_prepare_status_t station_payout_prepare(
+    world_t *w, int station_idx, station_payout_action_t action,
+    const uint8_t source_identity[32], const uint8_t recipient_pubkey[32],
+    float amount, station_payout_stage_t *out) {
+    if (out) memset(out, 0, sizeof(*out));
+    if (!w || !out || station_idx < 0 || station_idx >= MAX_STATIONS ||
+        !station_exists(&w->stations[station_idx]) ||
+        !recipient_pubkey || !bytes_any(recipient_pubkey, 32) ||
+        !isfinite(amount) || amount <= 0.0f || amount > LEDGER_FLOAT_LIMIT) {
+        return STATION_PAYOUT_PREPARE_INVALID;
+    }
+    station_payout_receipt_t receipt = {0};
+    if (!station_payout_identity(&w->stations[station_idx], action,
+                                 source_identity, receipt.payout_id)) {
+        return STATION_PAYOUT_PREPARE_INVALID;
+    }
+    const station_payout_receipt_t *duplicate =
+        station_payout_find(w, receipt.payout_id);
+    if (duplicate) {
+        out->status = STATION_PAYOUT_PREPARE_DUPLICATE;
+        out->receipt = *duplicate;
+        SIM_LOG("[payout] replay %02x%02x%02x%02x action=%s amount=%.2f\n",
+                duplicate->payout_id[0], duplicate->payout_id[1],
+                duplicate->payout_id[2], duplicate->payout_id[3],
+                station_payout_action_name(action), duplicate->amount);
+        return out->status;
+    }
+    if (w->payout_journal.count == UINT32_MAX ||
+        !station_payout_journal_reserve(
+            w, w->payout_journal.count + 1u)) {
+        out->status = STATION_PAYOUT_PREPARE_NO_MEMORY;
+        return out->status;
+    }
+    static const uint8_t recipient_domain[] =
+        "signal/station-payout-recipient/v1";
+    sha256_ctx_t recipient_hash;
+    sha256_init(&recipient_hash);
+    sha256_update(&recipient_hash, recipient_domain,
+                  sizeof(recipient_domain) - 1u);
+    sha256_update(&recipient_hash, recipient_pubkey, 32);
+    sha256_final(&recipient_hash, receipt.recipient_hash);
+    receipt.station_id = w->stations[station_idx].id;
+    receipt.committed_tick = w->tick;
+    receipt.amount = amount;
+    receipt.action = (uint8_t)action;
+    receipt.authority_generation =
+        w->stations[station_idx].authority_registry_version;
+    out->status = STATION_PAYOUT_PREPARE_READY;
+    out->receipt = receipt;
+    return out->status;
+}
+
+bool station_payout_commit(world_t *w,
+                           const station_payout_stage_t *stage) {
+    if (!w || !stage || stage->status != STATION_PAYOUT_PREPARE_READY ||
+        w->payout_journal.count >= w->payout_journal.capacity ||
+        !w->payout_journal.entries ||
+        station_payout_find(w, stage->receipt.payout_id)) {
+        return false;
+    }
+    w->payout_journal.entries[w->payout_journal.count++] = stage->receipt;
+    SIM_LOG("[payout] commit %02x%02x%02x%02x action=%s amount=%.2f\n",
+            stage->receipt.payout_id[0], stage->receipt.payout_id[1],
+            stage->receipt.payout_id[2], stage->receipt.payout_id[3],
+            station_payout_action_name(
+                (station_payout_action_t)stage->receipt.action),
+            stage->receipt.amount);
+    return true;
+}
+
+bool station_payout_credit_batch_prepare(
+    world_t *w, int station_idx, station_payout_action_t action,
+    const uint8_t (*source_identities)[32], const float *amounts,
+    uint16_t count, const uint8_t recipient_pubkey[32],
+    station_payout_credit_batch_stage_t *out) {
+    if (out) memset(out, 0, sizeof(*out));
+    if (!w || !out || !source_identities || !amounts ||
+        !recipient_pubkey || count == 0 ||
+        count > STATION_PAYOUT_BATCH_MAX ||
+        station_idx < 0 || station_idx >= MAX_STATIONS ||
+        (uint32_t)count > UINT32_MAX - w->payout_journal.count ||
+        !station_payout_journal_reserve(
+            w, w->payout_journal.count + (uint32_t)count)) {
+        return false;
+    }
+    float total = 0.0f;
+    for (uint16_t i = 0; i < count; i++) {
+        if (!isfinite(amounts[i]) || amounts[i] <= 0.0f ||
+            total > LEDGER_FLOAT_LIMIT - amounts[i]) {
+            return false;
+        }
+        if (station_payout_prepare(
+                w, station_idx, action, source_identities[i],
+                recipient_pubkey, amounts[i],
+                &out->payout_stages[i]) !=
+                STATION_PAYOUT_PREPARE_READY) {
+            memset(out, 0, sizeof(*out));
+            return false;
+        }
+        for (uint16_t prior = 0; prior < i; prior++) {
+            if (memcmp(
+                    out->payout_stages[prior].receipt.payout_id,
+                    out->payout_stages[i].receipt.payout_id, 32) == 0) {
+                memset(out, 0, sizeof(*out));
+                return false;
+            }
+        }
+        total += amounts[i];
+    }
+    ledger_earn_stage_t ledger = {0};
+    if (!ledger_stage_earn_by_pubkey(
+            &w->stations[station_idx], recipient_pubkey,
+            total, &ledger)) {
+        memset(out, 0, sizeof(*out));
+        return false;
+    }
+    out->ready = true;
+    out->ledger_index = ledger.index;
+    out->ledger_count = ledger.ledger_count;
+    out->ledger_row = ledger.row;
+    out->payout_count = count;
+    out->total_amount = total;
+    return true;
+}
+
+bool station_payout_credit_batch_commit(
+    world_t *w, station_t *station, ship_t *recipient_ship,
+    const station_payout_credit_batch_stage_t *stage) {
+    if (!w || !station || !stage || !stage->ready ||
+        stage->payout_count == 0 ||
+        stage->payout_count > STATION_PAYOUT_BATCH_MAX ||
+        stage->ledger_index < 0 ||
+        stage->ledger_index >= STATION_LEDGER_MAX ||
+        stage->ledger_count < 0 ||
+        stage->ledger_count > STATION_LEDGER_MAX) {
+        return false;
+    }
+    for (uint16_t i = 0; i < stage->payout_count; i++) {
+        if (!station_payout_commit(w, &stage->payout_stages[i]))
+            return false;
+    }
+    station->ledger[stage->ledger_index] = stage->ledger_row;
+    station->ledger_count = stage->ledger_count;
+    if (recipient_ship)
+        recipient_ship->stat_credits_earned += stage->total_amount;
+    return true;
+}
+
+bool station_payout_supply_prepare(
+    world_t *w, int station_idx, station_payout_action_t action,
+    const uint8_t source_identity[32], const uint8_t recipient_pubkey[32],
+    float supply_value, const station_payout_supply_stage_t *prior,
+    station_payout_supply_stage_t *out) {
+    if (out) memset(out, 0, sizeof(*out));
+    if (!w || !out || station_idx < 0 || station_idx >= MAX_STATIONS)
+        return false;
+    const station_t *ledger_source = &w->stations[station_idx];
+    station_t staged_station = {0};
+    if (prior) {
+        if (!prior->ready || prior->ledger_index < 0 ||
+            prior->ledger_index >= STATION_LEDGER_MAX ||
+            prior->ledger_count < 0 ||
+            prior->ledger_count > STATION_LEDGER_MAX) {
+            return false;
+        }
+        staged_station.ledger_count = ledger_source->ledger_count;
+        memcpy(staged_station.ledger, ledger_source->ledger,
+               sizeof(staged_station.ledger));
+        staged_station.ledger[prior->ledger_index] = prior->ledger_row;
+        staged_station.ledger_count = prior->ledger_count;
+        ledger_source = &staged_station;
+    }
+    ledger_earn_stage_t ledger = {0};
+    float credited = 0.0f;
+    if (!ledger_stage_supply_credit_by_pubkey(
+            ledger_source, recipient_pubkey,
+            supply_value, 0, 0, &ledger, &credited) ||
+        station_payout_prepare(
+            w, station_idx, action, source_identity,
+            recipient_pubkey, credited,
+            &out->payout_stage) != STATION_PAYOUT_PREPARE_READY) {
+        memset(out, 0, sizeof(*out));
+        return false;
+    }
+    out->ready = true;
+    out->ledger_index = ledger.index;
+    out->ledger_count = ledger.ledger_count;
+    out->ledger_row = ledger.row;
+    out->credited_amount = credited;
+    return true;
+}
+
+bool station_payout_supply_commit(
+    world_t *w, station_t *station, ship_t *recipient_ship,
+    const station_payout_supply_stage_t *stage) {
+    if (!w || !station || !stage || !stage->ready ||
+        stage->ledger_index < 0 ||
+        stage->ledger_index >= STATION_LEDGER_MAX ||
+        stage->ledger_count < 0 ||
+        stage->ledger_count > STATION_LEDGER_MAX ||
+        !station_payout_commit(w, &stage->payout_stage)) {
+        return false;
+    }
+    station->ledger[stage->ledger_index] = stage->ledger_row;
+    station->ledger_count = stage->ledger_count;
+    if (recipient_ship)
+        recipient_ship->stat_credits_earned += stage->credited_amount;
     return true;
 }
 
@@ -4744,6 +5108,7 @@ typedef struct {
     uint16_t units;
     contract_t staged_claim;
     ledger_earn_stage_t ledger_stage;
+    station_payout_stage_t payout_stage;
 } station_intake_sale_t;
 
 /*
@@ -4782,6 +5147,23 @@ static bool station_intake_stage_pod_sale(
             &ledger_stage)) {
         return false;
     }
+    uint8_t source_identity[32];
+    cargo_pod_t identity_pod = *pod;
+    if (identity_pod.manifest_count == 0 &&
+        !identity_pod.has_shell_frame) {
+        return false;
+    }
+    identity_pod.custody_station = 0;
+    cargo_pod_clear_custody_charge_anchor(&identity_pod);
+    if (!cargo_pod_selection_digest(&identity_pod, source_identity))
+        return false;
+    station_payout_stage_t payout_stage = {0};
+    if (station_payout_prepare(
+            w, station_idx, STATION_PAYOUT_POD_INTAKE,
+            source_identity, ledger_identity, value,
+            &payout_stage) != STATION_PAYOUT_PREPARE_READY) {
+        return false;
+    }
 
     *out = (station_intake_sale_t){
         .ready = true,
@@ -4791,16 +5173,17 @@ static bool station_intake_stage_pod_sale(
         .units = units,
         .staged_claim = staged_claim,
         .ledger_stage = ledger_stage,
+        .payout_stage = payout_stage,
     };
     return true;
 }
 
-static void station_intake_commit_pod_sale(
+static bool station_intake_commit_pod_sale(
     world_t *w, server_player_t *sp, station_t *st,
     int station_idx, int module_idx, cargo_pod_t *pod,
     const station_intake_sale_t *sale) {
     if (!w || !sp || !st || !pod || !sale || !sale->ready)
-        return;
+        return false;
 
     /*
      * The physical tow relation already belongs to the station module. Quote,
@@ -4809,6 +5192,8 @@ static void station_intake_commit_pod_sale(
      * visible together and a retry observes station ownership before it can
      * ever reach another payout.
      */
+    if (!station_payout_commit(w, &sale->payout_stage))
+        return false;
     cargo_pod_set_station_custody(pod, station_idx);
     st->ledger[sale->ledger_stage.index] =
         sale->ledger_stage.row;
@@ -4858,6 +5243,7 @@ static void station_intake_commit_pod_sale(
                   .module = (module_idx >= 0 &&
                              module_idx < MAX_MODULES_PER_STATION)
                       ? (uint8_t)module_idx : UINT8_MAX }});
+    return true;
 }
 
 static bool cargo_pod_matches_buy_grade(const cargo_pod_t *pod,
@@ -5551,14 +5937,52 @@ static void sync_station_finished_inventory(station_t *st, commodity_t c) {
 static const float DELIVERY_ORIGIN_CREDIT_RATE = 0.10f;
 static const uint32_t DELIVERY_DUE_TICKS = 120u * 60u * 8u; /* 8 minutes */
 
-static void player_ledger_earn_at(server_player_t *sp, station_t *st,
-                                  float amount) {
-    if (!sp || !st || amount <= 0.0f) return;
-    if (server_player_can_use_pubkey_persistence(sp))
-        ledger_earn_by_pubkey(st, sp->pubkey, amount);
-    else
-        ledger_earn(st, sp->session_token, amount);
-    sp->ship->stat_credits_earned += amount;
+static bool delivery_shipment_source_identity(
+    const delivery_shipment_t *shipment, uint8_t out[32]) {
+    static const uint8_t domain[] = "signal/delivery-shipment-source/v1";
+    if (out) memset(out, 0, 32);
+    if (!shipment || !out || !shipment->active ||
+        shipment->shipment_id == 0 || shipment->quantity_bound == 0 ||
+        shipment->quantity_bound > MAX_DELIVERY_BOUND_CARGO) {
+        return false;
+    }
+    uint8_t header[8] = {0};
+    wire_write_u16_le(header, shipment->shipment_id);
+    header[2] = shipment->origin_station;
+    header[3] = shipment->destination_station;
+    header[4] = shipment->contract_index;
+    header[5] = shipment->commodity;
+    wire_write_u16_le(&header[6], shipment->quantity_bound);
+    sha256_ctx_t hash;
+    sha256_init(&hash);
+    sha256_update(&hash, domain, sizeof(domain) - 1u);
+    sha256_update(&hash, header, sizeof(header));
+    for (uint16_t i = 0; i < shipment->quantity_bound; i++)
+        sha256_update(&hash, shipment->cargo_pub[i], 32);
+    sha256_final(&hash, out);
+    return bytes_any(out, 32);
+}
+
+static bool fragment_payout_source_identity(asteroid_t *fragment,
+                                            uint8_t out[32]) {
+    uint8_t zero_player_pub[32] = {0};
+    if (out) memset(out, 0, 32);
+    if (!fragment || !out || !fragment->active ||
+        !fragment->fracture_child) {
+        return false;
+    }
+    if (!bytes_any(fragment->fragment_pub,
+                   sizeof(fragment->fragment_pub))) {
+        mining_fragment_pub_compute(
+            fragment->fracture_seed, zero_player_pub, 0,
+            fragment->fragment_pub);
+    }
+    if (!bytes_any(fragment->fragment_pub,
+                   sizeof(fragment->fragment_pub))) {
+        return false;
+    }
+    memcpy(out, fragment->fragment_pub, 32);
+    return true;
 }
 
 static void player_ledger_force_debit_at(server_player_t *sp, station_t *st,
@@ -6137,14 +6561,36 @@ static float delivery_try_deliver_bound_cargo(world_t *w,
                 : 0.0f;
             shipment_payout += unit_pay;
         }
-        if (!ok ||
+        uint8_t source_identity[32];
+        uint8_t ledger_identity[32];
+        ledger_earn_stage_t ledger_stage = {0};
+        station_payout_stage_t payout_stage = {0};
+        if (!ok || !isfinite(shipment_payout) ||
+            shipment_payout <= FLOAT_EPSILON ||
+            !delivery_shipment_source_identity(
+                shipment, source_identity) ||
+            !server_player_ledger_identity(sp, ledger_identity) ||
+            !ledger_stage_earn_by_pubkey(
+                st, ledger_identity, shipment_payout,
+                &ledger_stage) ||
+            station_payout_prepare(
+                w, station_idx,
+                STATION_PAYOUT_BOUND_FREIGHT,
+                source_identity, ledger_identity,
+                shipment_payout, &payout_stage) !=
+                STATION_PAYOUT_PREPARE_READY ||
             !delivery_transfer_towed_pod_to_station_custody(
                 w, sp, shipment, shipment->quantity_delivered,
                 remaining, station_idx)) {
             continue;
         }
+        if (!station_payout_commit(w, &payout_stage))
+            continue;
         contract_ownership_commit_staged_claim(
             contract, &staged_claim);
+        st->ledger[ledger_stage.index] = ledger_stage.row;
+        st->ledger_count = ledger_stage.ledger_count;
+        sp->ship->stat_credits_earned += shipment_payout;
         shipment->quantity_delivered =
             (uint16_t)(shipment->quantity_delivered + remaining);
         payout += shipment_payout;
@@ -6158,7 +6604,6 @@ static float delivery_try_deliver_bound_cargo(world_t *w,
         }
     }
     if (payout > 0.01f) {
-        player_ledger_earn_at(sp, st, payout);
         emit_event(w, (sim_event_t){
             .type = SIM_EVENT_SELL, .player_id = sp->id,
             .sell = { .station = sp->current_station,
@@ -6233,14 +6678,36 @@ static float delivery_try_black_market_sell(world_t *w, server_player_t *sp,
                 unit_price = station_buy_price(st, c);
             shipment_payout += unit_price * BLACK_MARKET_CARGO_MARKDOWN;
         }
-        if (!ok ||
+        uint8_t source_identity[32];
+        uint8_t ledger_identity[32];
+        ledger_earn_stage_t ledger_stage = {0};
+        station_payout_stage_t payout_stage = {0};
+        if (!ok || !isfinite(shipment_payout) ||
+            shipment_payout <= FLOAT_EPSILON ||
+            !delivery_shipment_source_identity(
+                shipment, source_identity) ||
+            !server_player_ledger_identity(sp, ledger_identity) ||
+            !ledger_stage_earn_by_pubkey(
+                st, ledger_identity, shipment_payout,
+                &ledger_stage) ||
+            station_payout_prepare(
+                w, sp->current_station,
+                STATION_PAYOUT_BLACK_MARKET,
+                source_identity, ledger_identity,
+                shipment_payout, &payout_stage) !=
+                STATION_PAYOUT_PREPARE_READY ||
             !delivery_transfer_towed_pod_to_station_custody(
                 w, sp, shipment, cargo_offset, remaining,
                 sp->current_station)) {
             continue;
         }
+        if (!station_payout_commit(w, &payout_stage))
+            continue;
         contract_ownership_commit_staged_claim(
             contract, &staged_claim);
+        st->ledger[ledger_stage.index] = ledger_stage.row;
+        st->ledger_count = ledger_stage.ledger_count;
+        sp->ship->stat_credits_earned += shipment_payout;
         payout += shipment_payout;
         shipment->quantity_black_market_sold =
             (uint16_t)(shipment->quantity_black_market_sold + remaining);
@@ -6257,7 +6724,6 @@ static float delivery_try_black_market_sell(world_t *w, server_player_t *sp,
         if (single_unit && sold_bound_any) break;
     }
     if (payout > 0.01f) {
-        player_ledger_earn_at(sp, st, payout);
         emit_event(w, (sim_event_t){
             .type = SIM_EVENT_SELL, .player_id = sp->id,
             .sell = { .station = sp->current_station,
@@ -6292,11 +6758,32 @@ static void delivery_clear_origin_proofs(world_t *w, server_player_t *sp,
             delivery_stage_contract_use_for_player(
                 w, sp, shipment, &staged_claim);
         if (!contract) continue;
-        contract_ownership_commit_staged_claim(
-            contract, &staged_claim);
         float credit = shipment->debt_principal +
                        shipment->origin_completion_credit;
-        player_ledger_earn_at(sp, origin, credit);
+        uint8_t source_identity[32];
+        uint8_t ledger_identity[32];
+        ledger_earn_stage_t ledger_stage = {0};
+        station_payout_stage_t payout_stage = {0};
+        if (!isfinite(credit) || credit <= FLOAT_EPSILON ||
+            !delivery_shipment_source_identity(
+                shipment, source_identity) ||
+            !server_player_ledger_identity(sp, ledger_identity) ||
+            !ledger_stage_earn_by_pubkey(
+                origin, ledger_identity, credit,
+                &ledger_stage) ||
+            station_payout_prepare(
+                w, station_idx,
+                STATION_PAYOUT_BOUND_FREIGHT_ORIGIN,
+                source_identity, ledger_identity, credit,
+                &payout_stage) != STATION_PAYOUT_PREPARE_READY ||
+            !station_payout_commit(w, &payout_stage)) {
+            continue;
+        }
+        contract_ownership_commit_staged_claim(
+            contract, &staged_claim);
+        origin->ledger[ledger_stage.index] = ledger_stage.row;
+        origin->ledger_count = ledger_stage.ledger_count;
+        sp->ship->stat_credits_earned += credit;
         shipment->status = DELIVERY_SHIPMENT_CLEARED;
         contract->active = false;
         SIM_LOG("[delivery] player %d cleared shipment %u at %s for %.0f\n",
@@ -6414,24 +6901,36 @@ static float try_deliver_towed_fragments_to_contracts(world_t *w,
         float ore_units = a->ore;
         if (ore_units <= 0.0f) continue;
 
+        float ore_value = ore_units * best_price;
+        float graded_value = ore_value * mining_payout_multiplier(grade);
+        uint8_t ledger_identity[32];
+        ledger_earn_stage_t ledger_stage = {0};
+        float credited = 0.0f;
+        station_payout_stage_t payout_stage = {0};
+        uint8_t fragment_source[32];
+        if (!server_player_ledger_identity(sp, ledger_identity) ||
+            !fragment_payout_source_identity(a, fragment_source) ||
+            !ledger_stage_supply_credit_by_pubkey(
+                st, ledger_identity, graded_value,
+                (uint32_t)lroundf(ore_units),
+                (uint8_t)a->commodity, &ledger_stage,
+                &credited) ||
+            station_payout_prepare(
+                w, sp->current_station,
+                STATION_PAYOUT_CONTRACT_FRAGMENT,
+                fragment_source, ledger_identity, credited,
+                &payout_stage) != STATION_PAYOUT_PREPARE_READY ||
+            !station_payout_commit(w, &payout_stage)) {
+            continue;
+        }
+
         contract_ownership_commit_staged_claim(
             ct, &best_staged_claim);
         st->_inventory_cache[a->commodity] += ore_units;
         if (st->_inventory_cache[a->commodity] > REFINERY_HOPPER_CAPACITY)
             st->_inventory_cache[a->commodity] = REFINERY_HOPPER_CAPACITY;
-
-        float ore_value = ore_units * best_price;
-        float graded_value = ore_value * mining_payout_multiplier(grade);
-        float credited = 0.0f;
-        if (server_player_can_use_pubkey_persistence(sp)) {
-            credited = ledger_credit_supply_amount_by_pubkey(st, sp->pubkey,
-                                                             graded_value);
-            ledger_record_ore_sold(st, sp->pubkey, (uint32_t)lroundf(ore_units),
-                                   (uint8_t)a->commodity);
-        } else {
-            credited = ledger_credit_supply_amount(st, sp->session_token,
-                                                   graded_value);
-        }
+        st->ledger[ledger_stage.index] = ledger_stage.row;
+        st->ledger_count = ledger_stage.ledger_count;
         sp->ship->stat_credits_earned += credited;
         payout += credited;
 
@@ -6567,6 +7066,31 @@ static bool try_deliver_starter_refit_manifest_batch(
             (float)total_payout, &ledger_stage)) {
         return true;
     }
+    station_payout_stage_t
+        payout_stages[STARTER_REFIT_BATCH_MAX_UNITS] = {0};
+    if ((uint32_t)needed > UINT32_MAX - w->payout_journal.count ||
+        !station_payout_journal_reserve(
+            w, w->payout_journal.count + (uint32_t)needed)) {
+        return true;
+    }
+    for (int i = 0; i < needed; i++) {
+        if (station_payout_prepare(
+                w, sp->current_station,
+                STATION_PAYOUT_CONTRACT_CARGO,
+                units[i].pub, player_identity,
+                (float)unit_payouts[i],
+                &payout_stages[i]) !=
+                STATION_PAYOUT_PREPARE_READY) {
+            return true;
+        }
+        for (int prior = 0; prior < i; prior++) {
+            if (memcmp(
+                    payout_stages[prior].receipt.payout_id,
+                    payout_stages[i].receipt.payout_id, 32) == 0) {
+                return true;
+            }
+        }
+    }
 
     chain_payload_transfer_t
         transfers[STARTER_REFIT_BATCH_MAX_UNITS] = {0};
@@ -6688,6 +7212,14 @@ static bool try_deliver_starter_refit_manifest_batch(
      * it and let the next lookup rebuild from the now-durable chain.
      */
     cargo_receipt_origin_cache_reset();
+
+    for (int i = 0; i < needed; i++) {
+        if (!station_payout_commit(w, &payout_stages[i])) {
+            cargo_store_cleanup(&staged_ship);
+            cargo_store_cleanup(&staged_station);
+            return true;
+        }
+    }
 
     cargo_store_cleanup(&sp->ship->cargo_store);
     sp->ship->cargo_store = staged_ship;
@@ -6849,6 +7381,14 @@ static float try_deliver_trusted_ship_manifest_to_contracts(
                 &ledger_stage)) {
             break;
         }
+        station_payout_stage_t payout_stage = {0};
+        if (station_payout_prepare(
+                w, sp->current_station,
+                STATION_PAYOUT_CONTRACT_CARGO,
+                unit.pub, player_identity, (float)payout,
+                &payout_stage) != STATION_PAYOUT_PREPARE_READY) {
+            break;
+        }
 
         cargo_receipt_prepared_transfer_t prepared =
             cargo_receipt_prepare_transfer(
@@ -6898,6 +7438,11 @@ static float try_deliver_trusted_ship_manifest_to_contracts(
             cargo_receipt_commit_prepared_transfer(
                 w, &prepared);
         if (appended.status != CHAIN_LOG_APPEND_OK) {
+            cargo_store_cleanup(&staged_ship);
+            cargo_store_cleanup(&staged_station);
+            break;
+        }
+        if (!station_payout_commit(w, &payout_stage)) {
             cargo_store_cleanup(&staged_ship);
             cargo_store_cleanup(&staged_station);
             break;
@@ -9406,8 +9951,13 @@ static bool cargo_pod_try_handoff_to_matching_hopper(world_t *w,
             w, pod_idx, tractor_player);
         return false;
     }
-    station_intake_commit_pod_sale(
-        w, sp, st, best_station, best_module, pod, &sale);
+    if (!station_intake_commit_pod_sale(
+            w, sp, st, best_station, best_module, pod, &sale)) {
+        world_cargo_pod_clear_module_tractor(w, pod_idx);
+        (void)world_cargo_pod_set_player_tractor(
+            w, pod_idx, tractor_player);
+        return false;
+    }
     if (best_station >= 0 && best_station < MAX_STATIONS &&
         best_module >= 0 && best_module < MAX_MODULES_PER_STATION) {
         w->stations[best_station].modules[best_module].active_pulse = 1.0f;
@@ -10844,12 +11394,6 @@ static void step_station_interaction_system(world_t *w, server_player_t *sp, con
                                                   sp->current_station,
                                                   sp->ship, filter);
         if (build_payout > 0.01f) {
-            if (server_player_can_use_pubkey_persistence(sp)) {
-                ledger_earn_by_pubkey(docked_st, sp->pubkey, build_payout);
-            } else {
-                ledger_earn(docked_st, sp->session_token, build_payout);
-            }
-            sp->ship->stat_credits_earned += build_payout;
             int base_cr = (int)lroundf(build_payout);
             emit_event(w, (sim_event_t){
                 .type = SIM_EVENT_SELL, .player_id = sp->id,
@@ -16809,6 +17353,10 @@ void world_cleanup(world_t *w) {
         ship_cleanup(&w->ship_assets[i].stored_ship);
     for (int i = 0; i < MAX_STATIONS; i++)
         station_cleanup(&w->stations[i]);
+    free(w->payout_journal.entries);
+    w->payout_journal.entries = NULL;
+    w->payout_journal.count = 0;
+    w->payout_journal.capacity = 0;
     free(w->signal_cache.strength);
     w->signal_cache.strength = NULL;
     w->signal_cache.beacon_count = 0;
@@ -17378,12 +17926,15 @@ bool world_reseed_genesis_ship_assets(world_t *w) {
 void world_reset(world_t *w) {
     uint32_t seed = w->rng;  /* caller may pre-set seed; 0 = default */
     float *sig_buf = w->signal_cache.strength; /* preserve heap allocation */
+    station_payout_receipt_t *payout_entries =
+        w->payout_journal.entries;
     for (int i = 0; i < WORLD_SHIP_CAP; i++)
         ship_cleanup(&w->ships[i].component);
     for (int i = 0; i < MAX_SHIP_ASSETS; i++)
         ship_cleanup(&w->ship_assets[i].stored_ship);
     for (int i = 0; i < MAX_STATIONS; i++)
         station_cleanup(&w->stations[i]);
+    free(payout_entries);
     spatial_grid_destroy(&w->asteroid_grid);
     memset(w, 0, sizeof(*w));
     w->signal_cache.strength = sig_buf; /* restore — signal_grid_build reuses it */

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -557,6 +557,80 @@ typedef struct {
     cargo_receipt_chain_t cargo_chains[MAX_DELIVERY_BOUND_CARGO];
 } delivery_shipment_t;
 
+/* Durable at-most-once settlement receipts (#686).
+ *
+ * The source identity is folded into payout_id together with the immutable
+ * station actor, live signing authority generation, and action kind.  The
+ * journal is server-only: clients receive ordinary ledger/event projections,
+ * never the recipient identity stored here.  Entries are append-only and are
+ * persisted with the world snapshot; capacity is runtime allocation state. */
+typedef enum {
+    STATION_PAYOUT_NONE = 0,
+    STATION_PAYOUT_POD_INTAKE,
+    STATION_PAYOUT_CONTRACT_CARGO,
+    STATION_PAYOUT_CONTRACT_FRAGMENT,
+    STATION_PAYOUT_BOUND_FREIGHT,
+    STATION_PAYOUT_BOUND_FREIGHT_ORIGIN,
+    STATION_PAYOUT_BLACK_MARKET,
+    STATION_PAYOUT_SMELT_TOWER,
+    STATION_PAYOUT_SMELT_FRACTURER,
+    STATION_PAYOUT_BUILD_DELIVERY,
+    STATION_PAYOUT_COUNT,
+} station_payout_action_t;
+
+typedef struct {
+    uint8_t payout_id[32];
+    uint8_t recipient_hash[32]; /* one-way hash; never bearer/session bytes */
+    uint32_t station_id;
+    uint64_t committed_tick;
+    float amount;
+    uint8_t action;              /* station_payout_action_t */
+    uint8_t authority_generation;
+    uint8_t _pad[2];
+} station_payout_receipt_t;
+
+typedef struct {
+    station_payout_receipt_t *entries;
+    uint32_t count;
+    uint32_t capacity;
+} station_payout_journal_t;
+
+typedef enum {
+    STATION_PAYOUT_PREPARE_INVALID = 0,
+    STATION_PAYOUT_PREPARE_READY,
+    STATION_PAYOUT_PREPARE_DUPLICATE,
+    STATION_PAYOUT_PREPARE_NO_MEMORY,
+} station_payout_prepare_status_t;
+
+typedef struct {
+    station_payout_prepare_status_t status;
+    station_payout_receipt_t receipt;
+} station_payout_stage_t;
+
+enum {
+    STATION_PAYOUT_BATCH_MAX = 128,
+    STATION_PAYOUT_JOURNAL_MAX_ENTRIES = 65536,
+};
+
+typedef struct {
+    bool ready;
+    int ledger_index;
+    int ledger_count;
+    station_ledger_entry_t ledger_row;
+    uint16_t payout_count;
+    station_payout_stage_t payout_stages[STATION_PAYOUT_BATCH_MAX];
+    float total_amount;
+} station_payout_credit_batch_stage_t;
+
+typedef struct {
+    bool ready;
+    int ledger_index;
+    int ledger_count;
+    station_ledger_entry_t ledger_row;
+    station_payout_stage_t payout_stage;
+    float credited_amount;
+} station_payout_supply_stage_t;
+
 typedef struct {
     station_t stations[MAX_STATIONS];
     int station_count;              /* highest existing slot + 1 (seeded stations, then outposts) */
@@ -779,6 +853,7 @@ typedef struct {
     sim_interactions_t interactions;
     contract_t contracts[MAX_CONTRACTS];
     delivery_shipment_t delivery_shipments[MAX_DELIVERY_SHIPMENTS];
+    station_payout_journal_t payout_journal;
     /* Server-only, inert diagnostics for legacy owner rows that could not be
      * rebound to a proven stable principal. Never replicated to clients and
      * deliberately incapable of storing bearer/session material. */
@@ -931,6 +1006,35 @@ bool world_anchor_validated_legacy_cargo_origins(world_t *w);
  * in game_sim.c. */
 void world_seed_station_chain_genesis(world_t *w);
 void world_cleanup(world_t *w);
+
+bool station_payout_identity(const station_t *station,
+                             station_payout_action_t action,
+                             const uint8_t source_identity[32],
+                             uint8_t out[32]);
+station_payout_prepare_status_t station_payout_prepare(
+    world_t *w, int station_idx, station_payout_action_t action,
+    const uint8_t source_identity[32], const uint8_t recipient_pubkey[32],
+    float amount, station_payout_stage_t *out);
+bool station_payout_commit(world_t *w,
+                           const station_payout_stage_t *stage);
+const station_payout_receipt_t *station_payout_find(
+    const world_t *w, const uint8_t payout_id[32]);
+bool station_payout_credit_batch_prepare(
+    world_t *w, int station_idx, station_payout_action_t action,
+    const uint8_t (*source_identities)[32], const float *amounts,
+    uint16_t count, const uint8_t recipient_pubkey[32],
+    station_payout_credit_batch_stage_t *out);
+bool station_payout_credit_batch_commit(
+    world_t *w, station_t *station, ship_t *recipient_ship,
+    const station_payout_credit_batch_stage_t *stage);
+bool station_payout_supply_prepare(
+    world_t *w, int station_idx, station_payout_action_t action,
+    const uint8_t source_identity[32], const uint8_t recipient_pubkey[32],
+    float supply_value, const station_payout_supply_stage_t *prior,
+    station_payout_supply_stage_t *out);
+bool station_payout_supply_commit(
+    world_t *w, station_t *station, ship_t *recipient_ship,
+    const station_payout_supply_stage_t *stage);
 void world_sim_step(world_t *w, float dt);
 void world_sim_step_player_only(world_t *w, int player_idx, float dt);
 void server_player_queue_movement_input(server_player_t *sp,

--- a/server/game_sim.h
+++ b/server/game_sim.h
@@ -612,6 +612,11 @@ enum {
     STATION_PAYOUT_JOURNAL_MAX_ENTRIES = 65536,
 };
 
+_Static_assert(
+    STATION_PAYOUT_JOURNAL_MAX_ENTRIES <=
+        SIZE_MAX / sizeof(station_payout_receipt_t),
+    "station payout journal cap must fit in size_t");
+
 typedef struct {
     bool ready;
     int ledger_index;
@@ -1021,7 +1026,7 @@ const station_payout_receipt_t *station_payout_find(
     const world_t *w, const uint8_t payout_id[32]);
 bool station_payout_credit_batch_prepare(
     world_t *w, int station_idx, station_payout_action_t action,
-    const uint8_t (*source_identities)[32], const float *amounts,
+    uint8_t (*source_identities)[32], const float *amounts,
     uint16_t count, const uint8_t recipient_pubkey[32],
     station_payout_credit_batch_stage_t *out);
 bool station_payout_credit_batch_commit(

--- a/server/sim_production.c
+++ b/server/sim_production.c
@@ -19,6 +19,9 @@
 #include <stdio.h>
 #include <string.h>
 
+static bool production_player_ledger_identity(
+    const server_player_t *sp, uint8_t identity[32]);
+
 /* ------------------------------------------------------------------ */
 /* Smelting helpers                                                    */
 /* ------------------------------------------------------------------ */
@@ -1488,6 +1491,88 @@ void step_furnace_smelting(world_t *w, float dt) {
                 pushed++;
             }
 
+            /* Stage the complete economic side of this smelt before the
+             * durable SMELT append or physical shell/output commit. The
+             * fragment pub is the immutable source; tower and finder use
+             * distinct action kinds so the intentional split remains legal. */
+            float price = station_buy_price(st, a->commodity);
+            bool by_contract = false;
+            for (int k = 0; k < MAX_CONTRACTS; k++) {
+                if (!w->contracts[k].active) continue;
+                if (w->contracts[k].action != CONTRACT_TRACTOR) continue;
+                if (w->contracts[k].station_index != smelt_station) continue;
+                if (w->contracts[k].commodity != a->commodity) continue;
+                float cp = contract_price(&w->contracts[k]);
+                if (cp > price) { price = cp; by_contract = true; }
+            }
+            float ore_value = a->ore * price;
+            if (!by_contract && output != a->commodity && pushed > 0) {
+                float sum_mult = 0.0f;
+                for (int idx = 0; idx < pushed; idx++) {
+                    sum_mult += prefix_class_price_multiplier(
+                        (int)units[idx].prefix_class);
+                }
+                ore_value *= sum_mult / (float)pushed;
+            }
+            int tower = connected_player_by_token(
+                w, a->last_towed_token);
+            int fracturer = connected_player_by_token(
+                w, a->last_fractured_token);
+            float bonus_mult = mining_payout_multiplier(grade);
+            float graded_value = ore_value * bonus_mult;
+            int base_cr = (int)lroundf(ore_value);
+            int bonus_cr = (int)lroundf(graded_value - ore_value);
+            int roller = (tower >= 0) ? tower : fracturer;
+            station_payout_supply_stage_t tower_stage = {0};
+            station_payout_supply_stage_t finder_stage = {0};
+            bool tower_staged = false;
+            bool finder_staged = false;
+            uint8_t payout_identity[32] = {0};
+            if (ore_value > 0.0f && tower >= 0) {
+                server_player_t *pt = &w->players[tower];
+                if (production_player_ledger_identity(
+                        pt, payout_identity)) {
+                    if (!station_payout_supply_prepare(
+                            w, smelt_station,
+                            STATION_PAYOUT_SMELT_TOWER,
+                            a->fragment_pub, payout_identity,
+                            graded_value, NULL, &tower_stage)) {
+                        continue;
+                    }
+                    tower_staged = true;
+                }
+                if (fracturer >= 0 && fracturer != tower) {
+                    server_player_t *pf = &w->players[fracturer];
+                    if (production_player_ledger_identity(
+                            pf, payout_identity)) {
+                        float finders = graded_value * 0.25f;
+                        if (!station_payout_supply_prepare(
+                                w, smelt_station,
+                                STATION_PAYOUT_SMELT_FRACTURER,
+                                a->fragment_pub, payout_identity,
+                                finders, &tower_stage,
+                                &finder_stage)) {
+                            continue;
+                        }
+                        finder_staged = true;
+                    }
+                }
+            } else if (ore_value > 0.0f && fracturer >= 0) {
+                server_player_t *pf = &w->players[fracturer];
+                if (production_player_ledger_identity(
+                        pf, payout_identity)) {
+                    float half = graded_value * 0.5f;
+                    if (!station_payout_supply_prepare(
+                            w, smelt_station,
+                            STATION_PAYOUT_SMELT_FRACTURER,
+                            a->fragment_pub, payout_identity,
+                            half, NULL, &finder_stage)) {
+                        continue;
+                    }
+                    finder_staged = true;
+                }
+            }
+
             int pod_idx = -1;
             cargo_unit_t pod_shell = {0};
             if (pushed <= 0) continue;
@@ -1617,6 +1702,22 @@ void step_furnace_smelting(world_t *w, float dt) {
                             &staged_station);
                     continue;
                 }
+                if (tower_staged &&
+                    !station_payout_supply_commit(
+                        w, st, w->players[tower].ship,
+                        &tower_stage)) {
+                    if (staged_station_live)
+                        cargo_store_cleanup(&staged_station);
+                    continue;
+                }
+                if (finder_staged &&
+                    !station_payout_supply_commit(
+                        w, st, w->players[fracturer].ship,
+                        &finder_stage)) {
+                    if (staged_station_live)
+                        cargo_store_cleanup(&staged_station);
+                    continue;
+                }
 
                 if (staged_station_live) {
                     cargo_store_cleanup(&st->cargo_store);
@@ -1647,83 +1748,9 @@ void step_furnace_smelting(world_t *w, float dt) {
                 st->modules[smelt_module].active_pulse = 1.0f;
             }
 
-            /* M3: scan all matching contracts (was break-on-first). Pick the
-             * contract whose price is highest above the station buy price. */
-            float price = station_buy_price(st, a->commodity);
-            bool by_contract = false;
-            for (int k = 0; k < MAX_CONTRACTS; k++) {
-                if (!w->contracts[k].active) continue;
-                if (w->contracts[k].action != CONTRACT_TRACTOR) continue;
-                if (w->contracts[k].station_index != smelt_station) continue;
-                if (w->contracts[k].commodity != a->commodity) continue;
-                float cp = contract_price(&w->contracts[k]);
-                if (cp > price) { price = cp; by_contract = true; }
-            }
-            float ore_value = a->ore * price;
-
-            /* Prefix-class price multipliers (#prefix-pricing): project
-             * the to-be-minted ingot units and lift ore_value by the
-             * mean prefix multiplier across them. Anonymous-class units
-             * (the bulk of mining output) have multiplier 1.0×, so the
-             * historical balance is unchanged in expectation; the rare
-             * M/RATi-class fragment lifts the whole payout.
-             *
-             * The minted-unit pubkeys are deterministic in
-             * (output, grade, fragment_pub, idx) — see hash_ingot — so
-             * projecting here picks the same prefixes the manifest push
-             * below will mint. We project against the OUTPUT ingot
-             * commodity, not the raw ore, because the lineage substrate
-             * tags ingots, not ore.
-             *
-             * Skipped on contract payouts — by_contract paths pay the
-             * flat per-unit contract_price by design (see #496 / spec
-             * out-of-scope: filtered contracts come in a follow-up PR). */
-            if (!by_contract) {
-                if (output != a->commodity && pushed > 0) {
-                    float sum_mult = 0.0f;
-                    int counted = 0;
-                    for (int idx = 0; idx < pushed; idx++) {
-                        sum_mult += prefix_class_price_multiplier(
-                                        (int)units[idx].prefix_class);
-                        counted++;
-                    }
-                    if (counted > 0)
-                        ore_value *= (sum_mult / (float)counted);
-                }
-            }
-
-            /* Credit fracturer and tower.
-             *
-             * Credit attribution is strictly token-based: we look up each
-             * role's session_token against currently-connected sessions.
-             * The legacy `last_towed_by` / `last_fractured_by` slot
-             * fallback was REMOVED — it could pay the wrong player when a
-             * slot gets reused on disconnect/rejoin. Do not restore it
-             * without a token-match guard.
-             *
-             * Known gap: fragments in saves from before the token fields
-             * existed, or fragments towed/fractured before the player's
-             * session was `session_ready` (zero token at tow time), will
-             * now smelt with no credit recipient. The ore still becomes
-             * a loose ingot pod as infrastructure value; the embedded pod
-             * manifest still records the hash. If that's not acceptable
-             * for in-the-wild saves, add a one-time migration that
-             * stamps a synthetic-but-valid owner token on pre-token
-             * fragments at save-load time — do NOT re-enable the slot
-             * fallback. */
-            int tower = connected_player_by_token(w, a->last_towed_token);
-            int fracturer = connected_player_by_token(w, a->last_fractured_token);
             SIM_LOG("[smelt-attr] tower_match=%s fracturer_match=%s\n",
                     tower >= 0 ? "connected" : "unresolved",
                     fracturer >= 0 ? "connected" : "unresolved");
-
-            /* Grade is committed when the fracture claim resolves.
-             * Smelt only publishes that cached value — no fresh dice. */
-            float bonus_mult = mining_payout_multiplier(grade);
-            float graded_value = ore_value * bonus_mult;
-            int base_cr  = (int)lroundf(ore_value);
-            int bonus_cr = (int)lroundf(graded_value - ore_value);
-            int roller = (tower >= 0) ? tower : fracturer;
 
             /* Announce rare strikes on the station signal channel so
              * other players see them flicker across the Network tab. */
@@ -1743,25 +1770,13 @@ void step_furnace_smelting(world_t *w, float dt) {
 
             if (ore_value > 0.0f) {
                 uint8_t bc = by_contract ? 1 : 0;
-                /* Credit to the same identity the buy/balance paths read:
-                 * pubkey when registered, session_token-pseudokey otherwise.
-                 * Mismatched identity here was the visible-bug:
-                 * smelt-payouts landed on the session-token ledger entry
-                 * but the buy path read the pubkey entry → balance shown
-                 * as 0, "REJECT: finished good but whole=0 (afford=0)". */
-                if (tower >= 0) {
-                    float credited = 0.0f;
-                    server_player_t *pt = &w->players[tower];
-                    if (pt->session_ready) {
-                        credited = server_player_can_use_pubkey_persistence(pt)
-                            ? ledger_credit_supply_amount_by_pubkey(st, pt->pubkey, graded_value)
-                            : ledger_credit_supply_amount(st, pt->session_token, graded_value);
-                    }
+                if (tower_staged) {
                     SIM_LOG("[smelt-pay] player %d tower credit: graded=%.2f credited=%.2f pubkey_ledger=%d session_ready=%d\n",
-                            tower, graded_value, credited,
-                            server_player_can_use_pubkey_persistence(pt) ? 1 : 0,
-                            pt->session_ready ? 1 : 0);
-                    pt->ship->stat_credits_earned += credited;
+                            tower, graded_value,
+                            tower_stage.credited_amount,
+                            server_player_can_use_pubkey_persistence(
+                                &w->players[tower]) ? 1 : 0,
+                            w->players[tower].session_ready ? 1 : 0);
                     emit_event(w, (sim_event_t){
                         .type = SIM_EVENT_SELL, .player_id = tower,
                         .sell = { .station = smelt_station, .grade = (uint8_t)grade,
@@ -1771,16 +1786,8 @@ void step_furnace_smelting(world_t *w, float dt) {
                                   .origin_station = (uint8_t)smelt_station,
                                   .quantity = (uint16_t)pushed,
                                   .module = (uint8_t)smelt_module }});
-                    if (fracturer >= 0 && fracturer != tower) {
+                    if (finder_staged) {
                         float finders = graded_value * 0.25f;
-                        float fcredited = 0.0f;
-                        server_player_t *pf = &w->players[fracturer];
-                        if (pf->session_ready) {
-                            fcredited = server_player_can_use_pubkey_persistence(pf)
-                                ? ledger_credit_supply_amount_by_pubkey(st, pf->pubkey, finders)
-                                : ledger_credit_supply_amount(st, pf->session_token, finders);
-                        }
-                        pf->ship->stat_credits_earned += fcredited;
                         emit_event(w, (sim_event_t){
                             .type = SIM_EVENT_SELL, .player_id = fracturer,
                             .sell = { .station = smelt_station, .grade = (uint8_t)grade,
@@ -1792,16 +1799,8 @@ void step_furnace_smelting(world_t *w, float dt) {
                                       .quantity = (uint16_t)pushed,
                                       .module = (uint8_t)smelt_module }});
                     }
-                } else if (fracturer >= 0) {
+                } else if (finder_staged) {
                     float half = graded_value * 0.5f;
-                    float credited = 0.0f;
-                    server_player_t *pf = &w->players[fracturer];
-                    if (pf->session_ready) {
-                        credited = server_player_can_use_pubkey_persistence(pf)
-                            ? ledger_credit_supply_amount_by_pubkey(st, pf->pubkey, half)
-                            : ledger_credit_supply_amount(st, pf->session_token, half);
-                    }
-                    pf->ship->stat_credits_earned += credited;
                     emit_event(w, (sim_event_t){
                         .type = SIM_EVENT_SELL, .player_id = fracturer,
                         .sell = { .station = smelt_station, .grade = (uint8_t)grade,
@@ -2043,6 +2042,55 @@ static bool cargo_pub_nonzero(const cargo_unit_t *unit) {
     return unit && memcmp(unit->pub, zero, sizeof(zero)) != 0;
 }
 
+static bool production_player_ledger_identity(
+    const server_player_t *sp, uint8_t identity[32]) {
+    if (identity) memset(identity, 0, 32);
+    if (!sp || !identity || !sp->session_ready) return false;
+    if (!server_player_copy_verified_pubkey(sp, identity))
+        ledger_pubkey_from_token(sp->session_token, identity);
+    uint8_t any = 0;
+    for (size_t b = 0; b < 32; b++) any |= identity[b];
+    return any != 0;
+}
+
+static server_player_t *production_player_for_ship(world_t *w,
+                                                   ship_t *ship,
+                                                   uint8_t identity[32]) {
+    if (identity) memset(identity, 0, 32);
+    if (!w || !ship || !identity) return NULL;
+    for (int i = 0; i < MAX_PLAYERS; i++) {
+        server_player_t *sp = &w->players[i];
+        if (!server_player_is_gameplay_ready(sp) || sp->ship != ship)
+            continue;
+        if (!production_player_ledger_identity(sp, identity)) return NULL;
+        return sp;
+    }
+    return NULL;
+}
+
+static bool production_prepare_build_payout(
+    world_t *w, int station_idx, const cargo_unit_t *units,
+    int unit_count, float unit_price, const uint8_t recipient[32],
+    station_payout_credit_batch_stage_t *out) {
+    if (out) memset(out, 0, sizeof(*out));
+    if (!w || !units || !recipient || !out || unit_count <= 0 ||
+        unit_count > STATION_PAYOUT_BATCH_MAX ||
+        !isfinite(unit_price) || unit_price <= 0.0f) {
+        return false;
+    }
+    uint8_t sources[STATION_PAYOUT_BATCH_MAX][32] = {{0}};
+    float amounts[STATION_PAYOUT_BATCH_MAX] = {0};
+    for (int i = 0; i < unit_count; i++) {
+        memcpy(sources[i], units[i].pub, 32);
+        amounts[i] = mining_payout_multiplier(
+            (mining_grade_t)units[i].grade) * unit_price;
+    }
+    return station_payout_credit_batch_prepare(
+        w, station_idx, STATION_PAYOUT_BUILD_DELIVERY,
+        sources, amounts, (uint16_t)unit_count,
+        recipient, out);
+}
+
 static bool emit_construction_contribution_batch(
     world_t *w, station_t *st, int station_idx, int module_idx,
     const station_module_t *module, commodity_t commodity,
@@ -2094,12 +2142,15 @@ static bool emit_construction_contribution_batch(
 static int ship_contribute_trusted_module_supply(
     world_t *w, station_t *st, int station_idx, int module_idx,
     station_module_t *module, ship_t *ship, commodity_t material,
-    float cost, int max_units,
+    float cost, int max_units, server_player_t *payee,
+    const uint8_t payout_identity[32], float unit_price,
     cargo_unit_t out_units[CHAIN_LOG_BATCH_MAX_EVENTS]) {
     if (!w || !st || !module || !ship || !out_units ||
         cost <= 0.0f || max_units <= 0) {
         return 0;
     }
+    if (payee && (!isfinite(unit_price) || unit_price < 0.0f))
+        return 0;
     if (max_units > CHAIN_LOG_BATCH_MAX_EVENTS)
         max_units = CHAIN_LOG_BATCH_MAX_EVENTS;
     cargo_unit_t selected[CHAIN_LOG_BATCH_MAX_EVENTS] = {{0}};
@@ -2138,10 +2189,23 @@ static int ship_contribute_trusted_module_supply(
         (float)selected_count / cost;
     if (progress_after > 1.0f - 0.0001f)
         progress_after = 1.0f;
+    station_payout_credit_batch_stage_t payout_stage = {0};
+    bool payout_required = payee && unit_price > FLOAT_EPSILON;
+    if (payout_required && !production_prepare_build_payout(
+            w, station_idx, out_units, selected_count,
+            unit_price, payout_identity, &payout_stage)) {
+        cargo_store_cleanup(&staged);
+        return 0;
+    }
     if (!emit_construction_contribution_batch(
             w, st, station_idx, module_idx, module,
             material, out_units, (size_t)selected_count,
             progress_before, cost)) {
+        cargo_store_cleanup(&staged);
+        return 0;
+    }
+    if (payout_required && !station_payout_credit_batch_commit(
+            w, st, payee->ship, &payout_stage)) {
         cargo_store_cleanup(&staged);
         return 0;
     }
@@ -2222,12 +2286,16 @@ static int pod_contribute_trusted_module_supply(
     world_t *w, station_t *st, int station_idx, int module_idx,
     station_module_t *module, ship_t *ship,
     commodity_t material, float cost, int max_units,
+    server_player_t *payee, const uint8_t payout_identity[32],
+    float unit_price,
     cargo_unit_t out_units[CHAIN_LOG_BATCH_MAX_EVENTS]) {
     if (!w || !st || !module || !ship || !out_units ||
         material >= COMMODITY_COUNT || cost <= 0.0f ||
         max_units <= 0) {
         return 0;
     }
+    if (payee && (!isfinite(unit_price) || unit_price < 0.0f))
+        return 0;
     if (max_units > CHAIN_LOG_BATCH_MAX_EVENTS)
         max_units = CHAIN_LOG_BATCH_MAX_EVENTS;
     int pod_idx = -1;
@@ -2283,11 +2351,22 @@ static int pod_contribute_trusted_module_supply(
         (float)selected_count / cost;
     if (progress_after > 1.0f - 0.0001f)
         progress_after = 1.0f;
+    station_payout_credit_batch_stage_t payout_stage = {0};
+    bool payout_required = payee && unit_price > FLOAT_EPSILON;
+    if (payout_required && !production_prepare_build_payout(
+            w, station_idx, out_units, selected_count,
+            unit_price, payout_identity, &payout_stage)) {
+        return 0;
+    }
     if (!emit_construction_contribution_batch(
             w, st, station_idx, module_idx,
             module, material, out_units,
             (size_t)selected_count,
             progress_before, cost)) {
+        return 0;
+    }
+    if (payout_required && !station_payout_credit_batch_commit(
+            w, st, payee->ship, &payout_stage)) {
         return 0;
     }
 
@@ -2317,6 +2396,9 @@ float step_module_delivery(world_t *w, station_t *st, int station_idx,
      * runs AFTER this function and would have paid, but module
      * construction had already consumed the cargo. */
     float payout = 0.0f;
+    uint8_t payout_identity[32] = {0};
+    server_player_t *payee =
+        production_player_for_ship(w, ship, payout_identity);
     for (int i = 0; i < st->module_count; i++) {
         station_module_t *m = &st->modules[i];
         if (module_build_state(m) != MODULE_BUILD_AWAITING_SUPPLY) continue;
@@ -2349,7 +2431,8 @@ float step_module_delivery(world_t *w, station_t *st, int station_idx,
                     pod_contribute_trusted_module_supply(
                         w, st, station_idx, i, m,
                         ship, mat, cost,
-                        whole - removed, units);
+                        whole - removed, payee,
+                        payout_identity, price, units);
                 if (count <= 0) {
                     break;
                 }
@@ -2378,7 +2461,8 @@ float step_module_delivery(world_t *w, station_t *st, int station_idx,
                 int count =
                     ship_contribute_trusted_module_supply(
                         w, st, station_idx, i, m, ship,
-                        mat, cost, whole - removed, units);
+                        mat, cost, whole - removed, payee,
+                        payout_identity, price, units);
                 if (count <= 0) {
                     break;
                 }

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -4976,13 +4976,18 @@ static player_save_create_result_t player_save_internal(
         return PLAYER_SAVE_CREATE_IO_FAILURE;
     }
     encode_v4_ship(&ship_disk, sp->ship);
-    player_save_data_t data = {
-        .magic = PLAYER_MAGIC,
-        .ship = ship_disk,
-        .last_station = sp->current_station,
-        .last_pos = sp->ship->pos,
-        .last_angle = sp->ship->angle,
-    };
+    /* This fixed blob is written and checksummed byte-for-byte.  A
+     * designated initializer initializes every member, but C leaves struct
+     * padding indeterminate; Valgrind therefore correctly rejects passing
+     * the blob to fwrite.  Clear the complete object first so the save is
+     * deterministic and never persists bytes from the stack. */
+    player_save_data_t data;
+    memset(&data, 0, sizeof(data));
+    data.magic = PLAYER_MAGIC;
+    data.ship = ship_disk;
+    data.last_station = sp->current_station;
+    data.last_pos = sp->ship->pos;
+    data.last_angle = sp->ship->angle;
     bool ok = fwrite(&data, sizeof(data), 1, f) == 1;
     uint32_t crc = ok ? crc32_update(0, &data, sizeof(data)) : 0;
     /* Manifest tail (PLY5). Count + entries; CRC accumulates both. */

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -3851,9 +3851,7 @@ static bool world_load_payload(
     if (version >= 84) {
         uint32_t count = 0;
         READ_FIELD(f, count);
-        if (count > STATION_PAYOUT_JOURNAL_MAX_ENTRIES ||
-            (size_t)count > SIZE_MAX /
-                sizeof(*w->payout_journal.entries)) {
+        if (count > STATION_PAYOUT_JOURNAL_MAX_ENTRIES) {
             return false;
         }
         if (count > 0) {
@@ -4521,9 +4519,9 @@ static world_t *world_load_candidate_create(const world_t *source) {
     }
     if (source->payout_journal.count > 0) {
         if (source->payout_journal.count > source->payout_journal.capacity ||
-            !source->payout_journal.entries ||
-            (size_t)source->payout_journal.count >
-                SIZE_MAX / sizeof(*source->payout_journal.entries)) {
+            source->payout_journal.count >
+                STATION_PAYOUT_JOURNAL_MAX_ENTRIES ||
+            !source->payout_journal.entries) {
             world_cleanup(candidate);
             free(candidate);
             return NULL;

--- a/server/sim_save.c
+++ b/server/sim_save.c
@@ -90,7 +90,10 @@
 #define SAVE_CRC_MAGIC 0x43524332u /* "CRC2" */
 #define SAVE_STATION_SLOTS_V25 64
 #define OWNERSHIP_QUARANTINE_AUTO_REPORT_ROWS 32
-#define SAVE_VERSION 83  /* v83: append Engine commodity/module identities and
+#define SAVE_VERSION 84  /* v84: append the durable station payout journal so
+                          * a source/action identity cannot credit twice across
+                          * retries, reconnects, or save/load.
+                          * v83: append Engine commodity/module identities and
                           * expand station module slots from 16 to 18.
                           * v82: cargo-pod player tow custody uses canonical
                           * actor principals. Runtime player slots are
@@ -3448,9 +3451,34 @@ static bool world_save_payload(const world_t *w, FILE *f,
         }
     }
 
-    /* v78: bounded, server-only legacy ownership quarantine. Rows are
-     * serialized field-by-field in canonical record-ID order and contain no
-     * pubkeys, session tokens, reconnect secrets, or other bearer material. */
+    /* v84: append-only at-most-once station settlement receipts. Runtime
+     * allocation capacity is deliberately omitted. */
+    if (output_version >= 84) {
+        if (w->payout_journal.count >
+                STATION_PAYOUT_JOURNAL_MAX_ENTRIES ||
+            w->payout_journal.count > w->payout_journal.capacity ||
+            (w->payout_journal.count > 0 &&
+             !w->payout_journal.entries)) {
+            return false;
+        }
+        WRITE_FIELD(f, w->payout_journal.count);
+        for (uint32_t i = 0; i < w->payout_journal.count; i++) {
+            const station_payout_receipt_t *receipt =
+                &w->payout_journal.entries[i];
+            WRITE_FIELD(f, receipt->payout_id);
+            WRITE_FIELD(f, receipt->recipient_hash);
+            WRITE_FIELD(f, receipt->station_id);
+            WRITE_FIELD(f, receipt->committed_tick);
+            WRITE_FIELD(f, receipt->amount);
+            WRITE_FIELD(f, receipt->action);
+            WRITE_FIELD(f, receipt->authority_generation);
+            WRITE_FIELD(f, receipt->_pad);
+        }
+    }
+
+    /* v78: bounded, server-only legacy ownership quarantine. Keep this
+     * immediately before CRC2 so its corruption fixtures remain a stable
+     * tail contract across later append-only sections. */
     if (!write_ownership_quarantine(f, &w->ownership_quarantine))
         return false;
 
@@ -3816,6 +3844,70 @@ static bool world_load_payload(
                 return false;
             }
         }
+    }
+
+    free(w->payout_journal.entries);
+    w->payout_journal = (station_payout_journal_t){0};
+    if (version >= 84) {
+        uint32_t count = 0;
+        READ_FIELD(f, count);
+        if (count > STATION_PAYOUT_JOURNAL_MAX_ENTRIES ||
+            (size_t)count > SIZE_MAX /
+                sizeof(*w->payout_journal.entries)) {
+            return false;
+        }
+        if (count > 0) {
+            w->payout_journal.entries = calloc(
+                count, sizeof(*w->payout_journal.entries));
+            if (!w->payout_journal.entries)
+                return world_load_record_oom(result);
+        }
+        for (uint32_t i = 0; i < count; i++) {
+            station_payout_receipt_t *receipt =
+                &w->payout_journal.entries[i];
+            READ_FIELD(f, receipt->payout_id);
+            READ_FIELD(f, receipt->recipient_hash);
+            READ_FIELD(f, receipt->station_id);
+            READ_FIELD(f, receipt->committed_tick);
+            READ_FIELD(f, receipt->amount);
+            READ_FIELD(f, receipt->action);
+            READ_FIELD(f, receipt->authority_generation);
+            READ_FIELD(f, receipt->_pad);
+            bool payout_nonzero = false;
+            bool recipient_nonzero = false;
+            bool station_known = false;
+            for (size_t b = 0; b < 32; b++) {
+                payout_nonzero |= receipt->payout_id[b] != 0;
+                recipient_nonzero |=
+                    receipt->recipient_hash[b] != 0;
+            }
+            for (int station_idx = 0;
+                 station_idx < MAX_STATIONS; station_idx++) {
+                if (station_exists(&w->stations[station_idx]) &&
+                    w->stations[station_idx].id == receipt->station_id) {
+                    station_known = true;
+                    break;
+                }
+            }
+            if (!payout_nonzero || !recipient_nonzero ||
+                receipt->station_id == 0 || !station_known ||
+                !isfinite(receipt->amount) || receipt->amount <= 0.0f ||
+                receipt->amount > LEDGER_FLOAT_LIMIT ||
+                receipt->action <= STATION_PAYOUT_NONE ||
+                receipt->action >= STATION_PAYOUT_COUNT ||
+                receipt->_pad[0] != 0 || receipt->_pad[1] != 0) {
+                return false;
+            }
+            for (uint32_t prior = 0; prior < i; prior++) {
+                if (memcmp(
+                        w->payout_journal.entries[prior].payout_id,
+                        receipt->payout_id, 32) == 0) {
+                    return false;
+                }
+            }
+        }
+        w->payout_journal.count = count;
+        w->payout_journal.capacity = count;
     }
 
     if (version >= 78) {
@@ -4400,6 +4492,7 @@ static world_t *world_load_candidate_create(const world_t *source) {
            sizeof(candidate->signal_cache));
     memset(&candidate->asteroid_grid, 0,
            sizeof(candidate->asteroid_grid));
+    candidate->payout_journal = (station_payout_journal_t){0};
 
     for (int i = 0; i < MAX_STATIONS; i++) {
         if (!station_copy(&candidate->stations[i],
@@ -4425,6 +4518,30 @@ static world_t *world_load_candidate_create(const world_t *source) {
             free(candidate);
             return NULL;
         }
+    }
+    if (source->payout_journal.count > 0) {
+        if (source->payout_journal.count > source->payout_journal.capacity ||
+            !source->payout_journal.entries ||
+            (size_t)source->payout_journal.count >
+                SIZE_MAX / sizeof(*source->payout_journal.entries)) {
+            world_cleanup(candidate);
+            free(candidate);
+            return NULL;
+        }
+        candidate->payout_journal.entries = calloc(
+            source->payout_journal.count,
+            sizeof(*candidate->payout_journal.entries));
+        if (!candidate->payout_journal.entries) {
+            world_cleanup(candidate);
+            free(candidate);
+            return NULL;
+        }
+        memcpy(candidate->payout_journal.entries,
+               source->payout_journal.entries,
+               (size_t)source->payout_journal.count *
+                   sizeof(*candidate->payout_journal.entries));
+        candidate->payout_journal.count = source->payout_journal.count;
+        candidate->payout_journal.capacity = source->payout_journal.count;
     }
     for (int i = 0; i < MAX_PLAYERS; i++) {
         candidate->players[i].connection =

--- a/server/state_digest.c
+++ b/server/state_digest.c
@@ -1249,6 +1249,26 @@ void signal_authoritative_state_digest(
         digest_delivery_shipment(&ctx, &world->delivery_shipments[i]);
     }
 
+    uint32_t payout_count = world->payout_journal.count;
+    if (payout_count > world->payout_journal.capacity ||
+        (payout_count > 0 && !world->payout_journal.entries)) {
+        payout_count = 0;
+    }
+    digest_u32(&ctx, payout_count);
+    for (uint32_t i = 0; i < payout_count; i++) {
+        const station_payout_receipt_t *receipt =
+            &world->payout_journal.entries[i];
+        digest_bytes(&ctx, receipt->payout_id,
+                     sizeof(receipt->payout_id));
+        digest_bytes(&ctx, receipt->recipient_hash,
+                     sizeof(receipt->recipient_hash));
+        digest_u32(&ctx, receipt->station_id);
+        digest_u64(&ctx, receipt->committed_tick);
+        digest_float(&ctx, receipt->amount);
+        digest_u8(&ctx, receipt->action);
+        digest_u8(&ctx, receipt->authority_generation);
+    }
+
     digest_ownership_quarantine(&ctx, &world->ownership_quarantine);
     digest_signal_channel(&ctx, &world->signal_channel);
 

--- a/tests/c/test_economy.c
+++ b/tests/c/test_economy.c
@@ -44,6 +44,121 @@ static void economy_finalize_token_identity(
     player->pubkey_identity_finalized = true;
 }
 
+TEST(test_station_payout_journal_covers_every_action_and_replays_inert) {
+    WORLD_DECL;
+    world_reset(&w);
+    station_t *station = &w.stations[1];
+    uint8_t recipient[32];
+    economy_fill_pubkey(recipient, 0x91);
+    float expected = 0.0f;
+
+    for (int raw = STATION_PAYOUT_NONE + 1;
+         raw < STATION_PAYOUT_COUNT; raw++) {
+        uint8_t sources[1][32] = {{0}};
+        float amounts[1] = {10.0f + (float)raw};
+        sources[0][0] = 0xA6;
+        sources[0][31] = (uint8_t)raw;
+        station_payout_credit_batch_stage_t stage = {0};
+        ASSERT(station_payout_credit_batch_prepare(
+            &w, 1, (station_payout_action_t)raw,
+            sources, amounts, 1, recipient, &stage));
+        ASSERT(station_payout_credit_batch_commit(
+            &w, station, NULL, &stage));
+        expected += amounts[0];
+    }
+
+    ASSERT_EQ_INT((int)w.payout_journal.count,
+                  STATION_PAYOUT_COUNT - 1);
+    ASSERT_EQ_FLOAT(ledger_balance_by_pubkey(station, recipient),
+                    expected, 0.001f);
+
+    uint8_t source[32] = {0};
+    source[0] = 0xA6;
+    source[31] = STATION_PAYOUT_POD_INTAKE;
+    float balance_after = ledger_balance_by_pubkey(station, recipient);
+    for (int retry = 0; retry < 1000; retry++) {
+        station_payout_stage_t replay = {0};
+        ASSERT_EQ_INT(station_payout_prepare(
+            &w, 1, STATION_PAYOUT_POD_INTAKE,
+            source, recipient,
+            10.0f + (float)STATION_PAYOUT_POD_INTAKE,
+            &replay),
+            STATION_PAYOUT_PREPARE_DUPLICATE);
+        ASSERT_EQ_FLOAT(
+            replay.receipt.amount,
+            10.0f + (float)STATION_PAYOUT_POD_INTAKE,
+            0.001f);
+    }
+    ASSERT_EQ_FLOAT(ledger_balance_by_pubkey(station, recipient),
+                    balance_after, 0.001f);
+    ASSERT_EQ_INT((int)w.payout_journal.count,
+                  STATION_PAYOUT_COUNT - 1);
+}
+
+TEST(test_station_payout_identity_binds_station_action_and_authority) {
+    WORLD_DECL;
+    world_reset(&w);
+    uint8_t source[32] = {0};
+    uint8_t first[32] = {0};
+    uint8_t other_action[32] = {0};
+    uint8_t other_station[32] = {0};
+    uint8_t other_authority[32] = {0};
+    source[31] = 0x6e;
+    station_t *station = &w.stations[1];
+    ASSERT(station_payout_identity(
+        station, STATION_PAYOUT_POD_INTAKE, source, first));
+    ASSERT(station_payout_identity(
+        station, STATION_PAYOUT_BUILD_DELIVERY,
+        source, other_action));
+    ASSERT(station_payout_identity(
+        &w.stations[0], STATION_PAYOUT_POD_INTAKE,
+        source, other_station));
+    station->authority_registry_version++;
+    ASSERT(station_payout_identity(
+        station, STATION_PAYOUT_POD_INTAKE,
+        source, other_authority));
+    ASSERT(memcmp(first, other_action, 32) != 0);
+    ASSERT(memcmp(first, other_station, 32) != 0);
+    ASSERT(memcmp(first, other_authority, 32) != 0);
+}
+
+TEST(test_station_payout_stages_two_new_smelt_recipients_in_order) {
+    WORLD_DECL;
+    world_reset(&w);
+    station_t *station = &w.stations[1];
+    uint8_t source[32] = {0};
+    uint8_t tower[32];
+    uint8_t fracturer[32];
+    source[31] = 0x71;
+    economy_fill_pubkey(tower, 0x31);
+    economy_fill_pubkey(fracturer, 0x61);
+    ASSERT_EQ_FLOAT(ledger_balance_by_pubkey(station, tower),
+                    0.0f, 0.001f);
+    ASSERT_EQ_FLOAT(ledger_balance_by_pubkey(station, fracturer),
+                    0.0f, 0.001f);
+
+    station_payout_supply_stage_t tower_stage = {0};
+    station_payout_supply_stage_t fracturer_stage = {0};
+    ASSERT(station_payout_supply_prepare(
+        &w, 1, STATION_PAYOUT_SMELT_TOWER,
+        source, tower, 100.0f, NULL, &tower_stage));
+    ASSERT(station_payout_supply_prepare(
+        &w, 1, STATION_PAYOUT_SMELT_FRACTURER,
+        source, fracturer, 25.0f, &tower_stage,
+        &fracturer_stage));
+    ASSERT(tower_stage.ledger_index != fracturer_stage.ledger_index);
+    ASSERT(station_payout_supply_commit(
+        &w, station, NULL, &tower_stage));
+    ASSERT(station_payout_supply_commit(
+        &w, station, NULL, &fracturer_stage));
+
+    ASSERT_EQ_FLOAT(ledger_balance_by_pubkey(station, tower),
+                    65.0f, 0.001f);
+    ASSERT_EQ_FLOAT(ledger_balance_by_pubkey(station, fracturer),
+                    16.25f, 0.001f);
+    ASSERT_EQ_INT((int)w.payout_journal.count, 2);
+}
+
 static cargo_unit_t economy_test_cargo_unit(
     const uint8_t fragment_pub[32],
     uint16_t *out_output_index) {
@@ -5238,6 +5353,9 @@ void register_economy_basic_tests(void) {
     RUN(test_can_afford_upgrade_rejects_float_only_finished_goods);
     RUN(test_commodity_volume_kit_dense);
     RUN(test_ship_total_cargo_kit_density);
+    RUN(test_station_payout_journal_covers_every_action_and_replays_inert);
+    RUN(test_station_payout_identity_binds_station_action_and_authority);
+    RUN(test_station_payout_stages_two_new_smelt_recipients_in_order);
 }
 
 void register_economy_contracts_tests(void) {

--- a/tests/c/test_save.c
+++ b/tests/c/test_save.c
@@ -3095,8 +3095,9 @@ TEST(test_v81_cargo_pod_player_slot_migrates_to_bound_quarantine) {
              * quarantine bindings (+1,920 bytes).
              * v82: each active cargo pod replaces its 1-byte player slot
              * with a 33-byte principal plus 8-byte quarantine binding.
-             * Fresh worlds have two starter pods, so +80 bytes. */
-#define EXPECTED_SAVE_SIZE 846454
+             * Fresh worlds have two starter pods, so +80 bytes.
+             * v84: +4B empty durable payout-journal count. */
+#define EXPECTED_SAVE_SIZE 846458
 
 TEST(test_save_file_size_stable) {
     WORLD_HEAP w = calloc(1, sizeof(world_t));
@@ -3133,7 +3134,7 @@ TEST(test_save_header_golden_bytes) {
     ASSERT_EQ_INT((int)fread(&spawn_timer, 4, 1, f), 1);
     fclose(f);
     ASSERT_EQ_INT((int)magic, (int)0x5349474E);    /* "SIGN" */
-    ASSERT_EQ_INT((int)version, 83);
+    ASSERT_EQ_INT((int)version, 84);
     ASSERT(rng != 0);  /* seed is set */
     ASSERT_EQ_FLOAT(time_val, 0.0f, 0.001f);
     ASSERT_EQ_FLOAT(spawn_timer, 0.0f, 0.001f);
@@ -4272,6 +4273,54 @@ TEST(test_world_load_rejects_nested_crc_trailer) {
     remove(path);
 }
 
+TEST(test_world_save_load_preserves_payout_replay_barrier) {
+    const char *path = TMP("test_payout_replay_barrier.sav");
+    WORLD_HEAP saved = calloc(1, sizeof(world_t));
+    WORLD_HEAP loaded = calloc(1, sizeof(world_t));
+    ASSERT(saved != NULL);
+    ASSERT(loaded != NULL);
+    world_reset(saved);
+
+    uint8_t recipient[32] = {0};
+    uint8_t sources[1][32] = {{0}};
+    float amounts[1] = {73.0f};
+    recipient[0] = 0x84;
+    recipient[31] = 0x2a;
+    sources[0][0] = 0x51;
+    sources[0][31] = 0x9d;
+    station_payout_credit_batch_stage_t stage = {0};
+    ASSERT(station_payout_credit_batch_prepare(
+        saved, 1, STATION_PAYOUT_POD_INTAKE,
+        sources, amounts, 1, recipient, &stage));
+    uint8_t payout_id[32];
+    memcpy(payout_id, stage.payout_stages[0].receipt.payout_id, 32);
+    ASSERT(station_payout_credit_batch_commit(
+        saved, &saved->stations[1], NULL, &stage));
+    ASSERT(world_save(saved, path));
+
+    world_reset(loaded);
+    ASSERT(world_load(loaded, path));
+    ASSERT_EQ_INT((int)loaded->payout_journal.count, 1);
+    const station_payout_receipt_t *receipt =
+        station_payout_find(loaded, payout_id);
+    ASSERT(receipt != NULL);
+    ASSERT_EQ_FLOAT(receipt->amount, 73.0f, 0.001f);
+    float balance = ledger_balance_by_pubkey(
+        &loaded->stations[1], recipient);
+    ASSERT_EQ_FLOAT(balance, 73.0f, 0.001f);
+
+    station_payout_stage_t replay = {0};
+    ASSERT_EQ_INT(station_payout_prepare(
+        loaded, 1, STATION_PAYOUT_POD_INTAKE,
+        sources[0], recipient, 73.0f, &replay),
+        STATION_PAYOUT_PREPARE_DUPLICATE);
+    ASSERT_EQ_FLOAT(ledger_balance_by_pubkey(
+                        &loaded->stations[1], recipient),
+                    balance, 0.001f);
+    ASSERT_EQ_INT((int)loaded->payout_journal.count, 1);
+    remove(path);
+}
+
 void register_save_persistence_tests(void) {
     TEST_SECTION("\nPersistence tests:\n");
     RUN(test_player_save_load_roundtrip);
@@ -4344,6 +4393,7 @@ void register_save_persistence_tests(void) {
     RUN(test_v79_birth_proofs_recompute_and_reject_fragment_reuse);
     RUN(test_world_save_rejects_invalid_station_actor_preserving_destination);
     RUN(test_world_save_invalid_ownership_quarantine_preserves_destination);
+    RUN(test_world_save_load_preserves_payout_replay_barrier);
 }
 
 void register_save_format_tests(void) {


### PR DESCRIPTION
Closes #686.

Summary:
- persist a source/action/station/authority payout identity and replay journal
- make pod intake, contracts, freight, black market, smelting, and player build delivery commit credits at most once
- preserve original station currency and zero-price frontier construction behavior
- fix the Nightly Valgrind padding defect and split the suite into diagnosable shards

Validation:
- native: 1658/1658
- ASan/UBSan: 1658/1658
- functional soak: 9/9
- server, native client, and release WebAssembly builds
- fresh deterministic replay: 21/21 scenarios
- cargo trust, banned API, deterministic libm, documentation, soak automation, vendor/container policy, memzero codegen, cppcheck
- Nightly Valgrind manual run: 16/16 shards green