### PR TITLE
Unify singleplayer and multiplayer gameplay paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -964,6 +964,8 @@ if(EMSCRIPTEN)
         "'_signal_debug_held_control_mask'"
         "'_signal_debug_identity_available'"
         "'_signal_debug_auth_available'"
+        "'_signal_debug_net_connected'"
+        "'_signal_smoke_market_memory_packet_parity'"
         "'_signal_debug_local_authority_state'"
         "'_signal_debug_local_authority_generation'"
         "'_signal_debug_restart_local_authority'"

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ for the `swarm.rati.chat` avatar sync workflow.
   it on a ring slot or found/materialize an outpost.
 - Utility: `H` hail/scan the local area. After one manual paid ore delivery,
   `O` toggles mining autopilot. `[` and
-  `]` switch music tracks, `/` toggle music pause, `X` self-destruct/reset in
-  singleplayer, `Esc` quits.
+  `]` switch music tracks, `/` toggle music pause, `X` self-destruct/reset,
+  `Esc` quits.
 
 ## Build
 

--- a/client/local_server.c
+++ b/client/local_server.c
@@ -271,7 +271,6 @@ static bool local_server_loopback_send(const uint8_t *data, int len, void *user)
             uint8_t pong[NET_LATENCY_PONG_SIZE];
             uint32_t seq = read_u32_le(&data[1]);
             uint32_t client_sent = read_u32_le(&data[5]);
-            uint32_t now_ms = (uint32_t)(LS_WORLD(ls).time * 1000.0f);
             int plen = serialize_latency_pong(pong, seq, client_sent, now_ms,
                                               now_ms, LS_WORLD(ls).tick);
             local_server_send_to_client(pong, plen);

--- a/client/local_server.c
+++ b/client/local_server.c
@@ -22,6 +22,8 @@
 #include <string.h>
 
 static void local_server_emit_frame(local_server_t *ls, int player_slot);
+static void local_server_mark_station_identity_dirty(void *user,
+                                                     int station_idx);
 
 #define LS_WORLD(ls) (*local_server_world((ls)))
 
