### PR TITLE
Stabilize towed crate scale and player correction

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -4482,6 +4482,11 @@ int signal_smoke_remote_towable_interp_check(void) {
 }
 
 EMSCRIPTEN_KEEPALIVE
+int signal_smoke_local_tow_replay_stability_check(void) {
+    return net_smoke_local_tow_replay_stability_check();
+}
+
+EMSCRIPTEN_KEEPALIVE
 int signal_smoke_prepare_npc_scaffold_tether(void) {
     const int npc_idx = 0;
     const int scaffold_idx = MAX_SCAFFOLDS - 1;

--- a/client/net_sync.c
+++ b/client/net_sync.c
@@ -720,6 +720,126 @@ static void accept_authoritative_local_launch_state(const NetPlayerState *state,
     frame_camera_on_authoritative_baseline(sp);
 }
 
+typedef struct {
+    int index;
+    vec2 pos;
+    vec2 vel;
+    float rotation;
+    float spin;
+    float age;
+    uint8_t tow_hardpoint_tag;
+} net_local_tow_replay_pose_t;
+
+typedef struct {
+    int asteroid_count;
+    net_local_tow_replay_pose_t asteroids[10];
+    int pod_count;
+    net_local_tow_replay_pose_t pods[10];
+    bool scaffold_active;
+    net_local_tow_replay_pose_t scaffold;
+} net_local_tow_replay_guard_t;
+
+static net_local_tow_replay_pose_t net_local_tow_replay_pose(
+    int index, vec2 pos, vec2 vel,
+    float rotation, float spin, float age)
+{
+    return (net_local_tow_replay_pose_t){
+        .index = index,
+        .pos = pos,
+        .vel = vel,
+        .rotation = rotation,
+        .spin = spin,
+        .age = age,
+    };
+}
+
+static void net_local_tow_replay_guard_capture(
+    net_local_tow_replay_guard_t *guard,
+    const server_player_t *sp)
+{
+    if (!guard) return;
+    memset(guard, 0, sizeof(*guard));
+    guard->scaffold.index = -1;
+    if (!sp || !sp->ship) return;
+
+    int asteroid_count = ship_towed_fragment_count(sp->ship);
+    for (int t = 0; t < asteroid_count; t++) {
+        int idx = sp->ship->towed_fragments[t];
+        if (idx < 0 || idx >= MAX_ASTEROIDS ||
+            !g.world.asteroids[idx].active) {
+            continue;
+        }
+        int save = guard->asteroid_count++;
+        const asteroid_t *asteroid = &g.world.asteroids[idx];
+        guard->asteroids[save] = net_local_tow_replay_pose(
+            idx, asteroid->pos, asteroid->vel,
+            asteroid->rotation, asteroid->spin, asteroid->age);
+    }
+
+    int pod_count = ship_towed_pod_count(sp->ship);
+    for (int t = 0; t < pod_count; t++) {
+        int idx = sp->ship->towed_pods[t];
+        if (idx < 0 || idx >= MAX_CARGO_PODS ||
+            !g.world.cargo_pods[idx].active) {
+            continue;
+        }
+        int save = guard->pod_count++;
+        const cargo_pod_t *pod = &g.world.cargo_pods[idx];
+        guard->pods[save] = net_local_tow_replay_pose(
+            idx, pod->pos, pod->vel,
+            pod->rotation, pod->spin, pod->age);
+        guard->pods[save].tow_hardpoint_tag = pod->tow_hardpoint_tag;
+    }
+
+    int scaffold_idx = sp->ship->towed_scaffold;
+    if (scaffold_idx >= 0 && scaffold_idx < MAX_SCAFFOLDS &&
+        g.world.scaffolds[scaffold_idx].active) {
+        const scaffold_t *scaffold = &g.world.scaffolds[scaffold_idx];
+        guard->scaffold_active = true;
+        guard->scaffold = net_local_tow_replay_pose(
+            scaffold_idx, scaffold->pos, scaffold->vel,
+            scaffold->rotation, scaffold->spin, scaffold->age);
+    }
+}
+
+static void net_local_tow_replay_guard_restore(
+    const net_local_tow_replay_guard_t *guard)
+{
+    if (!guard) return;
+    for (int i = 0; i < guard->asteroid_count; i++) {
+        const net_local_tow_replay_pose_t *saved = &guard->asteroids[i];
+        if (saved->index < 0 || saved->index >= MAX_ASTEROIDS) continue;
+        asteroid_t *asteroid = &g.world.asteroids[saved->index];
+        asteroid->pos = saved->pos;
+        asteroid->vel = saved->vel;
+        asteroid->rotation = saved->rotation;
+        asteroid->spin = saved->spin;
+        asteroid->age = saved->age;
+    }
+    for (int i = 0; i < guard->pod_count; i++) {
+        const net_local_tow_replay_pose_t *saved = &guard->pods[i];
+        if (saved->index < 0 || saved->index >= MAX_CARGO_PODS) continue;
+        cargo_pod_t *pod = &g.world.cargo_pods[saved->index];
+        pod->pos = saved->pos;
+        pod->vel = saved->vel;
+        pod->rotation = saved->rotation;
+        pod->spin = saved->spin;
+        pod->age = saved->age;
+        pod->tow_hardpoint_tag = saved->tow_hardpoint_tag;
+    }
+    if (guard->scaffold_active &&
+        guard->scaffold.index >= 0 &&
+        guard->scaffold.index < MAX_SCAFFOLDS) {
+        const net_local_tow_replay_pose_t *saved = &guard->scaffold;
+        scaffold_t *scaffold = &g.world.scaffolds[saved->index];
+        scaffold->pos = saved->pos;
+        scaffold->vel = saved->vel;
+        scaffold->rotation = saved->rotation;
+        scaffold->spin = saved->spin;
+        scaffold->age = saved->age;
+    }
+}
+
 static bool net_replay_reconcile_local_player(const NetPlayerState *state,
                                               server_player_t *sp,
                                               int *out_replayed) {
@@ -744,6 +864,8 @@ static bool net_replay_reconcile_local_player(const NetPlayerState *state,
     if (net_replay_missing_prefix(server_tick, first_after)) return false;
 
     sim_events_t saved_events = g.world.events;
+    net_local_tow_replay_guard_t tow_guard;
+    net_local_tow_replay_guard_capture(&tow_guard, sp);
     apply_authoritative_local_motion(state, sp);
     uint32_t last_tick = server_tick;
     int replay_count = (int)g.net_replay_count;
@@ -754,6 +876,11 @@ static bool net_replay_reconcile_local_player(const NetPlayerState *state,
         last_tick = frame->tick;
         (*out_replayed)++;
     }
+    /* Player snapshots and towable motion use independent streams. The
+     * towable is already predicted to the local present when an older player
+     * baseline arrives, so replay may use a temporary copy for its reaction
+     * on the ship but must not advance that live towable a second time. */
+    net_local_tow_replay_guard_restore(&tow_guard);
     net_adopt_local_tow_prediction(0.0f);
     g.world.events = saved_events;
 
@@ -761,6 +888,107 @@ static bool net_replay_reconcile_local_player(const NetPlayerState *state,
     g.net_prediction_tick_valid = true;
     net_replay_prune_through(server_tick);
     return true;
+}
+
+int net_smoke_local_tow_replay_stability_check(void) {
+    const int player_idx = 0;
+    const int pod_idx = MAX_CARGO_PODS - 1;
+    server_player_t *sp = &g.world.players[player_idx];
+    if (!sp->ship) return 0;
+
+    bool saved_net_authority_enabled = g.net_authority_enabled;
+    bool saved_net_input_tick_protocol = g.net_input_tick_protocol;
+    int saved_local_player_slot = g.local_player_slot;
+    uint32_t saved_prediction_tick = g.net_prediction_tick;
+    bool saved_prediction_tick_valid = g.net_prediction_tick_valid;
+    uint16_t saved_replay_start = g.net_replay_start;
+    uint16_t saved_replay_count = g.net_replay_count;
+    input_replay_frame_t saved_replay[NET_REPLAY_FRAME_CAP];
+    memcpy(saved_replay, g.net_replay, sizeof(saved_replay));
+    server_player_t saved_player = *sp;
+    ship_t saved_ship = *sp->ship;
+    cargo_pod_t saved_world_pod = g.world.cargo_pods[pod_idx];
+    cargo_pod_t saved_prev_pod = g.cargo_pod_interp.prev[pod_idx];
+    cargo_pod_t saved_curr_pod = g.cargo_pod_interp.curr[pod_idx];
+    float saved_pod_elapsed = g.cargo_pod_interp.elapsed[pod_idx];
+    sim_events_t saved_events = g.world.events;
+    bool saved_player_only_mode = g.world.player_only_mode;
+
+    g.net_authority_enabled = true;
+    g.net_input_tick_protocol = true;
+    g.local_player_slot = player_idx;
+    sp->connected = true;
+    sp->docked = false;
+    sp->ship->pos = saved_ship.pos;
+    sp->ship->vel = v2(0.0f, 0.0f);
+    sp->ship->towed_count = 0;
+    memset(sp->ship->towed_fragments, -1,
+           sizeof(sp->ship->towed_fragments));
+    sp->ship->towed_pod_count = 1;
+    memset(sp->ship->towed_pods, -1, sizeof(sp->ship->towed_pods));
+    sp->ship->towed_pods[0] = (int16_t)pod_idx;
+    sp->ship->towed_scaffold = -1;
+
+    cargo_pod_t replay_pod = {0};
+    replay_pod.active = true;
+    replay_pod.kind = CARGO_POD_CARGO;
+    replay_pod.commodity = COMMODITY_FERRITE_INGOT;
+    replay_pod.radius = 18.0f;
+    replay_pod.quantity = 12;
+    replay_pod.pos = v2_add(sp->ship->pos, v2(260.0f, 35.0f));
+    replay_pod.vel = v2(30.0f, -4.0f);
+    cargo_pod_set_player_tractor(&replay_pod, player_idx);
+    g.world.cargo_pods[pod_idx] = replay_pod;
+    g.cargo_pod_interp.prev[pod_idx] = replay_pod;
+    g.cargo_pod_interp.curr[pod_idx] = replay_pod;
+    g.cargo_pod_interp.elapsed[pod_idx] = 0.0f;
+
+    g.net_prediction_tick = 102;
+    g.net_prediction_tick_valid = true;
+    g.net_replay_start = 0;
+    g.net_replay_count = 2;
+    memset(g.net_replay, 0, sizeof(g.net_replay));
+    for (int i = 0; i < 2; i++) {
+        g.net_replay[i].tick = (uint32_t)(101 + i);
+        g.net_replay[i].dt = SIM_DT;
+        g.net_replay[i].intent.mining_target_hint = -1;
+    }
+
+    NetPlayerState authority = {0};
+    authority.player_id = (uint8_t)player_idx;
+    authority.active = true;
+    authority.x = sp->ship->pos.x;
+    authority.y = sp->ship->pos.y;
+    authority.angle = sp->ship->angle;
+    authority.server_tick = 100;
+
+    int replayed = 0;
+    bool reconciled = net_replay_reconcile_local_player(
+        &authority, sp, &replayed);
+    const cargo_pod_t *after = &g.world.cargo_pods[pod_idx];
+    bool pod_preserved =
+        memcmp(after, &replay_pod, sizeof(replay_pod)) == 0;
+    int ok = reconciled && replayed == 2 && pod_preserved &&
+        isfinite(sp->ship->pos.x) && isfinite(sp->ship->pos.y) &&
+        isfinite(sp->ship->vel.x) && isfinite(sp->ship->vel.y);
+
+    g.net_authority_enabled = saved_net_authority_enabled;
+    g.net_input_tick_protocol = saved_net_input_tick_protocol;
+    g.local_player_slot = saved_local_player_slot;
+    g.net_prediction_tick = saved_prediction_tick;
+    g.net_prediction_tick_valid = saved_prediction_tick_valid;
+    g.net_replay_start = saved_replay_start;
+    g.net_replay_count = saved_replay_count;
+    memcpy(g.net_replay, saved_replay, sizeof(saved_replay));
+    *sp = saved_player;
+    if (sp->ship) *sp->ship = saved_ship;
+    g.world.cargo_pods[pod_idx] = saved_world_pod;
+    g.cargo_pod_interp.prev[pod_idx] = saved_prev_pod;
+    g.cargo_pod_interp.curr[pod_idx] = saved_curr_pod;
+    g.cargo_pod_interp.elapsed[pod_idx] = saved_pod_elapsed;
+    g.world.events = saved_events;
+    g.world.player_only_mode = saved_player_only_mode;
+    return ok ? 1 : 0;
 }
 
 static void client_reset_player_slot(int player_slot) {

--- a/client/net_sync.h
+++ b/client/net_sync.h
@@ -51,6 +51,7 @@ void net_observe_transport_latency_sample(float rtt_ms,
                                           uint32_t server_tick,
                                           bool from_input_ack);
 void net_adopt_local_tow_prediction(float dt);
+int net_smoke_local_tow_replay_stability_check(void);
 void net_advance_asteroid_interpolation(float dt);
 void net_advance_npc_interpolation(float dt);
 void net_advance_scaffold_interpolation(float dt);

--- a/client/world_draw.c
+++ b/client/world_draw.c
@@ -51,11 +51,8 @@
  * deliberately modest: they make cargo and module roles readable without
  * implying a radically larger collision target. */
 #define CARGO_POD_BASE_VISUAL_SCALE 1.18f
-#define CARGO_POD_TOWED_VISUAL_SCALE 1.30f
 #define CARGO_POD_MAX_VISUAL_SCALE 1.48f
-#define CARGO_POD_TOWED_MAX_VISUAL_SCALE 2.60f
 #define CARGO_POD_MIN_SCREEN_RADIUS_PX 22.0f
-#define CARGO_POD_TOWED_MIN_SCREEN_RADIUS_PX 25.0f
 
 /* --- Frustum culling: skip objects entirely off-screen --- */
 static float g_cam_left, g_cam_right, g_cam_top, g_cam_bottom;
@@ -4924,10 +4921,7 @@ static int cargo_pod_filled_load_rails(const cargo_pod_t *pod) {
 }
 
 static float cargo_pod_visual_scale(const cargo_pod_t *pod) {
-    bool locally_towed = pod &&
-        cargo_pod_player_tractor(pod) == LOCAL_PLAYER.id;
-    float base = locally_towed ? CARGO_POD_TOWED_VISUAL_SCALE
-                               : CARGO_POD_BASE_VISUAL_SCALE;
+    float base = CARGO_POD_BASE_VISUAL_SCALE;
     /* Cargo is world geometry, so convert with the unscaled window width.
      * ui_screen_width() is divided by the HUD layout scale and would make
      * world objects appear artificially smaller in compact UI modes. */
@@ -4936,12 +4930,10 @@ static float cargo_pod_visual_scale(const cargo_pod_t *pod) {
         g_cam_half_w <= 1.0f) return base;
 
     float pixels_per_world = screen_w / (2.0f * g_cam_half_w);
-    float target_px = locally_towed ? CARGO_POD_TOWED_MIN_SCREEN_RADIUS_PX
-                                    : CARGO_POD_MIN_SCREEN_RADIUS_PX;
+    float target_px = CARGO_POD_MIN_SCREEN_RADIUS_PX;
     float minimum = target_px / (pod->radius * pixels_per_world);
-    float cap = locally_towed ? CARGO_POD_TOWED_MAX_VISUAL_SCALE
-                              : CARGO_POD_MAX_VISUAL_SCALE;
-    return clampf(fmaxf(base, minimum), base, cap);
+    return clampf(fmaxf(base, minimum), base,
+                  CARGO_POD_MAX_VISUAL_SCALE);
 }
 
 static void cargo_pod_record_readability(const cargo_pod_t *pod,

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -627,6 +627,16 @@ async function remoteTowableInterpCheck(page: Page): Promise<number> {
   });
 }
 
+async function localTowReplayStabilityCheck(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const mod = (window as unknown as {
+      Module?: { ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => number };
+    }).Module;
+    if (!mod || typeof mod.ccall !== 'function') return 0;
+    return mod.ccall('signal_smoke_local_tow_replay_stability_check', 'number', [], []);
+  });
+}
+
 async function adverseTowableGate(page: Page): Promise<number> {
   return page.evaluate(() => {
     const mod = (window as unknown as {
@@ -2740,7 +2750,11 @@ test.describe('Browser smoke tests', () => {
     expect(
       await wasmNumber(page, 'signal_cargo_readability_towed_screen_radius'),
       'the towed carrier should retain a readable radius at the flight camera',
-    ).toBeGreaterThanOrEqual(24.5);
+    ).toBeGreaterThanOrEqual(21.5);
+    expect(
+      await wasmNumber(page, 'signal_cargo_readability_max_scale'),
+      'towing must not inflate a carrier beyond the normal readability cap',
+    ).toBeLessThanOrEqual(1.5);
     expect(
       await wasmNumber(page, 'signal_station_hopper_glyph_count'),
       'visible station storage cells should retain their hopper silhouettes',
@@ -2871,6 +2885,10 @@ test.describe('Browser smoke tests', () => {
     await loadGame(page, false, { singleplayer: true });
 
     expect(await remoteTowableInterpCheck(page)).toBe(1);
+    expect(
+      await localTowReplayStabilityCheck(page),
+      'player reconciliation must not advance an already-predicted tow body again',
+    ).toBe(1);
 
     expectNoFatalErrors(logs);
   });

--- a/tests/c/test_ai_feature_contract.c
+++ b/tests/c/test_ai_feature_contract.c
@@ -270,9 +270,9 @@ static bool write_checkpoint(const char *path,
 }
 
 TEST(test_legacy_ai_checkpoints_fail_closed_with_actionable_errors) {
-    const char *worker_v1_path = "signal-test-worker-v1.nnckpt";
-    const char *worker_old_v2_path = "signal-test-worker-old-v2.nnckpt";
-    const char *contract_v1_path = "signal-test-contract-v1.nnckpt";
+    const char *worker_v1_path = TMP("signal-test-worker-v1.nnckpt");
+    const char *worker_old_v2_path = TMP("signal-test-worker-old-v2.nnckpt");
+    const char *contract_v1_path = TMP("signal-test-contract-v1.nnckpt");
     char err[256];
 
     ASSERT(write_checkpoint(worker_v1_path, 56, 1,
@@ -301,8 +301,8 @@ TEST(test_legacy_ai_checkpoints_fail_closed_with_actionable_errors) {
 }
 
 TEST(test_v2_checkpoints_score_every_declared_option) {
-    const char *worker_path = "signal-test-worker-v2.nnckpt";
-    const char *contract_path = "signal-test-contract-v2.nnckpt";
+    const char *worker_path = TMP("signal-test-worker-v2.nnckpt");
+    const char *contract_path = TMP("signal-test-contract-v2.nnckpt");
     char err[256];
 
     ASSERT(write_checkpoint(worker_path, SIGNAL_NPC_WORKER_FEATURE_COUNT,


### PR DESCRIPTION
## What changed

- Keep towed crates under the normal cargo readability scale cap.
- Preserve the live tow-body pose while replaying authoritative player corrections.
- Add deterministic browser coverage for crate scale and tow replay stability.

## Root cause

Locally towed cargo had a special visual cap up to 2.6x. Separately, player reconciliation replayed ship inputs against a tow body that was already predicted to the local present, advancing it twice and creating a correction storm.

## Validation

- Required exact-head native gate: 1,659 passed, 0 failed.
- Release WASM build passed within the memory budget.
- Targeted Chromium towing tests passed.

Closes #702.