### PR TITLE
Close towing lifecycle matrix gaps

### DIFF
--- a/client/client.h
+++ b/client/client.h
@@ -768,14 +768,16 @@ typedef struct {
     struct {
         client_npc_render_state_t prev[MAX_NPC_SHIPS];
         client_npc_render_state_t curr[MAX_NPC_SHIPS];
-        float t;
-        float interval;
+        /* Sparse NPC identity, pose, and linear packets arrive on separate
+         * schedules. One clock per slot prevents traffic for NPC B from
+         * restarting NPC A's correction baseline. */
+        float elapsed[MAX_NPC_SHIPS];
     } npc_interp;
     struct {
         scaffold_t prev[MAX_SCAFFOLDS];
         scaffold_t curr[MAX_SCAFFOLDS];
-        float t;
-        float interval;
+        /* Scaffold metadata and motion are sparse independent streams. */
+        float elapsed[MAX_SCAFFOLDS];
     } scaffold_interp;
     struct {
         cargo_pod_t prev[MAX_CARGO_PODS];

--- a/client/hud.c
+++ b/client/hud.c
@@ -5050,8 +5050,7 @@ static int smoke_apply_loop_state(int state) {
                sizeof(g.asteroid_interp.elapsed));
         memset(g.npc_interp.curr, 0, sizeof(g.npc_interp.curr));
         memset(g.npc_interp.prev, 0, sizeof(g.npc_interp.prev));
-        g.npc_interp.t = 0.0f;
-        g.npc_interp.interval = 0.1f;
+        memset(g.npc_interp.elapsed, 0, sizeof(g.npc_interp.elapsed));
         return 1;
     }
     case SMOKE_LOOP_STATE_CUPRITE_GATE:

--- a/client/main.c
+++ b/client/main.c
@@ -562,9 +562,7 @@ static void reset_world(void) {
     memset(&g.asteroid_interp, 0, sizeof(g.asteroid_interp));
     reset_local_asteroid_motion_telemetry();
     memset(&g.npc_interp, 0, sizeof(g.npc_interp));
-    g.npc_interp.interval = 0.1f;
     memset(&g.scaffold_interp, 0, sizeof(g.scaffold_interp));
-    g.scaffold_interp.interval = 0.1f;
     memset(&g.cargo_pod_interp, 0, sizeof(g.cargo_pod_interp));
     memset(&g.player_interp, 0, sizeof(g.player_interp));
     g.player_interp.interval = 0.1f;
@@ -1741,9 +1739,9 @@ static void sim_step(float dt) {
 
     /* Advance interpolation timers (both modes) */
     net_advance_asteroid_interpolation(dt);
+    net_advance_npc_interpolation(dt);
+    net_advance_scaffold_interpolation(dt);
     net_advance_cargo_pod_interpolation(dt);
-    g.npc_interp.t += dt / fmaxf(g.npc_interp.interval, 0.01f);
-    g.scaffold_interp.t += dt / fmaxf(g.scaffold_interp.interval, 0.01f);
     g.player_interp.t += dt / fmaxf(g.player_interp.interval, 0.01f);
 
     /* Thrust flame: local input for manual, server input for autopilot.
@@ -3698,16 +3696,18 @@ int signal_smoke_remote_towable_interp_check(void) {
     asteroid_t saved_asteroid_prev[MAX_ASTEROIDS];
     asteroid_t saved_asteroid_curr[MAX_ASTEROIDS];
     float saved_asteroid_elapsed[MAX_ASTEROIDS];
+    client_npc_render_state_t saved_npc_prev[MAX_NPC_SHIPS];
+    client_npc_render_state_t saved_npc_curr[MAX_NPC_SHIPS];
+    float saved_npc_elapsed[MAX_NPC_SHIPS];
     sim_interactions_t saved_world_interactions = g.world.interactions;
     scaffold_t saved_world_scaffolds[MAX_SCAFFOLDS];
     scaffold_t saved_scaffold_prev[MAX_SCAFFOLDS];
     scaffold_t saved_scaffold_curr[MAX_SCAFFOLDS];
+    float saved_scaffold_elapsed[MAX_SCAFFOLDS];
     cargo_pod_t saved_world_cargo_pods[MAX_CARGO_PODS];
     cargo_pod_t saved_cargo_pod_prev[MAX_CARGO_PODS];
     cargo_pod_t saved_cargo_pod_curr[MAX_CARGO_PODS];
     float saved_cargo_pod_elapsed[MAX_CARGO_PODS];
-    float saved_scaffold_t = g.scaffold_interp.t;
-    float saved_scaffold_interval = g.scaffold_interp.interval;
 
     memcpy(saved_player0_towed_fragments,
            g.world.players[0].ship->towed_fragments,
@@ -3724,9 +3724,15 @@ int signal_smoke_remote_towable_interp_check(void) {
     memcpy(saved_asteroid_curr, g.asteroid_interp.curr, sizeof(saved_asteroid_curr));
     memcpy(saved_asteroid_elapsed, g.asteroid_interp.elapsed,
            sizeof(saved_asteroid_elapsed));
+    memcpy(saved_npc_prev, g.npc_interp.prev, sizeof(saved_npc_prev));
+    memcpy(saved_npc_curr, g.npc_interp.curr, sizeof(saved_npc_curr));
+    memcpy(saved_npc_elapsed, g.npc_interp.elapsed,
+           sizeof(saved_npc_elapsed));
     memcpy(saved_world_scaffolds, g.world.scaffolds, sizeof(saved_world_scaffolds));
     memcpy(saved_scaffold_prev, g.scaffold_interp.prev, sizeof(saved_scaffold_prev));
     memcpy(saved_scaffold_curr, g.scaffold_interp.curr, sizeof(saved_scaffold_curr));
+    memcpy(saved_scaffold_elapsed, g.scaffold_interp.elapsed,
+           sizeof(saved_scaffold_elapsed));
     memcpy(saved_world_cargo_pods, g.world.cargo_pods, sizeof(saved_world_cargo_pods));
     memcpy(saved_cargo_pod_prev, g.cargo_pod_interp.prev, sizeof(saved_cargo_pod_prev));
     memcpy(saved_cargo_pod_curr, g.cargo_pod_interp.curr, sizeof(saved_cargo_pod_curr));
@@ -3752,9 +3758,51 @@ int signal_smoke_remote_towable_interp_check(void) {
     memset(&g.world.interactions, 0, sizeof(g.world.interactions));
     memset(g.world.scaffolds, 0, sizeof(g.world.scaffolds));
     memset(&g.scaffold_interp, 0, sizeof(g.scaffold_interp));
-    g.scaffold_interp.interval = 0.1f;
     memset(g.world.cargo_pods, 0, sizeof(g.world.cargo_pods));
     memset(&g.cargo_pod_interp, 0, sizeof(g.cargo_pod_interp));
+
+    memset(&g.npc_interp, 0, sizeof(g.npc_interp));
+    NetNpcState npc_pair[2] = {
+        {
+            .index = 3,
+            .flags = 1u,
+            .x = 0.0f,
+            .y = 0.0f,
+            .vx = 100.0f,
+            .vy = 0.0f,
+            .target_asteroid = -1,
+            .towed_fragment = -1,
+            .home_station = 0xFFu,
+        },
+        {
+            .index = 4,
+            .flags = 1u,
+            .x = 0.0f,
+            .y = 90.0f,
+            .vx = 0.0f,
+            .vy = 0.0f,
+            .target_asteroid = -1,
+            .towed_fragment = -1,
+            .home_station = 0xFFu,
+        },
+    };
+    apply_remote_npcs(npc_pair, 2);
+    g.npc_interp.elapsed[3] = 0.1f;
+    vec2 npc_before_unrelated_pos = {0};
+    vec2 npc_before_unrelated_vel = {0};
+    bool npc_before_unrelated_visible = net_remote_npc_presentation(
+        3, &npc_before_unrelated_pos, &npc_before_unrelated_vel);
+    NetNpcPosState unrelated_npc_pos = {
+        .index = 4,
+        .x = 5.0f,
+        .y = 90.0f,
+    };
+    apply_remote_npc_pos(&unrelated_npc_pos, 1);
+    net_advance_npc_interpolation(0.05f);
+    vec2 npc_after_unrelated_pos = {0};
+    vec2 npc_after_unrelated_vel = {0};
+    bool npc_after_unrelated_visible = net_remote_npc_presentation(
+        3, &npc_after_unrelated_pos, &npc_after_unrelated_vel);
 
     NetScaffoldState scaffold = {
         .index = 3,
@@ -3772,15 +3820,41 @@ int signal_smoke_remote_towable_interp_check(void) {
     apply_remote_scaffolds(&scaffold, 1);
     bool scaffold_station_authoritative =
         g.scaffold_interp.curr[3].built_at_station == 2;
-    g.scaffold_interp.t = 0.1f / fmaxf(g.scaffold_interp.interval, 0.001f);
+    g.scaffold_interp.elapsed[3] = 0.1f;
     interpolate_world_for_render();
     float scaffold_first_x = g.world.scaffolds[3].pos.x;
     scaffold.pos_x = 100.0f;
     scaffold.vel_x = 0.0f;
     apply_remote_scaffolds(&scaffold, 1);
-    g.scaffold_interp.t = 0.05f / fmaxf(g.scaffold_interp.interval, 0.001f);
+    g.scaffold_interp.elapsed[3] = 0.05f;
     interpolate_world_for_render();
     float scaffold_blended_x = g.world.scaffolds[3].pos.x;
+
+    memset(g.world.scaffolds, 0, sizeof(g.world.scaffolds));
+    memset(&g.scaffold_interp, 0, sizeof(g.scaffold_interp));
+    scaffold.pos_x = 0.0f;
+    scaffold.pos_y = 0.0f;
+    scaffold.vel_x = 100.0f;
+    NetScaffoldState unrelated_scaffold = scaffold;
+    unrelated_scaffold.index = 4;
+    unrelated_scaffold.pos_y = 90.0f;
+    unrelated_scaffold.vel_x = 0.0f;
+    NetScaffoldState scaffold_pair[2] = {scaffold, unrelated_scaffold};
+    apply_remote_scaffolds(scaffold_pair, 2);
+    g.scaffold_interp.elapsed[3] = 0.1f;
+    interpolate_world_for_render();
+    float scaffold_before_unrelated_x = g.world.scaffolds[3].pos.x;
+    NetScaffoldMotionState unrelated_scaffold_motion = {
+        .index = 4,
+        .pos_x = 5.0f,
+        .pos_y = 90.0f,
+        .vel_x = 0.0f,
+        .vel_y = 0.0f,
+    };
+    apply_remote_scaffold_motion(&unrelated_scaffold_motion, 1);
+    net_advance_scaffold_interpolation(0.05f);
+    interpolate_world_for_render();
+    float scaffold_after_unrelated_x = g.world.scaffolds[3].pos.x;
 
     NetCargoPodState pod = {
         .index = 5,
@@ -4303,9 +4377,21 @@ int signal_smoke_remote_towable_interp_check(void) {
         !net_is_loopback() || net_local_prediction_enabled();
 
     int ok = scaffold_first_x > 9.0f && scaffold_first_x < 11.5f &&
+             npc_before_unrelated_visible &&
+             npc_after_unrelated_visible &&
+             npc_before_unrelated_pos.x > 9.0f &&
+             npc_before_unrelated_pos.x < 11.5f &&
+             npc_after_unrelated_pos.x > 14.0f &&
+             npc_after_unrelated_pos.x < 16.0f &&
+             npc_before_unrelated_vel.x > 99.9f &&
+             npc_after_unrelated_vel.x > 99.9f &&
              scaffold_blended_x > scaffold_first_x &&
              scaffold_blended_x < 95.0f &&
              scaffold_station_authoritative &&
+             scaffold_before_unrelated_x > 9.0f &&
+             scaffold_before_unrelated_x < 11.5f &&
+             scaffold_after_unrelated_x > 14.0f &&
+             scaffold_after_unrelated_x < 16.0f &&
              pod_first_x > 9.0f && pod_first_x < 11.5f &&
              pod_blended_x > pod_first_x &&
              pod_blended_x < 95.0f &&
@@ -4356,17 +4442,21 @@ int signal_smoke_remote_towable_interp_check(void) {
     memcpy(g.asteroid_interp.curr, saved_asteroid_curr, sizeof(saved_asteroid_curr));
     memcpy(g.asteroid_interp.elapsed, saved_asteroid_elapsed,
            sizeof(saved_asteroid_elapsed));
+    memcpy(g.npc_interp.prev, saved_npc_prev, sizeof(saved_npc_prev));
+    memcpy(g.npc_interp.curr, saved_npc_curr, sizeof(saved_npc_curr));
+    memcpy(g.npc_interp.elapsed, saved_npc_elapsed,
+           sizeof(saved_npc_elapsed));
     g.world.interactions = saved_world_interactions;
     memcpy(g.world.scaffolds, saved_world_scaffolds, sizeof(saved_world_scaffolds));
     memcpy(g.scaffold_interp.prev, saved_scaffold_prev, sizeof(saved_scaffold_prev));
     memcpy(g.scaffold_interp.curr, saved_scaffold_curr, sizeof(saved_scaffold_curr));
+    memcpy(g.scaffold_interp.elapsed, saved_scaffold_elapsed,
+           sizeof(saved_scaffold_elapsed));
     memcpy(g.world.cargo_pods, saved_world_cargo_pods, sizeof(saved_world_cargo_pods));
     memcpy(g.cargo_pod_interp.prev, saved_cargo_pod_prev, sizeof(saved_cargo_pod_prev));
     memcpy(g.cargo_pod_interp.curr, saved_cargo_pod_curr, sizeof(saved_cargo_pod_curr));
     memcpy(g.cargo_pod_interp.elapsed, saved_cargo_pod_elapsed,
            sizeof(saved_cargo_pod_elapsed));
-    g.scaffold_interp.t = saved_scaffold_t;
-    g.scaffold_interp.interval = saved_scaffold_interval;
     g.local_server.active = saved_local_server_active;
     g.net_authority_enabled = saved_net_authority_enabled;
     g.net_input_tick_protocol = saved_net_input_tick_protocol;
@@ -4389,6 +4479,64 @@ int signal_smoke_remote_towable_interp_check(void) {
            saved_player0_towed_pods,
            sizeof(saved_player0_towed_pods));
     return ok ? 1 : 0;
+}
+
+EMSCRIPTEN_KEEPALIVE
+int signal_smoke_prepare_npc_scaffold_tether(void) {
+    const int npc_idx = 0;
+    const int scaffold_idx = MAX_SCAFFOLDS - 1;
+    g.local_server.active = false;
+
+    if (!world_npc_ship_slot_activate(&g.world, npc_idx)) return 0;
+    npc_ship_t *npc = &g.world.npc_ships[npc_idx];
+    npc->active = true;
+    npc->role = NPC_ROLE_HAULER;
+    npc->ship->pos = v2_add(LOCAL_PLAYER.ship->pos, v2(80.0f, 0.0f));
+    npc->ship->vel = v2(0.0f, 0.0f);
+
+    client_npc_render_state_t render_npc = {
+        .active = true,
+        .role = NPC_ROLE_HAULER,
+        .state = NPC_STATE_IDLE,
+        .hull_class = npc->ship->hull_class,
+        .pos = npc->ship->pos,
+        .vel = npc->ship->vel,
+        .angle = npc->ship->angle,
+        .target_asteroid = -1,
+        .towed_fragment = -1,
+        .towed_scaffold = scaffold_idx,
+        .home_station = -1,
+    };
+    g.npc_interp.prev[npc_idx] = render_npc;
+    g.npc_interp.curr[npc_idx] = render_npc;
+    g.npc_interp.elapsed[npc_idx] = 0.0f;
+
+    scaffold_t scaffold = {
+        .active = true,
+        .state = SCAFFOLD_TOWING,
+        .module_type = MODULE_DOCK,
+        .owner = -1,
+        .pos = v2_add(npc->ship->pos, v2(90.0f, 0.0f)),
+        .vel = v2(0.0f, 0.0f),
+        .radius = 18.0f,
+        .built_at_station = -1,
+    };
+    g.world.scaffolds[scaffold_idx] = scaffold;
+    g.scaffold_interp.prev[scaffold_idx] = scaffold;
+    g.scaffold_interp.curr[scaffold_idx] = scaffold;
+    g.scaffold_interp.elapsed[scaffold_idx] = 0.0f;
+
+    world_tow_links_clear_source(&g.world, npc->ship_ref);
+    if (!world_scaffold_set_npc_tractor(
+            &g.world, scaffold_idx, npc_idx)) return 0;
+    g.scaffold_interp.prev[scaffold_idx].tractor =
+        g.world.scaffolds[scaffold_idx].tractor;
+    g.scaffold_interp.curr[scaffold_idx].tractor =
+        g.world.scaffolds[scaffold_idx].tractor;
+    g.tow_snapshot_received = true;
+    g.tow_snapshot_revision = g.world.tow_revision;
+    g.tow_snapshot_server_tick = g.world.tow_revision_tick;
+    return 1;
 }
 #endif
 

--- a/client/net_sync.c
+++ b/client/net_sync.c
@@ -30,8 +30,10 @@
 #define ASTEROID_RENDER_PREDICT_MAX_SEC 60.0f
 #define ASTEROID_RENDER_CORRECTION_CUTOFF_SEC \
     (ASTEROID_RENDER_CORRECTION_SEC * 4.0f)
-#define NPC_RENDER_CORRECTION_SEC 0.18f
+#define NPC_RENDER_CORRECTION_SEC 0.50f
 #define NPC_RENDER_EXTRAPOLATE_MAX_SEC 2.20f
+#define NPC_RENDER_CORRECTION_CUTOFF_SEC \
+    (NPC_RENDER_CORRECTION_SEC * 4.0f)
 #define REMOTE_PLAYER_RENDER_CORRECTION_SEC 0.18f
 #define REMOTE_PLAYER_RENDER_EXTRAPOLATE_MAX_SEC 2.25f
 #define SCAFFOLD_RENDER_CORRECTION_SEC 0.18f
@@ -915,12 +917,46 @@ static client_npc_render_state_t npc_render_state_at(int slot, float elapsed) {
     out.pos.y += curr->vel.y * elapsed;
 
     if (prev->active) {
+        /* Preserve both position and velocity across a late sparse update,
+         * then critically damp the visual offset. A position-only lerp
+         * visibly kicks tractor emitters after a long extrapolation gap. */
+        float omega = 4.0f / NPC_RENDER_CORRECTION_SEC;
+        float decay = expf(-omega * elapsed);
+        vec2 pos_error = v2_sub(prev->pos, curr->pos);
+        vec2 vel_error = v2_sub(prev->vel, curr->vel);
+        vec2 c = v2_add(vel_error, v2_scale(pos_error, omega));
+        vec2 offset = v2_scale(
+            v2_add(pos_error, v2_scale(c, elapsed)), decay);
+        vec2 offset_vel = v2_scale(
+            v2_sub(vel_error, v2_scale(c, omega * elapsed)), decay);
+        out.pos = v2_add(out.pos, offset);
+        out.vel = v2_add(out.vel, offset_vel);
         float blend = clampf(elapsed / NPC_RENDER_CORRECTION_SEC, 0.0f, 1.0f);
-        out.pos.x = lerpf(prev->pos.x, out.pos.x, blend);
-        out.pos.y = lerpf(prev->pos.y, out.pos.y, blend);
         out.angle = lerp_angle(prev->angle, out.angle, blend);
     }
     return out;
+}
+
+static void npc_interp_begin_update(int slot) {
+    if (slot < 0 || slot >= MAX_NPC_SHIPS) return;
+    float elapsed = clampf(g.npc_interp.elapsed[slot], 0.0f,
+                           NPC_RENDER_EXTRAPOLATE_MAX_SEC);
+    g.npc_interp.prev[slot] = npc_render_state_at(slot, elapsed);
+    g.npc_interp.elapsed[slot] = 0.0f;
+}
+
+bool net_remote_npc_presentation(
+    int index, vec2 *out_pos, vec2 *out_vel) {
+    if (index < 0 || index >= MAX_NPC_SHIPS ||
+        !out_pos || !out_vel || !g.npc_interp.curr[index].active) {
+        return false;
+    }
+    client_npc_render_state_t presented = npc_render_state_at(
+        index, g.npc_interp.elapsed[index]);
+    if (!presented.active) return false;
+    *out_pos = presented.pos;
+    *out_vel = presented.vel;
+    return true;
 }
 
 static scaffold_t scaffold_render_state_at(int slot, float elapsed) {
@@ -940,6 +976,47 @@ static scaffold_t scaffold_render_state_at(int slot, float elapsed) {
         out.pos.y = lerpf(prev->pos.y, out.pos.y, blend);
     }
     return out;
+}
+
+static void scaffold_interp_begin_update(int slot) {
+    if (slot < 0 || slot >= MAX_SCAFFOLDS) return;
+    float elapsed = clampf(g.scaffold_interp.elapsed[slot], 0.0f,
+                           SCAFFOLD_RENDER_EXTRAPOLATE_MAX_SEC);
+    g.scaffold_interp.prev[slot] =
+        scaffold_render_state_at(slot, elapsed);
+    g.scaffold_interp.elapsed[slot] = 0.0f;
+}
+
+bool net_remote_asteroid_presentation(
+    int index, vec2 *out_pos, vec2 *out_vel) {
+    if (index < 0 || index >= MAX_ASTEROIDS ||
+        !out_pos || !out_vel ||
+        !g.asteroid_interp.curr[index].active) {
+        return false;
+    }
+    bool towed[MAX_ASTEROIDS];
+    net_collect_towed_asteroids(towed);
+    asteroid_t presented = asteroid_render_state_at(
+        index, g.asteroid_interp.elapsed[index], towed[index]);
+    if (!presented.active) return false;
+    *out_pos = presented.pos;
+    *out_vel = presented.vel;
+    return true;
+}
+
+bool net_remote_scaffold_presentation(
+    int index, vec2 *out_pos, vec2 *out_vel) {
+    if (index < 0 || index >= MAX_SCAFFOLDS ||
+        !out_pos || !out_vel ||
+        !g.scaffold_interp.curr[index].active) {
+        return false;
+    }
+    scaffold_t presented = scaffold_render_state_at(
+        index, g.scaffold_interp.elapsed[index]);
+    if (!presented.active) return false;
+    *out_pos = presented.pos;
+    *out_vel = presented.vel;
+    return true;
 }
 
 static cargo_pod_t cargo_pod_render_state_at(int slot, float elapsed) {
@@ -1030,14 +1107,6 @@ static bool net_local_player_towing_asteroid(int idx) {
         if (sp->ship->towed_fragments[t] == idx) return true;
     }
     return false;
-}
-
-static float net_prediction_future_elapsed(float t, float interval,
-                                           float dt, float max_elapsed) {
-    if (!isfinite(interval) || interval <= 0.0f) interval = 0.01f;
-    float elapsed = (isfinite(t) && t > 0.0f) ? t * interval : 0.0f;
-    if (isfinite(dt) && dt > 0.0f) elapsed += dt;
-    return clampf(elapsed, 0.0f, max_elapsed);
 }
 
 static void net_adopt_local_asteroid_prediction_base(int idx, float elapsed,
@@ -1152,11 +1221,14 @@ void net_adopt_local_tow_prediction(float dt) {
         net_adopt_local_cargo_pod_prediction(idx, elapsed);
     }
 
-    float scaffold_elapsed = net_prediction_future_elapsed(
-        g.scaffold_interp.t, g.scaffold_interp.interval, dt,
-        SCAFFOLD_RENDER_EXTRAPOLATE_MAX_SEC);
-    net_adopt_local_scaffold_prediction(sp->ship->towed_scaffold,
-                                        scaffold_elapsed);
+    int scaffold_idx = sp->ship->towed_scaffold;
+    if (scaffold_idx >= 0 && scaffold_idx < MAX_SCAFFOLDS) {
+        float elapsed = g.scaffold_interp.elapsed[scaffold_idx];
+        if (isfinite(dt) && dt > 0.0f) elapsed += dt;
+        elapsed = clampf(elapsed, 0.0f,
+                         SCAFFOLD_RENDER_EXTRAPOLATE_MAX_SEC);
+        net_adopt_local_scaffold_prediction(scaffold_idx, elapsed);
+    }
 }
 
 void net_advance_asteroid_interpolation(float dt) {
@@ -1181,6 +1253,43 @@ void net_advance_asteroid_interpolation(float dt) {
         if (prev->active &&
             elapsed >= ASTEROID_RENDER_CORRECTION_CUTOFF_SEC)
             prev->active = false;
+    }
+}
+
+void net_advance_npc_interpolation(float dt) {
+    if (!isfinite(dt) || dt <= 0.0f) return;
+    for (int i = 0; i < MAX_NPC_SHIPS; i++) {
+        client_npc_render_state_t *curr = &g.npc_interp.curr[i];
+        client_npc_render_state_t *prev = &g.npc_interp.prev[i];
+        if (!curr->active) {
+            g.npc_interp.elapsed[i] = 0.0f;
+            prev->active = false;
+            continue;
+        }
+        float elapsed = g.npc_interp.elapsed[i] + dt;
+        g.npc_interp.elapsed[i] = clampf(
+            elapsed, 0.0f, NPC_RENDER_EXTRAPOLATE_MAX_SEC);
+        if (prev->active &&
+            g.npc_interp.elapsed[i] >=
+                NPC_RENDER_CORRECTION_CUTOFF_SEC) {
+            prev->active = false;
+        }
+    }
+}
+
+void net_advance_scaffold_interpolation(float dt) {
+    if (!isfinite(dt) || dt <= 0.0f) return;
+    for (int i = 0; i < MAX_SCAFFOLDS; i++) {
+        scaffold_t *curr = &g.scaffold_interp.curr[i];
+        scaffold_t *prev = &g.scaffold_interp.prev[i];
+        if (!curr->active) {
+            g.scaffold_interp.elapsed[i] = 0.0f;
+            prev->active = false;
+            continue;
+        }
+        float elapsed = g.scaffold_interp.elapsed[i] + dt;
+        g.scaffold_interp.elapsed[i] = clampf(
+            elapsed, 0.0f, SCAFFOLD_RENDER_EXTRAPOLATE_MAX_SEC);
     }
 }
 
@@ -1286,11 +1395,9 @@ void reset_remote_dynamic_sync(void) {
         memset(&g.world.npc_ships[i], 0, sizeof(g.world.npc_ships[i]));
     }
     memset(&g.npc_interp, 0, sizeof(g.npc_interp));
-    g.npc_interp.interval = 0.1f;
 
     memset(g.world.scaffolds, 0, sizeof(g.world.scaffolds));
     memset(&g.scaffold_interp, 0, sizeof(g.scaffold_interp));
-    g.scaffold_interp.interval = 0.1f;
 
     memset(g.world.cargo_pods, 0, sizeof(g.world.cargo_pods));
     memset(&g.cargo_pod_interp, 0, sizeof(g.cargo_pod_interp));
@@ -1512,15 +1619,6 @@ static int16_t remote_npc_asteroid_index(int value) {
 }
 
 void apply_remote_npcs(const NetNpcState* npcs, int count) {
-    float npc_elapsed = g.npc_interp.t * g.npc_interp.interval;
-    npc_elapsed = clampf(npc_elapsed, 0.0f, NPC_RENDER_EXTRAPOLATE_MAX_SEC);
-    for (int i = 0; i < MAX_NPC_SHIPS; i++)
-        g.npc_interp.prev[i] = npc_render_state_at(i, npc_elapsed);
-
-    float packet_interval = clampf(npc_elapsed, 0.05f, 0.2f);
-    g.npc_interp.interval = lerpf(g.npc_interp.interval, packet_interval, 0.3f);
-    g.npc_interp.t = 0.0f;
-
     bool received[MAX_NPC_SHIPS];
     memset(received, 0, sizeof(received));
 
@@ -1529,6 +1627,7 @@ void apply_remote_npcs(const NetNpcState* npcs, int count) {
         if (idx >= MAX_NPC_SHIPS) continue;
         received[idx] = true;
 
+        npc_interp_begin_update(idx);
         client_npc_render_state_t* n = &g.npc_interp.curr[idx];
         bool motion_changed = n->active &&
             (npcs[i].flags & 1u) != 0u &&
@@ -1563,7 +1662,8 @@ void apply_remote_npcs(const NetNpcState* npcs, int count) {
     }
 
     for (int i = 0; i < MAX_NPC_SHIPS; i++) {
-        if (!received[i]) {
+        if (!received[i] && g.npc_interp.curr[i].active) {
+            npc_interp_begin_update(i);
             g.npc_interp.curr[i].active = false;
         }
     }
@@ -1572,21 +1672,13 @@ void apply_remote_npcs(const NetNpcState* npcs, int count) {
 }
 
 void apply_remote_npc_motion(const NetNpcMotionState* npcs, int count) {
-    float npc_elapsed = g.npc_interp.t * g.npc_interp.interval;
-    npc_elapsed = clampf(npc_elapsed, 0.0f, NPC_RENDER_EXTRAPOLATE_MAX_SEC);
-    for (int i = 0; i < MAX_NPC_SHIPS; i++)
-        g.npc_interp.prev[i] = npc_render_state_at(i, npc_elapsed);
-
-    float packet_interval = clampf(npc_elapsed, 0.05f, 0.2f);
-    g.npc_interp.interval = lerpf(g.npc_interp.interval, packet_interval, 0.3f);
-    g.npc_interp.t = 0.0f;
-
     for (int i = 0; i < count; i++) {
         uint8_t idx = npcs[i].index;
         if (idx >= MAX_NPC_SHIPS) continue;
 
         client_npc_render_state_t* n = &g.npc_interp.curr[idx];
         if (!n->active) continue;
+        npc_interp_begin_update(idx);
         if (net_reconcile_motion_changed(
                 n->pos.x, n->pos.y, n->vel.x, n->vel.y, n->angle,
                 npcs[i].x, npcs[i].y, npcs[i].vx, npcs[i].vy,
@@ -1607,21 +1699,13 @@ void apply_remote_npc_motion(const NetNpcMotionState* npcs, int count) {
 void apply_remote_npc_pos(const NetNpcPosState* npcs, int count) {
     if (!npcs || count <= 0) return;
 
-    float npc_elapsed = g.npc_interp.t * g.npc_interp.interval;
-    npc_elapsed = clampf(npc_elapsed, 0.0f, NPC_RENDER_EXTRAPOLATE_MAX_SEC);
-    for (int i = 0; i < MAX_NPC_SHIPS; i++)
-        g.npc_interp.prev[i] = npc_render_state_at(i, npc_elapsed);
-
-    float packet_interval = clampf(npc_elapsed, 0.05f, 0.2f);
-    g.npc_interp.interval = lerpf(g.npc_interp.interval, packet_interval, 0.3f);
-    g.npc_interp.t = 0.0f;
-
     for (int i = 0; i < count; i++) {
         uint8_t idx = npcs[i].index;
         if (idx >= MAX_NPC_SHIPS) continue;
 
         client_npc_render_state_t* n = &g.npc_interp.curr[idx];
         if (!n->active) continue;
+        npc_interp_begin_update(idx);
         if (net_reconcile_motion_changed(
                 n->pos.x, n->pos.y, n->vel.x, n->vel.y, n->angle,
                 npcs[i].x, npcs[i].y, n->vel.x, n->vel.y, n->angle)) {
@@ -1635,21 +1719,13 @@ void apply_remote_npc_pos(const NetNpcPosState* npcs, int count) {
 void apply_remote_npc_pose(const NetNpcPoseState* npcs, int count) {
     if (!npcs || count <= 0) return;
 
-    float npc_elapsed = g.npc_interp.t * g.npc_interp.interval;
-    npc_elapsed = clampf(npc_elapsed, 0.0f, NPC_RENDER_EXTRAPOLATE_MAX_SEC);
-    for (int i = 0; i < MAX_NPC_SHIPS; i++)
-        g.npc_interp.prev[i] = npc_render_state_at(i, npc_elapsed);
-
-    float packet_interval = clampf(npc_elapsed, 0.05f, 0.2f);
-    g.npc_interp.interval = lerpf(g.npc_interp.interval, packet_interval, 0.3f);
-    g.npc_interp.t = 0.0f;
-
     for (int i = 0; i < count; i++) {
         uint8_t idx = npcs[i].index;
         if (idx >= MAX_NPC_SHIPS) continue;
 
         client_npc_render_state_t* n = &g.npc_interp.curr[idx];
         if (!n->active) continue;
+        npc_interp_begin_update(idx);
         if (net_reconcile_motion_changed(
                 n->pos.x, n->pos.y, n->vel.x, n->vel.y, n->angle,
                 npcs[i].x, npcs[i].y, n->vel.x, n->vel.y,
@@ -1665,21 +1741,13 @@ void apply_remote_npc_pose(const NetNpcPoseState* npcs, int count) {
 void apply_remote_npc_linear(const NetNpcLinearState* npcs, int count) {
     if (!npcs || count <= 0) return;
 
-    float npc_elapsed = g.npc_interp.t * g.npc_interp.interval;
-    npc_elapsed = clampf(npc_elapsed, 0.0f, NPC_RENDER_EXTRAPOLATE_MAX_SEC);
-    for (int i = 0; i < MAX_NPC_SHIPS; i++)
-        g.npc_interp.prev[i] = npc_render_state_at(i, npc_elapsed);
-
-    float packet_interval = clampf(npc_elapsed, 0.05f, 0.2f);
-    g.npc_interp.interval = lerpf(g.npc_interp.interval, packet_interval, 0.3f);
-    g.npc_interp.t = 0.0f;
-
     for (int i = 0; i < count; i++) {
         uint8_t idx = npcs[i].index;
         if (idx >= MAX_NPC_SHIPS) continue;
 
         client_npc_render_state_t* n = &g.npc_interp.curr[idx];
         if (!n->active) continue;
+        npc_interp_begin_update(idx);
         if (net_reconcile_motion_changed(
                 n->pos.x, n->pos.y, n->vel.x, n->vel.y, n->angle,
                 npcs[i].x, npcs[i].y, npcs[i].vx, npcs[i].vy,
@@ -2184,15 +2252,6 @@ void apply_remote_station_diag(uint8_t station_id, const uint8_t *diag,
 }
 
 void apply_remote_scaffolds(const NetScaffoldState* received, int count) {
-    float elapsed = g.scaffold_interp.t * g.scaffold_interp.interval;
-    elapsed = clampf(elapsed, 0.0f, SCAFFOLD_RENDER_EXTRAPOLATE_MAX_SEC);
-    for (int i = 0; i < MAX_SCAFFOLDS; i++)
-        g.scaffold_interp.prev[i] = scaffold_render_state_at(i, elapsed);
-
-    float packet_interval = clampf(elapsed, 0.05f, 0.2f);
-    g.scaffold_interp.interval = lerpf(g.scaffold_interp.interval, packet_interval, 0.3f);
-    g.scaffold_interp.t = 0.0f;
-
     bool seen[MAX_SCAFFOLDS] = { false };
     bool tow_relevance_changed = false;
     const NetProtocolInfo *info = net_protocol_info();
@@ -2201,6 +2260,7 @@ void apply_remote_scaffolds(const NetScaffoldState* received, int count) {
     for (int i = 0; i < count; i++) {
         uint8_t idx = received[i].index;
         if (idx >= MAX_SCAFFOLDS) continue;
+        scaffold_interp_begin_update(idx);
         scaffold_t *sc = &g.scaffold_interp.curr[idx];
         bool was_active = sc->active;
         sc->active = true;
@@ -2222,6 +2282,7 @@ void apply_remote_scaffolds(const NetScaffoldState* received, int count) {
     if (replacement_snapshot) {
         for (int i = 0; i < MAX_SCAFFOLDS; i++) {
             if (!seen[i] && g.scaffold_interp.curr[i].active) {
+                scaffold_interp_begin_update(i);
                 g.scaffold_interp.curr[i].active = false;
                 tow_relevance_changed = true;
             }
@@ -2234,19 +2295,10 @@ void apply_remote_scaffolds(const NetScaffoldState* received, int count) {
 void apply_remote_scaffold_remove(const uint8_t* indices, int count) {
     if (!indices || count <= 0) return;
 
-    float elapsed = g.scaffold_interp.t * g.scaffold_interp.interval;
-    elapsed = clampf(elapsed, 0.0f, SCAFFOLD_RENDER_EXTRAPOLATE_MAX_SEC);
-    for (int i = 0; i < MAX_SCAFFOLDS; i++)
-        g.scaffold_interp.prev[i] = scaffold_render_state_at(i, elapsed);
-
-    float packet_interval = clampf(elapsed, 0.05f, 0.2f);
-    g.scaffold_interp.interval = lerpf(g.scaffold_interp.interval,
-                                       packet_interval, 0.3f);
-    g.scaffold_interp.t = 0.0f;
-
     for (int i = 0; i < count; i++) {
         uint8_t idx = indices[i];
         if (idx >= MAX_SCAFFOLDS) continue;
+        scaffold_interp_begin_update(idx);
         g.scaffold_interp.curr[idx].active = false;
     }
     if (g.tow_snapshot_received)
@@ -2257,21 +2309,12 @@ void apply_remote_scaffold_motion(const NetScaffoldMotionState* received,
                                   int count) {
     if (!received || count <= 0) return;
 
-    float elapsed = g.scaffold_interp.t * g.scaffold_interp.interval;
-    elapsed = clampf(elapsed, 0.0f, SCAFFOLD_RENDER_EXTRAPOLATE_MAX_SEC);
-    for (int i = 0; i < MAX_SCAFFOLDS; i++)
-        g.scaffold_interp.prev[i] = scaffold_render_state_at(i, elapsed);
-
-    float packet_interval = clampf(elapsed, 0.05f, 0.3f);
-    g.scaffold_interp.interval = lerpf(g.scaffold_interp.interval,
-                                       packet_interval, 0.3f);
-    g.scaffold_interp.t = 0.0f;
-
     for (int i = 0; i < count; i++) {
         uint8_t idx = received[i].index;
         if (idx >= MAX_SCAFFOLDS) continue;
         scaffold_t *sc = &g.scaffold_interp.curr[idx];
         if (!sc->active) continue;
+        scaffold_interp_begin_update(idx);
         sc->pos = v2(received[i].pos_x, received[i].pos_y);
         sc->vel = v2(received[i].vel_x, received[i].vel_y);
     }
@@ -3472,8 +3515,6 @@ void interpolate_world_for_render_frame(float frame_dt) {
      * feed smoothed values back into gameplay. */
     apply_local_authority_asteroid_presentation(frame_dt);
 
-    float npc_elapsed = clampf(g.npc_interp.t * g.npc_interp.interval,
-                               0.0f, NPC_RENDER_EXTRAPOLATE_MAX_SEC);
     for (int i = 0; i < MAX_NPC_SHIPS; i++) {
         const client_npc_render_state_t *curr = &g.npc_interp.curr[i];
         const client_npc_render_state_t *prev = &g.npc_interp.prev[i];
@@ -3485,7 +3526,8 @@ void interpolate_world_for_render_frame(float frame_dt) {
             }
             continue;
         }
-        client_npc_render_state_t render = npc_render_state_at(i, npc_elapsed);
+        client_npc_render_state_t render = npc_render_state_at(
+            i, g.npc_interp.elapsed[i]);
         if (!g.world.npc_ships[i].ship &&
             !world_npc_ship_slot_activate(&g.world, i)) {
             continue;
@@ -3510,8 +3552,6 @@ void interpolate_world_for_render_frame(float frame_dt) {
         dst->ship->towed_scaffold = render.towed_scaffold;
     }
 
-    float scaffold_elapsed = clampf(g.scaffold_interp.t * g.scaffold_interp.interval,
-                                    0.0f, SCAFFOLD_RENDER_EXTRAPOLATE_MAX_SEC);
     for (int i = 0; i < MAX_SCAFFOLDS; i++) {
         const scaffold_t *curr = &g.scaffold_interp.curr[i];
         const scaffold_t *prev = &g.scaffold_interp.prev[i];
@@ -3520,7 +3560,8 @@ void interpolate_world_for_render_frame(float frame_dt) {
             continue;
         }
         scaffold_t *dst = &g.world.scaffolds[i];
-        *dst = scaffold_render_state_at(i, scaffold_elapsed);
+        *dst = scaffold_render_state_at(
+            i, g.scaffold_interp.elapsed[i]);
     }
 
     for (int i = 0; i < MAX_CARGO_PODS; i++) {

--- a/client/net_sync.h
+++ b/client/net_sync.h
@@ -52,7 +52,15 @@ void net_observe_transport_latency_sample(float rtt_ms,
                                           bool from_input_ack);
 void net_adopt_local_tow_prediction(float dt);
 void net_advance_asteroid_interpolation(float dt);
+void net_advance_npc_interpolation(float dt);
+void net_advance_scaffold_interpolation(float dt);
 void net_advance_cargo_pod_interpolation(float dt);
+bool net_remote_asteroid_presentation(
+    int index, vec2 *out_pos, vec2 *out_vel);
+bool net_remote_npc_presentation(
+    int index, vec2 *out_pos, vec2 *out_vel);
+bool net_remote_scaffold_presentation(
+    int index, vec2 *out_pos, vec2 *out_vel);
 bool net_remote_cargo_pod_presentation(
     int index, vec2 *out_pos, vec2 *out_vel);
 

--- a/client/tow_adverse_gate.c
+++ b/client/tow_adverse_gate.c
@@ -17,10 +17,12 @@
 
 enum {
     TOW_GATE_TARGET_INDEX = MAX_CARGO_PODS - 1,
+    TOW_GATE_ASTEROID_INDEX = MAX_ASTEROIDS - 1,
+    TOW_GATE_SCAFFOLD_INDEX = MAX_SCAFFOLDS - 1,
     TOW_GATE_PAYLOAD_INTERVAL_MS = 25,
     TOW_GATE_PAYLOAD_COUNT = 81,
     TOW_GATE_PACKET_COUNT = TOW_GATE_PAYLOAD_COUNT * 2,
-    TOW_GATE_REPORT_SIZE = 4096,
+    TOW_GATE_REPORT_SIZE = 8192,
 
     TOW_GATE_ATTACH = 1u << 0,
     TOW_GATE_RELEASE = 1u << 1,
@@ -80,6 +82,17 @@ typedef struct {
 
     cargo_pod_t target_prev;
     cargo_pod_t target_curr;
+    cargo_pod_t target_world;
+    asteroid_t asteroid_target_prev;
+    asteroid_t asteroid_target_curr;
+    asteroid_t asteroid_target_world;
+    bool asteroid_prev_active[MAX_ASTEROIDS];
+    float asteroid_elapsed[MAX_ASTEROIDS];
+    scaffold_t scaffold_target_prev;
+    scaffold_t scaffold_target_curr;
+    scaffold_t scaffold_target_world;
+    bool scaffold_prev_active[MAX_SCAFFOLDS];
+    float scaffold_elapsed[MAX_SCAFFOLDS];
     bool cargo_prev_active[MAX_CARGO_PODS];
     float cargo_elapsed[MAX_CARGO_PODS];
 
@@ -108,7 +121,31 @@ typedef struct {
     tow_presentation_diagnostics_t presentation;
 } tow_gate_profile_result_t;
 
+typedef struct {
+    const char *name;
+    entity_ref_t source;
+    entity_kind_t target_kind;
+    tow_profile_t profile;
+} tow_gate_scenario_t;
+
+typedef struct {
+    int scenario_count;
+    int profile_count;
+    int passed_profiles;
+    uint32_t stale_projection_failures;
+    uint32_t lifecycle_failures;
+    float max_correction_world;
+    float max_velocity_discontinuity;
+    float max_snapshot_gap_sec;
+    float max_world_jerk;
+    float max_screen_jerk;
+    const char *failure;
+    const char *failure_scenario;
+    uint16_t failure_latency_ms;
+} tow_gate_matrix_result_t;
+
 static tow_gate_profile_result_t tow_gate_results[3];
+static tow_gate_matrix_result_t tow_gate_matrix;
 static char tow_gate_report[TOW_GATE_REPORT_SIZE];
 
 static void tow_gate_save(tow_gate_restore_t *saved)
@@ -124,6 +161,20 @@ static void tow_gate_save(tow_gate_restore_t *saved)
         g.cargo_pod_interp.prev[TOW_GATE_TARGET_INDEX];
     saved->target_curr =
         g.cargo_pod_interp.curr[TOW_GATE_TARGET_INDEX];
+    saved->target_world =
+        g.world.cargo_pods[TOW_GATE_TARGET_INDEX];
+    saved->asteroid_target_prev =
+        g.asteroid_interp.prev[TOW_GATE_ASTEROID_INDEX];
+    saved->asteroid_target_curr =
+        g.asteroid_interp.curr[TOW_GATE_ASTEROID_INDEX];
+    saved->asteroid_target_world =
+        g.world.asteroids[TOW_GATE_ASTEROID_INDEX];
+    saved->scaffold_target_prev =
+        g.scaffold_interp.prev[TOW_GATE_SCAFFOLD_INDEX];
+    saved->scaffold_target_curr =
+        g.scaffold_interp.curr[TOW_GATE_SCAFFOLD_INDEX];
+    saved->scaffold_target_world =
+        g.world.scaffolds[TOW_GATE_SCAFFOLD_INDEX];
 
     for (int i = 0; i < MAX_CARGO_PODS; i++) {
         saved->cargo_prev_active[i] =
@@ -134,11 +185,17 @@ static void tow_gate_save(tow_gate_restore_t *saved)
         saved->cargo_curr[i] = g.cargo_pod_interp.curr[i].tractor;
     }
     for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        saved->asteroid_prev_active[i] =
+            g.asteroid_interp.prev[i].active;
+        saved->asteroid_elapsed[i] = g.asteroid_interp.elapsed[i];
         saved->asteroid_world[i] = g.world.asteroids[i].tractor;
         saved->asteroid_prev[i] = g.asteroid_interp.prev[i].tractor;
         saved->asteroid_curr[i] = g.asteroid_interp.curr[i].tractor;
     }
     for (int i = 0; i < MAX_SCAFFOLDS; i++) {
+        saved->scaffold_prev_active[i] =
+            g.scaffold_interp.prev[i].active;
+        saved->scaffold_elapsed[i] = g.scaffold_interp.elapsed[i];
         saved->scaffold_world[i] = g.world.scaffolds[i].tractor;
         saved->scaffold_prev[i] = g.scaffold_interp.prev[i].tractor;
         saved->scaffold_curr[i] = g.scaffold_interp.curr[i].tractor;
@@ -188,6 +245,20 @@ static void tow_gate_restore(const tow_gate_restore_t *saved)
         saved->target_prev;
     g.cargo_pod_interp.curr[TOW_GATE_TARGET_INDEX] =
         saved->target_curr;
+    g.world.cargo_pods[TOW_GATE_TARGET_INDEX] =
+        saved->target_world;
+    g.asteroid_interp.prev[TOW_GATE_ASTEROID_INDEX] =
+        saved->asteroid_target_prev;
+    g.asteroid_interp.curr[TOW_GATE_ASTEROID_INDEX] =
+        saved->asteroid_target_curr;
+    g.world.asteroids[TOW_GATE_ASTEROID_INDEX] =
+        saved->asteroid_target_world;
+    g.scaffold_interp.prev[TOW_GATE_SCAFFOLD_INDEX] =
+        saved->scaffold_target_prev;
+    g.scaffold_interp.curr[TOW_GATE_SCAFFOLD_INDEX] =
+        saved->scaffold_target_curr;
+    g.world.scaffolds[TOW_GATE_SCAFFOLD_INDEX] =
+        saved->scaffold_target_world;
 
     for (int i = 0; i < MAX_CARGO_PODS; i++) {
         g.cargo_pod_interp.prev[i].active =
@@ -198,11 +269,17 @@ static void tow_gate_restore(const tow_gate_restore_t *saved)
         g.cargo_pod_interp.curr[i].tractor = saved->cargo_curr[i];
     }
     for (int i = 0; i < MAX_ASTEROIDS; i++) {
+        g.asteroid_interp.prev[i].active =
+            saved->asteroid_prev_active[i];
+        g.asteroid_interp.elapsed[i] = saved->asteroid_elapsed[i];
         g.world.asteroids[i].tractor = saved->asteroid_world[i];
         g.asteroid_interp.prev[i].tractor = saved->asteroid_prev[i];
         g.asteroid_interp.curr[i].tractor = saved->asteroid_curr[i];
     }
     for (int i = 0; i < MAX_SCAFFOLDS; i++) {
+        g.scaffold_interp.prev[i].active =
+            saved->scaffold_prev_active[i];
+        g.scaffold_interp.elapsed[i] = saved->scaffold_elapsed[i];
         g.world.scaffolds[i].tractor = saved->scaffold_world[i];
         g.scaffold_interp.prev[i].tractor = saved->scaffold_prev[i];
         g.scaffold_interp.curr[i].tractor = saved->scaffold_curr[i];
@@ -656,6 +733,522 @@ static bool tow_gate_run_profile(
     return true;
 }
 
+static int tow_gate_matrix_target_index(entity_kind_t kind)
+{
+    if (kind == ENTITY_KIND_ASTEROID) return TOW_GATE_ASTEROID_INDEX;
+    if (kind == ENTITY_KIND_SCAFFOLD) return TOW_GATE_SCAFFOLD_INDEX;
+    return TOW_GATE_TARGET_INDEX;
+}
+
+static bool tow_gate_matrix_target_active(entity_kind_t kind)
+{
+    int index = tow_gate_matrix_target_index(kind);
+    if (kind == ENTITY_KIND_ASTEROID)
+        return g.asteroid_interp.curr[index].active;
+    if (kind == ENTITY_KIND_SCAFFOLD)
+        return g.scaffold_interp.curr[index].active;
+    return g.cargo_pod_interp.curr[index].active;
+}
+
+static const tractor_binding_t *tow_gate_matrix_target_binding(
+    entity_kind_t kind, int view)
+{
+    int index = tow_gate_matrix_target_index(kind);
+    if (kind == ENTITY_KIND_ASTEROID) {
+        if (view == 0) return &g.world.asteroids[index].tractor;
+        if (view == 1) return &g.asteroid_interp.prev[index].tractor;
+        return &g.asteroid_interp.curr[index].tractor;
+    }
+    if (kind == ENTITY_KIND_SCAFFOLD) {
+        if (view == 0) return &g.world.scaffolds[index].tractor;
+        if (view == 1) return &g.scaffold_interp.prev[index].tractor;
+        return &g.scaffold_interp.curr[index].tractor;
+    }
+    if (view == 0) return &g.world.cargo_pods[index].tractor;
+    if (view == 1) return &g.cargo_pod_interp.prev[index].tractor;
+    return &g.cargo_pod_interp.curr[index].tractor;
+}
+
+static bool tow_gate_matrix_binding_matches(
+    const tractor_binding_t *binding, entity_ref_t source)
+{
+    if (!binding) return false;
+    if (source.kind == ENTITY_KIND_STATION_MODULE) {
+        return binding->kind == TRACTOR_SOURCE_STATION_MODULE &&
+               binding->source_index == source.index &&
+               binding->source_part == source.part &&
+               binding->source_generation == source.generation;
+    }
+    if (source.index < WORLD_NPC_SHIP_BASE) {
+        return binding->kind == TRACTOR_SOURCE_PLAYER &&
+               binding->source_index ==
+                   source.index - WORLD_PLAYER_SHIP_BASE &&
+               binding->source_part == -1 &&
+               binding->source_generation == source.generation;
+    }
+    return binding->kind == TRACTOR_SOURCE_NPC &&
+           binding->source_index ==
+               source.index - WORLD_NPC_SHIP_BASE &&
+           binding->source_part == -1 &&
+           binding->source_generation == source.generation;
+}
+
+static bool tow_gate_matrix_ship_list_contains(
+    const int16_t *items, int count, int cap, int target)
+{
+    if (!items || count < 0) return false;
+    if (count > cap) count = cap;
+    for (int i = 0; i < count; i++)
+        if (items[i] == target) return true;
+    return false;
+}
+
+static bool tow_gate_matrix_player_interp_contains(
+    const NetPlayerState *state, int target)
+{
+    if (!state) return false;
+    int count = state->towed_count;
+    int cap = (int)(sizeof(state->towed_fragments) /
+                    sizeof(state->towed_fragments[0]));
+    if (count > cap) count = cap;
+    for (int i = 0; i < count; i++)
+        if (state->towed_fragments[i] == (uint16_t)target) return true;
+    return false;
+}
+
+static bool tow_gate_matrix_source_projection_present(
+    const tow_gate_scenario_t *scenario)
+{
+    if (!scenario || scenario->source.kind != ENTITY_KIND_SHIP)
+        return false;
+    int target = tow_gate_matrix_target_index(scenario->target_kind);
+    const ship_t *ship = world_ship_resolve_const(
+        &g.world, scenario->source);
+    if (!ship) return false;
+
+    if (scenario->profile == TOW_PROFILE_SHIP_FRAGMENT) {
+        bool ship_has = tow_gate_matrix_ship_list_contains(
+            ship->towed_fragments, ship->towed_count,
+            (int)(sizeof(ship->towed_fragments) /
+                  sizeof(ship->towed_fragments[0])), target);
+        if (!ship_has) return false;
+        if (scenario->source.index < WORLD_NPC_SHIP_BASE) {
+            int player = scenario->source.index - WORLD_PLAYER_SHIP_BASE;
+            return tow_gate_matrix_player_interp_contains(
+                       &g.player_interp.prev[player], target) &&
+                   tow_gate_matrix_player_interp_contains(
+                       &g.player_interp.curr[player], target);
+        }
+        int npc = scenario->source.index - WORLD_NPC_SHIP_BASE;
+        return g.npc_interp.prev[npc].towed_fragment == target &&
+               g.npc_interp.curr[npc].towed_fragment == target;
+    }
+    if (scenario->profile == TOW_PROFILE_SHIP_POD) {
+        return tow_gate_matrix_ship_list_contains(
+            ship->towed_pods, ship->towed_pod_count,
+            (int)(sizeof(ship->towed_pods) /
+                  sizeof(ship->towed_pods[0])), target);
+    }
+    if (scenario->profile == TOW_PROFILE_SHIP_SCAFFOLD) {
+        if (ship->towed_scaffold != target) return false;
+        if (scenario->source.index < WORLD_NPC_SHIP_BASE) return true;
+        int npc = scenario->source.index - WORLD_NPC_SHIP_BASE;
+        return g.npc_interp.prev[npc].towed_scaffold == target &&
+               g.npc_interp.curr[npc].towed_scaffold == target;
+    }
+    return false;
+}
+
+static const tow_link_t *tow_gate_matrix_current_link(
+    const tow_gate_scenario_t *scenario)
+{
+    int target = tow_gate_matrix_target_index(scenario->target_kind);
+    for (int i = 0; i < MAX_TOW_LINKS; i++) {
+        const tow_link_t *link = &g.world.tow_links[i];
+        if (link->active &&
+            link->target.kind == scenario->target_kind &&
+            link->target.index == target) {
+            return link;
+        }
+    }
+    return NULL;
+}
+
+static bool tow_gate_matrix_projection_consistent(
+    const tow_gate_scenario_t *scenario,
+    uint16_t current_generation)
+{
+    const tow_link_t *link = tow_gate_matrix_current_link(scenario);
+    bool current_relation = link &&
+        entity_ref_equal(link->source, scenario->source) &&
+        link->target.generation == current_generation;
+    bool should_project = current_relation &&
+        tow_gate_matrix_target_active(scenario->target_kind);
+    bool source_projection =
+        tow_gate_matrix_source_projection_present(scenario);
+    bool station_source =
+        scenario->source.kind == ENTITY_KIND_STATION_MODULE;
+
+    bool any_target_projection = false;
+    for (int view = 0; view < 3; view++) {
+        const tractor_binding_t *binding =
+            tow_gate_matrix_target_binding(scenario->target_kind, view);
+        if (binding->kind != TRACTOR_SOURCE_NONE)
+            any_target_projection = true;
+        if (should_project &&
+            !tow_gate_matrix_binding_matches(binding, scenario->source)) {
+            return false;
+        }
+    }
+    if (!should_project)
+        return !any_target_projection && !source_projection;
+    return any_target_projection && (station_source || source_projection);
+}
+
+static bool tow_gate_matrix_projection_present(
+    const tow_gate_scenario_t *scenario)
+{
+    const tractor_binding_t *binding =
+        tow_gate_matrix_target_binding(scenario->target_kind, 2);
+    if (!tow_gate_matrix_binding_matches(binding, scenario->source))
+        return false;
+    return scenario->source.kind == ENTITY_KIND_STATION_MODULE ||
+           tow_gate_matrix_source_projection_present(scenario);
+}
+
+static void tow_gate_matrix_observe_lifecycle(
+    tow_gate_profile_result_t *result,
+    const tow_gate_scenario_t *scenario,
+    uint16_t current_generation)
+{
+    const tow_link_t *link = tow_gate_matrix_current_link(scenario);
+    bool relation = link &&
+        entity_ref_equal(link->source, scenario->source) &&
+        link->target.generation == current_generation;
+    bool active = tow_gate_matrix_target_active(scenario->target_kind);
+    bool projection = tow_gate_matrix_projection_present(scenario);
+    uint32_t revision = g.tow_snapshot_revision;
+
+    if (revision == 2u && active && current_generation == 1u &&
+        relation && projection)
+        result->lifecycle_mask |= TOW_GATE_ATTACH;
+    if (revision == 3u && active && current_generation == 1u &&
+        !relation && !projection)
+        result->lifecycle_mask |= TOW_GATE_RELEASE;
+    if (revision == 4u && active && current_generation == 1u &&
+        relation && projection)
+        result->lifecycle_mask |= TOW_GATE_REATTACH;
+    if (revision == 5u && !active && current_generation == 1u &&
+        !relation && !projection)
+        result->lifecycle_mask |= TOW_GATE_RETIRE;
+    if (revision == 5u && active && current_generation == 2u &&
+        !relation && !projection)
+        result->lifecycle_mask |= TOW_GATE_REPLACEMENT_CLEAR;
+    if (revision == 6u && active && current_generation == 2u &&
+        relation && projection)
+        result->lifecycle_mask |= TOW_GATE_REPLACEMENT_ATTACH;
+    if (revision == 6u && !active && current_generation == 2u &&
+        relation && !projection)
+        result->lifecycle_mask |= TOW_GATE_RELEVANCE_EXIT;
+    if ((result->lifecycle_mask & TOW_GATE_RELEVANCE_EXIT) != 0u &&
+        revision == 6u && active && current_generation == 2u &&
+        relation && projection)
+        result->lifecycle_mask |= TOW_GATE_RELEVANCE_REENTRY;
+    if (revision == 7u && active && current_generation == 2u &&
+        !relation && !projection)
+        result->lifecycle_mask |= TOW_GATE_FINAL_RELEASE;
+}
+
+static bool tow_gate_matrix_presentation(
+    entity_kind_t kind, vec2 *pos, vec2 *vel)
+{
+    int index = tow_gate_matrix_target_index(kind);
+    if (kind == ENTITY_KIND_ASTEROID)
+        return net_remote_asteroid_presentation(index, pos, vel);
+    if (kind == ENTITY_KIND_SCAFFOLD)
+        return net_remote_scaffold_presentation(index, pos, vel);
+    return net_remote_cargo_pod_presentation(index, pos, vel);
+}
+
+static void tow_gate_matrix_apply_target(
+    const tow_gate_payload_t *payload,
+    const tow_gate_scenario_t *scenario,
+    tow_presentation_diagnostics_t *presentation,
+    uint16_t previous_generation)
+{
+    int index = tow_gate_matrix_target_index(scenario->target_kind);
+    if (!payload->target_active) {
+        if (scenario->target_kind == ENTITY_KIND_ASTEROID) {
+            NetAsteroidState state = {.index = (uint16_t)index};
+            apply_remote_asteroids(&state, 1);
+        } else if (scenario->target_kind == ENTITY_KIND_SCAFFOLD) {
+            uint8_t slot = (uint8_t)index;
+            apply_remote_scaffold_remove(&slot, 1);
+        } else {
+            uint8_t slot = (uint8_t)index;
+            apply_remote_cargo_pod_remove(&slot, 1);
+        }
+        return;
+    }
+
+    vec2 authoritative_pos = v2(
+        payload->target.pos_x, payload->target.pos_y);
+    vec2 authoritative_vel = v2(
+        payload->target.vel_x, payload->target.vel_y);
+    vec2 presented_pos = authoritative_pos;
+    vec2 presented_vel = authoritative_vel;
+    if (previous_generation == payload->target_generation) {
+        (void)tow_gate_matrix_presentation(
+            scenario->target_kind, &presented_pos, &presented_vel);
+    }
+    tow_presentation_diagnostics_snapshot(
+        presentation, presented_pos, presented_vel,
+        authoritative_pos, authoritative_vel);
+
+    if (scenario->target_kind == ENTITY_KIND_ASTEROID) {
+        NetAsteroidState state = {
+            .index = (uint16_t)index,
+            .flags = (uint8_t)(1u | (1u << 1) |
+                ((uint8_t)ASTEROID_TIER_S << 2) |
+                ((uint8_t)COMMODITY_FERRITE_ORE << 5)),
+            .x = authoritative_pos.x,
+            .y = authoritative_pos.y,
+            .vx = authoritative_vel.x,
+            .vy = authoritative_vel.y,
+            .hp = 10.0f,
+            .ore = 1.0f,
+            .radius = 12.0f,
+        };
+        apply_remote_asteroids(&state, 1);
+    } else if (scenario->target_kind == ENTITY_KIND_SCAFFOLD) {
+        NetScaffoldState state = {
+            .index = (uint8_t)index,
+            .state = SCAFFOLD_TOWING,
+            .module_type = MODULE_DOCK,
+            .owner = -1,
+            .pos_x = authoritative_pos.x,
+            .pos_y = authoritative_pos.y,
+            .vel_x = authoritative_vel.x,
+            .vel_y = authoritative_vel.y,
+            .radius = 18.0f,
+            .built_at_station = -1,
+        };
+        apply_remote_scaffolds(&state, 1);
+    } else {
+        NetCargoPodState state = payload->target;
+        state.index = (uint8_t)index;
+        apply_remote_cargo_pods(&state, 1);
+    }
+}
+
+static void tow_gate_matrix_apply_relation(
+    const tow_gate_payload_t *payload,
+    const tow_gate_scenario_t *scenario)
+{
+    if (!payload->relation_active) {
+        apply_remote_tow_links(
+            NULL, 0, payload->relation_revision,
+            payload->send_ms / TOW_GATE_PAYLOAD_INTERVAL_MS + 1u);
+        return;
+    }
+    tow_link_t link = {
+        .active = true,
+        .source = scenario->source,
+        .target = {
+            .kind = scenario->target_kind,
+            .index = (int16_t)tow_gate_matrix_target_index(
+                scenario->target_kind),
+            .part = -1,
+            .generation = payload->target_generation,
+        },
+        .profile = scenario->profile,
+        .slot = 0,
+        .state = TOW_LINK_HELD,
+        .attached_tick =
+            payload->send_ms / TOW_GATE_PAYLOAD_INTERVAL_MS + 1u,
+        .revision = payload->relation_revision,
+    };
+    apply_remote_tow_links(
+        &link, 1, payload->relation_revision, link.attached_tick);
+}
+
+static void tow_gate_matrix_reset_target(entity_kind_t kind)
+{
+    int index = tow_gate_matrix_target_index(kind);
+    if (kind == ENTITY_KIND_ASTEROID) {
+        memset(&g.world.asteroids[index], 0,
+               sizeof(g.world.asteroids[index]));
+        memset(&g.asteroid_interp.prev[index], 0,
+               sizeof(g.asteroid_interp.prev[index]));
+        memset(&g.asteroid_interp.curr[index], 0,
+               sizeof(g.asteroid_interp.curr[index]));
+        g.asteroid_interp.elapsed[index] = 0.0f;
+    } else if (kind == ENTITY_KIND_SCAFFOLD) {
+        memset(&g.world.scaffolds[index], 0,
+               sizeof(g.world.scaffolds[index]));
+        memset(&g.scaffold_interp.prev[index], 0,
+               sizeof(g.scaffold_interp.prev[index]));
+        memset(&g.scaffold_interp.curr[index], 0,
+               sizeof(g.scaffold_interp.curr[index]));
+        g.scaffold_interp.elapsed[index] = 0.0f;
+    } else {
+        memset(&g.world.cargo_pods[index], 0,
+               sizeof(g.world.cargo_pods[index]));
+        memset(&g.cargo_pod_interp.prev[index], 0,
+               sizeof(g.cargo_pod_interp.prev[index]));
+        memset(&g.cargo_pod_interp.curr[index], 0,
+               sizeof(g.cargo_pod_interp.curr[index]));
+        g.cargo_pod_interp.elapsed[index] = 0.0f;
+    }
+}
+
+static void tow_gate_matrix_advance(entity_kind_t kind, float dt)
+{
+    if (kind == ENTITY_KIND_ASTEROID)
+        net_advance_asteroid_interpolation(dt);
+    else if (kind == ENTITY_KIND_SCAFFOLD)
+        net_advance_scaffold_interpolation(dt);
+    else
+        net_advance_cargo_pod_interpolation(dt);
+}
+
+static bool tow_gate_run_matrix_profile(
+    tow_gate_profile_result_t *result,
+    const tow_gate_scenario_t *scenario,
+    uint16_t latency_ms,
+    const tow_gate_payload_t *payloads,
+    const tow_adverse_packet_t *packets,
+    int packet_count)
+{
+    memset(result, 0, sizeof(*result));
+    result->latency_ms = latency_ms;
+    result->failure = "none";
+    tow_presentation_diagnostics_reset(&result->presentation);
+
+    tow_adverse_profile_t profile = tow_adverse_profile(latency_ms);
+    tow_adverse_delivery_t deliveries[TOW_ADVERSE_MAX_DELIVERIES];
+    int delivery_count = tow_adverse_schedule(
+        &profile, packets, packet_count,
+        deliveries, TOW_ADVERSE_MAX_DELIVERIES,
+        &result->schedule);
+    if (delivery_count <= 0) {
+        result->failure = "schedule";
+        return false;
+    }
+
+    tow_gate_matrix_reset_target(scenario->target_kind);
+    memset(g.world.tow_links, 0, sizeof(g.world.tow_links));
+    g.tow_snapshot_received = false;
+    g.tow_snapshot_revision = 0;
+    g.tow_snapshot_server_tick = 0;
+    apply_remote_tow_links(NULL, 0, 1u, 1u);
+
+    int next_delivery = 0;
+    uint16_t current_generation = 0;
+    uint32_t last_delivery_ms =
+        deliveries[delivery_count - 1].delivery_ms;
+    uint32_t frame_count =
+        (last_delivery_ms * 60u + 999u) / 1000u + 1u;
+    const float frame_dt = 1.0f / 60.0f;
+
+    for (uint32_t frame = 0; frame < frame_count; frame++) {
+        uint32_t frame_ms = frame * 1000u / 60u;
+        while (next_delivery < delivery_count &&
+               deliveries[next_delivery].delivery_ms <= frame_ms) {
+            const tow_adverse_delivery_t *delivery =
+                &deliveries[next_delivery++];
+            const tow_gate_payload_t *payload =
+                &payloads[delivery->packet.payload_index];
+            if (delivery->packet.channel == TOW_ADVERSE_CHANNEL_TARGET) {
+                tow_gate_matrix_apply_target(
+                    payload, scenario, &result->presentation,
+                    current_generation);
+                current_generation = payload->target_generation;
+            } else {
+                if ((result->lifecycle_mask &
+                     TOW_GATE_RELEVANCE_REENTRY) != 0u &&
+                    payload->relation_revision == 6u) {
+                    result->post_reentry_relation_packets++;
+                    result->failure = "reentry_relation_blackout";
+                    return false;
+                }
+                tow_gate_matrix_apply_relation(payload, scenario);
+            }
+            if (!tow_gate_matrix_projection_consistent(
+                    scenario, current_generation)) {
+                result->stale_projection_failures++;
+                result->failure = "stale_projection";
+                return false;
+            }
+            tow_gate_matrix_observe_lifecycle(
+                result, scenario, current_generation);
+        }
+
+        tow_gate_matrix_advance(scenario->target_kind, frame_dt);
+        vec2 presented_pos = {0};
+        vec2 presented_vel = {0};
+        bool visible = tow_gate_matrix_presentation(
+            scenario->target_kind, &presented_pos, &presented_vel);
+        tow_presentation_diagnostics_frame(
+            &result->presentation, visible, presented_pos, frame_dt,
+            TOW_PRESENTATION_TEST_PIXELS_PER_WORLD);
+        if (!tow_gate_matrix_projection_consistent(
+                scenario, current_generation)) {
+            result->stale_projection_failures++;
+            result->failure = "frame_projection";
+            return false;
+        }
+        tow_gate_matrix_observe_lifecycle(
+            result, scenario, current_generation);
+    }
+
+    if (next_delivery != delivery_count) {
+        result->failure = "delivery_flush";
+        return false;
+    }
+    if (result->schedule.dropped_packets == 0 ||
+        result->schedule.duplicated_packets == 0 ||
+        result->schedule.reordered_packets == 0) {
+        result->failure = "adverse_coverage";
+        return false;
+    }
+    if (result->lifecycle_mask != TOW_GATE_REQUIRED_LIFECYCLE) {
+        result->failure = "lifecycle";
+        return false;
+    }
+    if (!tow_presentation_diagnostics_within_thresholds(
+            &result->presentation)) {
+        result->failure = "presentation_threshold";
+        return false;
+    }
+    result->passed = true;
+    return true;
+}
+
+static void tow_gate_matrix_accumulate(
+    const tow_gate_profile_result_t *result)
+{
+    tow_gate_matrix.stale_projection_failures +=
+        result->stale_projection_failures;
+    if (result->lifecycle_mask != TOW_GATE_REQUIRED_LIFECYCLE)
+        tow_gate_matrix.lifecycle_failures++;
+    tow_gate_matrix.max_correction_world = fmaxf(
+        tow_gate_matrix.max_correction_world,
+        result->presentation.max_correction_world);
+    tow_gate_matrix.max_velocity_discontinuity = fmaxf(
+        tow_gate_matrix.max_velocity_discontinuity,
+        result->presentation.max_velocity_discontinuity);
+    tow_gate_matrix.max_snapshot_gap_sec = fmaxf(
+        tow_gate_matrix.max_snapshot_gap_sec,
+        result->presentation.max_snapshot_gap_sec);
+    tow_gate_matrix.max_world_jerk = fmaxf(
+        tow_gate_matrix.max_world_jerk,
+        result->presentation.max_world_jerk);
+    tow_gate_matrix.max_screen_jerk = fmaxf(
+        tow_gate_matrix.max_screen_jerk,
+        result->presentation.max_screen_jerk);
+}
+
 static void tow_gate_format_report(bool passed, const char *failure)
 {
     const tow_gate_profile_result_t *a = &tow_gate_results[0];
@@ -663,7 +1256,7 @@ static void tow_gate_format_report(bool passed, const char *failure)
     const tow_gate_profile_result_t *c = &tow_gate_results[2];
     (void)snprintf(
         tow_gate_report, sizeof(tow_gate_report),
-        "{\"status\":%d,\"scope\":\"player_ship_to_cargo_pod\","
+        "{\"status\":%d,\"scope\":\"valid_owner_target_lifecycle_matrix\","
         "\"failure\":\"%s\","
         "\"thresholds\":{\"correction_world\":%.3f,"
         "\"velocity_discontinuity\":%.3f,"
@@ -690,7 +1283,17 @@ static void tow_gate_format_report(bool passed, const char *failure)
         "\"post_reentry_relation\":%u,"
         "\"correction\":%.6f,\"velocity\":%.6f,\"gap\":%.6f,"
         "\"starvation\":%u,\"world_jerk\":%.3f,"
-        "\"screen_jerk\":%.3f}]}",
+        "\"screen_jerk\":%.3f}],"
+        "\"matrix\":{\"scenarios\":[\"player_fragment\","
+        "\"npc_fragment\",\"player_cargo\",\"station_cargo\","
+        "\"player_scaffold\",\"npc_scaffold\"],"
+        "\"scenario_count\":%d,\"profile_count\":%d,"
+        "\"passed_profiles\":%d,\"stale\":%u,"
+        "\"lifecycle_failures\":%u,\"failure\":\"%s\","
+        "\"failure_scenario\":\"%s\",\"failure_latency_ms\":%u,"
+        "\"max_correction\":%.6f,\"max_velocity\":%.6f,"
+        "\"max_gap\":%.6f,\"max_world_jerk\":%.3f,"
+        "\"max_screen_jerk\":%.3f}}",
         passed ? 1 : 0, failure,
         TOW_PRESENTATION_MAX_CORRECTION_WORLD,
         TOW_PRESENTATION_MAX_VELOCITY_DISCONTINUITY,
@@ -730,7 +1333,21 @@ static void tow_gate_format_report(bool passed, const char *failure)
         c->presentation.max_snapshot_gap_sec,
         c->presentation.starvation_events,
         c->presentation.max_world_jerk,
-        c->presentation.max_screen_jerk);
+        c->presentation.max_screen_jerk,
+        tow_gate_matrix.scenario_count,
+        tow_gate_matrix.profile_count,
+        tow_gate_matrix.passed_profiles,
+        tow_gate_matrix.stale_projection_failures,
+        tow_gate_matrix.lifecycle_failures,
+        tow_gate_matrix.failure ? tow_gate_matrix.failure : "none",
+        tow_gate_matrix.failure_scenario
+            ? tow_gate_matrix.failure_scenario : "none",
+        tow_gate_matrix.failure_latency_ms,
+        tow_gate_matrix.max_correction_world,
+        tow_gate_matrix.max_velocity_discontinuity,
+        tow_gate_matrix.max_snapshot_gap_sec,
+        tow_gate_matrix.max_world_jerk,
+        tow_gate_matrix.max_screen_jerk);
 }
 
 EMSCRIPTEN_KEEPALIVE
@@ -738,6 +1355,9 @@ int signal_smoke_adverse_towable_gate(void)
 {
     static const uint16_t latencies[3] = {50, 125, 250};
     memset(tow_gate_results, 0, sizeof(tow_gate_results));
+    memset(&tow_gate_matrix, 0, sizeof(tow_gate_matrix));
+    tow_gate_matrix.failure = "not_run";
+    tow_gate_matrix.failure_scenario = "none";
     tow_gate_report[0] = '\0';
     for (int i = 0; i < 3; i++) {
         tow_gate_results[i].latency_ms = latencies[i];
@@ -751,16 +1371,53 @@ int signal_smoke_adverse_towable_gate(void)
         return 0;
     }
     const NetProtocolInfo *protocol = net_protocol_info();
+    const uint32_t required_remove_capabilities =
+        SIGNAL_PROTOCOL_CAP_ASTEROID_REMOVE |
+        SIGNAL_PROTOCOL_CAP_CARGO_POD_REMOVE |
+        SIGNAL_PROTOCOL_CAP_SCAFFOLD_REMOVE;
     if (!protocol ||
-        (protocol->capabilities &
-         SIGNAL_PROTOCOL_CAP_CARGO_POD_REMOVE) == 0u) {
-        tow_gate_format_report(false, "cargo_remove_capability");
+        (protocol->capabilities & required_remove_capabilities) !=
+            required_remove_capabilities) {
+        tow_gate_format_report(false, "remove_capabilities");
         return 0;
     }
     entity_ref_t source =
         g.world.players[g.local_player_slot].ship_ref;
     if (!world_ship_resolve_const(&g.world, source)) {
         tow_gate_format_report(false, "source_ship");
+        return 0;
+    }
+
+    entity_ref_t npc_source = entity_ref_none();
+    for (int i = 0; i < MAX_NPC_SHIPS; i++) {
+        const npc_ship_t *npc = &g.world.npc_ships[i];
+        if (!npc->active || !npc->ship) continue;
+        if (!world_ship_resolve_const(&g.world, npc->ship_ref)) continue;
+        npc_source = npc->ship_ref;
+        break;
+    }
+    if (entity_ref_is_none(npc_source)) {
+        tow_gate_format_report(false, "npc_source");
+        return 0;
+    }
+
+    entity_ref_t station_source = entity_ref_none();
+    for (int station = 0; station < MAX_STATIONS; station++) {
+        const station_t *candidate = &g.world.stations[station];
+        if (!station_exists(candidate) || candidate->module_count <= 0)
+            continue;
+        uint16_t generation =
+            g.world.station_module_generation[station][0];
+        station_source = (entity_ref_t){
+            .kind = ENTITY_KIND_STATION_MODULE,
+            .index = (int16_t)station,
+            .part = 0,
+            .generation = generation != 0 ? generation : 1u,
+        };
+        break;
+    }
+    if (entity_ref_is_none(station_source)) {
+        tow_gate_format_report(false, "station_source");
         return 0;
     }
 
@@ -784,6 +1441,48 @@ int signal_smoke_adverse_towable_gate(void)
                 payloads, packets, packet_count, source)) {
             passed = false;
             failure = tow_gate_results[i].failure;
+            break;
+        }
+    }
+
+    const tow_gate_scenario_t scenarios[] = {
+        {"player_fragment", source, ENTITY_KIND_ASTEROID,
+         TOW_PROFILE_SHIP_FRAGMENT},
+        {"npc_fragment", npc_source, ENTITY_KIND_ASTEROID,
+         TOW_PROFILE_SHIP_FRAGMENT},
+        {"player_cargo", source, ENTITY_KIND_CARGO_POD,
+         TOW_PROFILE_SHIP_POD},
+        {"station_cargo", station_source, ENTITY_KIND_CARGO_POD,
+         TOW_PROFILE_MODULE_POD},
+        {"player_scaffold", source, ENTITY_KIND_SCAFFOLD,
+         TOW_PROFILE_SHIP_SCAFFOLD},
+        {"npc_scaffold", npc_source, ENTITY_KIND_SCAFFOLD,
+         TOW_PROFILE_SHIP_SCAFFOLD},
+    };
+    tow_gate_matrix.scenario_count =
+        (int)(sizeof(scenarios) / sizeof(scenarios[0]));
+    tow_gate_matrix.profile_count = tow_gate_matrix.scenario_count * 3;
+    tow_gate_matrix.failure = "none";
+
+    for (int scenario_index = 0;
+         passed && scenario_index < tow_gate_matrix.scenario_count;
+         scenario_index++) {
+        for (int profile_index = 0; profile_index < 3; profile_index++) {
+            tow_gate_profile_result_t result;
+            bool profile_passed = tow_gate_run_matrix_profile(
+                &result, &scenarios[scenario_index],
+                latencies[profile_index], payloads, packets, packet_count);
+            tow_gate_matrix_accumulate(&result);
+            if (profile_passed) {
+                tow_gate_matrix.passed_profiles++;
+                continue;
+            }
+            tow_gate_matrix.failure = result.failure;
+            tow_gate_matrix.failure_scenario =
+                scenarios[scenario_index].name;
+            tow_gate_matrix.failure_latency_ms = latencies[profile_index];
+            failure = result.failure;
+            passed = false;
             break;
         }
     }

--- a/client/world_draw.c
+++ b/client/world_draw.c
@@ -3430,6 +3430,28 @@ void draw_npc_ships(void) {
                                          1.0f);
             }
         }
+        int towed_scaffold = tnpc->ship->towed_scaffold;
+        if (towed_scaffold >= 0 && towed_scaffold < MAX_SCAFFOLDS) {
+            const scaffold_t *sc = &g.world.scaffolds[towed_scaffold];
+            if (sc->active && sc->state == SCAFFOLD_TOWING &&
+                scaffold_tractor_npc(sc) == i) {
+                float tr = ship_tractor_range(tnpc->ship);
+                tractor_beam_t beam = tractor_tow_beam(
+                    tr, TRACTOR_TOW_BAND_REST_LENGTH);
+                float stretch = tractor_beam_tautness(
+                    tnpc->ship->pos, sc->pos, &beam);
+                float pulse = 0.5f + 0.2f *
+                    sinf(g.world.time * 3.0f + (float)i * 1.5f);
+                draw_tractor_tether_wave(
+                    tnpc->ship->pos, sc->pos,
+                    0.5f, 0.85f, 0.75f, pulse,
+                    stretch, (float)i * 2.3f,
+                    SIM_INTERACTION_ENTITY_PLAYER_SHIP,
+                    SIM_INTERACTION_ENTITY_SCAFFOLD,
+                    SIM_INTERACTION_VISUAL_DEFAULT_TRACTOR,
+                    1.0f);
+            }
+        }
         if (i == scan_npc) {
             /* Hug the visible ship: ship_radius is the collision radius
              * and the rendered triangle sits within it, so a tight

--- a/client/zero_latency_gate.c
+++ b/client/zero_latency_gate.c
@@ -99,7 +99,6 @@ static void zero_latency_clear_client_interpolation(void)
 {
     memset(&g.asteroid_interp, 0, sizeof(g.asteroid_interp));
     memset(&g.npc_interp, 0, sizeof(g.npc_interp));
-    g.npc_interp.interval = 0.1f;
     memset(&g.cargo_pod_interp, 0, sizeof(g.cargo_pod_interp));
 }
 

--- a/server/game_sim.c
+++ b/server/game_sim.c
@@ -2171,11 +2171,15 @@ static bool world_tow_link_capacity_allows(const world_t *w,
         default: break;
         }
     }
-    if (profile == TOW_PROFILE_SHIP_SCAFFOLD) return scaffolds < 1;
     if (profile != TOW_PROFILE_SHIP_FRAGMENT &&
-        profile != TOW_PROFILE_SHIP_POD) return false;
-    if (source.index >= WORLD_NPC_SHIP_BASE)
-        return profile == TOW_PROFILE_SHIP_FRAGMENT && fragments < 1;
+        profile != TOW_PROFILE_SHIP_POD &&
+        profile != TOW_PROFILE_SHIP_SCAFFOLD) return false;
+    if (source.index >= WORLD_NPC_SHIP_BASE) {
+        if (profile != TOW_PROFILE_SHIP_FRAGMENT &&
+            profile != TOW_PROFILE_SHIP_SCAFFOLD) return false;
+        return fragments + scaffolds < 1;
+    }
+    if (profile == TOW_PROFILE_SHIP_SCAFFOLD) return scaffolds < 1;
     if (profile == TOW_PROFILE_SHIP_FRAGMENT && fragments >= 10) return false;
     if (profile == TOW_PROFILE_SHIP_POD && pods >= 10) return false;
     return fragments + pods < ship_tow_body_capacity(ship);

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -2875,7 +2875,30 @@ test.describe('Browser smoke tests', () => {
     expectNoFatalErrors(logs);
   });
 
-  rootBundleSmokeTest('bounds player-to-cargo-pod presentation under deterministic adverse delivery', async ({ page }) => {
+  rootBundleSmokeTest('renders an NPC-owned scaffold tether from canonical tow state', async ({ page }) => {
+    const logs = installFatalCollectors(page);
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await loadGame(page, false, { singleplayer: true });
+
+    expect(
+      await wasmNumber(page, 'signal_smoke_prepare_npc_scaffold_tether'),
+    ).toBe(1);
+    await expect
+      .poll(async () => (await tractorDrawTelemetry(page, 0)).count, {
+        timeout: 3_000,
+        message: 'the NPC-scaffold canonical relation should render a tether',
+      })
+      .toBeGreaterThanOrEqual(1);
+    const tether = await tractorDrawTelemetry(page, 0);
+    expect(tether.sourceType).toBe(3); // ship
+    expect(tether.targetType).toBe(5); // scaffold
+    expect(tether.span).toBeGreaterThan(40);
+    expect(tether.intensity).toBeGreaterThan(0);
+
+    expectNoFatalErrors(logs);
+  });
+
+  rootBundleSmokeTest('keeps every supported tow owner and target atomic under deterministic adverse delivery', async ({ page }) => {
     const logs = installFatalCollectors(page);
     await page.setViewportSize({ width: 1280, height: 720 });
     await loadGame(page, false, { singleplayer: true });
@@ -2896,9 +2919,18 @@ test.describe('Browser smoke tests', () => {
         stale: number;
         post_reentry_relation: number;
       }>;
+      matrix: {
+        scenarios: string[];
+        scenario_count: number;
+        profile_count: number;
+        passed_profiles: number;
+        stale: number;
+        lifecycle_failures: number;
+        failure: string;
+      };
     };
     expect(report.status).toBe(1);
-    expect(report.scope).toBe('player_ship_to_cargo_pod');
+    expect(report.scope).toBe('valid_owner_target_lifecycle_matrix');
     expect(report.profiles.map((profile) => profile.latency_ms)).toEqual([50, 125, 250]);
     for (const profile of report.profiles) {
       expect(profile.pass).toBe(1);
@@ -2909,6 +2941,20 @@ test.describe('Browser smoke tests', () => {
       expect(profile.stale).toBe(0);
       expect(profile.post_reentry_relation).toBe(0);
     }
+    expect(report.matrix.scenarios).toEqual([
+      'player_fragment',
+      'npc_fragment',
+      'player_cargo',
+      'station_cargo',
+      'player_scaffold',
+      'npc_scaffold',
+    ]);
+    expect(report.matrix.scenario_count).toBe(6);
+    expect(report.matrix.profile_count).toBe(18);
+    expect(report.matrix.passed_profiles).toBe(18);
+    expect(report.matrix.stale).toBe(0);
+    expect(report.matrix.lifecycle_failures).toBe(0);
+    expect(report.matrix.failure).toBe('none');
 
     expectNoFatalErrors(logs);
   });

--- a/tests/c/test_tractor.c
+++ b/tests/c/test_tractor.c
@@ -313,6 +313,158 @@ TEST(test_tow_links_ignore_stale_projection_capacity_and_collect_stably) {
     ASSERT_EQ_INT(sp->ship->towed_pods[1], 7);
 }
 
+static int test_active_tow_link_count(const world_t *w) {
+    int count = 0;
+    for (int i = 0; i < MAX_TOW_LINKS; i++)
+        if (w->tow_links[i].active) count++;
+    return count;
+}
+
+TEST(test_supported_tow_owner_target_matrix_is_atomic_and_idempotent) {
+    WORLD_DECL;
+    world_reset(&w);
+
+    server_player_t *player = &w.players[0];
+    player->connected = true;
+    player->session_ready = true;
+    player->id = 0;
+    player_init_ship(player, &w);
+
+    ASSERT(world_npc_ship_slot_activate(&w, 0));
+    npc_ship_t *npc = &w.npc_ships[0];
+    npc->active = true;
+    ASSERT(world_npc_ship_slot_activate(&w, 1));
+    npc_ship_t *scaffold_npc = &w.npc_ships[1];
+    scaffold_npc->active = true;
+
+    const int player_fragment = MAX_ASTEROIDS - 1;
+    const int npc_fragment = MAX_ASTEROIDS - 2;
+    const int player_pod = MAX_CARGO_PODS - 1;
+    const int station_pod = MAX_CARGO_PODS - 2;
+    const int player_scaffold = MAX_SCAFFOLDS - 1;
+    const int npc_scaffold = MAX_SCAFFOLDS - 2;
+
+    w.asteroids[player_fragment] = (asteroid_t){
+        .active = true, .fracture_child = true, .radius = 8.0f,
+    };
+    w.asteroids[npc_fragment] = (asteroid_t){
+        .active = true, .fracture_child = true, .radius = 8.0f,
+    };
+    w.cargo_pods[player_pod] = (cargo_pod_t){
+        .active = true, .kind = CARGO_POD_CARGO, .radius = 12.0f,
+    };
+    w.cargo_pods[station_pod] = (cargo_pod_t){
+        .active = true, .kind = CARGO_POD_CARGO, .radius = 12.0f,
+    };
+    w.scaffolds[player_scaffold] = (scaffold_t){
+        .active = true, .state = SCAFFOLD_TOWING, .radius = 18.0f,
+    };
+    w.scaffolds[npc_scaffold] = (scaffold_t){
+        .active = true, .state = SCAFFOLD_TOWING, .radius = 18.0f,
+    };
+
+    ASSERT(station_exists(&w.stations[0]));
+    ASSERT(w.stations[0].module_count > 0);
+    ASSERT(world_asteroid_set_player_tractor(&w, player_fragment, 0));
+    ASSERT(world_asteroid_set_npc_tractor(&w, npc_fragment, 0));
+    ASSERT(world_cargo_pod_set_player_tractor(&w, player_pod, 0));
+    ASSERT(world_cargo_pod_set_module_tractor(&w, station_pod, 0, 0));
+    ASSERT(world_scaffold_set_player_tractor(&w, player_scaffold, 0));
+    ASSERT(world_scaffold_set_npc_tractor(&w, npc_scaffold, 1));
+    ASSERT_EQ_INT(test_active_tow_link_count(&w), 6);
+
+    ASSERT_EQ_INT(asteroid_tractor_player(
+                      &w.asteroids[player_fragment]), 0);
+    ASSERT_EQ_INT(asteroid_tractor_npc(
+                      &w.asteroids[npc_fragment]), 0);
+    ASSERT_EQ_INT(cargo_pod_player_tractor(
+                      &w.cargo_pods[player_pod]), 0);
+    ASSERT(cargo_pod_is_tractored_by_module(
+        &w.cargo_pods[station_pod], 0, 0));
+    ASSERT_EQ_INT(scaffold_tractor_player(
+                      &w.scaffolds[player_scaffold]), 0);
+    ASSERT_EQ_INT(scaffold_tractor_npc(
+                      &w.scaffolds[npc_scaffold]), 1);
+    ASSERT_EQ_INT(player->ship->towed_count, 1);
+    ASSERT_EQ_INT(player->ship->towed_fragments[0], player_fragment);
+    ASSERT_EQ_INT(player->ship->towed_pod_count, 1);
+    ASSERT_EQ_INT(player->ship->towed_pods[0], player_pod);
+    ASSERT_EQ_INT(player->ship->towed_scaffold, player_scaffold);
+    ASSERT_EQ_INT(npc_towed_fragment_index(npc), npc_fragment);
+    ASSERT_EQ_INT(scaffold_npc->ship->towed_scaffold, npc_scaffold);
+
+    entity_ref_t targets[] = {
+        world_entity_ref_for_slot(
+            &w, ENTITY_KIND_ASTEROID, player_fragment, -1),
+        world_entity_ref_for_slot(
+            &w, ENTITY_KIND_ASTEROID, npc_fragment, -1),
+        world_entity_ref_for_slot(
+            &w, ENTITY_KIND_CARGO_POD, player_pod, -1),
+        world_entity_ref_for_slot(
+            &w, ENTITY_KIND_CARGO_POD, station_pod, -1),
+        world_entity_ref_for_slot(
+            &w, ENTITY_KIND_SCAFFOLD, player_scaffold, -1),
+        world_entity_ref_for_slot(
+            &w, ENTITY_KIND_SCAFFOLD, npc_scaffold, -1),
+    };
+    const tow_profile_t profiles[] = {
+        TOW_PROFILE_SHIP_FRAGMENT,
+        TOW_PROFILE_SHIP_FRAGMENT,
+        TOW_PROFILE_SHIP_POD,
+        TOW_PROFILE_MODULE_POD,
+        TOW_PROFILE_SHIP_SCAFFOLD,
+        TOW_PROFILE_SHIP_SCAFFOLD,
+    };
+    for (int i = 0; i < 6; i++) {
+        const tow_link_t *link =
+            world_tow_link_for_target_const(&w, targets[i]);
+        ASSERT(link != NULL);
+        ASSERT_EQ_INT(link->profile, profiles[i]);
+        ASSERT_EQ_INT(link->state, TOW_LINK_HELD);
+    }
+
+    uint32_t attached_revision = w.tow_revision;
+    ASSERT(world_asteroid_set_player_tractor(&w, player_fragment, 0));
+    ASSERT(world_asteroid_set_npc_tractor(&w, npc_fragment, 0));
+    ASSERT(world_cargo_pod_set_player_tractor(&w, player_pod, 0));
+    ASSERT(world_cargo_pod_set_module_tractor(&w, station_pod, 0, 0));
+    ASSERT(world_scaffold_set_player_tractor(&w, player_scaffold, 0));
+    ASSERT(world_scaffold_set_npc_tractor(&w, npc_scaffold, 1));
+    ASSERT_EQ_INT(w.tow_revision, attached_revision);
+    ASSERT_EQ_INT(test_active_tow_link_count(&w), 6);
+
+    /* NPC cargo pods are deliberately not a supported relation: NPC haulers
+     * carry manifests in their ship hold, while towable pods have player or
+     * station-module custody. */
+    ASSERT(!world_tow_link_set(
+        &w, npc->ship_ref, targets[2], TOW_PROFILE_SHIP_POD,
+        0, TOW_LINK_HELD));
+    ASSERT_EQ_INT(w.tow_revision, attached_revision);
+
+    world_asteroid_clear_tractor(&w, player_fragment);
+    world_asteroid_clear_tractor(&w, npc_fragment);
+    world_cargo_pod_clear_tractor(&w, player_pod);
+    world_cargo_pod_clear_tractor(&w, station_pod);
+    world_scaffold_clear_tractor(&w, player_scaffold);
+    world_scaffold_clear_tractor(&w, npc_scaffold);
+    ASSERT_EQ_INT(test_active_tow_link_count(&w), 0);
+    ASSERT_EQ_INT(player->ship->towed_count, 0);
+    ASSERT_EQ_INT(player->ship->towed_pod_count, 0);
+    ASSERT_EQ_INT(player->ship->towed_scaffold, -1);
+    ASSERT_EQ_INT(npc_towed_fragment_index(npc), -1);
+    ASSERT_EQ_INT(scaffold_npc->ship->towed_scaffold, -1);
+
+    uint32_t released_revision = w.tow_revision;
+    world_asteroid_clear_tractor(&w, player_fragment);
+    world_asteroid_clear_tractor(&w, npc_fragment);
+    world_cargo_pod_clear_tractor(&w, player_pod);
+    world_cargo_pod_clear_tractor(&w, station_pod);
+    world_scaffold_clear_tractor(&w, player_scaffold);
+    world_scaffold_clear_tractor(&w, npc_scaffold);
+    ASSERT_EQ_INT(w.tow_revision, released_revision);
+    ASSERT_EQ_INT(test_active_tow_link_count(&w), 0);
+}
+
 TEST(test_ship_pointer_cache_rebinds_and_clears_stale_views) {
     WORLD_DECL;
     world_reset(&w);
@@ -615,6 +767,7 @@ void register_tractor_tests(void) {
     RUN(test_tow_link_revision_is_monotonic_and_idempotent);
     RUN(test_cargo_tow_slot_teardown_preserves_owner_until_explicit_release);
     RUN(test_tow_links_ignore_stale_projection_capacity_and_collect_stably);
+    RUN(test_supported_tow_owner_target_matrix_is_atomic_and_idempotent);
     RUN(test_ship_pointer_cache_rebinds_and_clears_stale_views);
     RUN(test_tractor_pull_engages_beyond_rest);
     RUN(test_tractor_push_engages_below_rest);


### PR DESCRIPTION
Closes #617

## What changed

- Gives NPC and scaffold motion independent per-entity interpolation timelines and smooths NPC position and velocity together.
- Restores canonical NPC-to-scaffold towing and renders its replicated tether.
- Expands the deterministic adverse-delivery gate across player, NPC, and station owners with fragment, cargo, and scaffold targets at 50, 125, and 250 ms.
- Covers idempotent attach, release, immediate reattach, retirement, replacement, and relevance exit/re-entry, with native atomicity checks for every supported pairing.

## Why

Sparse remote updates could reset unrelated render baselines, NPC scaffold tow requests were rejected despite existing support paths, and the maintained release gate did not cover the full supported owner/target matrix.

## Validation

- Required exact-head native verifier: 1,659 passed
- Full native suite: 1,668 passed
- ASan and UBSan: 1,659 passed across 8 shards
- Browser smoke: 49 passed
- Live multiplayer latency suite: both scenarios passed
- Replay repeatability: 21 scenarios passed
- Determinism, banned API, cppcheck, and diff hygiene checks passed