@@ -53,6 +55,7 @@ void local_server_shutdown(local_server_t *ls) {
     ls->active = false;
     net_set_loopback_send(NULL, NULL);
     ls->station_snapshot_dirty = false;
+    ls->station_econ_snapshot_dirty = false;
     ls->private_snapshot_dirty = false;
     ls->global_snapshot_dirty = false;
     local_authority_release(&ls->authority);
@@ -84,6 +87,7 @@ bool local_server_init(local_server_t *ls, uint32_t seed) {
     player_init_ship(&LS_WORLD(ls).players[0], &LS_WORLD(ls));
     ls->active = true;
     ls->station_snapshot_dirty = true;
+    ls->station_econ_snapshot_dirty = true;
     ls->private_snapshot_dirty = true;
     ls->global_snapshot_dirty = true;
     ls->generation = generation == UINT32_MAX ? 1u : generation + 1u;
@@ -217,43 +221,24 @@ static void local_server_handle_signed_action(local_server_t *ls, int pid,
     if (server_dispatch_signed_action_payload(
         &LS_WORLD(ls), pid, action_type, payload, payload_len,
         local_server_receipt_chain_sink, NULL, &dispatch_result)) {
+        if (dispatch_result.station_identity_dirty >= 0 &&
+            dispatch_result.station_identity_dirty < MAX_STATIONS) {
+            local_server_mark_station_identity_dirty(
+                ls, dispatch_result.station_identity_dirty);
+        }
         local_server_send_immediate_pod_present_result(
             ls, pid, &dispatch_result);
     }
 }
 
-static void local_server_handle_input(local_server_t *ls, int pid,
-                                      const uint8_t *data, int len) {
-    server_input_dispatch_result_t result;
-    if (!ls || !local_server_has_world(ls)) return;
-    uint32_t now_ms = (uint32_t)(LS_WORLD(ls).time * 1000.0f);
-    if (!server_dispatch_input_message(&LS_WORLD(ls), pid, data, len,
-                                       now_ms, &result)) {
-        return;
-    }
-    server_player_t *sp = &LS_WORLD(ls).players[pid];
-    if (result.ack_status == NET_ACTION_ACK_RECEIVED &&
-        result.action_id != 0) {
-        server_begin_pending_action_result(&LS_WORLD(ls), sp, result.action_id,
-                                           result.input_seq, result.action);
-    }
-    server_merge_one_shot_input(&sp->input, &result.intent);
-    if (result.ack_status != 0) {
-        uint8_t ack[NET_ACTION_ACK_SIZE];
-        int alen = serialize_action_ack(ack, result.action_id,
-                                        result.input_seq,
-                                        result.ack_status,
-                                        result.action);
-        local_server_send_to_client(ack, alen);
-        if (result.force_authoritative_resync) {
-            sp->replication->force_authoritative_resync = true;
-            local_server_send_action_result(result.action_id,
-                                            result.input_seq,
-                                            NET_ACTION_RESULT_REJECTED,
-                                            result.action,
-                                            LS_WORLD(ls).tick);
-        }
-    }
+static void local_server_mark_station_identity_dirty(void *user,
+                                                     int station_idx) {
+    (void)station_idx;
+    local_server_t *ls = (local_server_t *)user;
+    if (!ls) return;
+    ls->station_snapshot_dirty = true;
+    ls->station_econ_snapshot_dirty = true;
+    ls->global_snapshot_dirty = true;
 }
 
 static bool local_server_loopback_send(const uint8_t *data, int len, void *user) {
@@ -264,6 +249,21 @@ static bool local_server_loopback_send(const uint8_t *data, int len, void *user)
     }
     int pid = 0;
     server_player_t *sp = &LS_WORLD(ls).players[pid];
+
+    server_gameplay_packet_policy_t gameplay_policy = {
+        .user = ls,
+        .send_packet = local_server_send_packet,
+        .mark_station_identity_dirty =
+            local_server_mark_station_identity_dirty,
+        .receipt_chain_sink = local_server_receipt_chain_sink,
+        .handoff_ticket_sink = local_server_handoff_ticket_sink,
+        .handoff_result_sink = local_server_handoff_result_sink,
+    };
+    uint32_t now_ms = (uint32_t)(LS_WORLD(ls).time * 1000.0f);
+    if (server_dispatch_gameplay_packet(
+            &LS_WORLD(ls), pid, data, len, now_ms, &gameplay_policy)) {
+        return true;
+    }
 
     switch (data[0]) {
     case NET_MSG_LATENCY_PING:
@@ -326,44 +326,6 @@ static bool local_server_loopback_send(const uint8_t *data, int len, void *user)
         }
         break;
     }
-    case NET_MSG_INPUT:
-        local_server_handle_input(ls, pid, data, len);
-        break;
-    case NET_MSG_PLAN:
-        (void)server_dispatch_legacy_plan_message(&LS_WORLD(ls), pid, data,
-                                                  len, NULL);
-        break;
-    case NET_MSG_STATE:
-    case NET_MSG_MINING_ACTION:
-        break;
-    case NET_MSG_BUY_INGOT:
-        (void)server_dispatch_legacy_buy_ingot_message(
-            &LS_WORLD(ls), pid, data, len, local_server_receipt_chain_sink,
-            NULL, NULL);
-        break;
-    case NET_MSG_DELIVER_INGOT:
-        (void)server_dispatch_legacy_deliver_ingot_message(
-            &LS_WORLD(ls), pid, data, len, local_server_receipt_chain_sink,
-            NULL, NULL);
-        break;
-    case NET_MSG_PRESENT_RECEIPT_CHAIN:
-        (void)server_dispatch_receipt_presentation_message(
-            &LS_WORLD(ls), pid, data, len, NULL);
-        break;
-    case NET_MSG_HANDOFF_REQUEST:
-        (void)server_dispatch_handoff_request(&LS_WORLD(ls), pid, data, len,
-                                              local_server_handoff_ticket_sink,
-                                              NULL);
-        break;
-    case NET_MSG_HANDOFF_PRESENT:
-        (void)server_dispatch_handoff_present(&LS_WORLD(ls), pid, data, len,
-                                              local_server_handoff_result_sink,
-                                              NULL);
-        break;
-    case NET_MSG_FRACTURE_CLAIM:
-        (void)server_dispatch_fracture_claim_message(&LS_WORLD(ls), pid,
-                                                     data, len, NULL);
-        break;
     case NET_MSG_SIGNED_ACTION:
         local_server_handle_signed_action(ls, pid, data, len);
         break;
@@ -417,6 +379,9 @@ static void local_server_event_hail_response(void *user,
         (local_server_event_context_t *)user;
     if (!ctx || !ctx->ls) return;
     local_server_emit_hail_response(ctx->ls, ev);
+    ctx->ls->private_snapshot_dirty = true;
+    ctx->ls->station_econ_snapshot_dirty = true;
+    ctx->ls->global_snapshot_dirty = true;
 }
 
 static void local_server_event_death(void *user, const sim_event_t *ev) {
@@ -427,6 +392,9 @@ static void local_server_event_death(void *user, const sim_event_t *ev) {
     uint8_t msg[NET_DEATH_MSG_SIZE];
     int len = serialize_death(msg, (uint8_t)ctx->player_slot, ev);
     local_server_send_to_client(msg, len);
+    ctx->ls->private_snapshot_dirty = true;
+    ctx->ls->station_econ_snapshot_dirty = true;
+    ctx->ls->global_snapshot_dirty = true;
 }
 
 static void local_server_event_player_state_change(void *user,
@@ -436,6 +404,28 @@ static void local_server_event_player_state_change(void *user,
         (local_server_event_context_t *)user;
     if (!ctx || !ctx->ls) return;
     ctx->ls->private_snapshot_dirty = true;
+    ctx->ls->station_econ_snapshot_dirty = true;
+    ctx->ls->global_snapshot_dirty = true;
+}
+
+static void local_server_event_outpost_placed(void *user,
+                                              const sim_event_t *ev) {
+    (void)ev;
+    local_server_event_context_t *ctx =
+        (local_server_event_context_t *)user;
+    if (!ctx || !ctx->ls) return;
+    ctx->ls->station_snapshot_dirty = true;
+    ctx->ls->station_econ_snapshot_dirty = true;
+    ctx->ls->global_snapshot_dirty = true;
+}
+
+static void local_server_event_contract_complete(void *user,
+                                                 const sim_event_t *ev) {
+    (void)ev;
+    local_server_event_context_t *ctx =
+        (local_server_event_context_t *)user;
+    if (!ctx || !ctx->ls) return;
+    ctx->ls->station_econ_snapshot_dirty = true;
     ctx->ls->global_snapshot_dirty = true;
 }
 
@@ -446,13 +436,16 @@ static void local_server_event_structure_dirty(void *user,
         (local_server_event_context_t *)user;
     if (!ctx || !ctx->ls) return;
     ctx->ls->station_snapshot_dirty = true;
+    ctx->ls->station_econ_snapshot_dirty = true;
     ctx->ls->global_snapshot_dirty = true;
 }
 
 static const server_sim_event_hooks_t local_server_event_hooks = {
+    .outpost_placed = local_server_event_outpost_placed,
     .player_state_change = local_server_event_player_state_change,
     .hail_response = local_server_event_hail_response,
     .death = local_server_event_death,
+    .contract_complete = local_server_event_contract_complete,
     .structure_dirty = local_server_event_structure_dirty,
 };
 
@@ -510,6 +503,7 @@ static void local_server_emit_station_snapshots(local_server_t *ls) {
     for (int s = 0; s < MAX_STATIONS; s++)
         LS_WORLD(ls).stations[s].manifest_dirty = false;
     ls->station_snapshot_dirty = false;
+    ls->station_econ_snapshot_dirty = false;
 }
 
 static void local_server_emit_station_identity_snapshots(local_server_t *ls) {
@@ -560,6 +554,7 @@ static void local_server_emit_station_econ_snapshots(local_server_t *ls) {
     local_server_send_to_client(
         local_server_station_snapshot_scratch.world_stations,
         station_len);
+    ls->station_econ_snapshot_dirty = false;
 }
 
 static void local_server_emit_world_snapshots(local_server_t *ls,
@@ -650,7 +645,8 @@ static void local_server_emit_frame(local_server_t *ls, int player_slot) {
         local_server_emit_global_snapshots(ls);
         if ((tick % LOCAL_SERVER_STATION_DIAG_TICKS) == 0u)
             local_server_emit_station_diag_snapshots(ls);
-        if ((tick % LOCAL_SERVER_STATION_ECON_TICKS) == 0u)
+        if (ls->station_econ_snapshot_dirty ||
+            (tick % LOCAL_SERVER_STATION_ECON_TICKS) == 0u)
             local_server_emit_station_econ_snapshots(ls);
         return;
     }
@@ -674,7 +670,8 @@ static void local_server_emit_frame(local_server_t *ls, int player_slot) {
     }
     if ((tick % LOCAL_SERVER_STATION_DIAG_TICKS) == 0u)
         local_server_emit_station_diag_snapshots(ls);
-    if ((tick % LOCAL_SERVER_STATION_ECON_TICKS) == 0u)
+    if (ls->station_econ_snapshot_dirty ||
+        (tick % LOCAL_SERVER_STATION_ECON_TICKS) == 0u)
         local_server_emit_station_econ_snapshots(ls);
     if (ls->global_snapshot_dirty ||
         (tick % LOCAL_SERVER_GLOBAL_TICKS) == 0u) {

--- a/client/local_server.h
+++ b/client/local_server.h
@@ -14,6 +14,7 @@ typedef struct {
     local_authority_t authority;
     bool active;
     bool station_snapshot_dirty;
+    bool station_econ_snapshot_dirty;
     bool private_snapshot_dirty;
     bool global_snapshot_dirty;
     /* true (default): mirror the dedicated server's bounded broadcast

--- a/client/main.c
+++ b/client/main.c
@@ -422,7 +422,7 @@ static bool start_local_loopback_authority(const NetCallbacks *cbs) {
     return true;
 }
 
-static bool start_fresh_local_fallback_authority(const NetCallbacks *cbs) {
+static bool start_fresh_local_authority(const NetCallbacks *cbs) {
     net_shutdown();
     g.net_authority_enabled = false;
     g.local_player_slot = 0;
@@ -1988,20 +1988,25 @@ static void init(void) {
                 g.identity_ready ? g.identity.pubkey : NULL);
             net_set_identity_secret(
                 g.identity_ready ? g.identity.secret : NULL);
-            if (server_url && server_url[0] != '\0') {
-                g.net_authority_enabled = net_init(server_url, &cbs);
-                if (g.net_authority_enabled) {
-                    /* Remote mode never constructs a local authority world.
-                     * Clear the replicated dynamic view before sparse remote
-                     * snapshots begin arriving. */
-                    reset_remote_dynamic_sync();
-                } else {
-                    set_notice("Remote unavailable; using local server.");
+            bool remote_requested = server_url && server_url[0] != '\0';
+            if (remote_requested) {
+                bool remote_started = net_init(server_url, &cbs);
+                /* Keep the requested authority mode even when transport
+                 * setup fails. Falling through to local authority here
+                 * creates a different world while presenting it as a
+                * continuation of multiplayer. The offline frame path can
+                 * now offer an honest reconnect/reload instead. */
+                g.net_authority_enabled = true;
+                /* A failed first connection must not leave the seeded client
+                 * bootstrap world visible as if it were multiplayer. */
+                reset_remote_dynamic_sync();
+                if (!remote_started) {
+                    set_notice("Remote unavailable. Press [P] to reconnect.");
                 }
             }
-            if (!g.net_authority_enabled) {
+            if (!remote_requested) {
                 g.net_authority_enabled =
-                    start_fresh_local_fallback_authority(&cbs);
+                    start_fresh_local_authority(&cbs);
                 if (!g.net_authority_enabled) {
                     set_notice(
                         "Local authority unavailable (out of memory).");
@@ -4367,8 +4372,8 @@ int signal_smoke_remote_towable_interp_check(void) {
 
         interpolate_world_for_render();
         loopback_packet_path_ok =
-            fabsf(g.world.asteroids[7].pos.x - 100.0f) < 0.001f &&
-            fabsf(g.world.asteroids[7].pos.y - 25.0f) < 0.001f &&
+            fabsf(g.world.asteroids[7].pos.x) < 0.001f &&
+            fabsf(g.world.asteroids[7].pos.y) < 0.001f &&
             fabsf(g.asteroid_interp.curr[7].pos.x) < 0.001f &&
             g.asteroid_interp.elapsed[7] > 0.0f;
     }
@@ -5105,27 +5110,17 @@ static void frame(void) {
                 recovery_notice, sizeof(recovery_notice), "%s",
                 legacy_recovery_disconnect_notice);
             bool recovery_interrupted = recovery_notice[0] != '\0';
-            NetCallbacks fallback_cbs;
-            configure_net_callbacks(&fallback_cbs);
-            if (start_fresh_local_fallback_authority(&fallback_cbs)) {
-                set_notice(
-                    "%s",
-                    recovery_interrupted
-                        ? recovery_notice
-                        : "Network lost; continuing locally.");
-            } else {
-                set_notice(
-                    "%s",
-                    recovery_interrupted
-                        ? recovery_notice
-                        : "Connection lost. Reload to reconnect.");
-                g.local_server.active = false;
-            }
+            set_notice(
+                "%s",
+                recovery_interrupted
+                    ? recovery_notice
+                    : "Connection lost. Press [P] to reconnect.");
+            g.local_server.active = false;
             /*
              * Cancellation, expiry, and rejected migrations deliberately
              * close the remote session. Keep their bounded result console
-             * alive across local fallback; otherwise the same frame that
-             * receives the semantic result would erase it before rendering.
+             * alive after disconnect; otherwise the same frame that receives
+             * the semantic result would erase it before rendering.
              * A success stays tied to its authoritative remote session.
              */
             if (!preserve_recovery_result)
@@ -5888,6 +5883,49 @@ int signal_debug_auth_available(void) {
 }
 
 EMSCRIPTEN_KEEPALIVE
+int signal_debug_net_connected(void) {
+    return net_is_connected() ? 1 : 0;
+}
+
+EMSCRIPTEN_KEEPALIVE
+int signal_smoke_market_memory_packet_parity(void) {
+    if (!LOCAL_PLAYER.ship) return 0;
+    knowledge_view_t saved = LOCAL_PLAYER.ship->knowledge;
+    NetMarketMemoryEntry entry = {0};
+    entry.memory.active = true;
+    entry.memory.memory_kind = (uint8_t)MARKET_MEMORY_SUPPLY;
+    entry.memory.station_a = 1;
+    entry.memory.station_b = 2;
+    entry.memory.commodity = (uint8_t)COMMODITY_FERRITE_INGOT;
+    entry.memory.action = 0xFFu;
+    entry.memory.confidence = 201;
+    entry.memory.salience = 177;
+    entry.memory.quantity_hint = 12;
+    entry.memory.value_hint = 345;
+    entry.memory.observed_tick = 6789;
+    entry.memory.subject_nonce = 0x12345678u;
+    entry.hops = 3;
+
+    apply_remote_player_market_memories(&entry, 1);
+    const knowledge_view_t *view = &LOCAL_PLAYER.ship->knowledge;
+    market_memory_t decoded = {0};
+    if (view->count == 1)
+        memcpy(&decoded, view->items[0].payload, sizeof(decoded));
+    bool ok = view->count == 1 &&
+              view->items[0].kind == (uint8_t)KNOW_MARKET &&
+              view->items[0].payload_kind ==
+                  (uint8_t)KNOW_PAYLOAD_MARKET_MEMORY &&
+              view->items[0].hops == 3 &&
+              decoded.active &&
+              decoded.memory_kind == (uint8_t)MARKET_MEMORY_SUPPLY &&
+              decoded.station_a == 1 && decoded.station_b == 2 &&
+              decoded.quantity_hint == 12 && decoded.value_hint == 345 &&
+              decoded.observed_tick == 6789;
+    LOCAL_PLAYER.ship->knowledge = saved;
+    return ok ? 1 : 0;
+}
+
+EMSCRIPTEN_KEEPALIVE
 int signal_debug_local_authority_state(void) {
     int state = 0;
     if (local_server_has_world(&g.local_server)) state |= 1 << 0;
@@ -5906,7 +5944,7 @@ EMSCRIPTEN_KEEPALIVE
 int signal_debug_restart_local_authority(void) {
     NetCallbacks cbs;
     configure_net_callbacks(&cbs);
-    return start_fresh_local_fallback_authority(&cbs) ? 1 : 0;
+    return start_fresh_local_authority(&cbs) ? 1 : 0;
 }
 #endif
 

--- a/client/net_sync.c
+++ b/client/net_sync.c
@@ -2319,9 +2319,10 @@ void apply_remote_player_known_contracts(uint32_t mask) {
 
 void apply_remote_player_market_memories(
     const NetMarketMemoryEntry *entries, int count) {
-    /* Loopback already shares the authoritative ship component; rebuilding it
-     * from a presentation packet would discard carried contract summaries. */
-    if (net_is_loopback()) return;
+    /* Both transports own a separate presentation world. Rebuild the same
+     * recipient-scoped market view from the wire packet in loopback and
+     * remote play; the in-process authority has not shared this ship object
+     * since local authority became a separate allocation. */
     if (count < 0) count = 0;
     if (count > PLAYER_MARKET_MEMORY_MAX_RECORDS)
         count = PLAYER_MARKET_MEMORY_MAX_RECORDS;
@@ -3671,56 +3672,8 @@ void sync_local_player_slot_from_network(void) {
     if (LOCAL_PLAYER.connection) LOCAL_PLAYER.connection->conn = NULL;
 }
 
-static void apply_local_authority_asteroid_presentation(float frame_dt)
-{
-    local_asteroid_presentation_feed_active = false;
-    const world_t *authority =
-        local_server_world_const(&g.local_server);
-    if (!g.net_authority_enabled || !net_is_loopback() ||
-        !g.local_server.active || !authority) {
-        return;
-    }
-
-    local_asteroid_presentation_feed_active = true;
-    asteroid_presentation_diagnostics_begin_frame(
-        &local_asteroid_presentation_diagnostics);
-    float render_ahead = g.runtime.accumulator;
-    if (!isfinite(render_ahead) || render_ahead < 0.0f)
-        render_ahead = 0.0f;
-    if (render_ahead > SIM_DT) render_ahead = SIM_DT;
-    float zoom = g.boost_zoom;
-    if (!isfinite(zoom) || zoom <= 0.01f) zoom = 1.0f;
-    float pixels_per_world = 1.0f / zoom;
-
-    for (int i = 0; i < MAX_ASTEROIDS; i++) {
-        asteroid_t *dst = &g.world.asteroids[i];
-        asteroid_t legacy = *dst;
-        asteroid_t presented;
-        asteroid_motion_class_t motion_class = ASTEROID_MOTION_LOOSE;
-        asteroid_presentation_action_t action =
-            asteroid_presentation_resolve(
-                authority, &legacy, i, render_ahead,
-                &presented, &motion_class);
-        if (action == ASTEROID_PRESENTATION_PRESENT) {
-            *dst = presented;
-            asteroid_presentation_diagnostics_present(
-                &local_asteroid_presentation_diagnostics,
-                i, motion_class, &legacy, dst, &presented,
-                frame_dt, pixels_per_world);
-        } else if (action == ASTEROID_PRESENTATION_RETIRE) {
-            dst->active = false;
-            asteroid_presentation_diagnostics_retire(
-                &local_asteroid_presentation_diagnostics, i);
-        } else if (authority->asteroids[i].active && legacy.active) {
-            asteroid_presentation_diagnostics_skip(
-                &local_asteroid_presentation_diagnostics,
-                i, motion_class, &legacy,
-                frame_dt, pixels_per_world);
-        }
-    }
-}
-
 void interpolate_world_for_render_frame(float frame_dt) {
+    (void)frame_dt;
     bool asteroid_towed[MAX_ASTEROIDS];
     net_collect_towed_asteroids(asteroid_towed);
 
@@ -3737,11 +3690,10 @@ void interpolate_world_for_render_frame(float frame_dt) {
             i, g.asteroid_interp.elapsed[i], asteroid_towed[i]);
     }
 
-    /* Local singleplayer still decodes the exact 10 Hz multiplayer stream,
-     * then replaces only render pose with the in-process 120 Hz authority.
-     * Server state is separate and const here, so presentation can never
-     * feed smoothed values back into gameplay. */
-    apply_local_authority_asteroid_presentation(frame_dt);
+    /* Loopback and remote play both render the decoded packet stream. Do not
+     * replace loopback poses from the in-process authority: that shortcut
+     * hid stale/missing multiplayer motion packets and tow corrections. */
+    local_asteroid_presentation_feed_active = false;
 
     for (int i = 0; i < MAX_NPC_SHIPS; i++) {
         const client_npc_render_state_t *curr = &g.npc_interp.curr[i];

--- a/docs/fly-multiplayer.md
+++ b/docs/fly-multiplayer.md
@@ -141,8 +141,10 @@ SMOKE_LIVE_RELAY_ASSERT=1 \
 
 ## Cost Controls
 
-- `shared-cpu-1x` with `512mb` RAM is the starting point. Move to `1gb` only
-  if `/health`, logs, or Fly metrics show memory pressure.
+- `performance-1x` with `2gb` RAM keeps the 120 Hz authority off Fly's
+  shared-CPU baseline throttle. A shared CPU exhausted its burst balance under
+  the live simulation and produced long initial syncs plus roughly 500 ms
+  input acknowledgements.
 - `auto_stop_machines = "suspend"` means CPU and RAM billing stop while idle;
   the persistent cost is the root filesystem, the `signal_data` volume, and
   any public egress.

--- a/docs/sp-mp-duplication-divergence.md
+++ b/docs/sp-mp-duplication-divergence.md
@@ -1,281 +1,102 @@
-# Singleplayer / Multiplayer Duplication And Divergence
-
-Audit date: 2026-06-23
-
-## Summary
-
-Signal mostly succeeds at the intended architecture: singleplayer runs an
-in-process authoritative server and the client consumes serialized protocol
-packets through `net.c` loopback. Core simulation mutations are shared in
-`server/game_sim.c` and helpers, not reimplemented separately for SP and MP.
-
-The remaining duplication is in the transport shell:
-
-- client packet ingress is duplicated between `client/local_server.c` and
-  `server/main.c`
-- sim-event side effects are duplicated between `local_server_emit_events()`
-  and `srv_dispatch_sim_event()`
-- snapshot timing differs sharply between loopback and remote
-- several client UI checks still treat `g.net_authority_enabled` as "remote MP",
-  even though current SP loopback also sets it
-
-## Shared Paths
-
-These are healthy parity points.
-
-- `client/main.c` starts local loopback via `start_local_loopback_authority()`
-  when no remote server URL is present. Loopback calls `net_init_loopback()`,
-  sends initial snapshots, and then the same `NetCallbacks` process remote and
-  local packets.
-- `client/local_server.c` routes client packets through
-  `local_server_loopback_send()` and delegates actual mutations to shared
-  server reducers such as `server_dispatch_input_message()`,
-  `server_dispatch_signed_action_payload()`,
-  `server_dispatch_handoff_request()`, and
-  `server_dispatch_fracture_claim_message()`.
-- Both SP and MP use `world_sim_step()` as the authoritative sim step.
-- Both SP and MP use `server_emit_world_snapshot_for_player()` and
-  `server_emit_private_snapshot_for_player()` for serialized world/private
-  state.
-- Client-side death cinematic now primarily arrives through `NET_MSG_DEATH` in
-  both remote WebSocket and local loopback modes.
-
-## Intentional Divergences
-
-These differences appear designed rather than accidental.
-
-- MP has WebSocket rate limiting, origin/session constraints, analytics, save
-  persistence, reconnect transfer, highscore replay, and REST/operator API
-  paths in `server/main.c`. SP loopback intentionally omits most of that
-  production shell.
-- MP broadcasts public state at coarse cadences:
-  `STATE_TICK_MS=50`, `WORLD_TICK_MS=100`, and `SHIP_TICK_MS=250`.
-  SP loopback emits station, world, private, contract, and signal-channel
-  snapshots every local sim frame.
-- MP uses per-player private-packet caches (`ws_private_packet_sink()` and
-  `ws_send_if_changed()`), while SP loopback sends every private snapshot
-  without cache suppression.
-- MP filters dirty station identity rebroadcasts by signal range; SP loopback
-  sends full station snapshots with `include_world_stations=true`.
-- MP owns highscore persistence and replay from station chain logs. SP loopback
-  has no highscore table in `local_server_t`.
-
-## Risky Divergences
-
-### 1. SP loopback did not emit `NET_MSG_INPUT_APPLIED`
-
-Status: fixed in the current worktree. `server_emit_input_applied_if_changed()`
-is now shared by MP `run_sim_ticks()` and SP `local_server_step_loopback()`, so
-loopback singleplayer emits the same applied-input ACK when the authoritative
-world advances a new input sequence.
-
-MP sends `NET_MSG_INPUT_APPLIED` from `run_sim_ticks()` after the authoritative
-world applies a new input sequence. The client callback
-`on_remote_input_applied()` calls `net_record_input_ack()`, which updates
-`g.net_last_server_ack`, ack RTT, input tick error, and net-motion counters.
-
-Previously, SP loopback handled `NET_MSG_INPUT`, queued movement, and sent
-action ACKs for one-shot actions, but never serialized
-`NET_MSG_INPUT_APPLIED`.
-
-Impact:
-
-- loopback SP runs with `g.net_authority_enabled=true` but does not exercise the
-  same input-ack path as MP
-- SP net HUD/telemetry can show missing ack RTT or growing unacked input state
-- action and replay diagnostics are less representative in SP than in MP
-
-Recommended fix:
-
-- In `local_server_step_loopback()`, mirror the MP `run_sim_ticks()` pattern:
-  capture `last_input_seq` before `world_sim_step()`, then emit
-  `serialize_input_applied()` when it changes for the local player.
-- Add a focused loopback test or protocol-level test proving an input packet
-  produces `NET_MSG_INPUT_APPLIED`.
-
-### 2. `g.net_authority_enabled` hid SP-only ledger UI under loopback
-
-Status: fixed in the current worktree for balance rows. Station UI now uses a
-`ui_remote_authority_enabled()` predicate where it needs to distinguish remote
-authority, solo loopback reads local station ledger data, and MP receives
-`NET_MSG_PLAYER_KNOWN_LEDGER` as a compact per-player station/balance snapshot.
-
-Docs say singleplayer can show a cross-station station-local ledger strip and
-local-credit bridge notice, while multiplayer still needs known-ledger
-snapshots.
-
-Current code disagrees in an important way:
-
-- `client/main.c` sets `g.net_authority_enabled` to the result of
-  `start_local_loopback_authority()` for SP.
-- `ui_build_ledger_strip()` returns after the current station row whenever
-  `g.net_authority_enabled` is true.
-- `ui_local_player_pubkey()` returns false whenever `g.net_authority_enabled`
-  is true.
-- `station_credit_bridge_line()` returns false whenever
-  `g.net_authority_enabled` is true.
-
-Impact:
-
-- the intended SP ledger strip and credit-bridge notice are disabled in current
-  loopback SP unless there is some older non-loopback path still in use
-- the docs' "SP closed, MP open" claim is stale against current code
-- MP previously lacked the wire payload for honest cross-station balance rows
-
-Recommended fix:
-
-- Split the predicate into "remote authority" versus "loopback authority";
-  likely use `g.net_authority_enabled && !net_is_loopback()` for UI that should
-  only be blocked in remote MP.
-- For MP parity, keep `NET_MSG_PLAYER_KNOWN_LEDGER` in the private player
-  snapshot and decode it into station UI known-ledger rows.
-- Add an acceptance test around the documented flow: earn at Prospect, dock at
-  Helios, and see Prospect non-zero plus Helios zero in SP; repeat in MP after
-  the wire snapshot exists.
-
-### 3. Client packet ingress policy is duplicated and can drift
-
-`local_server_loopback_send()` and `handle_ws_message()` switch over nearly the
-same message set and call many of the same shared reducers. The reducers are a
-good extraction, but the policy around them is duplicated.
-
-MP-only policy currently includes:
-
-- pre-session allowlist via `ws_message_allowed_before_session()`
-- rate limiting via `ws_rate`
-- unsigned-action counters and logs
-- station identity dirty flags after shipyard/order actions
-- signed-action rejection logging
-- persistent save load/reconnect policy
-- session reconnect/live-state transfer
-- player-save load by token/pubkey
-- join/leave broadcasts and analytics
-
-SP-only behavior currently includes:
-
-- a single fixed pid (`0`)
-- no pre-session message gate at the loopback shell
-- immediate local credit seeding on same-pubkey/proof/session
-- retired legacy-save claim packets share the same inert reducer as MP
-- no reconnect/live-state transfer path
-
-Impact:
-
-- new message types must be remembered in two switch statements
-- security/session rules are not identical between loopback and remote
-- SP may fail to exercise MP-only state dirtying, analytics, persistence, and
-  reconnect behavior
-
-Recommended fix:
-
-- Extract a shared `server_dispatch_client_packet()` shell that accepts a policy
-  struct/callbacks for transport-specific side effects:
-  `send_packet`, `broadcast_join_leave`, `mark_station_identity_dirty`,
-  `record_analytics`, `load/save identity`, and `reject/log`.
-- Keep production-only behavior in callbacks, but keep the message allowlist,
-  reducer dispatch, and action ACK/result emission shape shared.
-
-### 4. Sim-event side effects were not dispatched through one shared event bus
-
-Status: partially fixed in the current worktree. MP and loopback now call
-`server_process_sim_event_transport()` with transport hooks, and the shared
-`server_sim_event_effects()` bucket table is covered by a protocol regression
-test. Generic event serialization, pending action results, and fracture updates
-are still emitted by each transport's frame loop, and MP-only persistence/
-highscore side effects remain MP hooks.
-
-Both SP and MP serialize the generic event stream with `serialize_events()`.
-Only selected events get extra transport-specific side effects:
-
-- SP `local_server_emit_events()` special-cases `SIM_EVENT_HAIL_RESPONSE` and
-  local `SIM_EVENT_DEATH`.
-- MP `srv_dispatch_sim_event()` handles outpost placement, buy/sell/repair/
-  upgrade/dock/launch, death, contract complete, hail response, module/outpost
-  activation, scaffold readiness, highscore/chain-log death side effects, and
-  dirty station flags.
-
-Some MP side effects are unnecessary in SP because SP sends full snapshots every
-frame. Others are gameplay-visible or persistence-visible and are simply absent
-from SP, most notably highscore projection/broadcast and death chain-log
-append.
-
-Impact:
-
-- adding a new sim event requires updating at least client handling, MP event
-  side effects, and possibly SP loopback side effects
-- SP can miss persistence/broadcast consequences that are not needed for local
-  rendering but are still part of "server truth"
-
-Recommended fix:
-
-- Introduce a shared `server_process_sim_events(world, transport_hooks)` helper.
-- The helper should emit generic events, pending action results, fracture
-  updates, and typed event side effects via hooks.
-- SP hooks can no-op analytics/persistence/highscore if intentionally local, but
-  the missing behavior becomes explicit.
-
-### 5. Snapshot cadence and dirty-state behavior can mask MP bugs in SP
-
-SP loopback emits all relevant snapshots every frame. MP emits public/private
-snapshots at 20 Hz / 10 Hz / 4 Hz and relies on dirty flags plus cache
-invalidation for immediate correctness.
-
-Impact:
-
-- SP can look correct even when an MP dirty flag is missing
-- MP can stay stale until a fallback cadence or reconnect, while SP updates
-  immediately
-- tests that only use `world_sim_step()` or loopback-style snapshots do not
-  prove MP broadcast freshness
-
-Recommended fix:
-
-- Add parity tests at the serializer/broadcast-helper layer for events that must
-  refresh MP clients immediately: shipyard orders, station manifest changes,
-  module activation, outpost placement, hail credit changes, death/respawn, and
-  delivery ledger changes.
-- Prefer dirty-flag assertions over visual/client-only assertions where
-  possible.
-
-### 6. Documentation still describes an older SP architecture
-
-`docs/engineering-report-2026-06-09.md` says singleplayer "memcpy-mirrors the
-world into the client each frame." Current `client/local_server.c` explicitly
-says direct copies are legacy and sends serialized protocol packets via
-loopback.
-
-Impact:
-
-- future audits may reason from stale architecture
-- SP-only UI decisions can accidentally key off `g.net_authority_enabled`
-  because the docs imply "network authority" means MP
-
-Recommended fix:
-
-- Update architecture docs to say: singleplayer is loopback network authority,
-  not direct world mirroring.
-- Name the predicates explicitly:
-  - `network authority`: remote or loopback authoritative server
-  - `remote multiplayer`: non-loopback WebSocket/WebRTC authority
-  - `solo loopback`: local authoritative server using protocol packets
-
-## Suggested Priority
-
-1. Emit `NET_MSG_INPUT_APPLIED` from loopback SP.
-2. Fix the ledger predicate split so loopback SP can show documented
-   cross-station balances again.
-3. Add MP known-ledger snapshot parity.
-4. Extract shared client-packet dispatch policy.
-5. Extract shared sim-event transport side-effect dispatch.
-6. Add MP dirty-state freshness tests.
-7. Refresh stale architecture docs after the code-level predicates are settled.
-
-Current follow-up status:
-
-- Done: loopback SP `NET_MSG_INPUT_APPLIED` emission.
-- Done: loopback-vs-remote ledger predicate split for SP ledger UI.
-- Done: MP known-ledger snapshot parity for station-local balance rows.
-- Done: shared sim-event transport hook routing plus freshness-bucket test.
-- Done: stale singleplayer architecture docs refreshed.
-- Still open: shared client-packet dispatch extraction, deeper event side-effect
-  parity for persistence/highscores, and broader MP dirty-state freshness tests.
+# Singleplayer / Multiplayer Parity
+
+Audit updated: 2026-08-22
+
+## Result
+
+Singleplayer and multiplayer now use the same gameplay path where the player
+can see or affect the result:
+
+- the same authoritative simulation in `server/game_sim.c`
+- the same gameplay packet dispatcher in `server/net_protocol.h`
+- the same snapshot serializers and client packet decoders
+- the same packet-driven interpolation for ships, asteroids, cargo pods,
+  scaffolds, NPCs, and interactions
+- matching 20 Hz player, 10 Hz world, and 4 Hz private snapshot cadences
+
+Singleplayer runs a separate in-process server world. It does not share the
+client's presentation objects. Packets still pass through the loopback network
+adapter, including serialization and decoding.
+
+## Parity Fixes
+
+### Disconnects preserve the selected mode
+
+A lost multiplayer connection no longer starts a fresh singleplayer universe.
+The client stays in remote mode, keeps the last visible state, and offers a
+reconnect. This removes the apparent lag-and-reset failure that could happen
+after a transport drop.
+
+### Asteroids use one presentation path
+
+Singleplayer no longer replaces decoded asteroid poses with direct reads from
+the in-process authority. Both modes render the packet stream and use the same
+prediction and correction code. Towing bugs can no longer be hidden by a
+singleplayer-only 120 Hz pose shortcut.
+
+### Private player knowledge uses packets in both modes
+
+Market memories are rebuilt from `NET_MSG_PLAYER_MARKET_MEMORIES` in both
+modes. The old loopback exception assumed that the client and local authority
+shared one ship object, which is no longer true.
+
+### Gameplay packet mutation is shared
+
+The common dispatcher owns movement input, one-shot action ACK/result handling,
+plans, old cargo messages, receipt presentation, handoff, and fracture claims.
+The WebSocket and loopback shells now provide only their transport-specific
+callbacks, such as sending a packet, logging a rejection, or marking a station
+dirty.
+
+Identity setup, latency probes, telemetry, signed legacy-save recovery, and
+production session policy remain in their transport shells. Their state
+reducers are still shared. These are transport and persistence concerns, not
+separate gameplay rules.
+
+### Event-driven snapshots refresh in both modes
+
+Both servers route simulation events through the shared event-effect table.
+The loopback server now marks private, station economy, station identity, and
+global snapshots dirty for the same visible event classes used remotely,
+including outpost placement and contract completion. Normal cadence remains a
+safety fallback.
+
+### Earlier parity work retained
+
+- loopback sends `NET_MSG_INPUT_APPLIED`, so prediction and ACK diagnostics use
+  the same path as multiplayer
+- both modes receive known station-ledger rows through the private snapshot
+- UI code distinguishes remote authority from local loopback where that
+  distinction is actually needed
+- reset/self-destruct is documented as available in both modes
+
+## Intentional Differences
+
+The following differences are part of the product boundary and should not be
+silently copied between modes:
+
+- Multiplayer has real network delay, rate limits, origin checks, reconnect
+  transfer, multiple players, and server operations APIs. Loopback does not.
+- Multiplayer persists its world, player identities, chain logs, and
+  highscores. A normal singleplayer launch starts a fresh local session.
+- Multiplayer filters and caches outgoing data per connected player.
+  Singleplayer has one recipient, but still uses bounded packet cadences and
+  the same semantic snapshot caches.
+- Durable legacy-save takeover exists only on the production server. Loopback
+  returns a bounded no-match result rather than touching remote save storage.
+
+Adding persistent singleplayer saves would be a separate product feature. It
+needs an explicit save location, migration policy, reset flow, and ownership
+rules; it is not safe to introduce as an automatic multiplayer parity fix.
+
+## Regression Coverage
+
+- Native protocol coverage checks the shared gameplay dispatcher, including
+  action ACKs, dirty station routing, unsigned-action rejection, forced
+  resync, malformed known packets, and transport-owned packets.
+- Shared event-effect tests cover player state, death, contract completion,
+  hail response, outpost placement, and structure changes.
+- Browser coverage requires singleplayer asteroid rendering to keep the local
+  authority pose bypass disabled.
+- The full native suite exercises the same reducers and serializers used by
+  both server shells.

--- a/fly.toml
+++ b/fly.toml
@@ -51,6 +51,6 @@ primary_region = "lax"
     port = 50000
 
 [[vm]]
-  cpu_kind = "shared"
+  cpu_kind = "performance"
   cpus = 1
-  memory = "512mb"
+  memory = "2gb"

--- a/scripts/check_fly_config.py
+++ b/scripts/check_fly_config.py
@@ -172,6 +172,21 @@ def fly_config_failures(
             "[[services]] must expose RTC_GATEWAY_ICE_PORT over UDP"
         )
 
+    machines = config.get("vm")
+    if not isinstance(machines, list) or len(machines) != 1:
+        failures.append("fly.toml must declare exactly one [[vm]] table")
+    else:
+        machine = machines[0]
+        if not isinstance(machine, dict):
+            failures.append("[[vm]] must be a table")
+        else:
+            if machine.get("cpu_kind") != "performance":
+                failures.append("[[vm]].cpu_kind must be 'performance'")
+            if machine.get("cpus") != 1:
+                failures.append("[[vm]].cpus must be 1")
+            if machine.get("memory") != "2gb":
+                failures.append("[[vm]].memory must be '2gb'")
+
     return failures
 
 

--- a/scripts/test_check_fly_config.py
+++ b/scripts/test_check_fly_config.py
@@ -128,6 +128,23 @@ class FlyConfigContractTests(unittest.TestCase):
         )
         self.assertTrue(any("GET /health" in failure for failure in failures))
 
+    def test_performance_cpu_cannot_drift(self) -> None:
+        mutations = {
+            "cpu_kind": "shared",
+            "cpus": 2,
+            "memory": "512mb",
+        }
+        for key, value in mutations.items():
+            with self.subTest(key=key):
+                failures = self.failures_after(
+                    lambda config, key=key, value=value:
+                        config["vm"][0].update({key: value})
+                )
+                self.assertTrue(
+                    any(f"[[vm]].{key}" in failure for failure in failures),
+                    failures,
+                )
+
     def test_udp_ice_mux_must_remain_exposed(self) -> None:
         failures = self.failures_after(
             lambda config: config["services"][0].update(protocol="tcp")

--- a/server/main.c
+++ b/server/main.c
@@ -1619,14 +1619,6 @@ static void invalidate_player_post_initial_sync_caches(
     sp->replication->world_player_dock_cache.valid = false;
 }
 
-static void send_action_ack(struct mg_connection *c, uint16_t action_id,
-                            uint16_t input_seq, uint8_t status,
-                            uint8_t action) {
-    uint8_t buf[NET_ACTION_ACK_SIZE];
-    int len = serialize_action_ack(buf, action_id, input_seq, status, action);
-    ws_send(c, buf, (size_t)len);
-}
-
 static void send_action_result(struct mg_connection *c, uint16_t action_id,
                                uint16_t input_seq, uint8_t status,
                                uint8_t action, uint32_t server_tick) {
@@ -4182,6 +4174,68 @@ static bool complete_ws_session_bootstrap_if_ready(
     return true;
 }
 
+static void ws_gameplay_packet_sink(void *user,
+                                    const uint8_t *data,
+                                    int len) {
+    struct mg_connection *c = (struct mg_connection *)user;
+    if (!c || !data || len <= 0) return;
+    ws_send(c, data, (size_t)len);
+}
+
+static void ws_gameplay_force_resync(void *user,
+                                     int player_idx,
+                                     server_player_t *sp) {
+    (void)user;
+    (void)player_idx;
+    force_player_authoritative_resync(sp);
+}
+
+static void ws_gameplay_mark_station_dirty(void *user, int station_idx) {
+    (void)user;
+    if (station_idx < 0 || station_idx >= MAX_STATIONS) return;
+    station_identity_dirty[station_idx] = true;
+}
+
+static void ws_gameplay_observe_input(
+    void *user,
+    int player_idx,
+    const server_input_dispatch_result_t *result) {
+    (void)user;
+    if (!result || !result->force_authoritative_resync) return;
+    printf("[server] action-result player=%d id=%u input_seq=%u "
+           "action=%u status=rejected tick=%u resync=unsigned-reject\n",
+           player_idx, (unsigned)result->action_id,
+           (unsigned)result->input_seq, (unsigned)result->action,
+           (unsigned)world.tick);
+}
+
+static void ws_gameplay_observe_unsigned_rejection(
+    void *user, int player_idx, uint8_t message_type) {
+    (void)user;
+    unsigned_action_count++;
+    const char *name = NULL;
+    if (message_type == NET_MSG_PLAN) name = "PLAN";
+    else if (message_type == NET_MSG_BUY_INGOT) name = "BUY_INGOT";
+    else if (message_type == NET_MSG_DELIVER_INGOT) name = "DELIVER_INGOT";
+    if (name) {
+        printf("[server] legacy unsigned %s rejected for pubkey player %d; "
+               "signed action required\n", name, player_idx);
+    }
+}
+
+static void ws_gameplay_observe_receipt_presentation(
+    void *user,
+    int player_idx,
+    const server_receipt_presentation_dispatch_result_t *result) {
+    (void)user;
+    if (!result || !result->evaluated ||
+        result->result == CARGO_RECEIPT_PRESENT_OK) {
+        return;
+    }
+    printf("[server] receipt_present rejected player=%d reason=%s\n",
+           player_idx, cargo_receipt_present_result_name(result->result));
+}
+
 static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm) {
     int pid = -1;
     for (int i = 0; i < MAX_PLAYERS; i++) {
@@ -4230,6 +4284,26 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
         return;
     }
 
+    server_gameplay_packet_policy_t gameplay_policy = {
+        .user = c,
+        .send_packet = ws_gameplay_packet_sink,
+        .force_resync = ws_gameplay_force_resync,
+        .mark_station_identity_dirty = ws_gameplay_mark_station_dirty,
+        .observe_input = ws_gameplay_observe_input,
+        .observe_unsigned_rejection =
+            ws_gameplay_observe_unsigned_rejection,
+        .observe_receipt_presentation =
+            ws_gameplay_observe_receipt_presentation,
+        .receipt_chain_sink = ws_cargo_receipt_chain_sink,
+        .handoff_ticket_sink = ws_handoff_ticket_sink,
+        .handoff_result_sink = ws_handoff_result_sink,
+    };
+    if (server_dispatch_gameplay_packet(
+            &world, pid, data, len, (uint32_t)now,
+            &gameplay_policy)) {
+        return;
+    }
+
     switch (type) {
     case NET_MSG_LATENCY_PING:
         if (len >= NET_LATENCY_PING_SIZE && c) {
@@ -4241,130 +4315,6 @@ static void handle_ws_message(struct mg_connection *c, struct mg_ws_message *wm)
     case NET_MSG_CLIENT_METRICS:
         analytics_handle_client_metrics(pid, &world.players[pid], data, len, now);
         break;
-    case NET_MSG_INPUT:
-    {
-        server_player_t *sp = &world.players[pid];
-        server_input_dispatch_result_t input_result;
-        if (!server_dispatch_input_message(&world, pid, data, len,
-                                           (uint32_t)now,
-                                           &input_result)) {
-            break;
-        }
-        if (input_result.rejected_unsigned_action) {
-            unsigned_action_count++;
-        }
-        if (input_result.ack_status == NET_ACTION_ACK_RECEIVED &&
-            input_result.action_id != 0) {
-            server_begin_pending_action_result(&world, sp,
-                                               input_result.action_id,
-                                               input_result.input_seq,
-                                               input_result.action);
-        }
-        server_merge_one_shot_input(&sp->input, &input_result.intent);
-        /* Movement-only input acks ride private INPUT_APPLIED/STATE receipts.
-         * ACTION_ACK is only for one-shot actions or rejections. */
-        if (c) {
-            if (input_result.ack_status != 0) {
-                send_action_ack(c, input_result.action_id,
-                                input_result.input_seq,
-                                input_result.ack_status,
-                                input_result.action);
-                if (input_result.force_authoritative_resync) {
-                    force_player_authoritative_resync(sp);
-                    printf("[server] action-result player=%d id=%u input_seq=%u action=%u status=rejected tick=%u resync=unsigned-reject\n",
-                           sp->id, (unsigned)input_result.action_id,
-                           (unsigned)input_result.input_seq,
-                           (unsigned)input_result.action,
-                           (unsigned)world.tick);
-                    send_action_result(c, input_result.action_id,
-                                       input_result.input_seq,
-                                       NET_ACTION_RESULT_REJECTED,
-                                       input_result.action, world.tick);
-                }
-            }
-        }
-        /* If the player just queued a shipyard order, refresh that station's
-         * identity on the next world tick so the SHIPYARD tab sees the new
-         * pending count immediately instead of waiting for the 2s fallback. */
-        if (input_result.station_identity_dirty >= 0 &&
-            input_result.station_identity_dirty < MAX_STATIONS)
-            station_identity_dirty[input_result.station_identity_dirty] = true;
-        break;
-    }
-    case NET_MSG_PLAN:
-    {
-        server_unsigned_dispatch_result_t result;
-        if (server_dispatch_legacy_plan_message(&world, pid, data, len,
-                                                &result) &&
-            result.rejected_unsigned_action) {
-            unsigned_action_count++;
-            printf("[server] legacy unsigned PLAN rejected for pubkey player %d; signed action required\n",
-                   pid);
-        }
-        break;
-    }
-    case NET_MSG_STATE:
-        /* Ignored -- server is authoritative. */
-        break;
-    case NET_MSG_MINING_ACTION:
-        /* Legacy -- mining handled via INPUT flags now. */
-        break;
-    case NET_MSG_BUY_INGOT:
-    {
-        server_legacy_cargo_dispatch_result_t result;
-        if (server_dispatch_legacy_buy_ingot_message(
-                &world, pid, data, len, ws_cargo_receipt_chain_sink,
-                c, &result) &&
-            result.rejected_unsigned_action) {
-            unsigned_action_count++;
-            printf("[server] legacy unsigned BUY_INGOT rejected for pubkey player %d; signed action required\n",
-                   pid);
-        }
-        break;
-    }
-    case NET_MSG_DELIVER_INGOT:
-    {
-        server_legacy_cargo_dispatch_result_t result;
-        if (server_dispatch_legacy_deliver_ingot_message(
-                &world, pid, data, len, ws_cargo_receipt_chain_sink,
-                c, &result) &&
-            result.rejected_unsigned_action) {
-            unsigned_action_count++;
-            printf("[server] legacy unsigned DELIVER_INGOT rejected for pubkey player %d; signed action required\n",
-                   pid);
-        }
-        break;
-    }
-    case NET_MSG_PRESENT_RECEIPT_CHAIN:
-    {
-        server_receipt_presentation_dispatch_result_t result;
-        if (server_dispatch_receipt_presentation_message(
-                &world, pid, data, len, &result) &&
-            result.evaluated &&
-            result.result != CARGO_RECEIPT_PRESENT_OK) {
-                printf("[server] receipt_present rejected player=%d reason=%s\n",
-                       pid, cargo_receipt_present_result_name(result.result));
-        }
-        break;
-    }
-    case NET_MSG_HANDOFF_REQUEST:
-        (void)server_dispatch_handoff_request(&world, pid, data, len,
-                                              ws_handoff_ticket_sink, c);
-        break;
-    case NET_MSG_HANDOFF_PRESENT:
-        (void)server_dispatch_handoff_present(&world, pid, data, len,
-                                              ws_handoff_result_sink, c);
-        break;
-    case NET_MSG_FRACTURE_CLAIM:
-    {
-        server_unsigned_dispatch_result_t result;
-        if (server_dispatch_fracture_claim_message(&world, pid, data, len,
-                                                   &result) &&
-            result.rejected_unsigned_action) {
-            unsigned_action_count++;
-        }
-        break;
-    }
     case NET_MSG_SIGNED_ACTION: {
         /* Layer A.3 of #479 — Ed25519-signed state-changing action. */
         uint8_t action_type = 0;
@@ -7254,6 +7204,7 @@ static void srv_on_death(const sim_event_t *ev) {
            pid, cs[0] ? cs : "?", ev->death.credits_earned,
            qualified ? "qualified" : "skipped", highscores.count);
     if (qualified) highscores_dirty = true;
+    station_econ_dirty = true;
 
     if (!sp->connection->conn) return;
 
@@ -7286,6 +7237,7 @@ static void srv_on_hail_response(const sim_event_t *ev) {
     if (msg_len > 0) ws_send(sp->connection->conn, msg, (size_t)msg_len);
 
     contracts_dirty = true;
+    station_econ_dirty = true;
     /* Push fresh ship state so the credit bump is visible immediately. */
     uint8_t buf[PLAYER_SHIP_SIZE + 4];
     int len = send_player_ship(buf, (uint8_t)pid, sp);

--- a/server/net_protocol.h
+++ b/server/net_protocol.h
@@ -70,6 +70,38 @@ static inline bool net_message_allowed_before_session(uint8_t type) {
     }
 }
 
+/* Transport policy for client gameplay packets shared by loopback and the
+ * dedicated server. Authentication, latency probes, telemetry, and durable
+ * legacy recovery stay in their transport shells; authoritative gameplay
+ * mutation and its immediate ACK/result shape live here. */
+typedef void (*server_gameplay_packet_sink_fn)(
+    void *user, const uint8_t *data, int len);
+typedef void (*server_gameplay_force_resync_fn)(
+    void *user, int player_idx, server_player_t *player);
+typedef void (*server_gameplay_station_dirty_fn)(
+    void *user, int station_idx);
+typedef void (*server_gameplay_input_observer_fn)(
+    void *user, int player_idx,
+    const server_input_dispatch_result_t *result);
+typedef void (*server_gameplay_unsigned_observer_fn)(
+    void *user, int player_idx, uint8_t message_type);
+typedef void (*server_gameplay_receipt_observer_fn)(
+    void *user, int player_idx,
+    const server_receipt_presentation_dispatch_result_t *result);
+
+typedef struct {
+    void *user;
+    server_gameplay_packet_sink_fn send_packet;
+    server_gameplay_force_resync_fn force_resync;
+    server_gameplay_station_dirty_fn mark_station_identity_dirty;
+    server_gameplay_input_observer_fn observe_input;
+    server_gameplay_unsigned_observer_fn observe_unsigned_rejection;
+    server_gameplay_receipt_observer_fn observe_receipt_presentation;
+    server_receipt_chain_sink_fn receipt_chain_sink;
+    server_handoff_ticket_sink_fn handoff_ticket_sink;
+    server_handoff_result_sink_fn handoff_result_sink;
+} server_gameplay_packet_policy_t;
+
 static inline bool net_payload_cache_should_send(net_payload_cache_t *cache,
                                                  void *conn,
                                                  const uint8_t *data,
@@ -7478,6 +7510,145 @@ static inline void parse_plan(const uint8_t *data, int len, input_intent_t *inte
         break;
     default:
         break;
+    }
+}
+
+/* Dispatch the authenticated gameplay subset of client traffic. Returns true
+ * whenever the message type belongs to this shared subset, including malformed
+ * packets that were safely rejected by a reducer. Returning false means the
+ * transport shell must handle latency, metrics, identity, session, signed
+ * action, or unknown traffic. */
+static inline bool server_dispatch_gameplay_packet(
+    world_t *w,
+    int player_idx,
+    const uint8_t *data,
+    int len,
+    uint32_t server_recv_ms,
+    const server_gameplay_packet_policy_t *policy) {
+    if (!w || !data || len < 1 || player_idx < 0 ||
+        player_idx >= MAX_PLAYERS) {
+        return false;
+    }
+
+    server_player_t *sp = &w->players[player_idx];
+    void *user = policy ? policy->user : NULL;
+    switch (data[0]) {
+    case NET_MSG_INPUT: {
+        server_input_dispatch_result_t result;
+        if (!server_dispatch_input_message(
+                w, player_idx, data, len, server_recv_ms, &result)) {
+            return true;
+        }
+        if (result.rejected_unsigned_action && policy &&
+            policy->observe_unsigned_rejection) {
+            policy->observe_unsigned_rejection(
+                user, player_idx, data[0]);
+        }
+        if (result.ack_status == NET_ACTION_ACK_RECEIVED &&
+            result.action_id != 0) {
+            server_begin_pending_action_result(
+                w, sp, result.action_id, result.input_seq, result.action);
+        }
+        server_merge_one_shot_input(&sp->input, &result.intent);
+        if (result.ack_status != 0) {
+            if (policy && policy->send_packet) {
+                uint8_t ack[NET_ACTION_ACK_SIZE];
+                int ack_len = serialize_action_ack(
+                    ack, result.action_id, result.input_seq,
+                    result.ack_status, result.action);
+                policy->send_packet(user, ack, ack_len);
+            }
+            if (result.force_authoritative_resync) {
+                if (policy && policy->force_resync) {
+                    policy->force_resync(user, player_idx, sp);
+                } else if (sp->replication) {
+                    sp->replication->force_authoritative_resync = true;
+                }
+                if (policy && policy->send_packet) {
+                    uint8_t action_result[NET_ACTION_RESULT_SIZE];
+                    int result_len = serialize_action_result(
+                        action_result, result.action_id, result.input_seq,
+                        NET_ACTION_RESULT_REJECTED, result.action, w->tick);
+                    policy->send_packet(user, action_result, result_len);
+                }
+            }
+        }
+        if (result.station_identity_dirty >= 0 &&
+            result.station_identity_dirty < MAX_STATIONS && policy &&
+            policy->mark_station_identity_dirty) {
+            policy->mark_station_identity_dirty(
+                user, result.station_identity_dirty);
+        }
+        if (policy && policy->observe_input)
+            policy->observe_input(user, player_idx, &result);
+        return true;
+    }
+    case NET_MSG_PLAN: {
+        server_unsigned_dispatch_result_t result;
+        if (server_dispatch_legacy_plan_message(
+                w, player_idx, data, len, &result) &&
+            result.rejected_unsigned_action && policy &&
+            policy->observe_unsigned_rejection) {
+            policy->observe_unsigned_rejection(
+                user, player_idx, data[0]);
+        }
+        return true;
+    }
+    case NET_MSG_STATE:
+    case NET_MSG_MINING_ACTION:
+        return true;
+    case NET_MSG_BUY_INGOT:
+    case NET_MSG_DELIVER_INGOT: {
+        server_legacy_cargo_dispatch_result_t result;
+        bool dispatched = data[0] == NET_MSG_BUY_INGOT
+            ? server_dispatch_legacy_buy_ingot_message(
+                  w, player_idx, data, len,
+                  policy ? policy->receipt_chain_sink : NULL,
+                  user, &result)
+            : server_dispatch_legacy_deliver_ingot_message(
+                  w, player_idx, data, len,
+                  policy ? policy->receipt_chain_sink : NULL,
+                  user, &result);
+        if (dispatched && result.rejected_unsigned_action && policy &&
+            policy->observe_unsigned_rejection) {
+            policy->observe_unsigned_rejection(
+                user, player_idx, data[0]);
+        }
+        return true;
+    }
+    case NET_MSG_PRESENT_RECEIPT_CHAIN: {
+        server_receipt_presentation_dispatch_result_t result;
+        if (server_dispatch_receipt_presentation_message(
+                w, player_idx, data, len, &result) && policy &&
+            policy->observe_receipt_presentation) {
+            policy->observe_receipt_presentation(
+                user, player_idx, &result);
+        }
+        return true;
+    }
+    case NET_MSG_HANDOFF_REQUEST:
+        (void)server_dispatch_handoff_request(
+            w, player_idx, data, len,
+            policy ? policy->handoff_ticket_sink : NULL, user);
+        return true;
+    case NET_MSG_HANDOFF_PRESENT:
+        (void)server_dispatch_handoff_present(
+            w, player_idx, data, len,
+            policy ? policy->handoff_result_sink : NULL, user);
+        return true;
+    case NET_MSG_FRACTURE_CLAIM: {
+        server_unsigned_dispatch_result_t result;
+        if (server_dispatch_fracture_claim_message(
+                w, player_idx, data, len, &result) &&
+            result.rejected_unsigned_action && policy &&
+            policy->observe_unsigned_rejection) {
+            policy->observe_unsigned_rejection(
+                user, player_idx, data[0]);
+        }
+        return true;
+    }
+    default:
+        return false;
     }
 }
 

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -1462,6 +1462,43 @@ test.describe('Browser smoke tests', () => {
     expectNoFatalErrors(logs);
   });
 
+  test('a multiplayer disconnect never starts a fresh local universe', async ({ page }) => {
+    test.skip(usesLiveSmokeUrl(), 'mock transport requires the local browser bundle');
+
+    const remoteUrl = 'ws://signal-disconnect-parity.invalid/ws';
+    let closeRemote: (() => Promise<void>) | undefined;
+    await page.routeWebSocket(remoteUrl, ws => {
+      closeRemote = () => ws.close({ code: 1012, reason: 'smoke disconnect' });
+      ws.onMessage(() => {});
+    });
+
+    const logs = installFatalCollectors(page);
+    await page.goto(
+      `/play.html?smoke=1&server=${encodeURIComponent(remoteUrl)}`,
+    );
+    await waitForRuntime(page);
+    await expect.poll(
+      () => wasmNumber(page, 'signal_debug_net_connected'),
+      { timeout: 5_000 },
+    ).toBe(1);
+    expect(await wasmNumber(page, 'signal_debug_local_authority_state'))
+      .toBe(1 << 3);
+    expect(await wasmNumber(page, 'signal_debug_local_authority_generation'))
+      .toBe(0);
+
+    expect(closeRemote).toBeDefined();
+    await closeRemote!();
+    await expect.poll(
+      () => wasmNumber(page, 'signal_debug_net_connected'),
+      { timeout: 5_000 },
+    ).toBe(0);
+    expect(await wasmNumber(page, 'signal_debug_local_authority_state'))
+      .toBe(1 << 3);
+    expect(await wasmNumber(page, 'signal_debug_local_authority_generation'))
+      .toBe(0);
+    expectNoFatalErrors(logs);
+  });
+
   test('multiplayer is the default while singleplayer and RTC remain explicit options', async ({ page }) => {
     test.skip(usesLiveSmokeUrl(), 'transport selection is covered against the local bundle');
 
@@ -2217,7 +2254,7 @@ test.describe('Browser smoke tests', () => {
     expectNoFatalErrors(logs);
   });
 
-  test('local asteroid presentation removes the 10 Hz correction rhythm', async ({ page }) => {
+  test('singleplayer renders the same packet-driven asteroid stream as multiplayer', async ({ page }) => {
     test.skip(usesLiveSmokeUrl(), 'requires local singleplayer authority');
     test.setTimeout(45_000);
 
@@ -2240,34 +2277,25 @@ test.describe('Browser smoke tests', () => {
       () => wasmNumber(page, 'get_local_asteroid_motion_feed_active'),
       {
         timeout: 10_000,
-        message: 'local authority asteroid pose feed should become active',
+        message: 'singleplayer must not bypass packets with local authority poses',
       },
-    ).toBe(1);
+    ).toBe(0);
 
-    await wasmNumber(page, 'reset_local_asteroid_motion_telemetry');
-    await expect.poll(
-      () => wasmNumber(page, 'get_local_asteroid_motion_presented_samples'),
-      { timeout: 8_000 },
-    ).toBeGreaterThan(30);
-
-    expect(await wasmNumber(page, 'get_local_asteroid_motion_frame_samples'))
-      .toBeGreaterThan(0);
-    expect(await wasmNumberArg(page, 'get_local_asteroid_motion_class_samples', 0))
-      .toBeGreaterThan(0); // loose drift
-    expect(await wasmNumber(page, 'get_local_asteroid_motion_starvation_events'))
+    expect(await wasmNumber(page, 'get_local_asteroid_motion_presented_samples'))
       .toBe(0);
-    expect(await wasmNumber(page, 'get_local_asteroid_motion_max_correction'))
-      .toBeLessThanOrEqual(0.01);
-    expect(await wasmNumber(
-      page, 'get_local_asteroid_motion_max_velocity_discontinuity',
-    )).toBeLessThanOrEqual(0.01);
-    expect(await wasmNumber(page, 'get_local_asteroid_motion_max_screen_jerk'))
-      .toBeLessThanOrEqual(500_000);
-    expect(await wasmNumber(page, 'get_local_asteroid_motion_max_avoided_correction'))
-      .toBeGreaterThan(0);
-    expect(await wasmNumber(page, 'local_asteroid_motion_within_thresholds'))
-      .toBe(1);
 
+    expectNoFatalErrors(logs);
+  });
+
+  test('singleplayer rebuilds market memories from the private packet', async ({ page }) => {
+    test.skip(usesLiveSmokeUrl(), 'requires local singleplayer authority');
+
+    const logs = installFatalCollectors(page);
+    await loadGame(page, false, { singleplayer: true });
+
+    expect(
+      await wasmNumber(page, 'signal_smoke_market_memory_packet_parity'),
+    ).toBe(1);
     expectNoFatalErrors(logs);
   });
 

--- a/tests/c/test_protocol.c
+++ b/tests/c/test_protocol.c
@@ -6315,6 +6315,120 @@ TEST(test_pending_action_result_status_shared) {
                   NET_ACTION_RESULT_REJECTED);
 }
 
+typedef struct {
+    packet_capture_t packets;
+    int input_observed;
+    int unsigned_rejections;
+    int station_dirty;
+    bool force_resync;
+} gameplay_dispatch_capture_t;
+
+static void gameplay_dispatch_packet_sink(void *user,
+                                          const uint8_t *data,
+                                          int len) {
+    gameplay_dispatch_capture_t *cap =
+        (gameplay_dispatch_capture_t *)user;
+    packet_capture_sink(&cap->packets, data, len);
+}
+
+static void gameplay_dispatch_force_resync(void *user, int player_idx,
+                                           server_player_t *player) {
+    (void)player_idx;
+    (void)player;
+    ((gameplay_dispatch_capture_t *)user)->force_resync = true;
+}
+
+static void gameplay_dispatch_station_dirty(void *user, int station_idx) {
+    gameplay_dispatch_capture_t *cap =
+        (gameplay_dispatch_capture_t *)user;
+    cap->station_dirty = station_idx;
+}
+
+static void gameplay_dispatch_observe_input(
+    void *user, int player_idx,
+    const server_input_dispatch_result_t *result) {
+    (void)player_idx;
+    (void)result;
+    ((gameplay_dispatch_capture_t *)user)->input_observed++;
+}
+
+static void gameplay_dispatch_observe_unsigned(void *user, int player_idx,
+                                                uint8_t message_type) {
+    (void)player_idx;
+    (void)message_type;
+    ((gameplay_dispatch_capture_t *)user)->unsigned_rejections++;
+}
+
+TEST(test_gameplay_packet_dispatch_is_shared_by_local_and_remote_shells) {
+    WORLD_DECL;
+    test_world_bind_ship_slots(&w);
+    world_reset(&w);
+    server_player_t *sp = &w.players[0];
+    sp->connected = true;
+    sp->session_ready = true;
+    sp->id = 0;
+    sp->current_station = 0;
+    player_init_ship(sp, &w);
+
+    gameplay_dispatch_capture_t cap;
+    memset(&cap, 0, sizeof(cap));
+    cap.station_dirty = -1;
+    const server_gameplay_packet_policy_t policy = {
+        .user = &cap,
+        .send_packet = gameplay_dispatch_packet_sink,
+        .force_resync = gameplay_dispatch_force_resync,
+        .mark_station_identity_dirty = gameplay_dispatch_station_dirty,
+        .observe_input = gameplay_dispatch_observe_input,
+        .observe_unsigned_rejection = gameplay_dispatch_observe_unsigned,
+    };
+
+    uint8_t input[NET_INPUT_MSG_SIZE] = {
+        NET_MSG_INPUT,
+        NET_INPUT_THRUST,
+        NET_ACTION_BUY_SCAFFOLD,
+        0xFF,
+        MINING_GRADE_COUNT,
+        0xFF, 0xFF, 0xFF,
+        0x78, 0x56,
+        0xFF, 0xFF,
+        0x34, 0x12,
+    };
+    ASSERT(server_dispatch_gameplay_packet(
+        &w, 0, input, sizeof(input), 1234u, &policy));
+    ASSERT_EQ_INT(cap.input_observed, 1);
+    ASSERT_EQ_INT(cap.station_dirty, 0);
+    ASSERT_EQ_INT(cap.packets.count, 1);
+    ASSERT_EQ_INT(cap.packets.type[0], NET_MSG_ACTION_ACK);
+    ASSERT_EQ_INT(sp->movement_queue_count, 1);
+    ASSERT(sp->input.buy_scaffold_kit);
+    ASSERT(sp->pending_action_result_valid);
+    ASSERT_EQ_INT(sp->pending_action_result_id, 0x1234);
+    ASSERT_EQ_INT(sp->pending_action_result_input_seq, 0x5678);
+
+    sp->pending_action_result_valid = false;
+    sp->pubkey_set = true;
+    input[2] = NET_ACTION_LAUNCH;
+    input[12] = 0x35;
+    ASSERT(server_dispatch_gameplay_packet(
+        &w, 0, input, sizeof(input), 1235u, &policy));
+    ASSERT_EQ_INT(cap.input_observed, 2);
+    ASSERT_EQ_INT(cap.unsigned_rejections, 1);
+    ASSERT(cap.force_resync);
+    ASSERT_EQ_INT(cap.packets.count, 3);
+    ASSERT_EQ_INT(cap.packets.type[1], NET_MSG_ACTION_ACK);
+    ASSERT_EQ_INT(cap.packets.type[2], NET_MSG_ACTION_RESULT);
+    ASSERT(!sp->pending_action_result_valid);
+
+    uint8_t malformed[] = { NET_MSG_INPUT };
+    ASSERT(server_dispatch_gameplay_packet(
+        &w, 0, malformed, sizeof(malformed), 0, &policy));
+    uint8_t latency[] = { NET_MSG_LATENCY_PING };
+    ASSERT(!server_dispatch_gameplay_packet(
+        &w, 0, latency, sizeof(latency), 0, &policy));
+
+    world_cleanup(&w);
+}
+
 TEST(test_hail_response_serializes_reason_tail) {
     WORLD_DECL;
     world_reset(&w);
@@ -10048,6 +10162,7 @@ void register_protocol_main_tests(void) {
     RUN(test_pending_input_ack_adaptive_promotes_heartbeat_state);
     RUN(test_sim_event_transport_hooks_cover_freshness_buckets);
     RUN(test_pending_action_result_status_shared);
+    RUN(test_gameplay_packet_dispatch_is_shared_by_local_and_remote_shells);
     RUN(test_hail_response_serializes_reason_tail);
     RUN(test_npc_role_default_hull_mapping_covers_tow);
     RUN(test_roundtrip_inspect_snapshot_npc_manifest_chain);


### PR DESCRIPTION
## Summary
- keep remote sessions remote after disconnect instead of silently starting a new local universe
- use the same packet-driven asteroid, towing, market-memory, and gameplay dispatch paths in singleplayer and multiplayer
- align event-driven snapshot freshness and document the remaining intentional server-only differences

## Verification
- make test-all: 1670 passed
- Playwright browser suite: 51 passed, 4 live-network tests skipped
- native client/server/test builds passed
- make build-web passed
- doc freshness, trust audit, banned APIs, deterministic libm, soak automation, vendor drift, and cppcheck passed