### PR TITLE
Restore online player tractor tethers

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -4052,6 +4052,13 @@ int signal_smoke_remote_towable_interp_check(void) {
         .attached_tick = 400,
         .revision = 40,
     };
+    /* Online clients allocate component generations independently from the
+     * server. The authenticated relation generation must still project onto
+     * the live player slot, or local tractor lines disappear after restart or
+     * reconnect. */
+    atomic_link.source.generation += 7;
+    if (atomic_link.source.generation == 0)
+        atomic_link.source.generation = 1;
     apply_remote_tow_links(&atomic_link, 1, 40, 400);
     bool atomic_attach_ok =
         g.tow_snapshot_received &&
@@ -4146,18 +4153,23 @@ int signal_smoke_remote_towable_interp_check(void) {
         cargo_pod_is_tractored_by_module(
             &g.cargo_pod_interp.curr[13], 0, 0);
 
-    /* A stale relation from a recycled ship slot remains stored for possible
-     * relevance recovery, but must not project onto the live replacement. */
-    tow_link_t stale_ship_source = atomic_link;
-    stale_ship_source.revision = 43;
-    stale_ship_source.source.generation++;
-    if (stale_ship_source.source.generation == 0)
-        stale_ship_source.source.generation = 1;
-    apply_remote_tow_links(&stale_ship_source, 1, 43, 406);
-    bool stale_ship_generation_not_projected =
+    /* A current relation stays stored while its source is absent, then an
+     * equal-revision delivery may re-project it when that roster slot is live
+     * again. This keeps the stale-actor guard without comparing unrelated
+     * client/server component generations. */
+    tow_link_t roster_ship_source = atomic_link;
+    roster_ship_source.revision = 43;
+    g.world.players[0].connected = false;
+    apply_remote_tow_links(&roster_ship_source, 1, 43, 406);
+    bool absent_ship_source_not_projected =
         g.tow_snapshot_revision == 43 &&
         !cargo_pod_has_player_tractor(
-            &g.cargo_pod_interp.curr[stale_ship_source.target.index]);
+            &g.cargo_pod_interp.curr[roster_ship_source.target.index]);
+    g.world.players[0].connected = true;
+    apply_remote_tow_links(&roster_ship_source, 1, 43, 407);
+    bool live_ship_source_reprojected =
+        cargo_pod_player_tractor(
+            &g.cargo_pod_interp.curr[roster_ship_source.target.index]) == 0;
 
     tow_link_t relevance_link = atomic_link;
     relevance_link.target.index = 12;
