### PR TITLE
Run Fly relay on performance CPU

### DIFF
--- a/docs/fly-multiplayer.md
+++ b/docs/fly-multiplayer.md
@@ -141,8 +141,10 @@ SMOKE_LIVE_RELAY_ASSERT=1 \
 
 ## Cost Controls
 
-- `shared-cpu-1x` with `512mb` RAM is the starting point. Move to `1gb` only
-  if `/health`, logs, or Fly metrics show memory pressure.
+- `performance-1x` with `2gb` RAM keeps the 120 Hz authority off Fly's
+  shared-CPU baseline throttle. A shared CPU exhausted its burst balance under
+  the live simulation and produced long initial syncs plus roughly 500 ms
+  input acknowledgements.
 - `auto_stop_machines = "suspend"` means CPU and RAM billing stop while idle;
   the persistent cost is the root filesystem, the `signal_data` volume, and
   any public egress.

--- a/fly.toml
+++ b/fly.toml
@@ -51,6 +51,6 @@ primary_region = "lax"
     port = 50000
 
 [[vm]]
-  cpu_kind = "shared"
+  cpu_kind = "performance"
   cpus = 1
-  memory = "512mb"
+  memory = "2gb"

--- a/scripts/check_fly_config.py
+++ b/scripts/check_fly_config.py
@@ -172,6 +172,21 @@ def fly_config_failures(
             "[[services]] must expose RTC_GATEWAY_ICE_PORT over UDP"
         )
 
+    machines = config.get("vm")
+    if not isinstance(machines, list) or len(machines) != 1:
+        failures.append("fly.toml must declare exactly one [[vm]] table")
+    else:
+        machine = machines[0]
+        if not isinstance(machine, dict):
+            failures.append("[[vm]] must be a table")
+        else:
+            if machine.get("cpu_kind") != "performance":
+                failures.append("[[vm]].cpu_kind must be 'performance'")
+            if machine.get("cpus") != 1:
+                failures.append("[[vm]].cpus must be 1")
+            if machine.get("memory") != "2gb":
+                failures.append("[[vm]].memory must be '2gb'")
+
     return failures
 
 

--- a/scripts/test_check_fly_config.py
+++ b/scripts/test_check_fly_config.py
@@ -128,6 +128,23 @@ class FlyConfigContractTests(unittest.TestCase):
         )
         self.assertTrue(any("GET /health" in failure for failure in failures))
 
+    def test_performance_cpu_cannot_drift(self) -> None:
+        mutations = {
+            "cpu_kind": "shared",
+            "cpus": 2,
+            "memory": "512mb",
+        }
+        for key, value in mutations.items():
+            with self.subTest(key=key):
+                failures = self.failures_after(
+                    lambda config, key=key, value=value:
+                        config["vm"][0].update({key: value})
+                )
+                self.assertTrue(
+                    any(f"[[vm]].{key}" in failure for failure in failures),
+                    failures,
+                )
+
     def test_udp_ice_mux_must_remain_exposed(self) -> None:
         failures = self.failures_after(
             lambda config: config["services"][0].update(protocol="tcp")


### PR DESCRIPTION
## Summary
- move the Fly relay from one shared CPU to performance-1x with 2 GB RAM
- enforce the production VM shape in the credential-free Fly config check
- document why the 120 Hz authority requires sustained CPU

## Production evidence
- the live shared CPU showed about 94% CPU steal after its burst balance drained
- player ping reached 536 ms and input acknowledgements reached 483 ms
- initial multiplayer sync took 27.9 seconds
- no server crash or WebSocket backpressure disconnect was present

## Validation
- python3 scripts/check_fly_config.py
- python3 scripts/test_check_fly_config.py
- python3 scripts/check_deployment_inputs.py
- python3 scripts/test_check_deployment_inputs.py
- python3 scripts/test_check_ci_workflow_contract.py
- flyctl config validate --config fly.toml
- make cargo-trust-audit banned-apis deterministic-libm doc-freshness soak-automation vendor-drift
- python3 -m py_compile scripts/check_fly_config.py scripts/test_check_fly_config.py
- git diff --check