### PR TITLE
Enable multiplayer by default

### DIFF
--- a/docs/fly-multiplayer.md
+++ b/docs/fly-multiplayer.md
@@ -11,12 +11,10 @@ relay, auto-start on demand, and keep persistent state on a small volume.
 - One Fly Volume mounted at `/app/data`.
 - The server listens on `PORT=8080`, serves the web client from `/app/public`,
   and exposes `/ws`, `/health`, and `/api/protocol`.
-- `/play` redirects to `/play.html`. The default is local-first singleplayer
-  with lobby promotion when another peer arrives; `?online=1` selects the
-  same-origin WebSocket relay (the lower-latency route in production probes)
-  immediately, while
-  `?online=1&transport=rtc` opts into WebRTC and `?singleplayer=1` forces the
-  in-process local sim.
+- `/play` redirects to `/play.html`. The default joins the shared same-origin
+  WebSocket world immediately. `?transport=rtc` opts into WebRTC,
+  `?singleplayer=1` forces the in-process local sim, and `?lobby=...` keeps the
+  old local-first lobby promotion flow available.
 - `auto_stop_machines = "suspend"` and `min_machines_running = 0` keep the
   server off when there are no connections, while resume is faster than a cold
   stop when Fly can preserve a snapshot.

--- a/docs/lightsail-lambda-multiplayer.md
+++ b/docs/lightsail-lambda-multiplayer.md
@@ -1,9 +1,12 @@
 # Lightsail + Lambda Local-First Multiplayer
 
-Signal's low-population multiplayer should be local-first:
+Signal now joins the shared same-origin WebSocket world by default. The older
+local-first lobby flow remains available when `?lobby=...` is present:
 
-1. Browser starts in local singleplayer unless `?server=...` or `?online=1` is present.
-2. Optional `?lobby=wss://...` connects to the AWS WebSocket lobby in the background.
+1. Browser connects to the same-origin `/ws` relay unless `?singleplayer=1` or
+   `?lobby=...` is present.
+2. `?lobby=wss://...` starts locally and connects to the AWS WebSocket lobby in
+   the background.
 3. When the lobby sees enough compatible players in a room, it wakes the relay.
 4. Clients reload into the authoritative session. The page converts the relay's
    RTC address to its lower-latency WebSocket `/ws` endpoint by default;

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -1462,14 +1462,18 @@ test.describe('Browser smoke tests', () => {
     expectNoFatalErrors(logs);
   });
 
-  test('online mode prefers WebSocket while preserving an RTC opt-in', async ({ page }) => {
+  test('multiplayer is the default while singleplayer and RTC remain explicit options', async ({ page }) => {
     test.skip(usesLiveSmokeUrl(), 'transport selection is covered against the local bundle');
 
-    await page.goto('/play.html?online=1', { waitUntil: 'domcontentloaded' });
+    await page.goto('/play.html', { waitUntil: 'domcontentloaded' });
     expect(await page.evaluate(() => (window as unknown as { SIGNAL_SERVER?: string }).SIGNAL_SERVER))
       .toBe(`ws://${new URL(page.url()).host}/ws`);
 
-    await page.goto('/play.html?online=1&transport=rtc', { waitUntil: 'domcontentloaded' });
+    await page.goto('/play.html?singleplayer=1', { waitUntil: 'domcontentloaded' });
+    expect(await page.evaluate(() => (window as unknown as { SIGNAL_SERVER?: string }).SIGNAL_SERVER))
+      .toBe('');
+
+    await page.goto('/play.html?transport=rtc', { waitUntil: 'domcontentloaded' });
     expect(await page.evaluate(() => (window as unknown as { SIGNAL_SERVER?: string }).SIGNAL_SERVER))
       .toBe(`rtc://${new URL(page.url()).host}/rtc/signal-main`);
   });

--- a/web/play.html
+++ b/web/play.html
@@ -264,12 +264,11 @@
     </script>
     <script>
 
-      /* ?singleplayer=1 forces the in-process server.
+      /* The default connects to the same-origin WebSocket multiplayer relay.
+       * ?singleplayer=1 forces the in-process server.
        * ?server=ws://... or ?server=rtcs://... connects to an explicit relay.
-       * ?online=1 connects to the same-origin WebSocket relay. Add
-       * ?transport=rtc to opt into the WebRTC gateway.
-       * Default is local-first singleplayer; ?lobby=wss://... lets a lobby
-       * promote the page into a network session when a second player arrives. */
+       * ?transport=rtc opts into the WebRTC gateway.
+       * ?lobby=wss://... keeps the old local-first lobby promotion flow. */
       var signalParams = new URLSearchParams(window.location.search);
       if (!window.SIGNAL_LOBBY_URL && window.location.hostname === 'signal.ratimics.com') {
         window.SIGNAL_LOBBY_URL = 'wss://jldrsi17o0.execute-api.us-west-2.amazonaws.com/prod';
@@ -277,7 +276,8 @@
 
       if (signalParams.has('singleplayer')) window.SIGNAL_SERVER = '';
       else if (signalParams.has('server')) window.SIGNAL_SERVER = signalParams.get('server');
-      else if (signalParams.has('online') || signalParams.has('multiplayer') || signalParams.has('network')) {
+      else if (signalParams.has('lobby')) window.SIGNAL_SERVER = '';
+      else {
         var signalTransport = (signalParams.get('transport') || 'ws').toLowerCase();
         if (signalTransport === 'rtc' || signalTransport === 'webrtc') {
           var signalRtcProto = window.location.protocol === 'https:' ? 'rtcs:' : 'rtc:';
@@ -286,9 +286,6 @@
           var signalWsProto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
           window.SIGNAL_SERVER = signalWsProto + '//' + window.location.host + '/ws';
         }
-      }
-      else {
-        window.SIGNAL_SERVER = '';
       }
 
       function setLoading(message) {
@@ -351,7 +348,8 @@
         /* Explicit authority selections are already connected by the game
          * client. Starting lobby matchmaking as well can receive serverReady
          * and replace the page while WASM is still initializing. */
-        if (signalParams.has('server') || signalParams.has('singleplayer') ||
+        if (window.SIGNAL_SERVER ||
+            signalParams.has('server') || signalParams.has('singleplayer') ||
             signalParams.has('online') || signalParams.has('multiplayer') ||
             signalParams.has('network')) return;
         var lobby = signalLobbyEndpoint(signalParams.get('lobby') || window.SIGNAL_LOBBY_URL || '');


### PR DESCRIPTION
## What changed

- make the normal `/play.html` URL join the shared same-origin WebSocket world
- keep `?singleplayer=1` as the local mode
- keep explicit server, RTC, and lobby options working
- add browser coverage and update multiplayer docs

## Local checks

- `make test` — 1,660 passed
- `make test-san` — 1,660 passed
- `make test-soak` — 9 passed
- policy/static audit targets and cppcheck passed
- `make smoke` — 49 passed, 4 expected skips
- `make smoke-latency-suite` — both network simulations passed