@@ -4187,7 +4199,8 @@ int signal_smoke_remote_towable_interp_check(void) {
         conflicting_duplicate_idempotent &&
         malformed_replacement_rejected && newer_release_applied &&
         multi_pod_module_snapshot_ok &&
-        stale_ship_generation_not_projected &&
+        absent_ship_source_not_projected &&
+        live_ship_source_reprojected &&
         relevant_target_projected &&
         irrelevant_target_not_projected &&
         relevance_reentry_reprojected &&
@@ -4585,6 +4598,62 @@ int signal_smoke_remote_towable_interp_check(void) {
 EMSCRIPTEN_KEEPALIVE
 int signal_smoke_local_tow_replay_stability_check(void) {
     return net_smoke_local_tow_replay_stability_check();
+}
+
+EMSCRIPTEN_KEEPALIVE
+int signal_smoke_prepare_local_generation_mismatch_tether(void) {
+    const int pod_idx = MAX_CARGO_PODS - 2;
+    int player_idx = g.local_player_slot;
+    if (player_idx < 0 || player_idx >= MAX_PLAYERS) return 0;
+    server_player_t *player = &g.world.players[player_idx];
+    if (!player->ship) return 0;
+
+    /* Freeze the loopback authority so the render frame observes exactly the
+     * online-style snapshot assembled below. */
+    g.local_server.active = false;
+    player->connected = true;
+    player->docked = false;
+
+    cargo_pod_t pod = {
+        .active = true,
+        .kind = CARGO_POD_CARGO,
+        .commodity = COMMODITY_FERRITE_INGOT,
+        .pos = {player->ship->pos.x + 100.0f, player->ship->pos.y},
+        .vel = {0.0f, 0.0f},
+        .radius = 18.0f,
+        .quantity = 8,
+    };
+    g.world.cargo_pods[pod_idx] = pod;
+    g.cargo_pod_interp.prev[pod_idx] = pod;
+    g.cargo_pod_interp.curr[pod_idx] = pod;
+    g.cargo_pod_interp.elapsed[pod_idx] = 0.0f;
+
+    uint32_t revision = g.tow_snapshot_received
+        ? g.tow_snapshot_revision + 1u : 1u;
+    if (revision == 0) revision = 1;
+    tow_link_t link = {
+        .active = true,
+        .source = player->ship_ref,
+        .target = {
+            .kind = ENTITY_KIND_CARGO_POD,
+            .index = pod_idx,
+            .part = -1,
+            .generation = 1,
+        },
+        .profile = TOW_PROFILE_SHIP_POD,
+        .slot = 0,
+        .state = TOW_LINK_HELD,
+        .attached_tick = g.world.tick,
+        .revision = revision,
+    };
+    link.source.generation += 7;
+    if (link.source.generation == 0) link.source.generation = 1;
+    apply_remote_tow_links(&link, 1, revision, g.world.tick);
+
+    return player->ship->towed_pod_count == 1 &&
+           player->ship->towed_pods[0] == pod_idx &&
+           cargo_pod_player_tractor(&g.cargo_pod_interp.curr[pod_idx]) ==
+               player_idx;
 }
 
 EMSCRIPTEN_KEEPALIVE

--- a/client/net_sync.c
+++ b/client/net_sync.c
@@ -2867,13 +2867,26 @@ static bool net_tow_ship_source_is_live(entity_ref_t source) {
         return false;
     }
     /*
-     * Ship generations are replicated by the atomic relation and are also
-     * present on the client's live component slot. Require an exact match so
-     * a delayed relation from a departed/recycled actor cannot paint a beam
-     * from the new occupant of the same numeric slot.
+     * The atomic relation carries the server's ship generation. Client ship
+     * slots are created independently, so their local generation can differ
+     * after a server restart or reconnect even though both sides name the
+     * same live player/NPC. Requiring equality here accepted the relation but
+     * then discarded its render projection, hiding every online tether.
+     *
+     * Snapshot revisions reject delayed relation sets. At projection time we
+     * only need to prove that the named source slot still has a live actor;
+     * the server generation remains attached to the target binding.
      */
-    return entity_ref_equal(
-        world_ship_ref_for_slot(&g.world, source.index), source);
+    if (source.index < WORLD_NPC_SHIP_BASE) {
+        int player = source.index - WORLD_PLAYER_SHIP_BASE;
+        return player >= 0 && player < MAX_PLAYERS &&
+               g.world.players[player].connected &&
+               g.world.players[player].ship != NULL;
+    }
+
+    int npc = source.index - WORLD_NPC_SHIP_BASE;
+    return npc >= 0 && npc < MAX_NPC_SHIPS &&
+           g.npc_interp.curr[npc].active;
 }
 
 static bool net_tow_source_is_relevant(entity_ref_t source) {

--- a/tests/browser-smoke.spec.ts
+++ b/tests/browser-smoke.spec.ts
@@ -2994,7 +2994,7 @@ test.describe('Browser smoke tests', () => {
     expectNoFatalErrors(logs);
   });
 
-  rootBundleSmokeTest('smooths remote towable scaffold, cargo pod, and fragment snapshots', async ({ page }) => {
+  rootBundleSmokeTest('smooths remote towables and draws a local online tether across generation mismatch', async ({ page }) => {
     const logs = installFatalCollectors(page);
     await page.setViewportSize({ width: 1280, height: 720 });
     await loadGame(page, false, { singleplayer: true });
@@ -3004,6 +3004,23 @@ test.describe('Browser smoke tests', () => {
       await localTowReplayStabilityCheck(page),
       'player reconciliation must not advance an already-predicted tow body again',
     ).toBe(1);
+    expect(
+      await wasmNumber(
+        page, 'signal_smoke_prepare_local_generation_mismatch_tether',
+      ),
+      'an authenticated server tow generation must project onto the live local player slot',
+    ).toBe(1);
+    await expect
+      .poll(async () => (await tractorDrawTelemetry(page, 0)).count, {
+        timeout: 3_000,
+        message: 'the local player-to-cargo tractor line should render',
+      })
+      .toBeGreaterThanOrEqual(1);
+    const localTether = await tractorDrawTelemetry(page, 0);
+    expect(localTether.sourceType).toBe(3); // ship
+    expect(localTether.targetType).toBe(2); // cargo pod
+    expect(localTether.span).toBeGreaterThan(40);
+    expect(localTether.intensity).toBeGreaterThan(0);
 
     expectNoFatalErrors(logs);
   });


### PR DESCRIPTION
## Summary
- project authenticated tow snapshots onto live online player/NPC slots even when client and server component generations differ
- retain source-liveness and revision guards against stale tow projections
- add state and render regressions that prove a local ship-to-cargo tether is actually drawn

## Verification
- `make test-fast` — 1666 passed
- release WebAssembly build and memory budget — 885/896 pages
- targeted tow interpolation/render browser regression — passed
- adverse tow delivery browser gate — passed
- `make smoke` — 52 passed, 4 expected live-only skips