### PR TITLE
Fix accelerated tow presentation and expose jank reports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,7 @@ set(SIGNAL_CLIENT_SOURCES
     client/legacy_recovery_view.c
     client/client_log.c
     client/reconciliation_diagnostics.c
+    client/gameplay_observability.c
     client/asteroid_presentation.c
     client/tow_presentation_diagnostics.c
     client/tow_adverse_gate.c
@@ -390,6 +391,7 @@ if(NOT EMSCRIPTEN AND NOT BUILD_SERVER_ONLY)
         tests/c/test_signal_field.c
         tests/c/test_state_digest.c
         tests/c/test_reconciliation_diagnostics.c
+        tests/c/test_gameplay_observability.c
         tests/c/test_asteroid_presentation.c
         tests/c/test_tow_presentation_diagnostics.c
         tests/c/test_gossip.c
@@ -400,6 +402,7 @@ if(NOT EMSCRIPTEN AND NOT BUILD_SERVER_ONLY)
         client/public_actor_presentation.c
         client/client_log.c
         client/reconciliation_diagnostics.c
+        client/gameplay_observability.c
         client/asteroid_presentation.c
         client/tow_presentation_diagnostics.c
         client/episode_lifecycle.c

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-web build-server build-test build-san test-san test-san-soak build-msan test-msan build-tsan test-tsan memzero-codegen build-mode-contract client-memory-budget build-flight-trace flight-trace build-signal-replay build-signal-replay-wasm signal-replay replay-repeatability replay-repeatability-long replay-ai-eval-repeatability replay-ai-eval-repeatability-long replay-ai-eval-native-wasm replay-ai-outcome-repeatability replay-ai-outcome-native-wasm replay-ai-outcome-modes signal-no-omniscience-soak replay-cross-build replay-cross-build-long replay-native-wasm replay-native-wasm-long build-chain-assets chain-assets build-rati-receipt rati-receipt rati-anchor-batch test-rati-anchor-batch rati-anchor-stamp test-rati-anchor-stamp neural-gap-ab signal-client-brain-shadow signal-hnn-shadow assets protocol-check test test-serial test-fast test-soak test-all asteroid-physics-bench smoke smoke-latency smoke-ack-lag smoke-latency-suite relay-traffic-probe ws-backpressure-soak ws-backpressure-soak-short cargo-trust-audit banned-apis deterministic-libm deterministic-build-flags doc-freshness soak-automation vendor-drift fuzz-receipts fuzz-receipts-standalone cppcheck crap profile-machine latency-proxy latency-proxy-high latency-proxy-ack-lag rtc-gateway test-rtc-gateway deploy-fly site clean install-hooks
+.PHONY: all build build-web build-server build-test build-san test-san test-san-soak build-msan test-msan build-tsan test-tsan memzero-codegen build-mode-contract client-memory-budget build-flight-trace flight-trace build-signal-replay build-signal-replay-wasm signal-replay replay-repeatability replay-repeatability-long replay-ai-eval-repeatability replay-ai-eval-repeatability-long replay-ai-eval-native-wasm replay-ai-outcome-repeatability replay-ai-outcome-native-wasm replay-ai-outcome-modes signal-no-omniscience-soak replay-cross-build replay-cross-build-long replay-native-wasm replay-native-wasm-long build-chain-assets chain-assets build-rati-receipt rati-receipt rati-anchor-batch test-rati-anchor-batch rati-anchor-stamp test-rati-anchor-stamp neural-gap-ab signal-client-brain-shadow signal-hnn-shadow assets protocol-check test test-serial test-fast test-soak test-all asteroid-physics-bench smoke smoke-latency smoke-ack-lag smoke-latency-suite jank-profile-native jank-profile-browser relay-traffic-probe ws-backpressure-soak ws-backpressure-soak-short cargo-trust-audit banned-apis deterministic-libm deterministic-build-flags doc-freshness soak-automation vendor-drift fuzz-receipts fuzz-receipts-standalone cppcheck crap profile-machine latency-proxy latency-proxy-high latency-proxy-ack-lag rtc-gateway test-rtc-gateway deploy-fly site clean install-hooks
 
 all: build build-web build-server
 
@@ -755,6 +755,13 @@ smoke-ack-lag:
 
 smoke-latency-suite: build-web build-server
 	node scripts/smoke-latency-suite.mjs
+
+# Opt-in gameplay profiling. Normal release play keeps this off.
+jank-profile-native: build
+	SIGNAL_JANK_PROFILE=1 SIGNAL_LOG_PERSIST=0 ./build/signal
+
+jank-profile-browser: build-web
+	SIGNAL_JANK_PROFILE_SECONDS=60 npx playwright test tests/browser-smoke.spec.ts --project=chromium --grep "fresh and mature play produce attributed jank reports"
 
 RELAY_PROBE_URL ?= ws://127.0.0.1:9091/ws
 RELAY_PROBE_CLIENTS ?= 2

--- a/client/asteroid_presentation.c
+++ b/client/asteroid_presentation.c
@@ -58,13 +58,42 @@ void asteroid_presentation_predict_motion(
     const asteroid_t *base, float elapsed, bool tow_driven,
     vec2 *out_pos, vec2 *out_vel)
 {
+    asteroid_presentation_predict_motion_accelerated(
+        base, elapsed, tow_driven, v2(0.0f, 0.0f), false,
+        out_pos, out_vel);
+}
+
+void asteroid_presentation_predict_motion_accelerated(
+    const asteroid_t *base, float elapsed, bool tow_driven,
+    vec2 acceleration, bool acceleration_valid,
+    vec2 *out_pos, vec2 *out_vel)
+{
     if (!out_pos || !out_vel) return;
     *out_pos = base ? base->pos : v2(0.0f, 0.0f);
     *out_vel = base ? base->vel : v2(0.0f, 0.0f);
     if (!base || !isfinite(elapsed) || elapsed <= 0.0f) return;
 
     if (tow_driven) {
-        *out_pos = v2_add(base->pos, v2_scale(base->vel, elapsed));
+        float accel_time = acceleration_valid && finite_vec(acceleration)
+            ? fminf(elapsed, ASTEROID_PRESENTATION_ACCEL_HORIZON_SEC)
+            : 0.0f;
+        float accel_len = vec_length(acceleration);
+        if (!isfinite(accel_len) ||
+            accel_len > ASTEROID_PRESENTATION_MAX_ACCEL) {
+            accel_time = 0.0f;
+        }
+        vec2 accelerated_vel = v2_add(
+            base->vel, v2_scale(acceleration, accel_time));
+        vec2 accelerated_pos = v2_add(
+            base->pos,
+            v2_add(v2_scale(base->vel, accel_time),
+                   v2_scale(acceleration,
+                            0.5f * accel_time * accel_time)));
+        float coast_time = elapsed - accel_time;
+        *out_pos = v2_add(
+            accelerated_pos,
+            v2_scale(accelerated_vel, coast_time));
+        *out_vel = accelerated_vel;
         return;
     }
 
@@ -85,6 +114,70 @@ void asteroid_presentation_predict_motion(
     *out_pos = v2_add(base->pos,
                       v2_scale(base->vel, displacement_scale));
     *out_vel = v2_scale(base->vel, retained);
+}
+
+bool asteroid_presentation_acceleration_gate(
+    float *out_max_position_error,
+    float *out_max_velocity_error)
+{
+    const float render_dt = 1.0f / 60.0f;
+    const float acceleration_value = 380.0f;
+    asteroid_t packet = {0};
+    packet.active = true;
+    vec2 estimated_acceleration = v2(0.0f, 0.0f);
+    vec2 last_packet_velocity = v2(0.0f, 0.0f);
+    bool have_packet_velocity = false;
+    bool acceleration_valid = false;
+    float packet_elapsed = 0.0f;
+    float max_position_error = 0.0f;
+    float max_velocity_error = 0.0f;
+
+    for (int frame = 0; frame <= 180; frame++) {
+        float time = (float)frame * render_dt;
+        vec2 authority_pos = v2(
+            0.5f * acceleration_value * time * time, 0.0f);
+        vec2 authority_vel = v2(acceleration_value * time, 0.0f);
+        if ((frame % 6) == 0) {
+            if (have_packet_velocity) {
+                estimated_acceleration = v2_scale(
+                    v2_sub(authority_vel, last_packet_velocity),
+                    1.0f / 0.1f);
+                acceleration_valid = true;
+            }
+            packet.pos = authority_pos;
+            packet.vel = authority_vel;
+            last_packet_velocity = authority_vel;
+            have_packet_velocity = true;
+            packet_elapsed = 0.0f;
+        }
+
+        vec2 presented_pos = {0};
+        vec2 presented_vel = {0};
+        asteroid_presentation_predict_motion_accelerated(
+            &packet, packet_elapsed, true,
+            estimated_acceleration, acceleration_valid,
+            &presented_pos, &presented_vel);
+        if (frame >= 12) {
+            float position_error = vec_length(v2_sub(
+                authority_pos, presented_pos));
+            float velocity_error = vec_length(v2_sub(
+                authority_vel, presented_vel));
+            if (max_position_error < position_error)
+                max_position_error = position_error;
+            if (max_velocity_error < velocity_error)
+                max_velocity_error = velocity_error;
+        }
+        packet_elapsed += render_dt;
+    }
+
+    if (out_max_position_error)
+        *out_max_position_error = max_position_error;
+    if (out_max_velocity_error)
+        *out_max_velocity_error = max_velocity_error;
+    return isfinite(max_position_error) &&
+        isfinite(max_velocity_error) &&
+        max_position_error <= 0.01f &&
+        max_velocity_error <= 0.01f;
 }
 
 static bool asteroid_presentation_identity_compatible(

--- a/client/asteroid_presentation.h
+++ b/client/asteroid_presentation.h
@@ -43,6 +43,22 @@ void asteroid_presentation_predict_motion(
     const asteroid_t *base, float elapsed, bool tow_driven,
     vec2 *out_pos, vec2 *out_vel);
 
+/* Packet-driven tow motion is accelerated. Use a short, bounded acceleration
+ * estimate from consecutive authoritative velocity samples, then coast if a
+ * packet is delayed. This changes presentation only; it never mutates sim. */
+#define ASTEROID_PRESENTATION_ACCEL_HORIZON_SEC 0.25f
+#define ASTEROID_PRESENTATION_MAX_ACCEL 2000.0f
+void asteroid_presentation_predict_motion_accelerated(
+    const asteroid_t *base, float elapsed, bool tow_driven,
+    vec2 acceleration, bool acceleration_valid,
+    vec2 *out_pos, vec2 *out_vel);
+
+/* Deterministic 60 Hz presentation against a 10 Hz accelerating packet
+ * source. Shared by native unit tests and the browser smoke gate. */
+bool asteroid_presentation_acceleration_gate(
+    float *out_max_position_error,
+    float *out_max_velocity_error);
+
 asteroid_presentation_action_t asteroid_presentation_resolve(
     const world_t *authority, const asteroid_t *client_asteroid,
     int asteroid_index, float render_ahead,

--- a/client/client.h
+++ b/client/client.h
@@ -764,6 +764,15 @@ typedef struct {
         /* Sparse asteroid packet classes arrive independently. Keep a clock
          * per slot so a packet for one rock cannot rebase every other rock. */
         float elapsed[MAX_ASTEROIDS];
+        /* Consecutive authoritative velocity samples provide a render-only
+         * acceleration estimate for tow and station-pull motion. Keep this
+         * separate from curr because local player prediction may temporarily
+         * adopt a newer visual pose between packets. */
+        vec2 snapshot_vel[MAX_ASTEROIDS];
+        vec2 acceleration[MAX_ASTEROIDS];
+        float snapshot_elapsed[MAX_ASTEROIDS];
+        bool snapshot_valid[MAX_ASTEROIDS];
+        bool acceleration_valid[MAX_ASTEROIDS];
     } asteroid_interp;
     struct {
         client_npc_render_state_t prev[MAX_NPC_SHIPS];

--- a/client/gameplay_observability.c
+++ b/client/gameplay_observability.c
@@ -1,0 +1,362 @@
+#include "gameplay_observability.h"
+
+#include <math.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten/emscripten.h>
+#elif defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <time.h>
+#endif
+
+#define OBS_HIST_BUCKETS 256u
+#define OBS_HIST_BUCKET_MS 0.25
+#define OBS_REPORT_CAP 8192u
+
+typedef struct {
+    uint64_t bucket[OBS_HIST_BUCKETS];
+    uint64_t samples;
+    double total_ms;
+    double max_ms;
+} obs_histogram_t;
+
+typedef struct {
+    uint64_t samples;
+    double total_ms;
+    double max_ms;
+} obs_phase_stats_t;
+
+typedef struct {
+    uint64_t samples;
+    float max_correction_world;
+    float max_velocity_discontinuity;
+    float max_correction_jerk;
+} obs_entity_stats_t;
+
+typedef struct {
+    bool enabled;
+    double report_interval_sec;
+    double configured_at;
+    double last_report_at;
+    double frame_started_at;
+    double frame_phase_ms[GAMEPLAY_PHASE_COUNT];
+    obs_histogram_t frame;
+    obs_histogram_t simulation;
+    obs_phase_stats_t phase[GAMEPLAY_PHASE_COUNT];
+    obs_entity_stats_t entity[GAMEPLAY_ENTITY_COUNT];
+    uint64_t slow_16ms;
+    uint64_t slow_33ms;
+    uint64_t unexplained_slow_frames;
+    uint64_t slow_cause[GAMEPLAY_PHASE_COUNT];
+    uint64_t sim_steps;
+    uint64_t missed_ticks;
+    uint64_t accumulator_dropped_ticks;
+    uint64_t packet_count;
+    uint64_t packet_bytes;
+    size_t max_packet_bytes;
+    double max_packet_gap_ms;
+    double last_packet_at[256];
+    uint64_t packet_type_count[256];
+    char report[OBS_REPORT_CAP];
+} obs_state_t;
+
+static obs_state_t obs;
+
+static const char *const phase_names[GAMEPLAY_PHASE_COUNT] = {
+    "input_network",
+    "simulation",
+    "interpolation",
+    "world_render",
+    "ui_render",
+    "submission",
+    "audio_media",
+    "unattributed",
+    "authority_sim",
+    "loopback_codec",
+};
+
+static const char *const entity_names[GAMEPLAY_ENTITY_COUNT] = {
+    "asteroid",
+    "cargo_pod",
+    "scaffold",
+    "npc",
+    "remote_player",
+};
+
+double gameplay_observability_now(void)
+{
+#ifdef __EMSCRIPTEN__
+    return emscripten_get_now() / 1000.0;
+#elif defined(_WIN32)
+    static LARGE_INTEGER frequency;
+    LARGE_INTEGER counter;
+    if (frequency.QuadPart == 0)
+        (void)QueryPerformanceFrequency(&frequency);
+    (void)QueryPerformanceCounter(&counter);
+    return frequency.QuadPart > 0
+        ? (double)counter.QuadPart / (double)frequency.QuadPart : 0.0;
+#else
+    struct timespec ts = {0};
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) return 0.0;
+    return (double)ts.tv_sec + (double)ts.tv_nsec / 1000000000.0;
+#endif
+}
+
+static void histogram_record(obs_histogram_t *histogram, double ms)
+{
+    if (!histogram || !isfinite(ms) || ms < 0.0) return;
+    size_t bucket = (size_t)(ms / OBS_HIST_BUCKET_MS);
+    if (bucket >= OBS_HIST_BUCKETS) bucket = OBS_HIST_BUCKETS - 1u;
+    histogram->bucket[bucket]++;
+    histogram->samples++;
+    histogram->total_ms += ms;
+    if (histogram->max_ms < ms) histogram->max_ms = ms;
+}
+
+static double histogram_percentile(const obs_histogram_t *histogram,
+                                   double percentile)
+{
+    if (!histogram || histogram->samples == 0) return 0.0;
+    uint64_t target = (uint64_t)ceil(
+        percentile * (double)histogram->samples);
+    if (target == 0) target = 1;
+    uint64_t seen = 0;
+    for (size_t i = 0; i < OBS_HIST_BUCKETS; i++) {
+        seen += histogram->bucket[i];
+        if (seen >= target)
+            return ((double)i + 0.5) * OBS_HIST_BUCKET_MS;
+    }
+    return histogram->max_ms;
+}
+
+void gameplay_observability_configure(bool enabled,
+                                      double report_interval_sec)
+{
+    memset(&obs, 0, sizeof(obs));
+    obs.enabled = enabled;
+    obs.report_interval_sec =
+        isfinite(report_interval_sec) && report_interval_sec > 0.0
+            ? report_interval_sec : 60.0;
+    obs.configured_at = gameplay_observability_now();
+    obs.last_report_at = obs.configured_at;
+}
+
+bool gameplay_observability_enabled(void)
+{
+    return obs.enabled;
+}
+
+void gameplay_observability_reset(void)
+{
+    bool enabled = obs.enabled;
+    double interval = obs.report_interval_sec;
+    gameplay_observability_configure(enabled, interval);
+}
+
+double gameplay_observability_phase_begin(void)
+{
+    return obs.enabled ? gameplay_observability_now() : 0.0;
+}
+
+void gameplay_observability_phase_end(
+    gameplay_observability_phase_t phase, double started_at)
+{
+    if (!obs.enabled || phase < 0 || phase >= GAMEPLAY_PHASE_COUNT ||
+        started_at <= 0.0) return;
+    double elapsed_ms = (gameplay_observability_now() - started_at) * 1000.0;
+    if (!isfinite(elapsed_ms) || elapsed_ms < 0.0) return;
+    obs.frame_phase_ms[phase] += elapsed_ms;
+    obs_phase_stats_t *stats = &obs.phase[phase];
+    stats->samples++;
+    stats->total_ms += elapsed_ms;
+    if (stats->max_ms < elapsed_ms) stats->max_ms = elapsed_ms;
+    if (phase == GAMEPLAY_PHASE_SIMULATION)
+        histogram_record(&obs.simulation, elapsed_ms);
+}
+
+void gameplay_observability_frame_begin(void)
+{
+    if (!obs.enabled) return;
+    memset(obs.frame_phase_ms, 0, sizeof(obs.frame_phase_ms));
+    obs.frame_started_at = gameplay_observability_now();
+}
+
+static void report_append(size_t *offset, const char *format, ...)
+{
+    if (!offset || *offset >= sizeof(obs.report)) return;
+    va_list args;
+    va_start(args, format);
+    int wrote = vsnprintf(obs.report + *offset,
+                          sizeof(obs.report) - *offset,
+                          format, args);
+    va_end(args);
+    if (wrote < 0) return;
+    size_t available = sizeof(obs.report) - *offset;
+    *offset += (size_t)wrote < available ? (size_t)wrote : available - 1u;
+}
+
+const char *gameplay_observability_report_json(void)
+{
+    size_t offset = 0;
+    double now = gameplay_observability_now();
+    double elapsed = now >= obs.configured_at
+        ? now - obs.configured_at : 0.0;
+    report_append(&offset,
+        "{\"schema\":\"signal.gameplay-jank.v1\","
+        "\"enabled\":%s,\"window_sec\":%.3f,"
+        "\"frames\":%llu,\"frame_ms\":{"
+        "\"p50\":%.3f,\"p95\":%.3f,\"p99\":%.3f,\"max\":%.3f},"
+        "\"simulation_ms\":{\"p50\":%.3f,\"p95\":%.3f,"
+        "\"p99\":%.3f,\"max\":%.3f},"
+        "\"slow_frames\":{\"over_16_6\":%llu,\"over_33_3\":%llu,"
+        "\"unexplained\":%llu},"
+        "\"fixed_step\":{\"completed\":%llu,\"missed\":%llu,"
+        "\"accumulator_dropped\":%llu},"
+        "\"snapshots\":{\"packets\":%llu,\"bytes\":%llu,"
+        "\"max_packet_bytes\":%zu,\"max_gap_ms\":%.3f},"
+        "\"phases\":{",
+        obs.enabled ? "true" : "false", elapsed,
+        (unsigned long long)obs.frame.samples,
+        histogram_percentile(&obs.frame, 0.50),
+        histogram_percentile(&obs.frame, 0.95),
+        histogram_percentile(&obs.frame, 0.99), obs.frame.max_ms,
+        histogram_percentile(&obs.simulation, 0.50),
+        histogram_percentile(&obs.simulation, 0.95),
+        histogram_percentile(&obs.simulation, 0.99), obs.simulation.max_ms,
+        (unsigned long long)obs.slow_16ms,
+        (unsigned long long)obs.slow_33ms,
+        (unsigned long long)obs.unexplained_slow_frames,
+        (unsigned long long)obs.sim_steps,
+        (unsigned long long)obs.missed_ticks,
+        (unsigned long long)obs.accumulator_dropped_ticks,
+        (unsigned long long)obs.packet_count,
+        (unsigned long long)obs.packet_bytes,
+        obs.max_packet_bytes, obs.max_packet_gap_ms);
+
+    for (int i = 0; i < GAMEPLAY_PHASE_COUNT; i++) {
+        const obs_phase_stats_t *phase = &obs.phase[i];
+        report_append(&offset,
+            "%s\"%s\":{\"avg_ms\":%.3f,\"max_ms\":%.3f,"
+            "\"slow_cause\":%llu}",
+            i == 0 ? "" : ",", phase_names[i],
+            phase->samples > 0
+                ? phase->total_ms / (double)phase->samples : 0.0,
+            phase->max_ms,
+            (unsigned long long)obs.slow_cause[i]);
+    }
+    report_append(&offset, "},\"entities\":{");
+    for (int i = 0; i < GAMEPLAY_ENTITY_COUNT; i++) {
+        const obs_entity_stats_t *entity = &obs.entity[i];
+        report_append(&offset,
+            "%s\"%s\":{\"samples\":%llu,"
+            "\"max_correction_world\":%.4f,"
+            "\"max_velocity_discontinuity\":%.4f,"
+            "\"max_correction_jerk\":%.4f}",
+            i == 0 ? "" : ",", entity_names[i],
+            (unsigned long long)entity->samples,
+            entity->max_correction_world,
+            entity->max_velocity_discontinuity,
+            entity->max_correction_jerk);
+    }
+    report_append(&offset, "}}");
+    return obs.report;
+}
+
+void gameplay_observability_frame_end(void)
+{
+    if (!obs.enabled || obs.frame_started_at <= 0.0) return;
+    double now = gameplay_observability_now();
+    double frame_ms = (now - obs.frame_started_at) * 1000.0;
+    obs.frame_started_at = 0.0;
+    if (!isfinite(frame_ms) || frame_ms < 0.0) return;
+    histogram_record(&obs.frame, frame_ms);
+
+    double attributed_before_remainder = 0.0;
+    for (int i = 0; i < GAMEPLAY_PHASE_UNATTRIBUTED; i++)
+        attributed_before_remainder += obs.frame_phase_ms[i];
+    double remainder = fmax(0.0, frame_ms - attributed_before_remainder);
+    obs.frame_phase_ms[GAMEPLAY_PHASE_UNATTRIBUTED] = remainder;
+    obs_phase_stats_t *unattributed =
+        &obs.phase[GAMEPLAY_PHASE_UNATTRIBUTED];
+    unattributed->samples++;
+    unattributed->total_ms += remainder;
+    if (unattributed->max_ms < remainder)
+        unattributed->max_ms = remainder;
+
+    if (frame_ms > 16.6) {
+        obs.slow_16ms++;
+        double largest = 0.0;
+        int cause = 0;
+        for (int i = 0; i < GAMEPLAY_PRIMARY_PHASE_COUNT; i++) {
+            if (obs.frame_phase_ms[i] > largest) {
+                largest = obs.frame_phase_ms[i];
+                cause = i;
+            }
+        }
+        obs.slow_cause[cause]++;
+    }
+    if (frame_ms > 33.3) obs.slow_33ms++;
+
+    if (obs.report_interval_sec > 0.0 &&
+        now - obs.last_report_at >= obs.report_interval_sec) {
+        obs.last_report_at = now;
+        fprintf(stdout, "[gameplay-jank] %s\n",
+                gameplay_observability_report_json());
+    }
+}
+
+void gameplay_observability_record_sim_steps(
+    uint32_t completed, uint32_t missed, uint32_t dropped)
+{
+    if (!obs.enabled) return;
+    obs.sim_steps += completed;
+    obs.missed_ticks += missed;
+    obs.accumulator_dropped_ticks += dropped;
+}
+
+void gameplay_observability_record_packet(uint8_t type, size_t bytes)
+{
+    if (!obs.enabled) return;
+    double now = gameplay_observability_now();
+    double last = obs.last_packet_at[type];
+    if (last > 0.0 && now >= last) {
+        double gap_ms = (now - last) * 1000.0;
+        if (obs.max_packet_gap_ms < gap_ms)
+            obs.max_packet_gap_ms = gap_ms;
+    }
+    obs.last_packet_at[type] = now;
+    obs.packet_type_count[type]++;
+    obs.packet_count++;
+    obs.packet_bytes += bytes;
+    if (obs.max_packet_bytes < bytes) obs.max_packet_bytes = bytes;
+}
+
+void gameplay_observability_record_entity_correction(
+    gameplay_observability_entity_t entity,
+    float correction_world, float velocity_discontinuity,
+    float packet_gap_sec)
+{
+    if (!obs.enabled || entity < 0 || entity >= GAMEPLAY_ENTITY_COUNT ||
+        !isfinite(correction_world) || correction_world < 0.0f ||
+        !isfinite(velocity_discontinuity) ||
+        velocity_discontinuity < 0.0f) return;
+    obs_entity_stats_t *stats = &obs.entity[entity];
+    stats->samples++;
+    if (stats->max_correction_world < correction_world)
+        stats->max_correction_world = correction_world;
+    if (stats->max_velocity_discontinuity < velocity_discontinuity)
+        stats->max_velocity_discontinuity = velocity_discontinuity;
+    if (isfinite(packet_gap_sec) && packet_gap_sec > 0.0001f) {
+        float jerk = correction_world /
+            (packet_gap_sec * packet_gap_sec);
+        if (isfinite(jerk) && stats->max_correction_jerk < jerk)
+            stats->max_correction_jerk = jerk;
+    }
+}

--- a/client/gameplay_observability.h
+++ b/client/gameplay_observability.h
@@ -1,0 +1,58 @@
+#ifndef SIGNAL_GAMEPLAY_OBSERVABILITY_H
+#define SIGNAL_GAMEPLAY_OBSERVABILITY_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef enum {
+    GAMEPLAY_PHASE_INPUT_NETWORK = 0,
+    GAMEPLAY_PHASE_SIMULATION,
+    GAMEPLAY_PHASE_INTERPOLATION,
+    GAMEPLAY_PHASE_WORLD_RENDER,
+    GAMEPLAY_PHASE_UI_RENDER,
+    GAMEPLAY_PHASE_SUBMISSION,
+    GAMEPLAY_PHASE_AUDIO_MEDIA,
+    GAMEPLAY_PHASE_UNATTRIBUTED,
+    /* Detail phases may sit inside simulation and are not double-counted
+     * when assigning a slow frame to its primary cause. */
+    GAMEPLAY_PHASE_AUTHORITY_SIM,
+    GAMEPLAY_PHASE_LOOPBACK_CODEC,
+    GAMEPLAY_PHASE_COUNT,
+} gameplay_observability_phase_t;
+
+#define GAMEPLAY_PRIMARY_PHASE_COUNT GAMEPLAY_PHASE_AUTHORITY_SIM
+
+typedef enum {
+    GAMEPLAY_ENTITY_ASTEROID = 0,
+    GAMEPLAY_ENTITY_CARGO_POD,
+    GAMEPLAY_ENTITY_SCAFFOLD,
+    GAMEPLAY_ENTITY_NPC,
+    GAMEPLAY_ENTITY_REMOTE_PLAYER,
+    GAMEPLAY_ENTITY_COUNT,
+} gameplay_observability_entity_t;
+
+/* Disabled by default. The disabled path is one predictable branch. */
+void gameplay_observability_configure(bool enabled, double report_interval_sec);
+bool gameplay_observability_enabled(void);
+void gameplay_observability_reset(void);
+
+double gameplay_observability_now(void);
+double gameplay_observability_phase_begin(void);
+void gameplay_observability_phase_end(
+    gameplay_observability_phase_t phase, double started_at);
+
+void gameplay_observability_frame_begin(void);
+void gameplay_observability_frame_end(void);
+void gameplay_observability_record_sim_steps(
+    uint32_t completed, uint32_t missed, uint32_t dropped);
+void gameplay_observability_record_packet(uint8_t type, size_t bytes);
+void gameplay_observability_record_entity_correction(
+    gameplay_observability_entity_t entity,
+    float correction_world, float velocity_discontinuity,
+    float packet_gap_sec);
+
+/* Stable until the next call. Intended for browser gates and bug reports. */
+const char *gameplay_observability_report_json(void);
+
+#endif /* SIGNAL_GAMEPLAY_OBSERVABILITY_H */

--- a/client/local_server.c
+++ b/client/local_server.c
@@ -8,6 +8,7 @@
  * path; direct copies into g.world are legacy architecture.
  */
 #include "local_server.h"
+#include "gameplay_observability.h"
 #include "client.h"
 #include "manifest.h"
 #include "mining_client.h"
@@ -734,7 +735,12 @@ void local_server_step_loopback(local_server_t *ls, int player_slot, float dt) {
     if (player_slot < 0 || player_slot >= MAX_PLAYERS) return;
     uint16_t input_ack_before =
         LS_WORLD(ls).players[player_slot].last_input_seq;
+    double authority_started = gameplay_observability_phase_begin();
     world_sim_step(&LS_WORLD(ls), dt);
+    gameplay_observability_phase_end(
+        GAMEPLAY_PHASE_AUTHORITY_SIM, authority_started);
+
+    double loopback_started = gameplay_observability_phase_begin();
     server_pending_input_ack_t pending;
     server_pending_input_ack_reset(&pending);
     if (server_pending_input_ack_note(
@@ -747,4 +753,6 @@ void local_server_step_loopback(local_server_t *ls, int player_slot, float dt) {
             local_server_send_packet, NULL);
     }
     local_server_emit_frame(ls, player_slot);
+    gameplay_observability_phase_end(
+        GAMEPLAY_PHASE_LOOPBACK_CODEC, loopback_started);
 }

--- a/client/main.c
+++ b/client/main.c
@@ -27,6 +27,8 @@
 #include "client_log.h"
 #include "hud_attention.h"
 #include "legacy_recovery_ui.h"
+#include "gameplay_observability.h"
+#include "asteroid_presentation.h"
 
 
 #ifdef __EMSCRIPTEN__
@@ -1910,6 +1912,17 @@ static void init(void) {
      */
     g.world.rng = 0xC0FFEE12u;
 
+    bool jank_profile_enabled = false;
+#ifdef __EMSCRIPTEN__
+    jank_profile_enabled = emscripten_run_script_int(
+        "new URLSearchParams(location.search).get('jankprofile')==='1'") != 0;
+#else
+    const char *jank_profile = getenv("SIGNAL_JANK_PROFILE");
+    jank_profile_enabled = jank_profile && jank_profile[0] != '\0' &&
+        strcmp(jank_profile, "0") != 0;
+#endif
+    gameplay_observability_configure(jank_profile_enabled, 60.0);
+
     sg_setup(&(sg_desc){
         .environment = sglue_environment(),
         .logger.func = slog_func,
@@ -2697,9 +2710,30 @@ EMSCRIPTEN_KEEPALIVE
 float signal_render_frame_duration_ms(void) {
     return g_render_frame_duration_ms;
 }
+
+EMSCRIPTEN_KEEPALIVE
+int signal_jank_profile_enabled(void) {
+    return gameplay_observability_enabled() ? 1 : 0;
+}
+
+EMSCRIPTEN_KEEPALIVE
+void signal_jank_profile_reset(void) {
+    gameplay_observability_reset();
+}
+
+EMSCRIPTEN_KEEPALIVE
+const char *signal_jank_profile_report_json(void) {
+    return gameplay_observability_report_json();
+}
+
+EMSCRIPTEN_KEEPALIVE
+int signal_smoke_accelerated_asteroid_prediction_gate(void) {
+    return asteroid_presentation_acceleration_gate(NULL, NULL) ? 1 : 0;
+}
 #endif
 
 static void render_frame(void) {
+    double interpolation_started = gameplay_observability_phase_begin();
     float frame_dt = (float)sapp_frame_duration();
     if (frame_dt <= 0.0f) frame_dt = 1.0f / 60.0f;
     if (frame_dt > 0.1f) frame_dt = 0.1f;
@@ -2751,6 +2785,10 @@ static void render_frame(void) {
         saved_scaffold_active = apply_local_towed_scaffold_render_pose(
             &saved_scaffold, g.local_player_render_offset, render_ahead);
     }
+    gameplay_observability_phase_end(
+        GAMEPLAY_PHASE_INTERPOLATION, interpolation_started);
+
+    double world_render_started = gameplay_observability_phase_begin();
     render_world();
     if (apply_visual_pose) {
         restore_local_towed_asteroid_render_pose(saved_asteroids,
@@ -2762,7 +2800,13 @@ static void render_frame(void) {
         LOCAL_PLAYER.ship->pos = saved_ship_pos;
         LOCAL_PLAYER.ship->angle = saved_ship_angle;
     }
+    gameplay_observability_phase_end(
+        GAMEPLAY_PHASE_WORLD_RENDER, world_render_started);
+
+    double ui_render_started = gameplay_observability_phase_begin();
     render_ui();
+    gameplay_observability_phase_end(
+        GAMEPLAY_PHASE_UI_RENDER, ui_render_started);
 
     g_render_queued_vertices = sgl_num_vertices();
     g_render_queued_commands = sgl_num_commands();
@@ -2775,6 +2819,7 @@ static void render_frame(void) {
         (render_error.stack_underflow ? 1u << 4 : 0u) |
         (render_error.no_context ? 1u << 5 : 0u);
 
+    double submission_started = gameplay_observability_phase_begin();
     sg_begin_pass(&(sg_pass){
         .action = g.pass_action,
         .swapchain = sglue_swapchain(),
@@ -2783,10 +2828,16 @@ static void render_frame(void) {
     sdtx_draw();
     sg_end_pass();
     sg_commit();
+    gameplay_observability_phase_end(
+        GAMEPLAY_PHASE_SUBMISSION, submission_started);
 }
 
 static void advance_simulation_frame(float frame_dt) {
     g.runtime.accumulator += frame_dt;
+
+    double due_f = floor((double)g.runtime.accumulator / (double)SIM_DT);
+    uint32_t due = due_f > (double)UINT32_MAX
+        ? UINT32_MAX : (uint32_t)due_f;
 
     int sim_steps = 0;
     while ((g.runtime.accumulator >= SIM_DT) && (sim_steps < MAX_SIM_STEPS_PER_FRAME)) {
@@ -2794,6 +2845,20 @@ static void advance_simulation_frame(float frame_dt) {
         g.runtime.accumulator -= SIM_DT;
         sim_steps++;
     }
+
+    uint32_t missed = due > (uint32_t)sim_steps
+        ? due - (uint32_t)sim_steps : 0u;
+    uint32_t dropped = 0;
+    if (g.runtime.accumulator >= SIM_DT) {
+        double drop_f = floor(
+            (double)g.runtime.accumulator / (double)SIM_DT);
+        dropped = drop_f > (double)UINT32_MAX
+            ? UINT32_MAX : (uint32_t)drop_f;
+        g.runtime.accumulator -= (float)dropped * SIM_DT;
+        if (g.runtime.accumulator < 0.0f) g.runtime.accumulator = 0.0f;
+    }
+    gameplay_observability_record_sim_steps(
+        (uint32_t)sim_steps, missed, dropped);
 }
 
 /* Exported for the JS music player — returns 0.0-1.0 */
@@ -3701,6 +3766,11 @@ int signal_smoke_remote_towable_interp_check(void) {
     asteroid_t saved_asteroid_prev[MAX_ASTEROIDS];
     asteroid_t saved_asteroid_curr[MAX_ASTEROIDS];
     float saved_asteroid_elapsed[MAX_ASTEROIDS];
+    vec2 saved_asteroid_snapshot_vel[MAX_ASTEROIDS];
+    vec2 saved_asteroid_acceleration[MAX_ASTEROIDS];
+    float saved_asteroid_snapshot_elapsed[MAX_ASTEROIDS];
+    bool saved_asteroid_snapshot_valid[MAX_ASTEROIDS];
+    bool saved_asteroid_acceleration_valid[MAX_ASTEROIDS];
     client_npc_render_state_t saved_npc_prev[MAX_NPC_SHIPS];
     client_npc_render_state_t saved_npc_curr[MAX_NPC_SHIPS];
     float saved_npc_elapsed[MAX_NPC_SHIPS];
@@ -3729,6 +3799,19 @@ int signal_smoke_remote_towable_interp_check(void) {
     memcpy(saved_asteroid_curr, g.asteroid_interp.curr, sizeof(saved_asteroid_curr));
     memcpy(saved_asteroid_elapsed, g.asteroid_interp.elapsed,
            sizeof(saved_asteroid_elapsed));
+    memcpy(saved_asteroid_snapshot_vel, g.asteroid_interp.snapshot_vel,
+           sizeof(saved_asteroid_snapshot_vel));
+    memcpy(saved_asteroid_acceleration, g.asteroid_interp.acceleration,
+           sizeof(saved_asteroid_acceleration));
+    memcpy(saved_asteroid_snapshot_elapsed,
+           g.asteroid_interp.snapshot_elapsed,
+           sizeof(saved_asteroid_snapshot_elapsed));
+    memcpy(saved_asteroid_snapshot_valid,
+           g.asteroid_interp.snapshot_valid,
+           sizeof(saved_asteroid_snapshot_valid));
+    memcpy(saved_asteroid_acceleration_valid,
+           g.asteroid_interp.acceleration_valid,
+           sizeof(saved_asteroid_acceleration_valid));
     memcpy(saved_npc_prev, g.npc_interp.prev, sizeof(saved_npc_prev));
     memcpy(saved_npc_curr, g.npc_interp.curr, sizeof(saved_npc_curr));
     memcpy(saved_npc_elapsed, g.npc_interp.elapsed,
@@ -4447,6 +4530,19 @@ int signal_smoke_remote_towable_interp_check(void) {
     memcpy(g.asteroid_interp.curr, saved_asteroid_curr, sizeof(saved_asteroid_curr));
     memcpy(g.asteroid_interp.elapsed, saved_asteroid_elapsed,
            sizeof(saved_asteroid_elapsed));
+    memcpy(g.asteroid_interp.snapshot_vel, saved_asteroid_snapshot_vel,
+           sizeof(saved_asteroid_snapshot_vel));
+    memcpy(g.asteroid_interp.acceleration, saved_asteroid_acceleration,
+           sizeof(saved_asteroid_acceleration));
+    memcpy(g.asteroid_interp.snapshot_elapsed,
+           saved_asteroid_snapshot_elapsed,
+           sizeof(saved_asteroid_snapshot_elapsed));
+    memcpy(g.asteroid_interp.snapshot_valid,
+           saved_asteroid_snapshot_valid,
+           sizeof(saved_asteroid_snapshot_valid));
+    memcpy(g.asteroid_interp.acceleration_valid,
+           saved_asteroid_acceleration_valid,
+           sizeof(saved_asteroid_acceleration_valid));
     memcpy(g.npc_interp.prev, saved_npc_prev, sizeof(saved_npc_prev));
     memcpy(g.npc_interp.curr, saved_npc_curr, sizeof(saved_npc_curr));
     memcpy(g.npc_interp.elapsed, saved_npc_elapsed,
@@ -5044,6 +5140,8 @@ static void legacy_recovery_ui_update_adapter(void) {
 }
 
 static void frame(void) {
+    gameplay_observability_frame_begin();
+    double input_started = gameplay_observability_phase_begin();
     float frame_dt = (float)sapp_frame_duration();
     if (!isfinite(frame_dt) || frame_dt < 0.0f)
         frame_dt = 0.0f;
@@ -5236,21 +5334,31 @@ static void frame(void) {
         }
     }
 
+    gameplay_observability_phase_end(
+        GAMEPLAY_PHASE_INPUT_NETWORK, input_started);
+
+    double simulation_started = gameplay_observability_phase_begin();
     advance_simulation_frame(frame_dt);
+    gameplay_observability_phase_end(
+        GAMEPLAY_PHASE_SIMULATION, simulation_started);
 
     /* Offline fallback: keep the client-side manifest summary fresh. The
      * network path fills the summary directly from server packets. */
     if (!g.net_authority_enabled) refresh_station_manifest_summaries();
 
 
+    double audio_started = gameplay_observability_phase_begin();
     audio_generate_stream(&g.audio);
 
     /* Upload the latest decoded episode frame once per render frame. Decoding
      * happens inside sim_step (possibly multiple steps per frame); uploading
      * here ensures at most one sg_update_image per image per frame. */
     episode_upload_frame(&g.episode);
+    gameplay_observability_phase_end(
+        GAMEPLAY_PHASE_AUDIO_MEDIA, audio_started);
 
     render_frame();
+    gameplay_observability_frame_end();
 }
 
 static void cleanup(void) {

--- a/client/net.c
+++ b/client/net.c
@@ -12,6 +12,7 @@
 #include "signal_crypto.h"
 #include "signal_memzero.h"
 #include "net_clock.h"
+#include "gameplay_observability.h"
 #include "net_message_gate.h"
 #include "wire_codec.h"
 
@@ -1310,6 +1311,8 @@ static void handle_message(const uint8_t* data, int len) {
             return;
         }
     }
+
+    gameplay_observability_record_packet(data[0], (size_t)len);
 
     switch (data[0]) {
     case NET_MSG_LEGACY_RECOVERY_OFFER:

--- a/client/net_sync.c
+++ b/client/net_sync.c
@@ -13,6 +13,7 @@
 #include "remote_receipt_cache.h"
 #include "state_digest.h"
 #include "asteroid_presentation.h"
+#include "gameplay_observability.h"
 
 #define STATION_RING_CORRECTION_SEC 0.35f
 #define NET_MOTION_TELEMETRY_WINDOW_SEC 5.0f
@@ -59,6 +60,7 @@ static bool local_asteroid_presentation_feed_active;
 static void net_replay_clear_frames(void);
 static void net_clear_tow_projections(void);
 static void net_reproject_tow_snapshot(void);
+static bool net_local_player_towing_asteroid(int idx);
 
 bool net_local_prediction_enabled(void) {
     if (!g.net_authority_enabled) return true;
@@ -1103,8 +1105,13 @@ static asteroid_t asteroid_render_state_at(int slot, float elapsed,
     if (!curr->active) return out;
 
     elapsed = clampf(elapsed, 0.0f, ASTEROID_RENDER_PREDICT_MAX_SEC);
-    asteroid_presentation_predict_motion(
-        curr, elapsed, towed, &out.pos, &out.vel);
+    bool acceleration_valid = towed &&
+        !net_local_player_towing_asteroid(slot) &&
+        g.asteroid_interp.acceleration_valid[slot];
+    asteroid_presentation_predict_motion_accelerated(
+        curr, elapsed, towed,
+        g.asteroid_interp.acceleration[slot], acceleration_valid,
+        &out.pos, &out.vel);
     out.age += elapsed;
     out.rotation = wrap_angle(curr->rotation + curr->spin * elapsed);
 
@@ -1133,6 +1140,40 @@ static asteroid_t asteroid_render_state_at(int slot, float elapsed,
         out.spin += (spin_error - omega * rotation_c * elapsed) * decay;
     }
     return out;
+}
+
+static void asteroid_note_authoritative_motion(
+    int slot, vec2 next_velocity, bool tow_driven, bool same_identity)
+{
+    if (slot < 0 || slot >= MAX_ASTEROIDS ||
+        !isfinite(next_velocity.x) || !isfinite(next_velocity.y)) return;
+
+    float gap = g.asteroid_interp.snapshot_elapsed[slot];
+    bool usable_gap = isfinite(gap) && gap >= SIM_DT && gap <= 1.0f;
+    if (same_identity && tow_driven &&
+        g.asteroid_interp.snapshot_valid[slot] && usable_gap) {
+        vec2 dv = v2_sub(next_velocity,
+                         g.asteroid_interp.snapshot_vel[slot]);
+        vec2 acceleration = v2_scale(dv, 1.0f / gap);
+        float length = v2_len(acceleration);
+        if (isfinite(length) &&
+            length <= ASTEROID_PRESENTATION_MAX_ACCEL * 4.0f) {
+            if (length > ASTEROID_PRESENTATION_MAX_ACCEL) {
+                acceleration = v2_scale(
+                    acceleration,
+                    ASTEROID_PRESENTATION_MAX_ACCEL / length);
+            }
+            g.asteroid_interp.acceleration[slot] = acceleration;
+            g.asteroid_interp.acceleration_valid[slot] = true;
+        } else {
+            g.asteroid_interp.acceleration_valid[slot] = false;
+        }
+    } else {
+        g.asteroid_interp.acceleration_valid[slot] = false;
+    }
+    g.asteroid_interp.snapshot_vel[slot] = next_velocity;
+    g.asteroid_interp.snapshot_elapsed[slot] = 0.0f;
+    g.asteroid_interp.snapshot_valid[slot] = same_identity || tow_driven;
 }
 
 static client_npc_render_state_t npc_render_state_at(int slot, float elapsed) {
@@ -1468,8 +1509,14 @@ void net_advance_asteroid_interpolation(float dt) {
             if (prev->active) prev->active = false;
             if (g.asteroid_interp.elapsed[i] != 0.0f)
                 g.asteroid_interp.elapsed[i] = 0.0f;
+            g.asteroid_interp.snapshot_elapsed[i] = 0.0f;
+            g.asteroid_interp.snapshot_valid[i] = false;
+            g.asteroid_interp.acceleration_valid[i] = false;
             continue;
         }
+        g.asteroid_interp.snapshot_elapsed[i] = fminf(
+            g.asteroid_interp.snapshot_elapsed[i] + dt,
+            ASTEROID_RENDER_PREDICT_MAX_SEC);
         float elapsed = g.asteroid_interp.elapsed[i];
         if (elapsed < ASTEROID_RENDER_PREDICT_MAX_SEC) {
             elapsed = fminf(elapsed + dt,
@@ -1724,6 +1771,19 @@ void apply_remote_asteroids(const NetAsteroidState* asteroids, int count) {
             was_child == a->fracture_child &&
             was_tier == a->tier &&
             was_commodity == a->commodity;
+        if (a->active) {
+            gameplay_observability_record_entity_correction(
+                GAMEPLAY_ENTITY_ASTEROID,
+                v2_len(v2_sub(visual.pos, a->pos)),
+                v2_len(v2_sub(visual.vel, a->vel)),
+                g.asteroid_interp.snapshot_elapsed[idx]);
+            asteroid_note_authoritative_motion(
+                (int)idx, a->vel, asteroid_towed[idx], same_identity);
+        } else {
+            g.asteroid_interp.snapshot_valid[idx] = false;
+            g.asteroid_interp.acceleration_valid[idx] = false;
+            g.asteroid_interp.snapshot_elapsed[idx] = 0.0f;
+        }
         if (!a->active) {
             if (was_active) tow_relevance_changed = true;
             a->age = 0.0f;
@@ -1760,6 +1820,9 @@ void apply_remote_asteroids(const NetAsteroidState* asteroids, int count) {
                 g.asteroid_interp.curr[i].active = false;
                 g.asteroid_interp.prev[i].active = false;
                 g.asteroid_interp.elapsed[i] = 0.0f;
+                g.asteroid_interp.snapshot_elapsed[i] = 0.0f;
+                g.asteroid_interp.snapshot_valid[i] = false;
+                g.asteroid_interp.acceleration_valid[i] = false;
                 tow_relevance_changed = true;
             }
         }
@@ -1800,6 +1863,14 @@ void apply_remote_asteroid_motion(const NetAsteroidMotionState* asteroids,
                 next_vx, next_vy, 0.0f)) {
             g.net_reconcile.asteroid_motion_samples++;
         }
+        gameplay_observability_record_entity_correction(
+            GAMEPLAY_ENTITY_ASTEROID,
+            v2_len(v2_sub(visual.pos,
+                          v2(asteroids[i].x, asteroids[i].y))),
+            v2_len(v2_sub(visual.vel, v2(next_vx, next_vy))),
+            g.asteroid_interp.snapshot_elapsed[idx]);
+        asteroid_note_authoritative_motion(
+            (int)idx, v2(next_vx, next_vy), asteroid_towed[idx], true);
         a->pos.x = asteroids[i].x;
         a->pos.y = asteroids[i].y;
         a->vel.x = next_vx;
@@ -3673,7 +3744,7 @@ void sync_local_player_slot_from_network(void) {
 }
 
 void interpolate_world_for_render_frame(float frame_dt) {
-    (void)frame_dt;
+    bool observe_corrections = gameplay_observability_enabled();
     bool asteroid_towed[MAX_ASTEROIDS];
     net_collect_towed_asteroids(asteroid_towed);
 
@@ -3708,6 +3779,13 @@ void interpolate_world_for_render_frame(float frame_dt) {
         }
         client_npc_render_state_t render = npc_render_state_at(
             i, g.npc_interp.elapsed[i]);
+        if (observe_corrections && curr->active && prev->active) {
+            gameplay_observability_record_entity_correction(
+                GAMEPLAY_ENTITY_NPC,
+                v2_len(v2_sub(prev->pos, curr->pos)),
+                v2_len(v2_sub(prev->vel, curr->vel)),
+                fmaxf(g.npc_interp.elapsed[i], frame_dt));
+        }
         if (!g.world.npc_ships[i].ship &&
             !world_npc_ship_slot_activate(&g.world, i)) {
             continue;
@@ -3740,6 +3818,13 @@ void interpolate_world_for_render_frame(float frame_dt) {
             continue;
         }
         scaffold_t *dst = &g.world.scaffolds[i];
+        if (observe_corrections && curr->active && prev->active) {
+            gameplay_observability_record_entity_correction(
+                GAMEPLAY_ENTITY_SCAFFOLD,
+                v2_len(v2_sub(prev->pos, curr->pos)),
+                v2_len(v2_sub(prev->vel, curr->vel)),
+                fmaxf(g.scaffold_interp.elapsed[i], frame_dt));
+        }
         *dst = scaffold_render_state_at(
             i, g.scaffold_interp.elapsed[i]);
     }
@@ -3752,6 +3837,13 @@ void interpolate_world_for_render_frame(float frame_dt) {
             continue;
         }
         cargo_pod_t *dst = &g.world.cargo_pods[i];
+        if (observe_corrections && curr->active && prev->active) {
+            gameplay_observability_record_entity_correction(
+                GAMEPLAY_ENTITY_CARGO_POD,
+                v2_len(v2_sub(prev->pos, curr->pos)),
+                v2_len(v2_sub(prev->vel, curr->vel)),
+                fmaxf(g.cargo_pod_interp.elapsed[i], frame_dt));
+        }
         *dst = cargo_pod_render_state_at(
             i, clampf(g.cargo_pod_interp.elapsed[i], 0.0f,
                       CARGO_POD_RENDER_EXTRAPOLATE_MAX_SEC));
@@ -3832,8 +3924,27 @@ const NetPlayerState* net_get_interpolated_players(void) {
 
     float elapsed = clampf(g.player_interp.t * g.player_interp.interval,
                            0.0f, REMOTE_PLAYER_RENDER_EXTRAPOLATE_MAX_SEC);
-    for (int i = 0; i < NET_MAX_PLAYERS; i++)
+    for (int i = 0; i < NET_MAX_PLAYERS; i++) {
+        if (gameplay_observability_enabled() &&
+            i != g.local_player_slot &&
+            g.player_interp.curr[i].active &&
+            g.player_interp.prev[i].active) {
+            float dx = g.player_interp.prev[i].x -
+                       g.player_interp.curr[i].x;
+            float dy = g.player_interp.prev[i].y -
+                       g.player_interp.curr[i].y;
+            float dvx = g.player_interp.prev[i].vx -
+                        g.player_interp.curr[i].vx;
+            float dvy = g.player_interp.prev[i].vy -
+                        g.player_interp.curr[i].vy;
+            gameplay_observability_record_entity_correction(
+                GAMEPLAY_ENTITY_REMOTE_PLAYER,
+                sqrtf(dx * dx + dy * dy),
+                sqrtf(dvx * dvx + dvy * dvy),
+                fmaxf(elapsed, g.player_interp.interval));
+        }
         result[i] = remote_player_render_state_at(i, elapsed);
+    }
     return result;
 }
 

--- a/docs/gameplay-jank-observability.md
+++ b/docs/gameplay-jank-observability.md
@@ -1,0 +1,65 @@
+# Gameplay jank report
+
+Signal now has an opt-in report for late frames. It is off during normal play.
+When enabled, it records bounded counters and small histograms. It does not
+record player input, identities, cargo contents, or world saves.
+
+The report includes:
+
+- frame and simulation p50, p95, p99, and maximum time;
+- input/network, simulation, interpolation, world, UI, submission, and media
+  time;
+- local authority simulation and loopback packet work;
+- completed, missed, and dropped 120 Hz ticks;
+- packet count, bytes, maximum size, and maximum cadence gap;
+- correction, velocity jump, and correction jerk for asteroids, cargo pods,
+  scaffolds, NPCs, and remote players;
+- the main phase responsible for each frame over 16.6 ms;
+- save snapshot clone time and background write time in server logs.
+
+## Native fresh and mature save
+
+Run:
+
+```sh
+make jank-profile-native
+```
+
+Play a fresh world for at least 60 seconds. Then load a mature save and play
+for another 60 seconds. A JSON line starting with `[gameplay-jank]` is printed
+every 60 seconds. Server saves print `[save-observability]` with the snapshot
+tick, collection tick, clone time, and background write time.
+
+## Browser fresh and mature scenario
+
+Run:
+
+```sh
+make jank-profile-browser
+```
+
+The browser gate runs the same packet-driven single-player client in a fresh
+world and a dense mature-world fixture for 60 seconds each. It checks that
+the report has frame percentiles, phase attribution, packet cadence, fixed
+steps, all entity classes, and the deterministic accelerated-asteroid gate.
+
+For manual browser play, add `jankprofile=1` to the play URL. Call
+`signal_jank_profile_report_json` from the browser module to copy the current
+report, or reload the page to start a new window.
+
+## Fixed-step overflow
+
+The client completes at most eight 120 Hz steps in one rendered frame. If a
+pause or machine stall leaves more work than that, full leftover ticks are
+dropped and counted while the fractional remainder is kept. This prevents a
+long catch-up spiral. The report makes the loss explicit under
+`fixed_step.accumulator_dropped` and `fixed_step.missed`.
+
+## Accelerated asteroid presentation
+
+Tow and station-pull asteroids still receive authoritative motion packets.
+Rendering estimates acceleration from consecutive packet velocities and uses
+it for at most 0.25 seconds. Invalid or extreme samples are rejected or
+clamped. After 0.25 seconds the asteroid coasts, so a lost packet cannot make
+an old force estimate run away. This is presentation-only and never changes
+the authoritative simulation.

--- a/server/main.c
+++ b/server/main.c
@@ -8441,6 +8441,20 @@ static void apply_persistence_writer_result(
     uint64_t now,
     uint64_t *last_save
 ) {
+    persistence_writer_metrics_t save_metrics = {0};
+    if (persistence_writer &&
+        persistence_writer_get_metrics(
+            persistence_writer, &save_metrics) &&
+        save_metrics.write_complete) {
+        fprintf(stdout,
+                "[save-observability] snapshot_tick=%u collect_tick=%u "
+                "clone_ms=%.3f write_ms=%.3f result=%s\n",
+                save_metrics.snapshot_tick, world.tick,
+                save_metrics.snapshot_clone_ms,
+                save_metrics.background_write_ms,
+                state == PERSISTENCE_WRITER_SUCCEEDED
+                    ? "succeeded" : "failed");
+    }
     if (state == PERSISTENCE_WRITER_SUCCEEDED) {
         if (adopt_published_generation(published)) {
             persistence_retry_not_before_ms = 0;

--- a/server/persistence_writer.c
+++ b/server/persistence_writer.c
@@ -11,6 +11,7 @@
 #include <windows.h>
 #else
 #include <pthread.h>
+#include <time.h>
 #endif
 
 struct persistence_writer {
@@ -28,7 +29,24 @@ struct persistence_writer {
     char legacy_player_dir[PERSISTENCE_GENERATION_PATH_MAX];
     bool save_player_slot[MAX_PLAYERS];
     persistence_generation_paths_t published;
+    persistence_writer_metrics_t metrics;
 };
+
+static double persistence_writer_now(void) {
+#ifdef _WIN32
+    static LARGE_INTEGER frequency;
+    LARGE_INTEGER counter;
+    if (frequency.QuadPart == 0)
+        (void)QueryPerformanceFrequency(&frequency);
+    (void)QueryPerformanceCounter(&counter);
+    return frequency.QuadPart > 0
+        ? (double)counter.QuadPart / (double)frequency.QuadPart : 0.0;
+#else
+    struct timespec ts = {0};
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) return 0.0;
+    return (double)ts.tv_sec + (double)ts.tv_nsec / 1000000000.0;
+#endif
+}
 
 static void writer_lock(persistence_writer_t *writer) {
 #ifdef _WIN32
@@ -47,6 +65,7 @@ static void writer_unlock(persistence_writer_t *writer) {
 }
 
 static void persistence_writer_run(persistence_writer_t *writer) {
+    double write_started = persistence_writer_now();
     persistence_generation_paths_t published = {0};
     bool ok = persistence_generation_commit(
         writer->root_dir,
@@ -59,6 +78,9 @@ static void persistence_writer_run(persistence_writer_t *writer) {
     writer->snapshot = NULL;
 
     writer_lock(writer);
+    writer->metrics.background_write_ms =
+        (persistence_writer_now() - write_started) * 1000.0;
+    writer->metrics.write_complete = true;
     if (ok) writer->published = published;
     writer->state = ok
         ? PERSISTENCE_WRITER_SUCCEEDED
@@ -137,11 +159,16 @@ bool persistence_writer_start(
         (size_t)legacy_len >= sizeof(writer->legacy_player_dir)) {
         return false;
     }
+    double clone_started = persistence_writer_now();
     writer->snapshot = world_snapshot_clone_create(world);
     if (!writer->snapshot) return false;
     memcpy(writer->save_player_slot, save_player_slot,
            sizeof(writer->save_player_slot));
     memset(&writer->published, 0, sizeof(writer->published));
+    memset(&writer->metrics, 0, sizeof(writer->metrics));
+    writer->metrics.snapshot_tick = world->tick;
+    writer->metrics.snapshot_clone_ms =
+        (persistence_writer_now() - clone_started) * 1000.0;
     writer->state = PERSISTENCE_WRITER_RUNNING;
 
 #ifdef _WIN32
@@ -166,6 +193,17 @@ bool persistence_writer_active(persistence_writer_t *writer) {
     /* A completed OS thread is still busy until poll/wait joins it and
      * consumes its result; start() enforces the same single-writer rule. */
     return writer && writer->thread_joinable;
+}
+
+bool persistence_writer_get_metrics(
+    persistence_writer_t *writer,
+    persistence_writer_metrics_t *out_metrics)
+{
+    if (!writer || !out_metrics) return false;
+    writer_lock(writer);
+    *out_metrics = writer->metrics;
+    writer_unlock(writer);
+    return true;
 }
 
 static persistence_writer_state_t persistence_writer_collect(

--- a/server/persistence_writer.h
+++ b/server/persistence_writer.h
@@ -13,6 +13,13 @@ typedef enum {
     PERSISTENCE_WRITER_FAILED,
 } persistence_writer_state_t;
 
+typedef struct {
+    uint32_t snapshot_tick;
+    double snapshot_clone_ms;
+    double background_write_ms;
+    bool write_complete;
+} persistence_writer_metrics_t;
+
 persistence_writer_t *persistence_writer_create(void);
 void persistence_writer_destroy(persistence_writer_t *writer);
 
@@ -25,6 +32,9 @@ bool persistence_writer_start(
     const bool save_player_slot[MAX_PLAYERS]);
 
 bool persistence_writer_active(persistence_writer_t *writer);
+bool persistence_writer_get_metrics(
+    persistence_writer_t *writer,
+    persistence_writer_metrics_t *out_metrics);
 
 /* Completed results are consumed by poll/wait and the writer returns idle. */
 persistence_writer_state_t persistence_writer_poll(

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -99,6 +99,38 @@ type PlayerStateSnapshot = {
   docked: number;
 };
 
+type JankProfileReport = {
+  schema: string;
+  enabled: boolean;
+  window_sec: number;
+  frames: number;
+  frame_ms: { p50: number; p95: number; p99: number; max: number };
+  simulation_ms: { p50: number; p95: number; p99: number; max: number };
+  slow_frames: { over_16_6: number; over_33_3: number; unexplained: number };
+  fixed_step: { completed: number; missed: number; accumulator_dropped: number };
+  snapshots: { packets: number; bytes: number; max_packet_bytes: number; max_gap_ms: number };
+  phases: Record<string, { avg_ms: number; max_ms: number; slow_cause: number }>;
+  entities: Record<string, {
+    samples: number;
+    max_correction_world: number;
+    max_velocity_discontinuity: number;
+    max_correction_jerk: number;
+  }>;
+};
+
+async function jankProfileReport(page: Page): Promise<JankProfileReport> {
+  const raw = await page.evaluate(() => {
+    const mod = (window as unknown as {
+      Module?: {
+        ccall?: (name: string, returnType: string, argTypes: unknown[], args: unknown[]) => string;
+      };
+    }).Module;
+    if (!mod || typeof mod.ccall !== 'function') return '';
+    return mod.ccall('signal_jank_profile_report_json', 'string', [], []) || '';
+  });
+  return JSON.parse(raw) as JankProfileReport;
+}
+
 function addQueryParam(rawUrl: string, key: string, value: string): string {
   const hashAt = rawUrl.indexOf('#');
   const beforeHash = hashAt >= 0 ? rawUrl.slice(0, hashAt) : rawUrl;
@@ -2284,6 +2316,57 @@ test.describe('Browser smoke tests', () => {
     expect(await wasmNumber(page, 'get_local_asteroid_motion_presented_samples'))
       .toBe(0);
 
+    expectNoFatalErrors(logs);
+  });
+
+  test('fresh and mature play produce attributed jank reports and smooth accelerated rocks', async ({ page }) => {
+    test.skip(usesLiveSmokeUrl(), 'requires the local singleplayer authority');
+    const seconds = Number(process.env.SIGNAL_JANK_PROFILE_SECONDS || '2');
+    test.setTimeout(Math.max(45_000, seconds * 2_000 + 30_000));
+
+    const logs = installFatalCollectors(page);
+    await page.goto(addQueryParam(
+      smokeUrl({ singleplayer: true }), 'jankprofile', '1',
+    ));
+    await waitForRenderedGame(page, page.locator('canvas'), false);
+    expect(await wasmNumber(page, 'signal_jank_profile_enabled')).toBe(1);
+    expect(
+      await wasmNumber(page, 'signal_smoke_accelerated_asteroid_prediction_gate'),
+    ).toBe(1);
+
+    await page.waitForTimeout(seconds * 1_000);
+    const fresh = await jankProfileReport(page);
+    expect(fresh.schema).toBe('signal.gameplay-jank.v1');
+    expect(fresh.enabled).toBe(true);
+    expect(fresh.frames).toBeGreaterThan(30);
+    expect(fresh.frame_ms.p50).toBeGreaterThan(0);
+    expect(fresh.frame_ms.p95).toBeGreaterThanOrEqual(fresh.frame_ms.p50);
+    expect(fresh.frame_ms.p99).toBeGreaterThanOrEqual(fresh.frame_ms.p95);
+    expect(fresh.simulation_ms.p99).toBeGreaterThanOrEqual(0);
+    expect(fresh.snapshots.packets).toBeGreaterThan(0);
+    expect(fresh.snapshots.bytes).toBeGreaterThan(0);
+    expect(fresh.fixed_step.completed).toBeGreaterThan(0);
+    expect(fresh.slow_frames.unexplained)
+      .toBeLessThanOrEqual(fresh.slow_frames.over_16_6);
+
+    await page.evaluate(() => {
+      const mod = (window as unknown as {
+        Module?: { ccall?: (name: string, returnType: null, argTypes: unknown[], args: unknown[]) => void };
+      }).Module;
+      mod?.ccall?.('signal_jank_profile_reset', null, [], []);
+    });
+    await setSmokeLoopState(page, smokeLoopState.fractureTableau);
+    await page.waitForTimeout(seconds * 1_000);
+    const mature = await jankProfileReport(page);
+    expect(mature.frames).toBeGreaterThan(30);
+    expect(mature.frame_ms.p99).toBeGreaterThan(0);
+    expect(mature.snapshots.packets).toBeGreaterThan(0);
+    for (const entity of [
+      'asteroid', 'cargo_pod', 'scaffold', 'npc', 'remote_player',
+    ]) {
+      expect(mature.entities[entity]).toBeTruthy();
+      expect(mature.entities[entity].samples).toBeGreaterThanOrEqual(0);
+    }
     expectNoFatalErrors(logs);
   });
 

--- a/tests/c/test_asteroid_presentation.c
+++ b/tests/c/test_asteroid_presentation.c
@@ -85,6 +85,54 @@ TEST(test_asteroid_presentation_tracks_tow_classes_and_station_force)
         ASTEROID_MOTION_STATION_TOW);
 }
 
+TEST(test_asteroid_presentation_tracks_accelerated_tow_between_10hz_packets)
+{
+    asteroid_t base = presentation_asteroid(
+        v2(10.0f, 20.0f), v2(30.0f, -5.0f));
+    vec2 position = {0};
+    vec2 velocity = {0};
+
+    asteroid_presentation_predict_motion_accelerated(
+        &base, 0.1f, true, v2(380.0f, 40.0f), true,
+        &position, &velocity);
+
+    ASSERT_EQ_FLOAT(position.x, 14.9f, 0.0002f);
+    ASSERT_EQ_FLOAT(position.y, 19.7f, 0.0002f);
+    ASSERT_EQ_FLOAT(velocity.x, 68.0f, 0.0002f);
+    ASSERT_EQ_FLOAT(velocity.y, -1.0f, 0.0002f);
+
+    /* A delayed packet may not let an old acceleration run away forever. */
+    asteroid_presentation_predict_motion_accelerated(
+        &base, 1.0f, true, v2(380.0f, 0.0f), true,
+        &position, &velocity);
+    ASSERT_EQ_FLOAT(velocity.x, 125.0f, 0.0002f);
+    ASSERT_EQ_FLOAT(position.x, 123.125f, 0.001f);
+}
+
+TEST(test_asteroid_presentation_rejects_bad_acceleration_sample)
+{
+    asteroid_t base = presentation_asteroid(
+        v2(0.0f, 0.0f), v2(20.0f, 0.0f));
+    vec2 position = {0};
+    vec2 velocity = {0};
+    asteroid_presentation_predict_motion_accelerated(
+        &base, 0.1f, true,
+        v2(ASTEROID_PRESENTATION_MAX_ACCEL * 2.0f, 0.0f), true,
+        &position, &velocity);
+    ASSERT_EQ_FLOAT(position.x, 2.0f, 0.0001f);
+    ASSERT_EQ_FLOAT(velocity.x, 20.0f, 0.0001f);
+}
+
+TEST(test_asteroid_presentation_10hz_acceleration_gate)
+{
+    float position_error = INFINITY;
+    float velocity_error = INFINITY;
+    ASSERT(asteroid_presentation_acceleration_gate(
+        &position_error, &velocity_error));
+    ASSERT(position_error <= 0.01f);
+    ASSERT(velocity_error <= 0.01f);
+}
+
 TEST(test_asteroid_presentation_waits_for_identity_and_retires_atomically)
 {
     WORLD_DECL;
@@ -280,6 +328,9 @@ void register_asteroid_presentation_tests(void)
     TEST_SECTION("\nLocal asteroid presentation (#685):\n");
     RUN(test_asteroid_presentation_uses_authority_pose_without_mutation);
     RUN(test_asteroid_presentation_tracks_tow_classes_and_station_force);
+    RUN(test_asteroid_presentation_tracks_accelerated_tow_between_10hz_packets);
+    RUN(test_asteroid_presentation_rejects_bad_acceleration_sample);
+    RUN(test_asteroid_presentation_10hz_acceleration_gate);
     RUN(test_asteroid_presentation_waits_for_identity_and_retires_atomically);
     RUN(test_asteroid_presentation_covers_npc_throw_release_and_reentry);
     RUN(test_asteroid_presentation_applies_collision_impulse_without_smoothing);

--- a/tests/c/test_gameplay_observability.c
+++ b/tests/c/test_gameplay_observability.c
@@ -1,0 +1,50 @@
+#include "test_harness.h"
+
+#include "gameplay_observability.h"
+
+TEST(test_gameplay_observability_reports_bounded_runtime_evidence)
+{
+    gameplay_observability_configure(true, 60.0);
+    gameplay_observability_frame_begin();
+    double simulation_started = gameplay_observability_now() - 0.004;
+    gameplay_observability_phase_end(
+        GAMEPLAY_PHASE_SIMULATION, simulation_started);
+    gameplay_observability_record_sim_steps(8, 3, 3);
+    gameplay_observability_record_packet(0x4b, 321);
+    gameplay_observability_record_entity_correction(
+        GAMEPLAY_ENTITY_ASTEROID, 2.5f, 18.0f, 0.1f);
+    gameplay_observability_frame_end();
+
+    const char *report = gameplay_observability_report_json();
+    ASSERT(report != NULL);
+    ASSERT(strstr(report, "\"schema\":\"signal.gameplay-jank.v1\"") != NULL);
+    ASSERT(strstr(report, "\"completed\":8") != NULL);
+    ASSERT(strstr(report, "\"missed\":3") != NULL);
+    ASSERT(strstr(report, "\"accumulator_dropped\":3") != NULL);
+    ASSERT(strstr(report, "\"packets\":1") != NULL);
+    ASSERT(strstr(report, "\"max_packet_bytes\":321") != NULL);
+    ASSERT(strstr(report, "\"asteroid\":{\"samples\":1") != NULL);
+    ASSERT(strstr(report, "\"simulation\":{\"avg_ms\":") != NULL);
+}
+
+TEST(test_gameplay_observability_disabled_path_stays_empty)
+{
+    gameplay_observability_configure(false, 60.0);
+    gameplay_observability_frame_begin();
+    gameplay_observability_record_sim_steps(4, 2, 2);
+    gameplay_observability_record_packet(1, 99);
+    gameplay_observability_frame_end();
+
+    const char *report = gameplay_observability_report_json();
+    ASSERT(strstr(report, "\"enabled\":false") != NULL);
+    ASSERT(strstr(report, "\"frames\":0") != NULL);
+    ASSERT(strstr(report, "\"completed\":0") != NULL);
+    ASSERT(strstr(report, "\"packets\":0") != NULL);
+}
+
+void register_gameplay_observability_tests(void)
+{
+    TEST_SECTION("\nGameplay jank observability (#687):\n");
+    RUN(test_gameplay_observability_reports_bounded_runtime_evidence);
+    RUN(test_gameplay_observability_disabled_path_stays_empty);
+}

--- a/tests/c/test_main.c
+++ b/tests/c/test_main.c
@@ -102,6 +102,7 @@ void register_settlement_engine_tests(void);
 void register_signal_field_tests(void);
 void register_state_digest_tests(void);
 void register_reconciliation_diagnostics_tests(void);
+void register_gameplay_observability_tests(void);
 void register_asteroid_presentation_tests(void);
 void register_tow_presentation_diagnostics_tests(void);
 void register_gossip_tests(void);
@@ -256,6 +257,7 @@ int main(int argc, char **argv) {
     register_signal_field_tests();
     register_state_digest_tests();
     register_reconciliation_diagnostics_tests();
+    register_gameplay_observability_tests();
     register_asteroid_presentation_tests();
     register_tow_presentation_diagnostics_tests();
     register_gossip_tests();

--- a/tests/c/test_persistence_generation.c
+++ b/tests/c/test_persistence_generation.c
@@ -621,6 +621,7 @@ TEST(test_persistence_writer_commits_immutable_snapshot) {
     ASSERT(world != NULL);
     ASSERT(test_prepare_generation_world(
         world, token, 12.0f, 44.0f, 75.0f));
+    world->tick = 123u;
     bool save_slots[MAX_PLAYERS] = {0};
     save_slots[0] = true;
 
@@ -640,6 +641,12 @@ TEST(test_persistence_writer_commits_immutable_snapshot) {
         persistence_writer_wait(writer, &published),
         PERSISTENCE_WRITER_SUCCEEDED);
     ASSERT(!persistence_writer_active(writer));
+    persistence_writer_metrics_t metrics = {0};
+    ASSERT(persistence_writer_get_metrics(writer, &metrics));
+    ASSERT_EQ_INT(metrics.snapshot_tick, 123);
+    ASSERT(metrics.snapshot_clone_ms >= 0.0);
+    ASSERT(metrics.background_write_ms >= 0.0);
+    ASSERT(metrics.write_complete);
     persistence_writer_destroy(writer);
 
     WORLD_HEAP loaded = calloc(1, sizeof(*loaded));


### PR DESCRIPTION
Summary:
- predict bounded asteroid acceleration between 10 Hz authority packets
- count fixed-step overflow instead of entering catch-up spirals
- add opt-in frame, packet, entity-correction, and save-latency reports
- add native and browser fresh/mature profiling gates

Verification:
- 1666 native tests passed
- native client and server builds passed
- WebAssembly build and deterministic flag check passed
- WebAssembly memory 885/896 pages
- fresh/mature browser jank gate passed
- existing remote towable interpolation browser gate passed

Closes #685
Closes #687